### PR TITLE
Add input parameter for ELEMENT_BOT_TOKEN

### DIFF
--- a/.github/workflows/triage-labelled.yml
+++ b/.github/workflows/triage-labelled.yml
@@ -4,6 +4,9 @@ on:
     issues:
         types: [labeled]
     workflow_call:
+        secrets:
+            ELEMENT_BOT_TOKEN:
+                required: true
 
 jobs:
     apply_Z-Labs_label:


### PR DESCRIPTION
This is required because the token is otherwise not available when calling the workflow from another.

For: https://github.com/vector-im/element-desktop/pull/1312

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->