### PR TITLE
Update tests not to mock out an ancient server

### DIFF
--- a/test/app-tests/loading-test.tsx
+++ b/test/app-tests/loading-test.tsx
@@ -39,6 +39,9 @@ import { cleanLocalstorage, deleteIndexedDB, waitForLoadingSpinner, waitForWelco
 const DEFAULT_HS_URL = "http://my_server";
 const DEFAULT_IS_URL = "http://my_is";
 
+/** The matrix versions our mock server claims to support */
+const SERVER_SUPPORTED_MATRIX_VERSIONS = ["v1.1", "v1.5", "v1.6", "v1.8", "v1.9"];
+
 describe("loading:", function () {
     let httpBackend: MockHttpBackend;
 
@@ -155,7 +158,7 @@ describe("loading:", function () {
     async function expectAndAwaitSync(opts?: { isGuest?: boolean }): Promise<any> {
         let syncRequest: (typeof MockHttpBackend.prototype.requests)[number] | null = null;
         httpBackend.when("GET", "/_matrix/client/versions").respond(200, {
-            versions: ["v1.1"],
+            versions: SERVER_SUPPORTED_MATRIX_VERSIONS,
             unstable_features: {},
         });
         const isGuest = opts?.isGuest;
@@ -215,7 +218,7 @@ describe("loading:", function () {
             });
 
             // Pass the liveliness checks
-            httpBackend.when("GET", "/versions").respond(200, { versions: ["v1.1"] });
+            httpBackend.when("GET", "/versions").respond(200, { versions: SERVER_SUPPORTED_MATRIX_VERSIONS });
             httpBackend.when("GET", "/_matrix/identity/v2").respond(200, {});
 
             return sleep(1)
@@ -265,7 +268,7 @@ describe("loading:", function () {
             });
 
             // Pass the liveliness checks
-            httpBackend.when("GET", "/versions").respond(200, { versions: ["v1.1"] });
+            httpBackend.when("GET", "/versions").respond(200, { versions: SERVER_SUPPORTED_MATRIX_VERSIONS });
             httpBackend.when("GET", "/_matrix/identity/v2").respond(200, {});
 
             return awaitLoginComponent(matrixChat)

--- a/test/app-tests/server-config-test.ts
+++ b/test/app-tests/server-config-test.ts
@@ -21,6 +21,9 @@ import fetchMock from "fetch-mock-jest";
 import { loadApp } from "../../src/vector/app";
 import WebPlatform from "../../src/vector/platform/WebPlatform";
 
+/** The matrix versions our mock server claims to support */
+const SERVER_SUPPORTED_MATRIX_VERSIONS = ["v1.1", "v1.5", "v1.6", "v1.8", "v1.9"];
+
 fetchMock.config.overwriteRoutes = true;
 
 describe("Loading server config", function () {
@@ -29,7 +32,7 @@ describe("Loading server config", function () {
         PlatformPeg.set(new WebPlatform());
         fetchMock.get("https://matrix-client.matrix.org/_matrix/client/versions", {
             unstable_features: {},
-            versions: ["v1.1"],
+            versions: SERVER_SUPPORTED_MATRIX_VERSIONS,
         });
         fetchMock.get("https://matrix.org/.well-known/matrix/client", {
             "m.homeserver": {

--- a/test/app-tests/wrapper-test.tsx
+++ b/test/app-tests/wrapper-test.tsx
@@ -28,6 +28,9 @@ import WebPlatform from "../../src/vector/platform/WebPlatform";
 import { loadApp } from "../../src/vector/app";
 import { waitForLoadingSpinner, waitForWelcomeComponent } from "../test-utils";
 
+/** The matrix versions our mock server claims to support */
+const SERVER_SUPPORTED_MATRIX_VERSIONS = ["v1.1", "v1.5", "v1.6", "v1.8", "v1.9"];
+
 fetchMock.config.overwriteRoutes = true;
 
 describe("Wrapper", () => {
@@ -36,7 +39,7 @@ describe("Wrapper", () => {
         PlatformPeg.set(new WebPlatform());
         fetchMock.get("https://matrix-client.matrix.org/_matrix/client/versions", {
             unstable_features: {},
-            versions: ["v1.1"],
+            versions: SERVER_SUPPORTED_MATRIX_VERSIONS,
         });
         fetchMock.get("https://matrix.org/.well-known/matrix/client", {
             "m.homeserver": {


### PR DESCRIPTION
As with https://github.com/matrix-org/matrix-react-sdk/pull/12081: our tests need to mock a modern server, not one that was released two years ago.

Another prerequisite for https://github.com/matrix-org/matrix-js-sdk/pull/3970

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->