### PR TITLE
Add workflow to upload sentry sourcemaps

### DIFF
--- a/.github/workflows/sentry-sourcemaps.yaml
+++ b/.github/workflows/sentry-sourcemaps.yaml
@@ -1,0 +1,24 @@
+name: Upload Sentry Sourcemaps
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+    runs-on: ubuntu-latest
+    environment: develop
+    steps:
+        -   uses: actions/checkout@v2
+        -   uses: actions/setup-node@v2
+            with:
+                node-version: '14'
+                cache: 'yarn'
+        -   run: ./scripts/fetch-develop.deps.sh --depth 1
+        -   run: yarn install
+        -   run: ./scripts/ci_package.sh
+            env:
+                SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+                SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+                SENTRY_URL: ${{ secrets.SENTRY_URL }}
+                SENTRY_ORG: sentry
+                SENTRY_PROJECT: riot-web


### PR DESCRIPTION
On push to develop, run ci_package.sh setting SENTRY_ environment variables, which causes webpack to invoke the sentry plugin to upload sourcemaps

Note that once we fully port the buildkite CD to GHA, this will be part of that job - but that's a bit more effort, as it'll require reworking the deployment script to respond to GHA webhooks, rather than BK ones

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->