### PR TITLE
Make Inter font paths relative.

### DIFF
--- a/src/vector/index.html
+++ b/src/vector/index.html
@@ -53,7 +53,7 @@
         var tag = htmlWebpackPlugin.tags.headTags[i];
         var path = tag.attributes && tag.attributes.href;
         if (path.indexOf("Inter") !== -1) { %>
-            <link rel="preload" as="font" href="<%= path %>" crossorigin="anonymous"/>
+            <link rel="preload" as="font" href=".<%= path %>" crossorigin="anonymous"/>
         <% }
     } %>
 


### PR DESCRIPTION
Currently, paths look like /fonts/Inter which is fine if Element is installed in the wwwroot.
This change makes the paths relative (./fonts/Inter) which helps when it's not.

Credit goes to @rkfg.

Fixes #17575.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->