### PR TITLE
Artificially set a VERSION environment variable during build steps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,11 @@ dotenv.config();
 let ogImageUrl = process.env.RIOT_OG_IMAGE_URL;
 if (!ogImageUrl) ogImageUrl = 'https://app.element.io/themes/element/img/logos/opengraph.png';
 
+if (!process.env.VERSION) {
+    console.warn("Unset VERSION variable - this may affect build output");
+    process.env.VERSION = "!!UNSET!!";
+}
+
 const cssThemes = {
     // CSS themes
     "theme-legacy-light": "./node_modules/matrix-react-sdk/res/themes/legacy-light/css/legacy-light.scss",


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-web/issues/19485

The variable should be set when it needs to by CI, but in every other environment it's not important. Simply setting it to *something* makes EnvironmentPlugin happy. We print a warning just in case people expect it to be set, and use a clear value in case the environment variable doesn't get properly set.

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->