### PR TITLE
Remove highlight.js CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
     "browser-request": "^0.3.3",
     "gfm.css": "^1.1.2",
-    "highlight.js": "^11.3.1",
     "jsrsasign": "^10.2.0",
     "katex": "^0.12.0",
     "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#develop",

--- a/src/vector/index.ts
+++ b/src/vector/index.ts
@@ -22,7 +22,6 @@ limitations under the License.
 // Our own CSS (which is themed) is imported via separate webpack entry points
 // in webpack.config.js
 require('gfm.css/gfm.css');
-require('highlight.js/styles/github.css');
 require('katex/dist/katex.css');
 
 /**


### PR DESCRIPTION
This was completely unnecessary: react-sdk includes appropriate CSS
for highlight.js in its themes. This was actually causing some of
those values to be overridden with silly ones that made text invisible
on the dark theme.

Fixes https://github.com/vector-im/element-web/issues/19476

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change has no change notes, so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->