### PR TITLE
Wire up electron download progress to toasts

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -30,8 +30,7 @@ type ElectronChannel =
     "seshatReply" |
     "setBadgeCount" |
     "update-downloaded" |
-    "userDownloadCompleted" |
-    "userDownloadOpen";
+    "userDownload";
 
 declare global {
     interface Window {
@@ -50,6 +49,7 @@ declare global {
 
     interface Electron {
         on(channel: ElectronChannel, listener: (event: Event, ...args: any[]) => void): void;
+        removeListener(event: ElectronChannel, listener: (...args: any[]) => void): void;
         send(channel: ElectronChannel, ...args: any[]): void;
     }
 

--- a/src/components/views/toasts/ElectronDownloadToast.tsx
+++ b/src/components/views/toasts/ElectronDownloadToast.tsx
@@ -1,0 +1,104 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, {useState} from "react";
+import GenericToast from "matrix-react-sdk/src/components/views/toasts/GenericToast";
+import { useEventEmitter } from "matrix-react-sdk/src/hooks/useEventEmitter";
+import ToastStore from "matrix-react-sdk/src/stores/ToastStore";
+import {_t} from "../../../vector/init";
+
+const electron = window.electron;
+
+interface IProps {
+    downloadPath: string;
+    name: string;
+    totalBytes: number;
+    receivedBytes: number;
+    toastKey: string;
+}
+
+const ElectronDownloadToast: React.FC<IProps> = ({
+    downloadPath,
+    name,
+    totalBytes,
+    receivedBytes: initialReceivedBytes,
+    toastKey,
+}) => {
+    const [state, setState] = useState<"progressing" | "paused" | "cancelled" | "failed">("progressing");
+    const [receivedBytes, setReceivedBytes] = useState(initialReceivedBytes);
+
+    useEventEmitter(electron, "userDownload", (ev, {state, path, name, totalBytes, receivedBytes, terminal, begin}) => {
+        if (path !== downloadPath) return;
+
+        setReceivedBytes(receivedBytes);
+        switch (state) {
+            case "progressing":
+                setState("progressing");
+                break;
+            case "interrupted":
+                if (terminal) {
+                    setState("failed");
+                } else {
+                    setState("paused");
+                }
+                break;
+            case "cancelled":
+                setState("cancelled");
+                break;
+        }
+    });
+
+    let acceptLabel: string;
+    let acceptFn;
+    // TODO decide if this should be cancel/dismiss
+    let rejectLabel = _t("Dismiss");
+    let rejectFn = () => {
+        ToastStore.sharedInstance().dismissToast(toastKey);
+    };
+    switch (state) {
+        case "progressing":
+            acceptLabel = _t("Pause");
+            acceptFn = () => {
+                electron.send("userDownload", {
+                    action: "pause",
+                    path: downloadPath,
+                });
+            };
+            break;
+        case "paused":
+            acceptLabel = _t("Resume");
+            acceptFn = () => {
+                electron.send("userDownload", {
+                    action: "resume",
+                    path: downloadPath,
+                });
+            };
+            break;
+        case "failed":
+            rejectLabel = null;
+            rejectFn = null;
+    }
+
+    return <GenericToast
+        description={`${name}: ${receivedBytes}b / ${totalBytes}b`}
+        acceptLabel={acceptLabel}
+        onAccept={acceptFn}
+        rejectLabel={rejectLabel}
+        onReject={rejectFn}
+    />;
+};
+
+export default ElectronDownloadToast;

--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -262,7 +262,7 @@ export default class ElectronPlatform extends VectorBasePlatform {
                         name,
                     },
                     component: ElectronDownloadToast,
-                    priority: 99,
+                    priority: 98,
                 });
             } else if (state === "completed") {
                 ToastStore.sharedInstance().addOrReplaceToast({


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-react-sdk/pull/5863
Requires https://github.com/vector-im/element-desktop/pull/184

Fixes https://github.com/vector-im/element-desktop/issues/713
Fixes https://github.com/vector-im/element-desktop/issues/699

Blocked on https://github.com/vector-im/element-desktop/issues/727 - due to this issue only e2ee downloads work in EleDesktop - and those are "instantaneous" as they're just from in-memory blobs so this is somewhat untested and blocked as such.

Probably could do with a progress bar and other fanciness, potentially also merging all active downloads into a single toast maybe or something like that.

<!-- CHANGELOG_PREVIEW_START -->
---
Here's what your changelog entry will look like:

## ✨ Features
 * Wire up electron download progress to toasts ([\#16947](https://github.com/vector-im/element-web/pull/16947)). Fixes vector-im/element-desktop#713 and vector-im/element-desktop#699.<!-- CHANGELOG_PREVIEW_END -->