### PR TITLE
Fix Twemoji loading on Windows dev machines

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,7 +76,7 @@ module.exports = {
                 // lifetime for assets while still delivering changes quickly.
                 oneOf: [
                     {
-                        // Images referenced in CSS files
+                        // Assets referenced in CSS files
                         issuer: /\.(scss|css)$/,
                         loader: 'file-loader',
                         options: {
@@ -92,11 +92,15 @@ module.exports = {
                         },
                     },
                     {
-                        // Images referenced in HTML and JS files
+                        // Assets referenced in HTML and JS files
                         loader: 'file-loader',
                         options: {
                             name: '[name].[hash:7].[ext]',
                             outputPath: getImgOutputPath,
+                            publicPath: function(url, resourcePath) {
+                                const outputPath = getImgOutputPath(url, resourcePath);
+                                return toPublicPath(outputPath);
+                            },
                         },
                     },
                 ],


### PR DESCRIPTION
This corrects our path handling on Windows development machines for
paths referenced in JS and HTML files. Both images and fonts (like
Twemoji) were afflicted (with Windows-style backslash path delimiters),
but browsers seems to tolerate them in the `src` attribute of images, so
we didn't notice that variant before.