### PR TITLE
Pass our VERSION to sentry plugin's release arg via env

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -9,7 +9,7 @@ else
 fi
 
 yarn clean
-yarn build
+VERSION=$version yarn build
 
 # include the sample config in the tarball. Arguably this should be done by
 # `yarn build`, but it's just too painful.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -532,9 +532,10 @@ module.exports = (env, argv) => {
             // upload to sentry if sentry env is present
             process.env.SENTRY_DSN &&
                 new SentryCliPlugin({
-                    release: process.env.RELEASE,
+                    release: process.env.VERSION,
                     include: "./webapp",
                 }),
+            new webpack.EnvironmentPlugin(['VERSION']),
         ].filter(Boolean),
 
         output: {


### PR DESCRIPTION
Use our existing VERSION, deduced by the packaging script, as the release for sentry sourcemaps. 

This will be undefined for dev builds, which is fine.


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->