### PR TITLE
Add functions for generic secret management to ElectronPlatform interface

### DIFF
--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -403,6 +403,24 @@ export default class ElectronPlatform extends VectorBasePlatform {
         return true;
     }
 
+    public async getPlatformSecret(key: string): Promise<string | null> {
+        return await this.ipc.call("getSecret", key).catch((error) => {
+            logger.info(`Failed to connect to password storage to get ${key}`, error);
+        });
+    }
+
+    public async savePlatformSecret(key: string, value: string): Promise<string | null> {
+        return await this.ipc.call("saveSecret", key, value).catch((error) => {
+            logger.info(`Failed to connect to password storage to save ${key}`, error);
+        });
+    }
+
+    public async destroyPlatformSecret(key: string): Promise<void> {
+        return await this.ipc.call("destroySecret", key).catch((error) => {
+            logger.info(`Failed to connect to password storage to destroy ${key}`, error);
+        });
+    }
+
     public async getPickleKey(userId: string, deviceId: string): Promise<string | null> {
         try {
             return await this.ipc.call("getPickleKey", userId, deviceId);

--- a/test/unit-tests/vector/platform/ElectronPlatform-test.ts
+++ b/test/unit-tests/vector/platform/ElectronPlatform-test.ts
@@ -284,6 +284,41 @@ describe("ElectronPlatform", () => {
         });
     });
 
+    describe("generic secrets", () => {
+        const secretKey = "secret-key";
+        const secretValue = "secret-value";
+
+        it("makes correct ipc call to get secret", () => {
+            const platform = new ElectronPlatform();
+            mockElectron.send.mockClear();
+            platform.getPlatformSecret(secretKey);
+
+            const [, { name, args }] = mockElectron.send.mock.calls[0];
+            expect(name).toEqual("getSecret");
+            expect(args).toEqual([secretKey]);
+        });
+
+        it("makes correct ipc call to save secret", () => {
+            const platform = new ElectronPlatform();
+            mockElectron.send.mockClear();
+            platform.savePlatformSecret(secretKey, secretValue);
+
+            const [, { name, args }] = mockElectron.send.mock.calls[0];
+            expect(name).toEqual("saveSecret");
+            expect(args).toEqual([secretKey, secretValue]);
+        });
+
+        it("makes correct ipc call to destroy pickle key", () => {
+            const platform = new ElectronPlatform();
+            mockElectron.send.mockClear();
+            platform.destroyPlatformSecret(secretKey);
+
+            const [, { name, args }] = mockElectron.send.mock.calls[0];
+            expect(name).toEqual("destroySecret");
+            expect(args).toEqual([secretKey]);
+        });
+    });
+
     describe("versions", () => {
         it("calls install update", () => {
             const platform = new ElectronPlatform();


### PR DESCRIPTION
This PR extended the IPC interface between the electron platform and application. The interface can be used to set, retrieve and destroy arbitrary secrets, similar to saving pickle keys. Notably, these changes allow setting a value for a secret instead of just generating a random one and retrieving it.

### Why?

For `element-desktop`, this functionality is intended to be used for persisting security keys on a machine with little user interaction, in an effort to reduce the complexity for non-tech users to not lose their encryption keys and thus access to messages. See <https://github.com/matrix-org/matrix-react-sdk/pull/11776>.
## Checklist

-   [x] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

Notes: none

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has none of the required changelog labels.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->