### PR TITLE
Updated 'Setting up a dev environment' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,11 +305,19 @@ yarn install
 popd
 ```
 
-Finally, build and start Element itself:
+Clone the repo and switch to the `element-web` directory:
 
 ```bash
 git clone https://github.com/vector-im/element-web.git
 cd element-web
+```
+
+Configure the app by copying `config.sample.json` to `config.json` and
+modifying it. See the [configuration docs](docs/config.md) for details.
+
+Finally, build and start Element itself:
+
+```bash
 yarn link matrix-js-sdk
 yarn link matrix-react-sdk
 yarn install
@@ -329,9 +337,6 @@ Wait a few seconds for the initial build to finish; you should see something lik
    Remember, the command will not terminate since it runs the web server
    and rebuilds source files when they change. This development server also
    disables caching, so do NOT use it in production.
-
-Configure the app by copying `config.sample.json` to `config.json` and
-modifying it. See the [configuration docs](docs/config.md) for details.
 
 Open <http://127.0.0.1:8080/> in your browser to see your newly built Element.
 


### PR DESCRIPTION
Updated **Setting up a dev environment** in README.md as the config.json (by copying config.sample.json) needs to be created before trying to build Element and can be confusing if not mentioned before the building step.

![image](https://user-images.githubusercontent.com/82967080/160790323-08472cad-8e15-4b11-9754-c8c5851a8599.png)

Signed-off-by: Shreeya <shreeya.singh@students.iiit.ac.in>

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->