### PR TITLE
Update documentation to use new GitHub organization name

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 -   [ ] Tests written for new code (and old code if feasible)
 -   [ ] Linter and other CI checks pass
--   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))
+-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md))
 
 <!--
 If you would like to specify text for the changelog entry other than your PR title, add the following:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@ Changes in [1.11.52](https://github.com/element-hq/element-web/releases/tag/v1.1
 * Prevent phantom notifications from events not in a room's timeline ([#3942](https://github.com/matrix-org/matrix-js-sdk/pull/3942)). Contributed by @dbkr.
 
 
-Changes in [1.11.51](https://github.com/vector-im/element-web/releases/tag/v1.11.51) (2023-12-05)
+Changes in [1.11.51](https://github.com/element-hq/element-web/releases/tag/v1.11.51) (2023-12-05)
 =================================================================================================
 ## ✨ Features
 
-* Improve debian package and docs ([#26618](https://github.com/vector-im/element-web/pull/26618)). Contributed by @t3chguy.
+* Improve debian package and docs ([#26618](https://github.com/element-hq/element-web/pull/26618)). Contributed by @t3chguy.
 
 ## 🦖 Deprecations
 
@@ -41,12 +41,12 @@ Changes in [1.11.51](https://github.com/vector-im/element-web/releases/tag/v1.11
 * Fix "not attempting encryption" warning ([#11899](https://github.com/matrix-org/matrix-react-sdk/pull/11899)). Contributed by @richvdh.
 
 
-Changes in [1.11.50](https://github.com/vector-im/element-web/releases/tag/v1.11.50) (2023-11-21)
+Changes in [1.11.50](https://github.com/element-hq/element-web/releases/tag/v1.11.50) (2023-11-21)
 =================================================================================================
 
 ## ✨ Features
 
-* Ship element-web as a debian package ([#26533](https://github.com/vector-im/element-web/pull/26533)). Contributed by @t3chguy.
+* Ship element-web as a debian package ([#26533](https://github.com/element-hq/element-web/pull/26533)). Contributed by @t3chguy.
 * Update room summary card header ([#11823](https://github.com/matrix-org/matrix-react-sdk/pull/11823)). Contributed by @germain-gg.
 * Add feature flag for disabling encryption in Element Call ([#11837](https://github.com/matrix-org/matrix-react-sdk/pull/11837)). Contributed by @toger5.
 * Adapt the rendering of extra icons in the room header ([#11835](https://github.com/matrix-org/matrix-react-sdk/pull/11835)). Contributed by @charlynguyen.
@@ -62,25 +62,25 @@ Changes in [1.11.50](https://github.com/vector-im/element-web/releases/tag/v1.11
 * Fix rightpanel hiding scrollbar ([#11831](https://github.com/matrix-org/matrix-react-sdk/pull/11831)). Contributed by @kerryarchibald.
 * Switch to updating presence via /sync calls instead of PUT /presence ([#11824](https://github.com/matrix-org/matrix-react-sdk/pull/11824)). Contributed by @t3chguy.
 
-Changes in [1.11.49](https://github.com/vector-im/element-web/releases/tag/v1.11.49) (2023-11-13)
+Changes in [1.11.49](https://github.com/element-hq/element-web/releases/tag/v1.11.49) (2023-11-13)
 =================================================================================================
 
 ## ✨ Features
- * Ship element-web as a debian package ([\#26533](https://github.com/vector-im/element-web/pull/26533)). Fixes #2777.
+ * Ship element-web as a debian package ([\#26533](https://github.com/element-hq/element-web/pull/26533)). Fixes #2777.
 
 ## 🐛 Bug Fixes
- * Ensure `setUserCreator` is called when a store is assigned ([\#3867](https://github.com/matrix-org/matrix-js-sdk/pull/3867)). Fixes vector-im/element-web#26520. Contributed by @MidhunSureshR.
+ * Ensure `setUserCreator` is called when a store is assigned ([\#3867](https://github.com/matrix-org/matrix-js-sdk/pull/3867)). Fixes element-hq/element-web#26520. Contributed by @MidhunSureshR.
 
-Changes in [1.11.48](https://github.com/vector-im/element-web/releases/tag/v1.11.48) (2023-11-07)
+Changes in [1.11.48](https://github.com/element-hq/element-web/releases/tag/v1.11.48) (2023-11-07)
 =================================================================================================
 
 ## ✨ Features
- * Correctly fill window.matrixChat even when a Wrapper module is active ([\#26395](https://github.com/vector-im/element-web/pull/26395)). Contributed by @dhenneke.
+ * Correctly fill window.matrixChat even when a Wrapper module is active ([\#26395](https://github.com/element-hq/element-web/pull/26395)). Contributed by @dhenneke.
  * Knock on a ask-to-join room if a module wants to join the room when navigating to a room ([\#11787](https://github.com/matrix-org/matrix-react-sdk/pull/11787)). Contributed by @dhenneke.
  * Element-R:  Include crypto info in sentry ([\#11798](https://github.com/matrix-org/matrix-react-sdk/pull/11798)). Contributed by @florianduros.
  * Element-R:  Include crypto info in rageshake ([\#11797](https://github.com/matrix-org/matrix-react-sdk/pull/11797)). Contributed by @florianduros.
  * Element-R: Add current version of the rust-sdk and vodozemac ([\#11785](https://github.com/matrix-org/matrix-react-sdk/pull/11785)). Contributed by @florianduros.
- * Fix unfederated invite dialog ([\#9618](https://github.com/matrix-org/matrix-react-sdk/pull/9618)). Fixes vector-im/element-meta#1466 and #22102. Contributed by @owi92.
+ * Fix unfederated invite dialog ([\#9618](https://github.com/matrix-org/matrix-react-sdk/pull/9618)). Fixes element-hq/element-meta#1466 and #22102. Contributed by @owi92.
  * New right panel visual language ([\#11664](https://github.com/matrix-org/matrix-react-sdk/pull/11664)).
  * OIDC: add friendly errors ([\#11184](https://github.com/matrix-org/matrix-react-sdk/pull/11184)). Fixes #25665. Contributed by @kerryarchibald.
 
@@ -101,14 +101,14 @@ Changes in [1.11.48](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix: emoji size in room header topic, remove obsolete emoji style ([\#11757](https://github.com/matrix-org/matrix-react-sdk/pull/11757)). Fixes #26326. Contributed by @kerryarchibald.
  * Fix: Bubble layout design is broken ([\#11763](https://github.com/matrix-org/matrix-react-sdk/pull/11763)). Fixes #25818. Contributed by @manancodes.
 
-Changes in [1.11.47](https://github.com/vector-im/element-web/releases/tag/v1.11.47) (2023-10-24)
+Changes in [1.11.47](https://github.com/element-hq/element-web/releases/tag/v1.11.47) (2023-10-24)
 =================================================================================================
 
 ## 🦖 Deprecations
- * Deprecate customisations in favour of Module API ([\#25736](https://github.com/vector-im/element-web/pull/25736)). Fixes #25733.
+ * Deprecate customisations in favour of Module API ([\#25736](https://github.com/element-hq/element-web/pull/25736)). Fixes #25733.
 
 ## ✨ Features
- * vector-im/element-x-ios/issues/1824 - Convert the apple-app-site-association file to a newer format… ([\#26307](https://github.com/vector-im/element-web/pull/26307)). Contributed by @stefanceriu.
+ * element-hq/element-x-ios/issues/1824 - Convert the apple-app-site-association file to a newer format… ([\#26307](https://github.com/element-hq/element-web/pull/26307)). Contributed by @stefanceriu.
  * Iterate `io.element.late_event` decoration ([\#11760](https://github.com/matrix-org/matrix-react-sdk/pull/11760)). Fixes #26384.
  * Render timeline separator for late event groups ([\#11739](https://github.com/matrix-org/matrix-react-sdk/pull/11739)).
  * OIDC: revoke tokens on logout ([\#11718](https://github.com/matrix-org/matrix-react-sdk/pull/11718)). Fixes #25394. Contributed by @kerryarchibald.
@@ -137,7 +137,7 @@ Changes in [1.11.47](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix: Wierd shadow below room avatar in dark mode. ([\#11678](https://github.com/matrix-org/matrix-react-sdk/pull/11678)). Fixes #26153. Contributed by @manancodes.
  * Fix start_sso / start_cas URLs failing to redirect to a authentication prompt ([\#11681](https://github.com/matrix-org/matrix-react-sdk/pull/11681)). Contributed by @Half-Shot.
 
-Changes in [1.11.46](https://github.com/vector-im/element-web/releases/tag/v1.11.46) (2023-10-10)
+Changes in [1.11.46](https://github.com/element-hq/element-web/releases/tag/v1.11.46) (2023-10-10)
 =================================================================================================
 
 ## ✨ Features
@@ -149,7 +149,7 @@ Changes in [1.11.46](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Show knock rooms in the list ([\#11573](https://github.com/matrix-org/matrix-react-sdk/pull/11573)). Contributed by @maheichyk.
 
 ## 🐛 Bug Fixes
- * Bump matrix-web-i18n dependency to 3.1.3 ([\#26287](https://github.com/vector-im/element-web/pull/26287))
+ * Bump matrix-web-i18n dependency to 3.1.3 ([\#26287](https://github.com/element-hq/element-web/pull/26287))
  * Fix: Avatar shrinks with long names ([\#11698](https://github.com/matrix-org/matrix-react-sdk/pull/11698)). Fixes #26252. Contributed by @manancodes.
  * Update custom translations to support nested fields in structured JSON ([\#11685](https://github.com/matrix-org/matrix-react-sdk/pull/11685)).
  * Fix: Edited message remove button is hard to reach. ([\#11674](https://github.com/matrix-org/matrix-react-sdk/pull/11674)). Fixes #24917. Contributed by @manancodes.
@@ -163,17 +163,17 @@ Changes in [1.11.46](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix add to space avatar text centering ([\#11643](https://github.com/matrix-org/matrix-react-sdk/pull/11643)). Fixes #26154.
  * fix avatar styling in lightbox ([\#11641](https://github.com/matrix-org/matrix-react-sdk/pull/11641)). Fixes #26196.
 
-Changes in [1.11.45](https://github.com/vector-im/element-web/releases/tag/v1.11.45) (2023-09-29)
+Changes in [1.11.45](https://github.com/element-hq/element-web/releases/tag/v1.11.45) (2023-09-29)
 =================================================================================================
 
 ## 🐛 Bug Fixes
  * Fix Emoji font on Safari 17 ([\#11673](https://github.com/matrix-org/matrix-react-sdk/pull/11673)).
 
-Changes in [1.11.44](https://github.com/vector-im/element-web/releases/tag/v1.11.44) (2023-09-26)
+Changes in [1.11.44](https://github.com/element-hq/element-web/releases/tag/v1.11.44) (2023-09-26)
 =================================================================================================
 
 ## ✨ Features
- * Make video & voice call buttons pin conference widget if unpinned ([\#11576](https://github.com/matrix-org/matrix-react-sdk/pull/11576)). Fixes vector-im/customer-retainer#72.
+ * Make video & voice call buttons pin conference widget if unpinned ([\#11576](https://github.com/matrix-org/matrix-react-sdk/pull/11576)). Fixes element-hq/customer-retainer#72.
  * OIDC: persist refresh token ([\#11249](https://github.com/matrix-org/matrix-react-sdk/pull/11249)). Contributed by @kerryarchibald.
  * ElementR: Cross user verification ([\#11364](https://github.com/matrix-org/matrix-react-sdk/pull/11364)). Fixes #25752. Contributed by @florianduros.
  * Default intentional mentions ([\#11602](https://github.com/matrix-org/matrix-react-sdk/pull/11602)).
@@ -193,26 +193,26 @@ Changes in [1.11.44](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix avatars in public room & space search being flex shrunk ([\#11580](https://github.com/matrix-org/matrix-react-sdk/pull/11580)). Fixes #26133.
  * Fix EventTile avatars being rendered with a size of 0 instead of hidden ([\#11558](https://github.com/matrix-org/matrix-react-sdk/pull/11558)). Fixes #26075.
 
-Changes in [1.11.43](https://github.com/vector-im/element-web/releases/tag/v1.11.43) (2023-09-15)
+Changes in [1.11.43](https://github.com/element-hq/element-web/releases/tag/v1.11.43) (2023-09-15)
 =================================================================================================
 
 (No changes - bumping the version number for an element-desktop release.)
 
-Changes in [1.11.42](https://github.com/vector-im/element-web/releases/tag/v1.11.42) (2023-09-13)
+Changes in [1.11.42](https://github.com/element-hq/element-web/releases/tag/v1.11.42) (2023-09-13)
 =================================================================================================
 
 ## 🐛 Bug Fixes
  * Update Compound to fix Firefox-specific avatar regression ([\#11604](https://github.com/matrix-org/matrix-react-sdk/pull/11604)). Fixes #26155.
 
-Changes in [1.11.41](https://github.com/vector-im/element-web/releases/tag/v1.11.41) (2023-09-12)
+Changes in [1.11.41](https://github.com/element-hq/element-web/releases/tag/v1.11.41) (2023-09-12)
 =================================================================================================
 
 ## 🦖 Deprecations
- * Deprecate customisations in favour of Module API ([\#25736](https://github.com/vector-im/element-web/pull/25736)). Fixes #25733.
+ * Deprecate customisations in favour of Module API ([\#25736](https://github.com/element-hq/element-web/pull/25736)). Fixes #25733.
 
 ## ✨ Features
- * Make SVGR icons use forward ref ([\#26082](https://github.com/vector-im/element-web/pull/26082)).
- * Add support for rendering a custom wrapper around Element ([\#25537](https://github.com/vector-im/element-web/pull/25537)). Contributed by @maheichyk.
+ * Make SVGR icons use forward ref ([\#26082](https://github.com/element-hq/element-web/pull/26082)).
+ * Add support for rendering a custom wrapper around Element ([\#25537](https://github.com/element-hq/element-web/pull/25537)). Contributed by @maheichyk.
  * Allow creating public knock rooms ([\#11481](https://github.com/matrix-org/matrix-react-sdk/pull/11481)). Contributed by @charlynguyen.
  * Render custom images in reactions according to MSC4027 ([\#11087](https://github.com/matrix-org/matrix-react-sdk/pull/11087)). Contributed by @sumnerevans.
  * Introduce room knocks bar ([\#11475](https://github.com/matrix-org/matrix-react-sdk/pull/11475)). Contributed by @charlynguyen.
@@ -228,7 +228,7 @@ Changes in [1.11.41](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix vertical alignment of default avatar font ([\#11582](https://github.com/matrix-org/matrix-react-sdk/pull/11582)). Fixes #26081.
  * Fix avatars in public room & space search being flex shrunk ([\#11580](https://github.com/matrix-org/matrix-react-sdk/pull/11580)). Fixes #26133.
  * Fix EventTile avatars being rendered with a size of 0 instead of hidden ([\#11558](https://github.com/matrix-org/matrix-react-sdk/pull/11558)). Fixes #26075.
- * Fix compound external assets path in bundle ([\#26069](https://github.com/vector-im/element-web/pull/26069)).
+ * Fix compound external assets path in bundle ([\#26069](https://github.com/element-hq/element-web/pull/26069)).
  * Use RoomStateEvent.Update for knocks ([\#11516](https://github.com/matrix-org/matrix-react-sdk/pull/11516)). Contributed by @charlynguyen.
  * Prevent event propagation when clicking icon buttons ([\#11515](https://github.com/matrix-org/matrix-react-sdk/pull/11515)).
  * Only display RoomKnocksBar when feature flag is enabled ([\#11513](https://github.com/matrix-org/matrix-react-sdk/pull/11513)). Contributed by @andybalaam.
@@ -240,7 +240,7 @@ Changes in [1.11.41](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix incompatibility of Soft Logout with Element-R ([\#11468](https://github.com/matrix-org/matrix-react-sdk/pull/11468)).
  * Fix instances of double translation and guard translation calls using typescript ([\#11443](https://github.com/matrix-org/matrix-react-sdk/pull/11443)).
 
-Changes in [1.11.40](https://github.com/vector-im/element-web/releases/tag/v1.11.40) (2023-08-29)
+Changes in [1.11.40](https://github.com/element-hq/element-web/releases/tag/v1.11.40) (2023-08-29)
 =================================================================================================
 
 ## ✨ Features
@@ -250,13 +250,13 @@ Changes in [1.11.40](https://github.com/vector-im/element-web/releases/tag/v1.11
  * OIDC: disable multi session signout for OIDC-aware servers in session manager ([\#11431](https://github.com/matrix-org/matrix-react-sdk/pull/11431)). Contributed by @kerryarchibald.
  * Implement updated open dialog method of the Module API ([\#11395](https://github.com/matrix-org/matrix-react-sdk/pull/11395)). Contributed by @dhenneke.
  * Polish & delabs `Exploring public spaces` feature ([\#11423](https://github.com/matrix-org/matrix-react-sdk/pull/11423)).
- * Treat lists with a single empty item as plain text, not Markdown. ([\#6833](https://github.com/matrix-org/matrix-react-sdk/pull/6833)). Fixes vector-im/element-meta#1265.
+ * Treat lists with a single empty item as plain text, not Markdown. ([\#6833](https://github.com/matrix-org/matrix-react-sdk/pull/6833)). Fixes element-hq/element-meta#1265.
  * Allow managing room knocks ([\#11404](https://github.com/matrix-org/matrix-react-sdk/pull/11404)). Contributed by @charlynguyen.
  * Pin the action buttons to the bottom of the scrollable dialogs ([\#11407](https://github.com/matrix-org/matrix-react-sdk/pull/11407)). Contributed by @dhenneke.
  * Support Matrix 1.1 (drop legacy r0 versions) ([\#9819](https://github.com/matrix-org/matrix-react-sdk/pull/9819)).
 
 ## 🐛 Bug Fixes
- * Fix path separator for Windows based systems ([\#25997](https://github.com/vector-im/element-web/pull/25997)).
+ * Fix path separator for Windows based systems ([\#25997](https://github.com/element-hq/element-web/pull/25997)).
  * Fix instances of double translation and guard translation calls using typescript ([\#11443](https://github.com/matrix-org/matrix-react-sdk/pull/11443)).
  * Fix export type "Current timeline" to match its behaviour to its name ([\#11426](https://github.com/matrix-org/matrix-react-sdk/pull/11426)). Fixes #25988.
  * Fix Room Settings > Notifications file upload input being shown superfluously ([\#11415](https://github.com/matrix-org/matrix-react-sdk/pull/11415)). Fixes #18392.
@@ -266,19 +266,19 @@ Changes in [1.11.40](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix useRoomMembers missing updates causing incorrect membership counts ([\#11392](https://github.com/matrix-org/matrix-react-sdk/pull/11392)). Fixes #17096.
  * Show error when searching public rooms fails ([\#11378](https://github.com/matrix-org/matrix-react-sdk/pull/11378)).
 
-Changes in [1.11.39](https://github.com/vector-im/element-web/releases/tag/v1.11.39) (2023-08-15)
+Changes in [1.11.39](https://github.com/element-hq/element-web/releases/tag/v1.11.39) (2023-08-15)
 =================================================================================================
 
 ## 🦖 Deprecations
- * Deprecate camelCase config options ([\#25800](https://github.com/vector-im/element-web/pull/25800)).
- * Deprecate customisations in favour of Module API ([\#25736](https://github.com/vector-im/element-web/pull/25736)). Fixes #25733.
+ * Deprecate camelCase config options ([\#25800](https://github.com/element-hq/element-web/pull/25800)).
+ * Deprecate customisations in favour of Module API ([\#25736](https://github.com/element-hq/element-web/pull/25736)). Fixes #25733.
 
 ## ✨ Features
- * Update labs.md for knock rooms ([\#25923](https://github.com/vector-im/element-web/pull/25923)). Contributed by @charlynguyen.
- * Package release builds of element-web in package.element.io debs ([\#25198](https://github.com/vector-im/element-web/pull/25198)).
+ * Update labs.md for knock rooms ([\#25923](https://github.com/element-hq/element-web/pull/25923)). Contributed by @charlynguyen.
+ * Package release builds of element-web in package.element.io debs ([\#25198](https://github.com/element-hq/element-web/pull/25198)).
  * Allow knocking rooms ([\#11353](https://github.com/matrix-org/matrix-react-sdk/pull/11353)). Contributed by @charlynguyen.
  * Support adding space-restricted joins on rooms not members of those spaces ([\#9017](https://github.com/matrix-org/matrix-react-sdk/pull/9017)). Fixes #19213.
- * Clear requiresClient and show pop-out if widget-api fails to ready ([\#11321](https://github.com/matrix-org/matrix-react-sdk/pull/11321)). Fixes vector-im/customer-retainer#73.
+ * Clear requiresClient and show pop-out if widget-api fails to ready ([\#11321](https://github.com/matrix-org/matrix-react-sdk/pull/11321)). Fixes element-hq/customer-retainer#73.
  * Bump pagination sizes due to hidden events ([\#11342](https://github.com/matrix-org/matrix-react-sdk/pull/11342)).
  * Remove display of key backup signatures from backup settings ([\#11333](https://github.com/matrix-org/matrix-react-sdk/pull/11333)).
  * Use PassphraseFields in ExportE2eKeysDialog to enforce minimum passphrase complexity ([\#11222](https://github.com/matrix-org/matrix-react-sdk/pull/11222)). Fixes #9478.
@@ -295,24 +295,24 @@ Changes in [1.11.39](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Make keyboard handling in and out of autocomplete completions consistent ([\#11344](https://github.com/matrix-org/matrix-react-sdk/pull/11344)). Fixes #25878.
  * De-duplicate reactions by sender to account for faulty/malicious servers ([\#11340](https://github.com/matrix-org/matrix-react-sdk/pull/11340)). Fixes #25872.
  * Fix disable_3pid_login being ignored for the email field ([\#11335](https://github.com/matrix-org/matrix-react-sdk/pull/11335)). Fixes #25863.
- * Upgrade wysiwyg editor for ctrl+backspace windows fix ([\#11324](https://github.com/matrix-org/matrix-react-sdk/pull/11324)). Fixes vector-im/verticals-internal#102.
+ * Upgrade wysiwyg editor for ctrl+backspace windows fix ([\#11324](https://github.com/matrix-org/matrix-react-sdk/pull/11324)). Fixes element-hq/verticals-internal#102.
  * Unhide the view source event toggle - it works well enough ([\#11336](https://github.com/matrix-org/matrix-react-sdk/pull/11336)). Fixes #25861.
 
-Changes in [1.11.38](https://github.com/vector-im/element-web/releases/tag/v1.11.38) (2023-08-04)
+Changes in [1.11.38](https://github.com/element-hq/element-web/releases/tag/v1.11.38) (2023-08-04)
 =================================================================================================
 
 ## ✨ Features
- * Package release builds of element-web in package.element.io debs ([\#25198](https://github.com/vector-im/element-web/pull/25198)).
+ * Package release builds of element-web in package.element.io debs ([\#25198](https://github.com/element-hq/element-web/pull/25198)).
 
 ## 🐛 Bug Fixes
  * Revert to using the /presence API for presence ([\#11366](https://github.com/matrix-org/matrix-react-sdk/pull/11366))
 
-Changes in [1.11.37](https://github.com/vector-im/element-web/releases/tag/v1.11.37) (2023-08-01)
+Changes in [1.11.37](https://github.com/element-hq/element-web/releases/tag/v1.11.37) (2023-08-01)
 =================================================================================================
 
 ## 🦖 Deprecations
- * Deprecate camelCase config options ([\#25800](https://github.com/vector-im/element-web/pull/25800)).
- * Deprecate customisations in favour of Module API ([\#25736](https://github.com/vector-im/element-web/pull/25736)). Fixes #25733.
+ * Deprecate camelCase config options ([\#25800](https://github.com/element-hq/element-web/pull/25800)).
+ * Deprecate customisations in favour of Module API ([\#25736](https://github.com/element-hq/element-web/pull/25736)). Fixes #25733.
 
 ## ✨ Features
  * Do not show "Forget room" button in Room View header for guest users ([\#10898](https://github.com/matrix-org/matrix-react-sdk/pull/10898)). Contributed by @spantaleev.
@@ -326,13 +326,13 @@ Changes in [1.11.37](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Offer to unban user during invite if inviter has sufficient permissions ([\#11256](https://github.com/matrix-org/matrix-react-sdk/pull/11256)). Fixes #3222.
  * Split join and goto slash commands, the latter shouldn't auto_join ([\#11259](https://github.com/matrix-org/matrix-react-sdk/pull/11259)). Fixes #10128.
  * Integration work for rich text editor 2.3.1 ([\#11172](https://github.com/matrix-org/matrix-react-sdk/pull/11172)). Contributed by @alunturner.
- * Compound color pass ([\#11079](https://github.com/matrix-org/matrix-react-sdk/pull/11079)). Fixes vector-im/internal-planning#450 and #25547.
+ * Compound color pass ([\#11079](https://github.com/matrix-org/matrix-react-sdk/pull/11079)). Fixes element-hq/internal-planning#450 and #25547.
  * Warn when demoting self via /op and /deop slash commands ([\#11214](https://github.com/matrix-org/matrix-react-sdk/pull/11214)). Fixes #13726.
 
 ## 🐛 Bug Fixes
- * Correct Jitsi preferred_domain property ([\#25813](https://github.com/vector-im/element-web/pull/25813)). Contributed by @benbz.
+ * Correct Jitsi preferred_domain property ([\#25813](https://github.com/element-hq/element-web/pull/25813)). Contributed by @benbz.
  * Fix edge case with sent indicator being drawn when it shouldn't be ([\#11320](https://github.com/matrix-org/matrix-react-sdk/pull/11320)).
- * Use correct translation function for WYSIWYG buttons ([\#11315](https://github.com/matrix-org/matrix-react-sdk/pull/11315)). Fixes vector-im/verticals-internal#109.
+ * Use correct translation function for WYSIWYG buttons ([\#11315](https://github.com/matrix-org/matrix-react-sdk/pull/11315)). Fixes element-hq/verticals-internal#109.
  * Handle empty own profile ([\#11319](https://github.com/matrix-org/matrix-react-sdk/pull/11319)). Fixes #25510.
  * Fix peeked rooms showing up in historical ([\#11316](https://github.com/matrix-org/matrix-react-sdk/pull/11316)). Fixes #22473.
  * Ensure consistency when rendering the sent event indicator ([\#11314](https://github.com/matrix-org/matrix-react-sdk/pull/11314)). Fixes #17937.
@@ -363,19 +363,19 @@ Changes in [1.11.37](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix color mapping for blockquote border ([\#11251](https://github.com/matrix-org/matrix-react-sdk/pull/11251)). Fixes #25782.
  * Strip emoji variation when searching emoji by emoji ([\#11221](https://github.com/matrix-org/matrix-react-sdk/pull/11221)). Fixes #18703.
 
-Changes in [1.11.36](https://github.com/vector-im/element-web/releases/tag/v1.11.36) (2023-07-18)
+Changes in [1.11.36](https://github.com/element-hq/element-web/releases/tag/v1.11.36) (2023-07-18)
 =================================================================================================
 
 ## 🔒 Security
  * Fixes for [CVE-2023-37259](https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=CVE-2023-37259) / [GHSA-c9vx-2g7w-rp65](https://github.com/matrix-org/matrix-react-sdk/security/advisories/GHSA-c9vx-2g7w-rp65)
 
 ## 🦖 Deprecations
- * Deprecate customisations in favour of Module API ([\#25736](https://github.com/vector-im/element-web/pull/25736)). Fixes #25733.
+ * Deprecate customisations in favour of Module API ([\#25736](https://github.com/element-hq/element-web/pull/25736)). Fixes #25733.
 
 ## ✨ Features
- * OIDC: store initial screen in session storage  ([\#25688](https://github.com/vector-im/element-web/pull/25688)). Fixes #25656. Contributed by @kerryarchibald.
- * Allow default_server_config as a fallback config ([\#25682](https://github.com/vector-im/element-web/pull/25682)). Contributed by @ShadowRZ.
- * OIDC: remove auth params from url after login attempt ([\#25664](https://github.com/vector-im/element-web/pull/25664)). Contributed by @kerryarchibald.
+ * OIDC: store initial screen in session storage  ([\#25688](https://github.com/element-hq/element-web/pull/25688)). Fixes #25656. Contributed by @kerryarchibald.
+ * Allow default_server_config as a fallback config ([\#25682](https://github.com/element-hq/element-web/pull/25682)). Contributed by @ShadowRZ.
+ * OIDC: remove auth params from url after login attempt ([\#25664](https://github.com/element-hq/element-web/pull/25664)). Contributed by @kerryarchibald.
  * feat(faq): remove keyboard shortcuts button ([\#9342](https://github.com/matrix-org/matrix-react-sdk/pull/9342)). Fixes #22625. Contributed by @gefgu.
  * GYU: Update banner ([\#11211](https://github.com/matrix-org/matrix-react-sdk/pull/11211)). Fixes #25530. Contributed by @justjanne.
  * Linkify mxc:// URLs as links to your media repo ([\#11213](https://github.com/matrix-org/matrix-react-sdk/pull/11213)). Fixes #6942.
@@ -385,7 +385,7 @@ Changes in [1.11.36](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Allow creating knock rooms ([\#11182](https://github.com/matrix-org/matrix-react-sdk/pull/11182)). Contributed by @charlynguyen.
  * Expose and pre-populate thread ID in devtools dialog ([\#10953](https://github.com/matrix-org/matrix-react-sdk/pull/10953)).
  * Hide URL preview if it will be empty ([\#9029](https://github.com/matrix-org/matrix-react-sdk/pull/9029)).
- * Change wording from avatar to profile picture ([\#7015](https://github.com/matrix-org/matrix-react-sdk/pull/7015)). Fixes vector-im/element-meta#1331. Contributed by @aaronraimist.
+ * Change wording from avatar to profile picture ([\#7015](https://github.com/matrix-org/matrix-react-sdk/pull/7015)). Fixes element-hq/element-meta#1331. Contributed by @aaronraimist.
  * Quick and dirty devtool to explore state history ([\#11197](https://github.com/matrix-org/matrix-react-sdk/pull/11197)).
  * Consider more user inputs when calculating zxcvbn score ([\#11180](https://github.com/matrix-org/matrix-react-sdk/pull/11180)).
  * GYU: Account Notification Settings ([\#11008](https://github.com/matrix-org/matrix-react-sdk/pull/11008)). Fixes #24567. Contributed by @justjanne.
@@ -417,7 +417,7 @@ Changes in [1.11.36](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Only trap escape key for cancel reply if there is a reply ([\#11140](https://github.com/matrix-org/matrix-react-sdk/pull/11140)). Fixes #25640.
  * Update linkify to 4.1.1 ([\#11132](https://github.com/matrix-org/matrix-react-sdk/pull/11132)). Fixes #23806.
 
-Changes in [1.11.35](https://github.com/vector-im/element-web/releases/tag/v1.11.35) (2023-07-04)
+Changes in [1.11.35](https://github.com/element-hq/element-web/releases/tag/v1.11.35) (2023-07-04)
 =================================================================================================
 
 ## 🦖 Deprecations
@@ -437,12 +437,12 @@ Changes in [1.11.35](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Implement new model, hooks and reconcilation code for new GYU notification settings ([\#11089](https://github.com/matrix-org/matrix-react-sdk/pull/11089)). Contributed by @justjanne.
  * Allow maintaining a different right panel width for thread panels ([\#11064](https://github.com/matrix-org/matrix-react-sdk/pull/11064)). Fixes #25487.
  * Make AppPermission pane scrollable ([\#10954](https://github.com/matrix-org/matrix-react-sdk/pull/10954)). Fixes #25438 and #25511. Contributed by @luixxiul.
- * Integrate compound design tokens ([\#11091](https://github.com/matrix-org/matrix-react-sdk/pull/11091)). Fixes vector-im/internal-planning#450.
+ * Integrate compound design tokens ([\#11091](https://github.com/matrix-org/matrix-react-sdk/pull/11091)). Fixes element-hq/internal-planning#450.
  * Don't warn about the effects of redacting state events when redacting non-state-events ([\#11071](https://github.com/matrix-org/matrix-react-sdk/pull/11071)). Fixes #8478.
  * Allow specifying help URLs in config.json ([\#11070](https://github.com/matrix-org/matrix-react-sdk/pull/11070)). Fixes #15268.
 
 ## 🐛 Bug Fixes
- * Fix error when generating error for polling for updates ([\#25609](https://github.com/vector-im/element-web/pull/25609)).
+ * Fix error when generating error for polling for updates ([\#25609](https://github.com/element-hq/element-web/pull/25609)).
  * Fix spurious notifications on non-live events ([\#11133](https://github.com/matrix-org/matrix-react-sdk/pull/11133)). Fixes #24336.
  * Prevent auto-translation within composer ([\#11114](https://github.com/matrix-org/matrix-react-sdk/pull/11114)). Fixes #25624.
  * Fix caret jump when backspacing into empty line at beginning of editor ([\#11128](https://github.com/matrix-org/matrix-react-sdk/pull/11128)). Fixes #22335.
@@ -456,7 +456,7 @@ Changes in [1.11.35](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix slash commands not being enabled in certain cases ([\#11090](https://github.com/matrix-org/matrix-react-sdk/pull/11090)). Fixes #25572.
  * Prevent escape in threads from sending focus to main timeline composer ([\#11061](https://github.com/matrix-org/matrix-react-sdk/pull/11061)). Fixes #23397.
 
-Changes in [1.11.34](https://github.com/vector-im/element-web/releases/tag/v1.11.34) (2023-06-20)
+Changes in [1.11.34](https://github.com/element-hq/element-web/releases/tag/v1.11.34) (2023-06-20)
 =================================================================================================
 
 ## ✨ Features
@@ -465,31 +465,31 @@ Changes in [1.11.34](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Show room options menu if "UIComponent.roomOptionsMenu" is enabled ([\#10365](https://github.com/matrix-org/matrix-react-sdk/pull/10365)). Contributed by @maheichyk.
  * Allow image pasting in rich text mode in RTE ([\#11049](https://github.com/matrix-org/matrix-react-sdk/pull/11049)). Contributed by @alunturner.
  * Update voice broadcast redaction to use MSC3912 `with_rel_type` instead of `with_relations` ([\#11014](https://github.com/matrix-org/matrix-react-sdk/pull/11014)). Fixes #25471.
- * Add config to skip widget_build_url for DM rooms ([\#11044](https://github.com/matrix-org/matrix-react-sdk/pull/11044)). Fixes vector-im/customer-retainer#74.
+ * Add config to skip widget_build_url for DM rooms ([\#11044](https://github.com/matrix-org/matrix-react-sdk/pull/11044)). Fixes element-hq/customer-retainer#74.
  * Inhibit interactions on forward dialog message previews ([\#11025](https://github.com/matrix-org/matrix-react-sdk/pull/11025)). Fixes #23459.
- * Removed `DecryptionFailureBar.tsx` ([\#11027](https://github.com/matrix-org/matrix-react-sdk/pull/11027)). Fixes vector-im/element-meta#1358. Contributed by @florianduros.
+ * Removed `DecryptionFailureBar.tsx` ([\#11027](https://github.com/matrix-org/matrix-react-sdk/pull/11027)). Fixes element-hq/element-meta#1358. Contributed by @florianduros.
 
 ## 🐛 Bug Fixes
  * Fix translucent `TextualEvent` on search results panel ([\#10810](https://github.com/matrix-org/matrix-react-sdk/pull/10810)). Fixes #25292. Contributed by @luixxiul.
  * Matrix matrix scheme permalink constructor not stripping query params ([\#11060](https://github.com/matrix-org/matrix-react-sdk/pull/11060)). Fixes #25535.
  * Fix: "manually verify by text" does nothing ([\#11059](https://github.com/matrix-org/matrix-react-sdk/pull/11059)). Fixes #25375. Contributed by @kerryarchibald.
- * Make group calls respect the ICE fallback setting ([\#11047](https://github.com/matrix-org/matrix-react-sdk/pull/11047)). Fixes vector-im/voip-internal#65.
+ * Make group calls respect the ICE fallback setting ([\#11047](https://github.com/matrix-org/matrix-react-sdk/pull/11047)). Fixes element-hq/voip-internal#65.
  * Align list items on the tooltip to the start ([\#11041](https://github.com/matrix-org/matrix-react-sdk/pull/11041)). Fixes #25355. Contributed by @luixxiul.
  * Clear thread panel event permalink when changing rooms ([\#11024](https://github.com/matrix-org/matrix-react-sdk/pull/11024)). Fixes #25484.
  * Fix spinner placement on pinned widgets being reloaded ([\#10970](https://github.com/matrix-org/matrix-react-sdk/pull/10970)). Fixes #25431. Contributed by @luixxiul.
 
-Changes in [1.11.33](https://github.com/vector-im/element-web/releases/tag/v1.11.33) (2023-06-09)
+Changes in [1.11.33](https://github.com/element-hq/element-web/releases/tag/v1.11.33) (2023-06-09)
 =================================================================================================
 
 ## 🐛 Bug Fixes
  * Bump matrix-react-sdk to v3.73.1 for matrix-js-sdk v26.0.1. Fixes #25526.
 
-Changes in [1.11.32](https://github.com/vector-im/element-web/releases/tag/v1.11.32) (2023-06-06)
+Changes in [1.11.32](https://github.com/element-hq/element-web/releases/tag/v1.11.32) (2023-06-06)
 =================================================================================================
 
 ## ✨ Features
- * Redirect to the SSO page if `sso_redirect_options.on_welcome_page` is enabled and the URL hash is empty ([\#25495](https://github.com/vector-im/element-web/pull/25495)). Contributed by @dhenneke.
- * vector/index.html: Allow fetching blob urls ([\#25336](https://github.com/vector-im/element-web/pull/25336)). Contributed by @SuperKenVery.
+ * Redirect to the SSO page if `sso_redirect_options.on_welcome_page` is enabled and the URL hash is empty ([\#25495](https://github.com/element-hq/element-web/pull/25495)). Contributed by @dhenneke.
+ * vector/index.html: Allow fetching blob urls ([\#25336](https://github.com/element-hq/element-web/pull/25336)). Contributed by @SuperKenVery.
  * When joining room in sub-space join the parents too ([\#11011](https://github.com/matrix-org/matrix-react-sdk/pull/11011)).
  * Include thread replies in message previews ([\#10631](https://github.com/matrix-org/matrix-react-sdk/pull/10631)). Fixes #23920.
  * Use semantic headings in space preferences ([\#11021](https://github.com/matrix-org/matrix-react-sdk/pull/11021)). Contributed by @kerryarchibald.
@@ -509,18 +509,18 @@ Changes in [1.11.32](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Use semantic headings in user settings Preferences ([\#10794](https://github.com/matrix-org/matrix-react-sdk/pull/10794)). Contributed by @kerryarchibald.
  * Use semantic headings in user settings Keyboard ([\#10793](https://github.com/matrix-org/matrix-react-sdk/pull/10793)). Contributed by @kerryarchibald.
  * RTE plain text mentions as pills ([\#10852](https://github.com/matrix-org/matrix-react-sdk/pull/10852)). Contributed by @alunturner.
- * Allow welcome.html logo to be replaced by config ([\#25339](https://github.com/vector-im/element-web/pull/25339)). Fixes #8636.
+ * Allow welcome.html logo to be replaced by config ([\#25339](https://github.com/element-hq/element-web/pull/25339)). Fixes #8636.
  * Use semantic headings in user settings Labs ([\#10773](https://github.com/matrix-org/matrix-react-sdk/pull/10773)). Contributed by @kerryarchibald.
  * Use semantic list elements for menu lists and tab lists ([\#10902](https://github.com/matrix-org/matrix-react-sdk/pull/10902)). Fixes #24928.
  * Fix aria-required-children axe violation ([\#10900](https://github.com/matrix-org/matrix-react-sdk/pull/10900)). Fixes #25342.
- * Enable pagination for overlay timelines ([\#10757](https://github.com/matrix-org/matrix-react-sdk/pull/10757)). Fixes vector-im/voip-internal#107.
+ * Enable pagination for overlay timelines ([\#10757](https://github.com/matrix-org/matrix-react-sdk/pull/10757)). Fixes element-hq/voip-internal#107.
  * Add tooltip to disabled invite button due to lack of permissions ([\#10869](https://github.com/matrix-org/matrix-react-sdk/pull/10869)). Fixes #9824.
  * Respect configured auth_header_logo_url for default Welcome page ([\#10870](https://github.com/matrix-org/matrix-react-sdk/pull/10870)).
  * Specify lazy loading for avatars ([\#10866](https://github.com/matrix-org/matrix-react-sdk/pull/10866)). Fixes #1983.
  * Room and user mentions for plain text editor ([\#10665](https://github.com/matrix-org/matrix-react-sdk/pull/10665)). Contributed by @alunturner.
  * Add audible notifcation on broadcast error ([\#10654](https://github.com/matrix-org/matrix-react-sdk/pull/10654)). Fixes #25132.
  * Fall back from server generated thumbnail to original image ([\#10853](https://github.com/matrix-org/matrix-react-sdk/pull/10853)).
- * Use semantically correct elements for room sublist context menu ([\#10831](https://github.com/matrix-org/matrix-react-sdk/pull/10831)). Fixes vector-im/customer-retainer#46.
+ * Use semantically correct elements for room sublist context menu ([\#10831](https://github.com/matrix-org/matrix-react-sdk/pull/10831)). Fixes element-hq/customer-retainer#46.
  * Avoid calling prepareToEncrypt onKeyDown ([\#10828](https://github.com/matrix-org/matrix-react-sdk/pull/10828)).
  * Allows search to recognize full room links ([\#8275](https://github.com/matrix-org/matrix-react-sdk/pull/8275)). Contributed by @bolu-tife.
  * "Show rooms with unread messages first" should not be on by default for new users ([\#10820](https://github.com/matrix-org/matrix-react-sdk/pull/10820)). Fixes #25304. Contributed by @kerryarchibald.
@@ -554,8 +554,8 @@ Changes in [1.11.32](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix big emoji in replies ([\#10932](https://github.com/matrix-org/matrix-react-sdk/pull/10932)). Fixes #24798.
  * Hide empty `MessageActionBar` on message edit history dialog ([\#10447](https://github.com/matrix-org/matrix-react-sdk/pull/10447)). Fixes #24903. Contributed by @luixxiul.
  * Fix roving tab index getting confused after dragging space order ([\#10901](https://github.com/matrix-org/matrix-react-sdk/pull/10901)).
- * Attempt a potential workaround for stuck notifs ([\#3384](https://github.com/matrix-org/matrix-js-sdk/pull/3384)). Fixes vector-im/element-web#25406. Contributed by @andybalaam.
- * Handle trailing dot FQDNs for domain-specific config.json files ([\#25351](https://github.com/vector-im/element-web/pull/25351)). Fixes #8858.
+ * Attempt a potential workaround for stuck notifs ([\#3384](https://github.com/matrix-org/matrix-js-sdk/pull/3384)). Fixes element-hq/element-web#25406. Contributed by @andybalaam.
+ * Handle trailing dot FQDNs for domain-specific config.json files ([\#25351](https://github.com/element-hq/element-web/pull/25351)). Fixes #8858.
  * Ignore edits in message previews when they concern messages other than latest ([\#10868](https://github.com/matrix-org/matrix-react-sdk/pull/10868)). Fixes #14872.
  * Send correct receipts when viewing a room ([\#10864](https://github.com/matrix-org/matrix-react-sdk/pull/10864)). Fixes #25196.
  * Fix timeline search bar being overlapped by the right panel ([\#10809](https://github.com/matrix-org/matrix-react-sdk/pull/10809)). Fixes #25291. Contributed by @luixxiul.
@@ -574,13 +574,13 @@ Changes in [1.11.32](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix: No feedback when waiting for the server on a /delete_devices request with SSO ([\#10795](https://github.com/matrix-org/matrix-react-sdk/pull/10795)). Fixes #23096. Contributed by @kerryarchibald.
  * Fix: reveal images when image previews are disabled ([\#10781](https://github.com/matrix-org/matrix-react-sdk/pull/10781)). Fixes #25271. Contributed by @kerryarchibald.
  * Fix accessibility issues around the room list and space panel ([\#10717](https://github.com/matrix-org/matrix-react-sdk/pull/10717)). Fixes #13345.
- * Ensure tooltip contents is linked via aria to the target element ([\#10729](https://github.com/matrix-org/matrix-react-sdk/pull/10729)). Fixes vector-im/customer-retainer#43.
+ * Ensure tooltip contents is linked via aria to the target element ([\#10729](https://github.com/matrix-org/matrix-react-sdk/pull/10729)). Fixes element-hq/customer-retainer#43.
 
-Changes in [1.11.31](https://github.com/vector-im/element-web/releases/tag/v1.11.31) (2023-05-10)
+Changes in [1.11.31](https://github.com/element-hq/element-web/releases/tag/v1.11.31) (2023-05-10)
 =================================================================================================
 
 ## ✨ Features
- * Improve Content-Security-Policy ([\#25210](https://github.com/vector-im/element-web/pull/25210)).
+ * Improve Content-Security-Policy ([\#25210](https://github.com/element-hq/element-web/pull/25210)).
  * Add UIFeature.locationSharing to hide location sharing ([\#10727](https://github.com/matrix-org/matrix-react-sdk/pull/10727)).
  * Memoize field validation results ([\#10714](https://github.com/matrix-org/matrix-react-sdk/pull/10714)).
  * Commands for plain text editor ([\#10567](https://github.com/matrix-org/matrix-react-sdk/pull/10567)). Contributed by @alunturner.
@@ -615,7 +615,7 @@ Changes in [1.11.31](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix wrong room topic tooltip position ([\#10667](https://github.com/matrix-org/matrix-react-sdk/pull/10667)). Fixes #25158.
  * Fix create subspace dialog not working ([\#10652](https://github.com/matrix-org/matrix-react-sdk/pull/10652)). Fixes #24882.
 
-Changes in [1.11.30](https://github.com/vector-im/element-web/releases/tag/v1.11.30) (2023-04-25)
+Changes in [1.11.30](https://github.com/element-hq/element-web/releases/tag/v1.11.30) (2023-04-25)
 =================================================================================================
 
 ## 🔒 Security
@@ -640,7 +640,7 @@ Changes in [1.11.30](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Update rte autocomplete styling ([\#10503](https://github.com/matrix-org/matrix-react-sdk/pull/10503)). Contributed by @alunturner.
 
 ## 🐛 Bug Fixes
- * Fix create subspace dialog not working ([\#10652](https://github.com/matrix-org/matrix-react-sdk/pull/10652)). Fixes vector-im/element-web#24882
+ * Fix create subspace dialog not working ([\#10652](https://github.com/matrix-org/matrix-react-sdk/pull/10652)). Fixes element-hq/element-web#24882
  * Fix multiple accessibility defects identified by AXE ([\#10606](https://github.com/matrix-org/matrix-react-sdk/pull/10606)).
  * Fix view source from edit history dialog always showing latest event ([\#10626](https://github.com/matrix-org/matrix-react-sdk/pull/10626)). Fixes #21859.
  * #21451 Fix WebGL disabled error message ([\#10589](https://github.com/matrix-org/matrix-react-sdk/pull/10589)). Contributed by @rashmitpankhania.
@@ -659,12 +659,12 @@ Changes in [1.11.30](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Highlight event when any version triggered a highlight ([\#10502](https://github.com/matrix-org/matrix-react-sdk/pull/10502)). Fixes #24923 and #24970. Contributed by @kerryarchibald.
  * Fix spacing of headings of integration manager on General settings tab ([\#10232](https://github.com/matrix-org/matrix-react-sdk/pull/10232)). Fixes #24085. Contributed by @luixxiul.
 
-Changes in [1.11.29](https://github.com/vector-im/element-web/releases/tag/v1.11.29) (2023-04-11)
+Changes in [1.11.29](https://github.com/element-hq/element-web/releases/tag/v1.11.29) (2023-04-11)
 =================================================================================================
 
 ## ✨ Features
- * Allow desktop app to expose recent rooms in UI integrations ([\#16940](https://github.com/vector-im/element-web/pull/16940)).
- * Add API params to mute audio and/or video in Jitsi calls by default ([\#24820](https://github.com/vector-im/element-web/pull/24820)). Contributed by @dhenneke.
+ * Allow desktop app to expose recent rooms in UI integrations ([\#16940](https://github.com/element-hq/element-web/pull/16940)).
+ * Add API params to mute audio and/or video in Jitsi calls by default ([\#24820](https://github.com/element-hq/element-web/pull/24820)). Contributed by @dhenneke.
  * Style mentions as pills in rich text editor ([\#10448](https://github.com/matrix-org/matrix-react-sdk/pull/10448)). Contributed by @alunturner.
  * Show room create icon if "UIComponent.roomCreation" is enabled ([\#10364](https://github.com/matrix-org/matrix-react-sdk/pull/10364)). Contributed by @maheichyk.
  * Mentions as links rte ([\#10463](https://github.com/matrix-org/matrix-react-sdk/pull/10463)). Contributed by @alunturner.
@@ -698,8 +698,8 @@ Changes in [1.11.29](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Support dynamic room predecessors in RoomNotificationStateStore ([\#10297](https://github.com/matrix-org/matrix-react-sdk/pull/10297)). Contributed by @andybalaam.
 
 ## 🐛 Bug Fixes
- * Use a newly generated access_token while joining Jitsi ([\#24646](https://github.com/vector-im/element-web/pull/24646)). Fixes #24687. Contributed by @emrahcom.
- * Fix cloudflare action pointing at commit hash instead of tag ([\#24777](https://github.com/vector-im/element-web/pull/24777)). Contributed by @justjanne.
+ * Use a newly generated access_token while joining Jitsi ([\#24646](https://github.com/element-hq/element-web/pull/24646)). Fixes #24687. Contributed by @emrahcom.
+ * Fix cloudflare action pointing at commit hash instead of tag ([\#24777](https://github.com/element-hq/element-web/pull/24777)). Contributed by @justjanne.
  * Allow editing with RTE to overflow for autocomplete visibility ([\#10499](https://github.com/matrix-org/matrix-react-sdk/pull/10499)). Contributed by @alunturner.
  * Added auto focus to Github URL on opening of debug logs modal ([\#10479](https://github.com/matrix-org/matrix-react-sdk/pull/10479)). Contributed by @ShivamSpm.
  * Fix detection of encryption for all users in a room ([\#10487](https://github.com/matrix-org/matrix-react-sdk/pull/10487)). Fixes #24995.
@@ -740,30 +740,30 @@ Changes in [1.11.29](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Handle more edge cases in ACL updates ([\#10279](https://github.com/matrix-org/matrix-react-sdk/pull/10279)). Contributed by @justjanne.
  * Allow parsing png files to fail if thumbnailing is successful ([\#10308](https://github.com/matrix-org/matrix-react-sdk/pull/10308)).
 
-Changes in [1.11.28](https://github.com/vector-im/element-web/releases/tag/v1.11.28) (2023-03-31)
+Changes in [1.11.28](https://github.com/element-hq/element-web/releases/tag/v1.11.28) (2023-03-31)
 =================================================================================================
 
 ## 🐛 Bug Fixes
  * (No changes, version bumped to sync with element-desktop.)
 
-Changes in [1.11.27](https://github.com/vector-im/element-web/releases/tag/v1.11.27) (2023-03-31)
+Changes in [1.11.27](https://github.com/element-hq/element-web/releases/tag/v1.11.27) (2023-03-31)
 =================================================================================================
 
 ## 🐛 Bug Fixes
  * Fix detection of encryption for all users in a room ([\#10487](https://github.com/matrix-org/matrix-react-sdk/pull/10487)). Fixes #24995.
 
-Changes in [1.11.26](https://github.com/vector-im/element-web/releases/tag/v1.11.26) (2023-03-28)
+Changes in [1.11.26](https://github.com/element-hq/element-web/releases/tag/v1.11.26) (2023-03-28)
 =================================================================================================
 
 ## 🔒 Security
  * Fixes for [CVE-2023-28427](https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=CVE-2023-28427) / GHSA-mwq8-fjpf-c2gr
  * Fixes for [CVE-2023-28103](https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=CVE-2023-28103) / GHSA-6g43-88cp-w5gv
 
-Changes in [1.11.25](https://github.com/vector-im/element-web/releases/tag/v1.11.25) (2023-03-15)
+Changes in [1.11.25](https://github.com/element-hq/element-web/releases/tag/v1.11.25) (2023-03-15)
 =================================================================================================
 
 ## ✨ Features
- * Remove experimental PWA support for Firefox and Safari ([\#24630](https://github.com/vector-im/element-web/pull/24630)).
+ * Remove experimental PWA support for Firefox and Safari ([\#24630](https://github.com/element-hq/element-web/pull/24630)).
  * Only allow to start a DM with one email if encryption by default is enabled ([\#10253](https://github.com/matrix-org/matrix-react-sdk/pull/10253)). Fixes #23133.
  * DM rooms are now encrypted if encryption by default is enabled and only inviting a single email address. Any action in the result DM room will be blocked until the other has joined. ([\#10229](https://github.com/matrix-org/matrix-react-sdk/pull/10229)).
  * Reduce bottom margin of ReplyChain on compact modern layout ([\#8972](https://github.com/matrix-org/matrix-react-sdk/pull/8972)). Fixes #22748. Contributed by @luixxiul.
@@ -801,7 +801,7 @@ Changes in [1.11.25](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Prevent multiple Jitsi calls started at the same time ([\#10183](https://github.com/matrix-org/matrix-react-sdk/pull/10183)). Fixes #23009.
  * Make localization keys compatible with agglutinative and/or SOV type languages ([\#10159](https://github.com/matrix-org/matrix-react-sdk/pull/10159)). Contributed by @luixxiul.
 
-Changes in [1.11.24](https://github.com/vector-im/element-web/releases/tag/v1.11.24) (2023-02-28)
+Changes in [1.11.24](https://github.com/element-hq/element-web/releases/tag/v1.11.24) (2023-02-28)
 =================================================================================================
 
 ## ✨ Features
@@ -833,11 +833,11 @@ Changes in [1.11.24](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Correctly Identify emoticons ([\#10108](https://github.com/matrix-org/matrix-react-sdk/pull/10108)). Fixes #19472. Contributed by @adarsh-sgh.
  * Remove a redundant white space ([\#10129](https://github.com/matrix-org/matrix-react-sdk/pull/10129)). Contributed by @luixxiul.
 
-Changes in [1.11.23](https://github.com/vector-im/element-web/releases/tag/v1.11.23) (2023-02-14)
+Changes in [1.11.23](https://github.com/element-hq/element-web/releases/tag/v1.11.23) (2023-02-14)
 =================================================================================================
 
 ## ✨ Features
- * Description of QR code sign in labs feature ([\#23513](https://github.com/vector-im/element-web/pull/23513)). Contributed by @hughns.
+ * Description of QR code sign in labs feature ([\#23513](https://github.com/element-hq/element-web/pull/23513)). Contributed by @hughns.
  * Add option to find own location in map views ([\#10083](https://github.com/matrix-org/matrix-react-sdk/pull/10083)).
  * Render poll end events in timeline ([\#10027](https://github.com/matrix-org/matrix-react-sdk/pull/10027)). Contributed by @kerryarchibald.
  * Indicate unread messages in tab title ([\#10096](https://github.com/matrix-org/matrix-react-sdk/pull/10096)). Contributed by @tnt7864.
@@ -861,7 +861,7 @@ Changes in [1.11.23](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Add support for [token authenticated registration](https ([\#7275](https://github.com/matrix-org/matrix-react-sdk/pull/7275)). Fixes #18931. Contributed by @govynnus.
 
 ## 🐛 Bug Fixes
- * Jitsi requests 'requires_client' capability if auth token is provided ([\#24294](https://github.com/vector-im/element-web/pull/24294)). Contributed by @maheichyk.
+ * Jitsi requests 'requires_client' capability if auth token is provided ([\#24294](https://github.com/element-hq/element-web/pull/24294)). Contributed by @maheichyk.
  * Remove duplicate white space characters from translation keys ([\#10152](https://github.com/matrix-org/matrix-react-sdk/pull/10152)). Contributed by @luixxiul.
  * Fix the caption of new sessions manager on Labs settings page for localization ([\#10143](https://github.com/matrix-org/matrix-react-sdk/pull/10143)). Contributed by @luixxiul.
  * Prevent start another DM with a user if one already exists ([\#10127](https://github.com/matrix-org/matrix-react-sdk/pull/10127)). Fixes #23138.
@@ -875,7 +875,7 @@ Changes in [1.11.23](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix scrollbar colliding with checkbox in add to space section ([\#10093](https://github.com/matrix-org/matrix-react-sdk/pull/10093)). Fixes #23189. Contributed by @Arnabdaz.
  * Add a whitespace character after 'broadcast?' ([\#10097](https://github.com/matrix-org/matrix-react-sdk/pull/10097)). Contributed by @luixxiul.
  * Seekbar in broadcast PiP view is now updated when switching between different broadcasts ([\#10072](https://github.com/matrix-org/matrix-react-sdk/pull/10072)). Fixes #24415.
- * Add border to "reject" button on room preview card for clickable area indication. It fixes vector-im/element-web#22623 ([\#9205](https://github.com/matrix-org/matrix-react-sdk/pull/9205)). Contributed by @gefgu.
+ * Add border to "reject" button on room preview card for clickable area indication. It fixes element-hq/element-web#22623 ([\#9205](https://github.com/matrix-org/matrix-react-sdk/pull/9205)). Contributed by @gefgu.
  * Element-R: fix rageshages ([\#10081](https://github.com/matrix-org/matrix-react-sdk/pull/10081)). Fixes #24430.
  * Fix markdown paragraph display in timeline ([\#10071](https://github.com/matrix-org/matrix-react-sdk/pull/10071)). Fixes #24419. Contributed by @alunturner.
  * Prevent the remaining broadcast time from being exceeded ([\#10070](https://github.com/matrix-org/matrix-react-sdk/pull/10070)).
@@ -896,17 +896,17 @@ Changes in [1.11.23](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix link creation with backward selection ([\#9986](https://github.com/matrix-org/matrix-react-sdk/pull/9986)). Fixes #24315. Contributed by @florianduros.
  * Misaligned reply preview in thread composer #23396 ([\#9977](https://github.com/matrix-org/matrix-react-sdk/pull/9977)). Fixes #23396. Contributed by @mustafa-kapadia1483.
 
-Changes in [1.11.22](https://github.com/vector-im/element-web/releases/tag/v1.11.22) (2023-01-31)
+Changes in [1.11.22](https://github.com/element-hq/element-web/releases/tag/v1.11.22) (2023-01-31)
 =================================================================================================
 
 ## 🐛 Bug Fixes
  * Bump version number to fix problems upgrading from v1.11.21-rc.1
 
-Changes in [1.11.21](https://github.com/vector-im/element-web/releases/tag/v1.11.21) (2023-01-31)
+Changes in [1.11.21](https://github.com/element-hq/element-web/releases/tag/v1.11.21) (2023-01-31)
 =================================================================================================
 
 ## ✨ Features
- * Move pin drop out of labs ([\#22993](https://github.com/vector-im/element-web/pull/22993)).
+ * Move pin drop out of labs ([\#22993](https://github.com/element-hq/element-web/pull/22993)).
  * Quotes for rich text editor (RTE) ([\#9932](https://github.com/matrix-org/matrix-react-sdk/pull/9932)). Contributed by @alunturner.
  * Show the room name in the room header during calls ([\#9942](https://github.com/matrix-org/matrix-react-sdk/pull/9942)). Fixes #24268.
  * Add code blocks to rich text editor ([\#9921](https://github.com/matrix-org/matrix-react-sdk/pull/9921)). Contributed by @alunturner.
@@ -942,19 +942,19 @@ Changes in [1.11.21](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix unexpected composer growing ([\#9889](https://github.com/matrix-org/matrix-react-sdk/pull/9889)). Contributed by @florianduros.
  * Fix misaligned timestamps for thread roots which are emotes ([\#9875](https://github.com/matrix-org/matrix-react-sdk/pull/9875)). Fixes #23897. Contributed by @justjanne.
 
-Changes in [1.11.20](https://github.com/vector-im/element-web/releases/tag/v1.11.20) (2023-01-20)
+Changes in [1.11.20](https://github.com/element-hq/element-web/releases/tag/v1.11.20) (2023-01-20)
 =================================================================================================
 
 ## 🐛 Bug Fixes
  * (Part 2) of prevent crash on older browsers (replace .at() with array.length-1)
 
-Changes in [1.11.19](https://github.com/vector-im/element-web/releases/tag/v1.11.19) (2023-01-18)
+Changes in [1.11.19](https://github.com/element-hq/element-web/releases/tag/v1.11.19) (2023-01-18)
 =================================================================================================
 
 ## 🐛 Bug Fixes
  * fix crash on browsers that don't support `Array.at` ([\#9935](https://github.com/matrix-org/matrix-react-sdk/pull/9935)). Contributed by @andybalaam.
 
-Changes in [1.11.18](https://github.com/vector-im/element-web/releases/tag/v1.11.18) (2023-01-18)
+Changes in [1.11.18](https://github.com/element-hq/element-web/releases/tag/v1.11.18) (2023-01-18)
 =================================================================================================
 
 ## ✨ Features
@@ -1009,10 +1009,10 @@ Changes in [1.11.18](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Ensure that events are correctly updated when they are edited. ([\#9789](https://github.com/matrix-org/matrix-react-sdk/pull/9789)).
  * When stopping a broadcast also stop the playback ([\#9795](https://github.com/matrix-org/matrix-react-sdk/pull/9795)). Fixes #24052.
  * Prevent to start two broadcasts at the same time ([\#9744](https://github.com/matrix-org/matrix-react-sdk/pull/9744)). Fixes #23973.
- * Correctly handle limited sync responses by resetting the thread timeline ([\#3056](https://github.com/matrix-org/matrix-js-sdk/pull/3056)). Fixes vector-im/element-web#23952.
- * Fix failure to start in firefox private browser ([\#3058](https://github.com/matrix-org/matrix-js-sdk/pull/3058)). Fixes vector-im/element-web#24216.
+ * Correctly handle limited sync responses by resetting the thread timeline ([\#3056](https://github.com/matrix-org/matrix-js-sdk/pull/3056)). Fixes element-hq/element-web#23952.
+ * Fix failure to start in firefox private browser ([\#3058](https://github.com/matrix-org/matrix-js-sdk/pull/3058)). Fixes element-hq/element-web#24216.
 
-Changes in [1.11.17](https://github.com/vector-im/element-web/releases/tag/v1.11.17) (2022-12-21)
+Changes in [1.11.17](https://github.com/element-hq/element-web/releases/tag/v1.11.17) (2022-12-21)
 =================================================================================================
 
 ## ✨ Features
@@ -1039,7 +1039,7 @@ Changes in [1.11.17](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Remove async call to get virtual room from room load ([\#9743](https://github.com/matrix-org/matrix-react-sdk/pull/9743)). Fixes #23968.
  * Check each thread for unread messages. ([\#9723](https://github.com/matrix-org/matrix-react-sdk/pull/9723)).
  * Device manage - handle sessions that don't support encryption ([\#9717](https://github.com/matrix-org/matrix-react-sdk/pull/9717)). Fixes #23722.
- * Fix hover state for formatting buttons (Rich text editor) (fix vector-im/element-web/issues/23832) ([\#9715](https://github.com/matrix-org/matrix-react-sdk/pull/9715)).
+ * Fix hover state for formatting buttons (Rich text editor) (fix element-hq/element-web/issues/23832) ([\#9715](https://github.com/matrix-org/matrix-react-sdk/pull/9715)).
  * Don't allow group calls to be unterminated ([\#9710](https://github.com/matrix-org/matrix-react-sdk/pull/9710)).
  * Fix replies to emotes not showing as inline ([\#9707](https://github.com/matrix-org/matrix-react-sdk/pull/9707)). Fixes #23903.
  * Update copy of 'Change layout' button to match Element Call ([\#9703](https://github.com/matrix-org/matrix-react-sdk/pull/9703)).
@@ -1048,7 +1048,7 @@ Changes in [1.11.17](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix power selector being wrongly disabled for admins themselves ([\#9681](https://github.com/matrix-org/matrix-react-sdk/pull/9681)). Fixes #23882.
  * Show day counts in call durations ([\#9641](https://github.com/matrix-org/matrix-react-sdk/pull/9641)).
 
-Changes in [1.11.16](https://github.com/vector-im/element-web/releases/tag/v1.11.16) (2022-12-06)
+Changes in [1.11.16](https://github.com/element-hq/element-web/releases/tag/v1.11.16) (2022-12-06)
 =================================================================================================
 
 ## ✨ Features
@@ -1076,7 +1076,7 @@ Changes in [1.11.16](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix call splitbrains when switching between rooms ([\#9692](https://github.com/matrix-org/matrix-react-sdk/pull/9692)).
  * [Backport staging] Fix replies to emotes not showing as inline ([\#9708](https://github.com/matrix-org/matrix-react-sdk/pull/9708)).
 
-Changes in [1.11.15](https://github.com/vector-im/element-web/releases/tag/v1.11.15) (2022-11-22)
+Changes in [1.11.15](https://github.com/element-hq/element-web/releases/tag/v1.11.15) (2022-11-22)
 =================================================================================================
 
 ## ✨ Features
@@ -1089,7 +1089,7 @@ Changes in [1.11.15](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Fix: Move "Leave Space" option to the bottom of space context menu ([\#9535](https://github.com/matrix-org/matrix-react-sdk/pull/9535)). Contributed by @hanadi92.
 
 ## 🐛 Bug Fixes
- * Make build scripts work on NixOS ([\#23740](https://github.com/vector-im/element-web/pull/23740)).
+ * Make build scripts work on NixOS ([\#23740](https://github.com/element-hq/element-web/pull/23740)).
  * Fix integration manager `get_open_id_token` action and add E2E tests ([\#9520](https://github.com/matrix-org/matrix-react-sdk/pull/9520)).
  * Fix links being mangled by markdown processing ([\#9570](https://github.com/matrix-org/matrix-react-sdk/pull/9570)). Fixes #23743.
  * Fix: inline links selecting radio button ([\#9543](https://github.com/matrix-org/matrix-react-sdk/pull/9543)). Contributed by @hanadi92.
@@ -1106,7 +1106,7 @@ Changes in [1.11.15](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Handle deletion of `m.call` events ([\#9540](https://github.com/matrix-org/matrix-react-sdk/pull/9540)). Fixes #23663.
  * Fix incorrect notification count after leaving a room with notifications ([\#9518](https://github.com/matrix-org/matrix-react-sdk/pull/9518)). Contributed by @Arnei.
 
-Changes in [1.11.14](https://github.com/vector-im/element-web/releases/tag/v1.11.14) (2022-11-08)
+Changes in [1.11.14](https://github.com/element-hq/element-web/releases/tag/v1.11.14) (2022-11-08)
 =================================================================================================
 
 ## ✨ Features
@@ -1125,9 +1125,9 @@ Changes in [1.11.14](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Allow pressing Enter to send messages in new composer ([\#9451](https://github.com/matrix-org/matrix-react-sdk/pull/9451)). Contributed by @andybalaam.
 
 ## 🐛 Bug Fixes
- * Fix regressions around media uploads failing and causing soft crashes ([\#9549](https://github.com/matrix-org/matrix-react-sdk/pull/9549)). Fixes matrix-org/element-web-rageshakes#16831, matrix-org/element-web-rageshakes#16824 matrix-org/element-web-rageshakes#16810 and vector-im/element-web#23641.
+ * Fix regressions around media uploads failing and causing soft crashes ([\#9549](https://github.com/matrix-org/matrix-react-sdk/pull/9549)). Fixes matrix-org/element-web-rageshakes#16831, matrix-org/element-web-rageshakes#16824 matrix-org/element-web-rageshakes#16810 and element-hq/element-web#23641.
  * Fix /myroomavatar slash command ([\#9536](https://github.com/matrix-org/matrix-react-sdk/pull/9536)). Fixes matrix-org/synapse#14321.
- * Fix config.json failing to load for Jitsi wrapper in non-root deployment ([\#23577](https://github.com/vector-im/element-web/pull/23577)).
+ * Fix config.json failing to load for Jitsi wrapper in non-root deployment ([\#23577](https://github.com/element-hq/element-web/pull/23577)).
  * Fix NotificationBadge unsent color ([\#9522](https://github.com/matrix-org/matrix-react-sdk/pull/9522)). Fixes #23646.
  * Fix room list sorted by recent on app startup ([\#9515](https://github.com/matrix-org/matrix-react-sdk/pull/9515)). Fixes #23635.
  * Reset custom power selector when blurred on empty ([\#9508](https://github.com/matrix-org/matrix-react-sdk/pull/9508)). Fixes #23481.
@@ -1144,27 +1144,27 @@ Changes in [1.11.14](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Device manager - put client/browser device metadata in correct section ([\#9447](https://github.com/matrix-org/matrix-react-sdk/pull/9447)). Contributed by @kerryarchibald.
  * Update the room unread notification counter when the server changes the value without any related read receipt ([\#9438](https://github.com/matrix-org/matrix-react-sdk/pull/9438)).
 
-Changes in [1.11.13](https://github.com/vector-im/element-web/releases/tag/v1.11.13) (2022-11-01)
+Changes in [1.11.13](https://github.com/element-hq/element-web/releases/tag/v1.11.13) (2022-11-01)
 =================================================================================================
 
 ## 🐛 Bug Fixes
  * Fix default behavior of Room.getBlacklistUnverifiedDevices ([\#2830](https://github.com/matrix-org/matrix-js-sdk/pull/2830)). Contributed by @duxovni.
- * Catch server versions API call exception when starting the client ([\#2828](https://github.com/matrix-org/matrix-js-sdk/pull/2828)). Fixes vector-im/element-web#23634.
- * Fix authedRequest including `Authorization: Bearer undefined` for password resets ([\#2822](https://github.com/matrix-org/matrix-js-sdk/pull/2822)). Fixes vector-im/element-web#23655.
+ * Catch server versions API call exception when starting the client ([\#2828](https://github.com/matrix-org/matrix-js-sdk/pull/2828)). Fixes element-hq/element-web#23634.
+ * Fix authedRequest including `Authorization: Bearer undefined` for password resets ([\#2822](https://github.com/matrix-org/matrix-js-sdk/pull/2822)). Fixes element-hq/element-web#23655.
 
-Changes in [1.11.12](https://github.com/vector-im/element-web/releases/tag/v1.11.12) (2022-10-26)
+Changes in [1.11.12](https://github.com/element-hq/element-web/releases/tag/v1.11.12) (2022-10-26)
 =================================================================================================
 
 ## 🐛 Bug Fixes
- * Fix config.json failing to load for Jitsi wrapper in non-root deployment ([\#23577](https://github.com/vector-im/element-web/pull/23577)).
+ * Fix config.json failing to load for Jitsi wrapper in non-root deployment ([\#23577](https://github.com/element-hq/element-web/pull/23577)).
 
-Changes in [1.11.11](https://github.com/vector-im/element-web/releases/tag/v1.11.11) (2022-10-25)
+Changes in [1.11.11](https://github.com/element-hq/element-web/releases/tag/v1.11.11) (2022-10-25)
 =================================================================================================
 
 ## ✨ Features
- * Device manager - tweak string formatting of default device name ([\#23457](https://github.com/vector-im/element-web/pull/23457)).
- * Add Element Call participant limit ([\#23431](https://github.com/vector-im/element-web/pull/23431)).
- * Add Element Call `brand` ([\#23443](https://github.com/vector-im/element-web/pull/23443)).
+ * Device manager - tweak string formatting of default device name ([\#23457](https://github.com/element-hq/element-web/pull/23457)).
+ * Add Element Call participant limit ([\#23431](https://github.com/element-hq/element-web/pull/23431)).
+ * Add Element Call `brand` ([\#23443](https://github.com/element-hq/element-web/pull/23443)).
  * Include a file-safe room name and ISO date in chat exports ([\#9440](https://github.com/matrix-org/matrix-react-sdk/pull/9440)). Fixes #21812 and #19724.
  * Room call banner ([\#9378](https://github.com/matrix-org/matrix-react-sdk/pull/9378)). Fixes #23453. Contributed by @toger5.
  * Device manager - spinners while devices are signing out ([\#9433](https://github.com/matrix-org/matrix-react-sdk/pull/9433)). Fixes #15865.
@@ -1192,7 +1192,7 @@ Changes in [1.11.11](https://github.com/vector-im/element-web/releases/tag/v1.11
 
 ## 🐛 Bug Fixes
  * Send Content-Type: application/json header for integration manager /register API ([\#9490](https://github.com/matrix-org/matrix-react-sdk/pull/9490)). Fixes #23580.
- * Make ErrorView & CompatibilityView scrollable ([\#23468](https://github.com/vector-im/element-web/pull/23468)). Fixes #23376.
+ * Make ErrorView & CompatibilityView scrollable ([\#23468](https://github.com/element-hq/element-web/pull/23468)). Fixes #23376.
  * Device manager - put client/browser device metadata in correct section ([\#9447](https://github.com/matrix-org/matrix-react-sdk/pull/9447)).
  * update the room unread notification counter when the server changes the value without any related read receipt ([\#9438](https://github.com/matrix-org/matrix-react-sdk/pull/9438)).
  * Don't show call banners in video rooms ([\#9441](https://github.com/matrix-org/matrix-react-sdk/pull/9441)).
@@ -1209,16 +1209,16 @@ Changes in [1.11.11](https://github.com/vector-im/element-web/releases/tag/v1.11
  * Device manager - eagerly create `m.local_notification_settings` events ([\#9353](https://github.com/matrix-org/matrix-react-sdk/pull/9353)).
  * Close incoming Element call toast when viewing the call lobby ([\#9375](https://github.com/matrix-org/matrix-react-sdk/pull/9375)).
  * Always allow enabling sending read receipts ([\#9367](https://github.com/matrix-org/matrix-react-sdk/pull/9367)). Fixes #23433.
- * Fixes (vector-im/element-web/issues/22609) where the white theme is not applied when `white -> dark -> white` sequence is done. ([\#9320](https://github.com/matrix-org/matrix-react-sdk/pull/9320)). Contributed by @florianduros.
+ * Fixes (element-hq/element-web/issues/22609) where the white theme is not applied when `white -> dark -> white` sequence is done. ([\#9320](https://github.com/matrix-org/matrix-react-sdk/pull/9320)). Contributed by @florianduros.
  * Fix applying programmatically set height for "top" room layout ([\#9339](https://github.com/matrix-org/matrix-react-sdk/pull/9339)). Contributed by @Fox32.
 
-Changes in [1.11.10](https://github.com/vector-im/element-web/releases/tag/v1.11.10) (2022-10-11)
+Changes in [1.11.10](https://github.com/element-hq/element-web/releases/tag/v1.11.10) (2022-10-11)
 =================================================================================================
 
 ## 🐛 Bug Fixes
- * Use correct default for notification silencing ([\#9388](https://github.com/matrix-org/matrix-react-sdk/pull/9388)). Fixes vector-im/element-web#23456.
+ * Use correct default for notification silencing ([\#9388](https://github.com/matrix-org/matrix-react-sdk/pull/9388)). Fixes element-hq/element-web#23456.
 
-Changes in [1.11.9](https://github.com/vector-im/element-web/releases/tag/v1.11.9) (2022-10-11)
+Changes in [1.11.9](https://github.com/element-hq/element-web/releases/tag/v1.11.9) (2022-10-11)
 ===============================================================================================
 
 ##   Deprecations
@@ -1239,7 +1239,7 @@ Changes in [1.11.9](https://github.com/vector-im/element-web/releases/tag/v1.11.
  * Read receipts for threads ([\#9239](https://github.com/matrix-org/matrix-react-sdk/pull/9239)). Fixes #23191.
 
 ## 🐛 Bug Fixes
- * Use the correct sender key when checking shared secret ([\#2730](https://github.com/matrix-org/matrix-js-sdk/pull/2730)). Fixes vector-im/element-web#23374.
+ * Use the correct sender key when checking shared secret ([\#2730](https://github.com/matrix-org/matrix-js-sdk/pull/2730)). Fixes element-hq/element-web#23374.
  * Fix device selection in pre-join screen for Element Call video rooms ([\#9321](https://github.com/matrix-org/matrix-react-sdk/pull/9321)). Fixes #23331.
  * Don't render a 1px high room topic if the room topic is empty ([\#9317](https://github.com/matrix-org/matrix-react-sdk/pull/9317)). Contributed by @Arnei.
  * Don't show feedback prompts when that UIFeature is disabled ([\#9305](https://github.com/matrix-org/matrix-react-sdk/pull/9305)). Fixes #23327.
@@ -1247,13 +1247,13 @@ Changes in [1.11.9](https://github.com/vector-im/element-web/releases/tag/v1.11.
  * Fix spaces feedback prompt wrongly showing when feedback is disabled ([\#9302](https://github.com/matrix-org/matrix-react-sdk/pull/9302)). Fixes #23314.
  * Fix tile soft crash in ReplyInThreadButton ([\#9300](https://github.com/matrix-org/matrix-react-sdk/pull/9300)). Fixes matrix-org/element-web-rageshakes#15493.
 
-Changes in [1.11.8](https://github.com/vector-im/element-web/releases/tag/v1.11.8) (2022-09-28)
+Changes in [1.11.8](https://github.com/element-hq/element-web/releases/tag/v1.11.8) (2022-09-28)
 ===============================================================================================
 
 ## 🐛 Bug Fixes
  * Bump IDB crypto store version ([\#2705](https://github.com/matrix-org/matrix-js-sdk/pull/2705)).
 
-Changes in [1.11.7](https://github.com/vector-im/element-web/releases/tag/v1.11.7) (2022-09-28)
+Changes in [1.11.7](https://github.com/element-hq/element-web/releases/tag/v1.11.7) (2022-09-28)
 ===============================================================================================
 
 ## 🔒 Security
@@ -1262,7 +1262,7 @@ Changes in [1.11.7](https://github.com/vector-im/element-web/releases/tag/v1.11.
 * Fix for [CVE-2022-39251](https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=CVE%2D2022%2D39251)
 * Fix for [CVE-2022-39236](https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=CVE%2D2022%2D39236)
 
-Changes in [1.11.6](https://github.com/vector-im/element-web/releases/tag/v1.11.6) (2022-09-20)
+Changes in [1.11.6](https://github.com/element-hq/element-web/releases/tag/v1.11.6) (2022-09-20)
 =========================================================================================================
 
 ## ✨ Features
@@ -1296,7 +1296,7 @@ Changes in [1.11.6](https://github.com/vector-im/element-web/releases/tag/v1.11.
  * Handle M_INVALID_USERNAME on /register/available ([\#9237](https://github.com/matrix-org/matrix-react-sdk/pull/9237)). Fixes #23161.
  * Fix issue with quiet zone around QR code ([\#9243](https://github.com/matrix-org/matrix-react-sdk/pull/9243)). Fixes #23199.
 
-Changes in [1.11.5](https://github.com/vector-im/element-web/releases/tag/v1.11.5) (2022-09-13)
+Changes in [1.11.5](https://github.com/element-hq/element-web/releases/tag/v1.11.5) (2022-09-13)
 ===============================================================================================
 
 ## ✨ Features
@@ -1316,7 +1316,7 @@ Changes in [1.11.5](https://github.com/vector-im/element-web/releases/tag/v1.11.
  * Fix progress bar regression throughout the app ([\#9219](https://github.com/matrix-org/matrix-react-sdk/pull/9219)). Fixes #23121.
  * Reuse empty string & space string logic for event types in devtools ([\#9218](https://github.com/matrix-org/matrix-react-sdk/pull/9218)). Fixes #23115.
 
-Changes in [1.11.4](https://github.com/vector-im/element-web/releases/tag/v1.11.4) (2022-08-31)
+Changes in [1.11.4](https://github.com/element-hq/element-web/releases/tag/v1.11.4) (2022-08-31)
 ===============================================================================================
 
 ## 🔒 Security
@@ -1351,7 +1351,7 @@ Find more details of the vulnerabilities at https://matrix.org/blog/2022/08/31/s
  * Avoid hardcoding branding in user onboarding ([\#9206](https://github.com/matrix-org/matrix-react-sdk/pull/9206)). Fixes #23111. Contributed by @justjanne.
  * End jitsi call when member is banned ([\#8879](https://github.com/matrix-org/matrix-react-sdk/pull/8879)). Contributed by @maheichyk.
  * Fix context menu being opened when clicking message action bar buttons ([\#9200](https://github.com/matrix-org/matrix-react-sdk/pull/9200)). Fixes #22279 and #23100.
- * Add gap between checkbox and text in report dialog following the same pattern (8px) used in the gap between the two buttons. It fixes vector-im/element-web#23060 ([\#9195](https://github.com/matrix-org/matrix-react-sdk/pull/9195)). Contributed by @gefgu.
+ * Add gap between checkbox and text in report dialog following the same pattern (8px) used in the gap between the two buttons. It fixes element-hq/element-web#23060 ([\#9195](https://github.com/matrix-org/matrix-react-sdk/pull/9195)). Contributed by @gefgu.
  * Fix url preview AXE and layout issue & add percy test ([\#9189](https://github.com/matrix-org/matrix-react-sdk/pull/9189)). Fixes #23083.
  * Wrap long space names ([\#9201](https://github.com/matrix-org/matrix-react-sdk/pull/9201)). Fixes #23095.
  * Attempt to fix `Failed to execute 'removeChild' on 'Node'` ([\#9196](https://github.com/matrix-org/matrix-react-sdk/pull/9196)).
@@ -1363,11 +1363,11 @@ Find more details of the vulnerabilities at https://matrix.org/blog/2022/08/31/s
  * Space panel accessibility improvements ([\#9157](https://github.com/matrix-org/matrix-react-sdk/pull/9157)). Fixes #22995.
  * Fix inverted logic for showing UserWelcomeTop component ([\#9164](https://github.com/matrix-org/matrix-react-sdk/pull/9164)). Fixes #23037.
 
-Changes in [1.11.3](https://github.com/vector-im/element-web/releases/tag/v1.11.3) (2022-08-16)
+Changes in [1.11.3](https://github.com/element-hq/element-web/releases/tag/v1.11.3) (2022-08-16)
 ===============================================================================================
 
 ## ✨ Features
- * Improve auth aria attributes and semantics ([\#22948](https://github.com/vector-im/element-web/pull/22948)).
+ * Improve auth aria attributes and semantics ([\#22948](https://github.com/element-hq/element-web/pull/22948)).
  * Device manager - New device tile info design ([\#9122](https://github.com/matrix-org/matrix-react-sdk/pull/9122)). Contributed by @kerryarchibald.
  * Device manager generic settings subsection component ([\#9147](https://github.com/matrix-org/matrix-react-sdk/pull/9147)). Contributed by @kerryarchibald.
  * Migrate the hidden read receipts flag to new "send read receipts" option ([\#9141](https://github.com/matrix-org/matrix-react-sdk/pull/9141)).
@@ -1394,7 +1394,7 @@ Changes in [1.11.3](https://github.com/vector-im/element-web/releases/tag/v1.11.
  * Use default styling on nested numbered lists due to MD being sensitive ([\#9110](https://github.com/matrix-org/matrix-react-sdk/pull/9110)). Fixes #22935.
  * Fix replying using chat effect commands ([\#9101](https://github.com/matrix-org/matrix-react-sdk/pull/9101)). Fixes #22824.
 
-Changes in [1.11.2](https://github.com/vector-im/element-web/releases/tag/v1.11.2) (2022-08-03)
+Changes in [1.11.2](https://github.com/element-hq/element-web/releases/tag/v1.11.2) (2022-08-03)
 ===============================================================================================
 
 ## ✨ Features
@@ -1422,11 +1422,11 @@ Changes in [1.11.2](https://github.com/vector-im/element-web/releases/tag/v1.11.
  * Re-add padding to generic event list summary on IRC layout ([\#9063](https://github.com/matrix-org/matrix-react-sdk/pull/9063)). Fixes #22869. Contributed by @luixxiul.
  * Joining federated rooms via the spotlight search should no longer cause a "No known servers" error. ([\#9055](https://github.com/matrix-org/matrix-react-sdk/pull/9055)). Fixes #22845. Contributed by @Half-Shot.
 
-Changes in [1.11.1](https://github.com/vector-im/element-web/releases/tag/v1.11.1) (2022-07-26)
+Changes in [1.11.1](https://github.com/element-hq/element-web/releases/tag/v1.11.1) (2022-07-26)
 ===============================================================================================
 
 ## ✨ Features
- * Enable URL tooltips on hover for Element Desktop ([\#22286](https://github.com/vector-im/element-web/pull/22286)). Fixes undefined/element-web#6532.
+ * Enable URL tooltips on hover for Element Desktop ([\#22286](https://github.com/element-hq/element-web/pull/22286)). Fixes undefined/element-web#6532.
  * Hide screenshare button in video rooms on Desktop ([\#9045](https://github.com/matrix-org/matrix-react-sdk/pull/9045)).
  * Add a developer command to reset Megolm and Olm sessions ([\#9044](https://github.com/matrix-org/matrix-react-sdk/pull/9044)).
  * add spaces to TileErrorBoundary ([\#9012](https://github.com/matrix-org/matrix-react-sdk/pull/9012)). Contributed by @HarHarLinks.
@@ -1451,7 +1451,7 @@ Changes in [1.11.1](https://github.com/vector-im/element-web/releases/tag/v1.11.
  * Live location share - disallow message pinning ([\#8928](https://github.com/matrix-org/matrix-react-sdk/pull/8928)). Contributed by @kerryarchibald.
 
 ## 🐛 Bug Fixes
- * Remove the ability to hide yourself in video rooms ([\#22806](https://github.com/vector-im/element-web/pull/22806)). Fixes #22805.
+ * Remove the ability to hide yourself in video rooms ([\#22806](https://github.com/element-hq/element-web/pull/22806)). Fixes #22805.
  * Unbreak in-app permalink tooltips  ([\#9100](https://github.com/matrix-org/matrix-react-sdk/pull/9100)).
  * Add space for the stroke on message editor on IRC layout ([\#9030](https://github.com/matrix-org/matrix-react-sdk/pull/9030)). Fixes #22785. Contributed by @luixxiul.
  * Fix pinned messages not re-linkifying on edit ([\#9042](https://github.com/matrix-org/matrix-react-sdk/pull/9042)). Fixes #22726.
@@ -1502,14 +1502,14 @@ Changes in [1.11.1](https://github.com/vector-im/element-web/releases/tag/v1.11.
  * Correct new search input’s rounded corners ([\#8921](https://github.com/matrix-org/matrix-react-sdk/pull/8921)). Fixes #22576. Contributed by @justjanne.
  * Align unread notification dot on threads list in compact modern=group layout ([\#8911](https://github.com/matrix-org/matrix-react-sdk/pull/8911)). Fixes #22677. Contributed by @luixxiul.
 
-Changes in [1.11.0](https://github.com/vector-im/element-web/releases/tag/v1.11.0) (2022-07-05)
+Changes in [1.11.0](https://github.com/element-hq/element-web/releases/tag/v1.11.0) (2022-07-05)
 ===============================================================================================
 
 ## 🚨 BREAKING CHANGES
  * Remove Piwik support ([\#8835](https://github.com/matrix-org/matrix-react-sdk/pull/8835)).
 
 ## ✨ Features
- * Document how to configure a custom `home.html`. ([\#21066](https://github.com/vector-im/element-web/pull/21066)). Contributed by @johannes-krude.
+ * Document how to configure a custom `home.html`. ([\#21066](https://github.com/element-hq/element-web/pull/21066)). Contributed by @johannes-krude.
  * Move New Search Experience out of beta ([\#8859](https://github.com/matrix-org/matrix-react-sdk/pull/8859)). Contributed by @justjanne.
  * Switch video rooms to spotlight layout when in PiP mode ([\#8912](https://github.com/matrix-org/matrix-react-sdk/pull/8912)). Fixes #22574.
  * Live location sharing - render message deleted tile for redacted beacons ([\#8905](https://github.com/matrix-org/matrix-react-sdk/pull/8905)). Contributed by @kerryarchibald.
@@ -1539,9 +1539,9 @@ Changes in [1.11.0](https://github.com/vector-im/element-web/releases/tag/v1.11.
  * Change dash to em dash issues fixed ([\#8455](https://github.com/matrix-org/matrix-react-sdk/pull/8455)). Fixes #21895. Contributed by @goelesha.
 
 ## 🐛 Bug Fixes
- * Reduce video rooms log spam ([\#22665](https://github.com/vector-im/element-web/pull/22665)).
- * Connect to Jitsi unmuted by default ([\#22660](https://github.com/vector-im/element-web/pull/22660)). Fixes #22637.
- * Work around a Jitsi bug with display name encoding ([\#22525](https://github.com/vector-im/element-web/pull/22525)). Fixes #22521.
+ * Reduce video rooms log spam ([\#22665](https://github.com/element-hq/element-web/pull/22665)).
+ * Connect to Jitsi unmuted by default ([\#22660](https://github.com/element-hq/element-web/pull/22660)). Fixes #22637.
+ * Work around a Jitsi bug with display name encoding ([\#22525](https://github.com/element-hq/element-web/pull/22525)). Fixes #22521.
  * Make invite dialogue fixed height ([\#8945](https://github.com/matrix-org/matrix-react-sdk/pull/8945)).
  * Correct issue with tab order in new search experience ([\#8919](https://github.com/matrix-org/matrix-react-sdk/pull/8919)). Fixes #22670. Contributed by @justjanne.
  * Clicking location replies now redirects to the replied event instead of opening the map ([\#8918](https://github.com/matrix-org/matrix-react-sdk/pull/8918)). Fixes #22667.
@@ -1611,18 +1611,18 @@ Changes in [1.11.0](https://github.com/vector-im/element-web/releases/tag/v1.11.
  * Fix read avatars overflow from the right chat panel with a maximized widget on bubble message layout ([\#8470](https://github.com/matrix-org/matrix-react-sdk/pull/8470)). Contributed by @luixxiul.
  * Fix `CallView` crash ([\#8735](https://github.com/matrix-org/matrix-react-sdk/pull/8735)). Fixes #22394.
 
-Changes in [1.10.15](https://github.com/vector-im/element-web/releases/tag/v1.10.15) (2022-06-14)
+Changes in [1.10.15](https://github.com/element-hq/element-web/releases/tag/v1.10.15) (2022-06-14)
 =================================================================================================
 
 ## 🐛 Bug Fixes
  * Fix missing element desktop preferences ([\#8798](https://github.com/matrix-org/matrix-react-sdk/pull/8798)). Contributed by @t3chguy.
 
-Changes in [1.10.14](https://github.com/vector-im/element-web/releases/tag/v1.10.14) (2022-06-07)
+Changes in [1.10.14](https://github.com/element-hq/element-web/releases/tag/v1.10.14) (2022-06-07)
 =================================================================================================
 
 ## ✨ Features
- * Make Lao translation available ([\#22358](https://github.com/vector-im/element-web/pull/22358)). Fixes #22327.
- * Option to disable hardware acceleration on Element Desktop ([\#22295](https://github.com/vector-im/element-web/pull/22295)). Contributed by @novocaine.
+ * Make Lao translation available ([\#22358](https://github.com/element-hq/element-web/pull/22358)). Fixes #22327.
+ * Option to disable hardware acceleration on Element Desktop ([\#22295](https://github.com/element-hq/element-web/pull/22295)). Contributed by @novocaine.
  * Configure custom home.html via `.well-known/matrix/client["io.element.embedded_pages"]["home_url"]` for all your element-web/desktop users ([\#7790](https://github.com/matrix-org/matrix-react-sdk/pull/7790)). Contributed by @johannes-krude.
  * Live location sharing - open location in OpenStreetMap ([\#8695](https://github.com/matrix-org/matrix-react-sdk/pull/8695)). Contributed by @kerryarchibald.
  * Show a dialog when Jitsi encounters an error ([\#8701](https://github.com/matrix-org/matrix-react-sdk/pull/8701)). Fixes #22284.
@@ -1634,7 +1634,7 @@ Changes in [1.10.14](https://github.com/vector-im/element-web/releases/tag/v1.10
  * Add public room directory hook ([\#8626](https://github.com/matrix-org/matrix-react-sdk/pull/8626)).
 
 ## 🐛 Bug Fixes
- * Stop Jitsi if we time out while connecting to a video room ([\#22301](https://github.com/vector-im/element-web/pull/22301)). Fixes #22283.
+ * Stop Jitsi if we time out while connecting to a video room ([\#22301](https://github.com/element-hq/element-web/pull/22301)). Fixes #22283.
  * Remove inline margin from UTD error message inside a reply tile on ThreadView ([\#8708](https://github.com/matrix-org/matrix-react-sdk/pull/8708)). Fixes #22376. Contributed by @luixxiul.
  * Move unread notification dots of the threads list to the expected position ([\#8700](https://github.com/matrix-org/matrix-react-sdk/pull/8700)). Fixes #22350. Contributed by @luixxiul.
  * Prevent overflow of grid items on a bubble with UTD generally ([\#8697](https://github.com/matrix-org/matrix-react-sdk/pull/8697)). Contributed by @luixxiul.
@@ -1674,7 +1674,7 @@ Changes in [1.10.14](https://github.com/vector-im/element-web/releases/tag/v1.10
  * Hide image banner on stickers, they have a tooltip already ([\#8641](https://github.com/matrix-org/matrix-react-sdk/pull/8641)). Fixes #22244.
  * Adjust EditMessageComposer style declarations ([\#8631](https://github.com/matrix-org/matrix-react-sdk/pull/8631)). Fixes #22231. Contributed by @luixxiul.
 
-Changes in [1.10.13](https://github.com/vector-im/element-web/releases/tag/v1.10.13) (2022-05-24)
+Changes in [1.10.13](https://github.com/element-hq/element-web/releases/tag/v1.10.13) (2022-05-24)
 =================================================================================================
 
 ## ✨ Features
@@ -1708,9 +1708,9 @@ Changes in [1.10.13](https://github.com/vector-im/element-web/releases/tag/v1.10
  * Add ability to change audio and video devices during a call ([\#7173](https://github.com/matrix-org/matrix-react-sdk/pull/7173)). Fixes #15595.
 
 ## 🐛 Bug Fixes
- * Fix video rooms sometimes connecting muted when they shouldn't ([\#22125](https://github.com/vector-im/element-web/pull/22125)).
- * Avoid flashing the 'join conference' button at the user in video rooms ([\#22120](https://github.com/vector-im/element-web/pull/22120)).
- * Fully close Jitsi conferences on errors ([\#22060](https://github.com/vector-im/element-web/pull/22060)).
+ * Fix video rooms sometimes connecting muted when they shouldn't ([\#22125](https://github.com/element-hq/element-web/pull/22125)).
+ * Avoid flashing the 'join conference' button at the user in video rooms ([\#22120](https://github.com/element-hq/element-web/pull/22120)).
+ * Fully close Jitsi conferences on errors ([\#22060](https://github.com/element-hq/element-web/pull/22060)).
  * Fix click behavior of notification badges on spaces ([\#8627](https://github.com/matrix-org/matrix-react-sdk/pull/8627)). Fixes #22241.
  * Add missing return values in Read Receipt animation code ([\#8625](https://github.com/matrix-org/matrix-react-sdk/pull/8625)). Fixes #22175.
  * Fix 'continue' button not working after accepting identity server terms of service ([\#8619](https://github.com/matrix-org/matrix-react-sdk/pull/8619)). Fixes #20003.
@@ -1767,7 +1767,7 @@ Changes in [1.10.13](https://github.com/vector-im/element-web/releases/tag/v1.10
  * Add loading spinners to threads panels ([\#8490](https://github.com/matrix-org/matrix-react-sdk/pull/8490)). Fixes #21335.
  * Fix forwarding UI papercuts ([\#8482](https://github.com/matrix-org/matrix-react-sdk/pull/8482)). Fixes #17616.
 
-Changes in [1.10.12](https://github.com/vector-im/element-web/releases/tag/v1.10.12) (2022-05-10)
+Changes in [1.10.12](https://github.com/element-hq/element-web/releases/tag/v1.10.12) (2022-05-10)
 =================================================================================================
 
 ## ✨ Features
@@ -1792,8 +1792,8 @@ Changes in [1.10.12](https://github.com/vector-im/element-web/releases/tag/v1.10
  * Bring `View Source` back from behind developer mode ([\#8369](https://github.com/matrix-org/matrix-react-sdk/pull/8369)). Fixes #21771.
 
 ## 🐛 Bug Fixes
- * Fix Jitsi Meet getting wedged at startup in some cases ([\#21995](https://github.com/vector-im/element-web/pull/21995)).
- * Fix camera getting muted when disconnecting from a video room ([\#21958](https://github.com/vector-im/element-web/pull/21958)).
+ * Fix Jitsi Meet getting wedged at startup in some cases ([\#21995](https://github.com/element-hq/element-web/pull/21995)).
+ * Fix camera getting muted when disconnecting from a video room ([\#21958](https://github.com/element-hq/element-web/pull/21958)).
  * Fix race conditions around threads ([\#8448](https://github.com/matrix-org/matrix-react-sdk/pull/8448)). Fixes #21627.
  * Fix reading of cached room device setting values ([\#8495](https://github.com/matrix-org/matrix-react-sdk/pull/8495)).
  * Fix issue with dispatch happening mid-dispatch due to js-sdk emit ([\#8473](https://github.com/matrix-org/matrix-react-sdk/pull/8473)). Fixes #22019.
@@ -1843,11 +1843,11 @@ Changes in [1.10.12](https://github.com/vector-im/element-web/releases/tag/v1.10
  * Fix issue with ServerInfo crashing the modal ([\#8364](https://github.com/matrix-org/matrix-react-sdk/pull/8364)).
  * Fixes around threads beta in degraded mode ([\#8319](https://github.com/matrix-org/matrix-react-sdk/pull/8319)). Fixes #21762.
 
-Changes in [1.10.11](https://github.com/vector-im/element-web/releases/tag/v1.10.11) (2022-04-26)
+Changes in [1.10.11](https://github.com/element-hq/element-web/releases/tag/v1.10.11) (2022-04-26)
 =================================================================================================
 
 ## ✨ Features
- * Handle forced disconnects from Jitsi ([\#21697](https://github.com/vector-im/element-web/pull/21697)). Fixes #21517.
+ * Handle forced disconnects from Jitsi ([\#21697](https://github.com/element-hq/element-web/pull/21697)). Fixes #21517.
  * Improve performance of switching to rooms with lots of servers and ACLs ([\#8347](https://github.com/matrix-org/matrix-react-sdk/pull/8347)).
  * Avoid a reflow when setting caret position on an empty composer ([\#8348](https://github.com/matrix-org/matrix-react-sdk/pull/8348)).
  * Add message right-click context menu as a labs feature ([\#5672](https://github.com/matrix-org/matrix-react-sdk/pull/5672)).
@@ -1889,13 +1889,13 @@ Changes in [1.10.11](https://github.com/vector-im/element-web/releases/tag/v1.10
  * Make Jitsi widgets in video rooms immutable ([\#8244](https://github.com/matrix-org/matrix-react-sdk/pull/8244)). Fixes #21647.
  * Fix: Ensure links to events scroll the correct events into view ([\#8250](https://github.com/matrix-org/matrix-react-sdk/pull/8250)). Fixes #19934.
 
-Changes in [1.10.10](https://github.com/vector-im/element-web/releases/tag/v1.10.10) (2022-04-14)
+Changes in [1.10.10](https://github.com/element-hq/element-web/releases/tag/v1.10.10) (2022-04-14)
 =================================================================================================
 
 ## 🐛 Bug Fixes
  * Fixes around threads beta in degraded mode ([\#8319](https://github.com/matrix-org/matrix-react-sdk/pull/8319)). Fixes #21762.
 
-Changes in [1.10.9](https://github.com/vector-im/element-web/releases/tag/v1.10.9) (2022-04-12)
+Changes in [1.10.9](https://github.com/element-hq/element-web/releases/tag/v1.10.9) (2022-04-12)
 ===============================================================================================
 
 ## ✨ Features
@@ -1923,7 +1923,7 @@ Changes in [1.10.9](https://github.com/vector-im/element-web/releases/tag/v1.10.
  * Add a prototype of voice rooms in labs ([\#8084](https://github.com/matrix-org/matrix-react-sdk/pull/8084)). Fixes #3546.
 
 ## 🐛 Bug Fixes
- * Avoid flashing the Jitsi prejoin screen at the user before skipping it ([\#21665](https://github.com/vector-im/element-web/pull/21665)).
+ * Avoid flashing the Jitsi prejoin screen at the user before skipping it ([\#21665](https://github.com/element-hq/element-web/pull/21665)).
  * Fix editing `<ol>` tags with a non-1 start attribute ([\#8211](https://github.com/matrix-org/matrix-react-sdk/pull/8211)). Fixes #21625.
  * Fix URL previews being enabled when room first created ([\#8227](https://github.com/matrix-org/matrix-react-sdk/pull/8227)). Fixes #21659.
  * Don't use m.call for Jitsi video rooms ([\#8223](https://github.com/matrix-org/matrix-react-sdk/pull/8223)).
@@ -1947,16 +1947,16 @@ Changes in [1.10.9](https://github.com/vector-im/element-web/releases/tag/v1.10.
  * Fix issue with falsey hrefs being sent in events ([\#8113](https://github.com/matrix-org/matrix-react-sdk/pull/8113)). Fixes #21417.
  * Make video sizing consistent with images ([\#8102](https://github.com/matrix-org/matrix-react-sdk/pull/8102)). Fixes #20072.
 
-Changes in [1.10.9-rc.4](https://github.com/vector-im/element-web/releases/tag/v1.10.9-rc.4) (2022-04-11)
+Changes in [1.10.9-rc.4](https://github.com/element-hq/element-web/releases/tag/v1.10.9-rc.4) (2022-04-11)
 =========================================================================================================
 
-Changes in [1.10.9-rc.3](https://github.com/vector-im/element-web/releases/tag/v1.10.9-rc.3) (2022-04-08)
+Changes in [1.10.9-rc.3](https://github.com/element-hq/element-web/releases/tag/v1.10.9-rc.3) (2022-04-08)
 =========================================================================================================
 
-Changes in [1.10.9-rc.2](https://github.com/vector-im/element-web/releases/tag/v1.10.9-rc.2) (2022-04-06)
+Changes in [1.10.9-rc.2](https://github.com/element-hq/element-web/releases/tag/v1.10.9-rc.2) (2022-04-06)
 =========================================================================================================
 
-Changes in [1.10.9-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.10.9-rc.1) (2022-04-05)
+Changes in [1.10.9-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.10.9-rc.1) (2022-04-05)
 =========================================================================================================
 
 ## ✨ Features
@@ -2007,7 +2007,7 @@ Changes in [1.10.9-rc.1](https://github.com/vector-im/element-web/releases/tag/v
  * Fix issue with falsey hrefs being sent in events ([\#8113](https://github.com/matrix-org/matrix-react-sdk/pull/8113)). Fixes #21417.
  * Make video sizing consistent with images ([\#8102](https://github.com/matrix-org/matrix-react-sdk/pull/8102)). Fixes #20072.
 
-Changes in [1.10.8-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.10.8-rc.1) (2022-03-22)
+Changes in [1.10.8-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.10.8-rc.1) (2022-03-22)
 =========================================================================================================
 
 ## ✨ Features
@@ -2053,7 +2053,7 @@ Changes in [1.10.8-rc.1](https://github.com/vector-im/element-web/releases/tag/v
  * Fix buttons and text layout on Security Key dialog ([\#7996](https://github.com/matrix-org/matrix-react-sdk/pull/7996)). Fixes #21330. Contributed by @luixxiul.
  * Fix formatting not being applied after links ([\#7990](https://github.com/matrix-org/matrix-react-sdk/pull/7990)). Fixes #20091.
 
-Changes in [1.10.7](https://github.com/vector-im/element-web/releases/tag/v1.10.7) (2022-03-15)
+Changes in [1.10.7](https://github.com/element-hq/element-web/releases/tag/v1.10.7) (2022-03-15)
 ===============================================================================================
 
 ## 🔒 SECURITY FIXES
@@ -2062,7 +2062,7 @@ Changes in [1.10.7](https://github.com/vector-im/element-web/releases/tag/v1.10.
    should not have been.
 
 ## ✨ Features
- * Add a config.json option to skip the built-in Jitsi welcome screen ([\#21190](https://github.com/vector-im/element-web/pull/21190)).
+ * Add a config.json option to skip the built-in Jitsi welcome screen ([\#21190](https://github.com/element-hq/element-web/pull/21190)).
  * Add unexposed account setting for hiding poll creation ([\#7972](https://github.com/matrix-org/matrix-react-sdk/pull/7972)).
  * Allow pinning polls ([\#7922](https://github.com/matrix-org/matrix-react-sdk/pull/7922)). Fixes #20152.
  * Make trailing `:` into a setting ([\#6711](https://github.com/matrix-org/matrix-react-sdk/pull/6711)). Fixes #16682. Contributed by @SimonBrandner.
@@ -2077,7 +2077,7 @@ Changes in [1.10.7](https://github.com/vector-im/element-web/releases/tag/v1.10.
  * Add slash command to switch to a room's virtual room ([\#7839](https://github.com/matrix-org/matrix-react-sdk/pull/7839)).
 
 ## 🐛 Bug Fixes
- * Remove Lojban translation ([\#21302](https://github.com/vector-im/element-web/pull/21302)).
+ * Remove Lojban translation ([\#21302](https://github.com/element-hq/element-web/pull/21302)).
  * Merge pull request from GHSA-qmf4-7w7j-vf23 ([\#8059](https://github.com/matrix-org/matrix-react-sdk/pull/8059)).
  * Add another null guard for member ([\#7984](https://github.com/matrix-org/matrix-react-sdk/pull/7984)). Fixes #21319.
  * Fix room account settings ([\#7999](https://github.com/matrix-org/matrix-react-sdk/pull/7999)).
@@ -2132,11 +2132,11 @@ Changes in [1.10.7](https://github.com/vector-im/element-web/releases/tag/v1.10.
  * Don't pillify code blocks ([\#7861](https://github.com/matrix-org/matrix-react-sdk/pull/7861)). Fixes #20851 and #18687.
  * Fix keyboard shortcut icons on macOS ([\#7869](https://github.com/matrix-org/matrix-react-sdk/pull/7869)).
 
-Changes in [1.10.7-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.10.7-rc.1) (2022-03-08)
+Changes in [1.10.7-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.10.7-rc.1) (2022-03-08)
 =========================================================================================================
 
 ## ✨ Features
- * Add a config.json option to skip the built-in Jitsi welcome screen ([\#21190](https://github.com/vector-im/element-web/pull/21190)).
+ * Add a config.json option to skip the built-in Jitsi welcome screen ([\#21190](https://github.com/element-hq/element-web/pull/21190)).
  * Add unexposed account setting for hiding poll creation ([\#7972](https://github.com/matrix-org/matrix-react-sdk/pull/7972)).
  * Allow pinning polls ([\#7922](https://github.com/matrix-org/matrix-react-sdk/pull/7922)). Fixes #20152.
  * Make trailing `:` into a setting ([\#6711](https://github.com/matrix-org/matrix-react-sdk/pull/6711)). Fixes #16682. Contributed by @SimonBrandner.
@@ -2151,7 +2151,7 @@ Changes in [1.10.7-rc.1](https://github.com/vector-im/element-web/releases/tag/v
  * Add slash command to switch to a room's virtual room ([\#7839](https://github.com/matrix-org/matrix-react-sdk/pull/7839)).
 
 ## 🐛 Bug Fixes
- * Remove Lojban translation ([\#21302](https://github.com/vector-im/element-web/pull/21302)).
+ * Remove Lojban translation ([\#21302](https://github.com/element-hq/element-web/pull/21302)).
  * Add another null guard for member ([\#7984](https://github.com/matrix-org/matrix-react-sdk/pull/7984)). Fixes #21319.
  * Fix room account settings ([\#7999](https://github.com/matrix-org/matrix-react-sdk/pull/7999)).
  * Fix missing summary text for pinned message changes ([\#7989](https://github.com/matrix-org/matrix-react-sdk/pull/7989)). Fixes #19823.
@@ -2205,13 +2205,13 @@ Changes in [1.10.7-rc.1](https://github.com/vector-im/element-web/releases/tag/v
  * Don't pillify code blocks ([\#7861](https://github.com/matrix-org/matrix-react-sdk/pull/7861)). Fixes #20851 and #18687.
  * Fix keyboard shortcut icons on macOS ([\#7869](https://github.com/matrix-org/matrix-react-sdk/pull/7869)).
 
-Changes in [1.10.6](https://github.com/vector-im/element-web/releases/tag/v1.10.6) (2022-03-01)
+Changes in [1.10.6](https://github.com/element-hq/element-web/releases/tag/v1.10.6) (2022-03-01)
 ===============================================================================================
 
 ## 🐛 Bug Fixes
  * Fix some crashes in the right panel
 
-Changes in [1.10.5](https://github.com/vector-im/element-web/releases/tag/v1.10.5) (2022-02-28)
+Changes in [1.10.5](https://github.com/element-hq/element-web/releases/tag/v1.10.5) (2022-02-28)
 ===============================================================================================
 
 ## 🌐 Translations
@@ -2236,7 +2236,7 @@ Changes in [1.10.5](https://github.com/vector-im/element-web/releases/tag/v1.10.
  * Improve new search dialog context text for exactly 2 parent spaces ([\#7761](https://github.com/matrix-org/matrix-react-sdk/pull/7761)).
 
 ## 🐛 Bug Fixes
- * Fix command key missing in keyboard shortcuts tab ([\#21102](https://github.com/vector-im/element-web/pull/21102)). Contributed by @SimonBrandner.
+ * Fix command key missing in keyboard shortcuts tab ([\#21102](https://github.com/element-hq/element-web/pull/21102)). Contributed by @SimonBrandner.
  * [Release] Tweak info message padding in right panel timeline ([\#7909](https://github.com/matrix-org/matrix-react-sdk/pull/7909)).
  * [Release] Fix edge case around event list summary layout ([\#7892](https://github.com/matrix-org/matrix-react-sdk/pull/7892)).
  * Wire up CallEventGroupers for Search Results ([\#7866](https://github.com/matrix-org/matrix-react-sdk/pull/7866)). Fixes #21150.
@@ -2278,7 +2278,7 @@ Changes in [1.10.5](https://github.com/vector-im/element-web/releases/tag/v1.10.
  * Inhibit Room List keyboard pass-thru when the search beta is enabled ([\#7752](https://github.com/matrix-org/matrix-react-sdk/pull/7752)). Fixes #20984.
  * Add unread notification dot to timeline card button ([\#7749](https://github.com/matrix-org/matrix-react-sdk/pull/7749)). Fixes #20946. Contributed by @SimonBrandner.
 
-Changes in [1.10.5-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.10.5-rc.1) (2022-02-22)
+Changes in [1.10.5-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.10.5-rc.1) (2022-02-22)
 =========================================================================================================
 
 ## 🌐 Translations
@@ -2303,7 +2303,7 @@ Changes in [1.10.5-rc.1](https://github.com/vector-im/element-web/releases/tag/v
  * Improve new search dialog context text for exactly 2 parent spaces ([\#7761](https://github.com/matrix-org/matrix-react-sdk/pull/7761)).
 
 ## 🐛 Bug Fixes
- * Fix command key missing in keyboard shortcuts tab ([\#21102](https://github.com/vector-im/element-web/pull/21102)). Contributed by @SimonBrandner.
+ * Fix command key missing in keyboard shortcuts tab ([\#21102](https://github.com/element-hq/element-web/pull/21102)). Contributed by @SimonBrandner.
  * Wire up CallEventGroupers for Search Results ([\#7866](https://github.com/matrix-org/matrix-react-sdk/pull/7866)). Fixes #21150.
  * Fix edge case around event list summary layout ([\#7867](https://github.com/matrix-org/matrix-react-sdk/pull/7867)). Fixes #21153.
  * Fix misalignment with Event List Summaries ([\#7865](https://github.com/matrix-org/matrix-react-sdk/pull/7865)). Fixes #21149.
@@ -2343,24 +2343,24 @@ Changes in [1.10.5-rc.1](https://github.com/vector-im/element-web/releases/tag/v
  * Inhibit Room List keyboard pass-thru when the search beta is enabled ([\#7752](https://github.com/matrix-org/matrix-react-sdk/pull/7752)). Fixes #20984.
  * Add unread notification dot to timeline card button ([\#7749](https://github.com/matrix-org/matrix-react-sdk/pull/7749)). Fixes #20946. Contributed by @SimonBrandner.
 
-Changes in [1.10.4](https://github.com/vector-im/element-web/releases/tag/v1.10.4) (2022-02-17)
+Changes in [1.10.4](https://github.com/element-hq/element-web/releases/tag/v1.10.4) (2022-02-17)
 ===============================================================================================
 
 ## 🐛 Bug Fixes
  * Fix bug where badge colour on encrypted rooms may not be correct until anothe rmessage is sent
 
-Changes in [1.10.3](https://github.com/vector-im/element-web/releases/tag/v1.10.3) (2022-02-14)
+Changes in [1.10.3](https://github.com/element-hq/element-web/releases/tag/v1.10.3) (2022-02-14)
 ===============================================================================================
 
  * Add map tile URL for location sharing maps to sample config (and element.io release app config)
 
-Changes in [1.10.2](https://github.com/vector-im/element-web/releases/tag/v1.10.2) (2022-02-14)
+Changes in [1.10.2](https://github.com/element-hq/element-web/releases/tag/v1.10.2) (2022-02-14)
 ===============================================================================================
 
 ## ✨ Features
- * Support a config option to change the default device name ([\#20790](https://github.com/vector-im/element-web/pull/20790)).
+ * Support a config option to change the default device name ([\#20790](https://github.com/element-hq/element-web/pull/20790)).
  * Capitalize "Privacy" in UserMenu ([\#7738](https://github.com/matrix-org/matrix-react-sdk/pull/7738)). Contributed by @aaronraimist.
- * Move new search experience to a Beta ([\#7718](https://github.com/matrix-org/matrix-react-sdk/pull/7718)). Fixes vector-im/element-meta#139 #20618 and #20339.
+ * Move new search experience to a Beta ([\#7718](https://github.com/matrix-org/matrix-react-sdk/pull/7718)). Fixes element-hq/element-meta#139 #20618 and #20339.
  * Auto select "Other homeserver" when user press "Edit" in homeserver field ([\#7337](https://github.com/matrix-org/matrix-react-sdk/pull/7337)). Fixes #20125. Contributed by @SimonBrandner.
  * Add unread badges and avatar decorations to spotlight search ([\#7696](https://github.com/matrix-org/matrix-react-sdk/pull/7696)). Fixes #20821.
  * Enable location sharing ([\#7703](https://github.com/matrix-org/matrix-react-sdk/pull/7703)).
@@ -2420,7 +2420,7 @@ Changes in [1.10.2](https://github.com/vector-im/element-web/releases/tag/v1.10.
  * Fix space panel edge gradient not applying on load ([\#7644](https://github.com/matrix-org/matrix-react-sdk/pull/7644)). Fixes #20756.
  * Fix search results view for layouts other than Group/Modern ([\#7648](https://github.com/matrix-org/matrix-react-sdk/pull/7648)). Fixes #20745.
 
-Changes in [1.10.2-rc.2](https://github.com/vector-im/element-web/releases/tag/v1.10.2-rc.2) (2022-02-09)
+Changes in [1.10.2-rc.2](https://github.com/element-hq/element-web/releases/tag/v1.10.2-rc.2) (2022-02-09)
 =========================================================================================================
 
 ## 🐛 Bug Fixes
@@ -2428,12 +2428,12 @@ Changes in [1.10.2-rc.2](https://github.com/vector-im/element-web/releases/tag/v
  * [Release] Inhibit Room List keyboard pass-thru when the search beta is enabled ([\#7754](https://github.com/matrix-org/matrix-react-sdk/pull/7754)).
  * [Release] Fix space member list not opening ([\#7755](https://github.com/matrix-org/matrix-react-sdk/pull/7755)).
 
-Changes in [1.10.2-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.10.2-rc.1) (2022-02-08)
+Changes in [1.10.2-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.10.2-rc.1) (2022-02-08)
 =========================================================================================================
 
 ## ✨ Features
- * Support a config option to change the default device name ([\#20790](https://github.com/vector-im/element-web/pull/20790)).
- * Move new search experience to a Beta ([\#7718](https://github.com/matrix-org/matrix-react-sdk/pull/7718)). Fixes vector-im/element-meta#139 #20618 and #20339.
+ * Support a config option to change the default device name ([\#20790](https://github.com/element-hq/element-web/pull/20790)).
+ * Move new search experience to a Beta ([\#7718](https://github.com/matrix-org/matrix-react-sdk/pull/7718)). Fixes element-hq/element-meta#139 #20618 and #20339.
  * Capitalize "Privacy" in UserMenu ([\#7738](https://github.com/matrix-org/matrix-react-sdk/pull/7738)). Contributed by @aaronraimist.
  * Auto select "Other homeserver" when user press "Edit" in homeserver field ([\#7337](https://github.com/matrix-org/matrix-react-sdk/pull/7337)). Fixes #20125. Contributed by @SimonBrandner.
  * Add unread badges and avatar decorations to spotlight search ([\#7696](https://github.com/matrix-org/matrix-react-sdk/pull/7696)). Fixes #20821.
@@ -2490,15 +2490,15 @@ Changes in [1.10.2-rc.1](https://github.com/vector-im/element-web/releases/tag/v
  * Fix space panel edge gradient not applying on load ([\#7644](https://github.com/matrix-org/matrix-react-sdk/pull/7644)). Fixes #20756.
  * Fix search results view for layouts other than Group/Modern ([\#7648](https://github.com/matrix-org/matrix-react-sdk/pull/7648)). Fixes #20745.
 
-Changes in [1.10.1](https://github.com/vector-im/element-web/releases/tag/v1.10.1) (2022-02-01)
+Changes in [1.10.1](https://github.com/element-hq/element-web/releases/tag/v1.10.1) (2022-02-01)
 ===============================================================================================
 
 ## 🐛 Bug Fixes
- * Fix the sticker picker ([\#7692](https://github.com/matrix-org/matrix-react-sdk/pull/7692)). Fixes vector-im/element-web#20797.
- * Ensure UserInfo can be rendered without a room ([\#7687](https://github.com/matrix-org/matrix-react-sdk/pull/7687)). Fixes vector-im/element-web#20830.
- * Fix publishing address wrongly demanding the alias be available ([\#7690](https://github.com/matrix-org/matrix-react-sdk/pull/7690)). Fixes vector-im/element-web#12013 and vector-im/element-web#20833.
+ * Fix the sticker picker ([\#7692](https://github.com/matrix-org/matrix-react-sdk/pull/7692)). Fixes element-hq/element-web#20797.
+ * Ensure UserInfo can be rendered without a room ([\#7687](https://github.com/matrix-org/matrix-react-sdk/pull/7687)). Fixes element-hq/element-web#20830.
+ * Fix publishing address wrongly demanding the alias be available ([\#7690](https://github.com/matrix-org/matrix-react-sdk/pull/7690)). Fixes element-hq/element-web#12013 and element-hq/element-web#20833.
 
-Changes in [1.10.0](https://github.com/vector-im/element-web/releases/tag/v1.10.0) (2022-01-31)
+Changes in [1.10.0](https://github.com/element-hq/element-web/releases/tag/v1.10.0) (2022-01-31)
 ===============================================================================================
 
 ## ✨ Features
@@ -2586,17 +2586,17 @@ Changes in [1.10.0](https://github.com/vector-im/element-web/releases/tag/v1.10.
  * Prevent enter to send edit weirdness when no change has been made ([\#7522](https://github.com/matrix-org/matrix-react-sdk/pull/7522)). Fixes #20507.
  * Allow using room pills in slash commands ([\#7513](https://github.com/matrix-org/matrix-react-sdk/pull/7513)). Fixes #20343.
 
-Changes in [1.9.10-rc.2](https://github.com/vector-im/element-web/releases/tag/v1.9.10-rc.2) (2022-01-26)
+Changes in [1.9.10-rc.2](https://github.com/element-hq/element-web/releases/tag/v1.9.10-rc.2) (2022-01-26)
 =========================================================================================================
 
 ## 🐛 Bug Fixes
  * Fix crash in settings / appearance
 
-Changes in [1.9.10-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.9.10-rc.1) (2022-01-26)
+Changes in [1.9.10-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.9.10-rc.1) (2022-01-26)
 =========================================================================================================
 
 ## ✨ Features
- * Enable posthog on app.element.io ([\#20539](https://github.com/vector-im/element-web/pull/20539)).
+ * Enable posthog on app.element.io ([\#20539](https://github.com/element-hq/element-web/pull/20539)).
  * Tweak room list header menu for when space is active ([\#7577](https://github.com/matrix-org/matrix-react-sdk/pull/7577)). Fixes #20601.
  * Tweak light hover & active color for bubble layout ([\#7626](https://github.com/matrix-org/matrix-react-sdk/pull/7626)). Fixes #19475.
  * De-labs Metaspaces ([\#7613](https://github.com/matrix-org/matrix-react-sdk/pull/7613)).
@@ -2680,7 +2680,7 @@ Changes in [1.9.10-rc.1](https://github.com/vector-im/element-web/releases/tag/v
  * Prevent enter to send edit weirdness when no change has been made ([\#7522](https://github.com/matrix-org/matrix-react-sdk/pull/7522)). Fixes #20507.
  * Allow using room pills in slash commands ([\#7513](https://github.com/matrix-org/matrix-react-sdk/pull/7513)). Fixes #20343.
 
-Changes in [1.9.9](https://github.com/vector-im/element-web/releases/tag/v1.9.9) (2022-01-17)
+Changes in [1.9.9](https://github.com/element-hq/element-web/releases/tag/v1.9.9) (2022-01-17)
 =============================================================================================
 
 ## ✨ Features
@@ -2711,7 +2711,7 @@ Changes in [1.9.9](https://github.com/vector-im/element-web/releases/tag/v1.9.9)
  * Tweak FacePile tooltip to include whether or not you are included ([\#7367](https://github.com/matrix-org/matrix-react-sdk/pull/7367)). Fixes #17278.
 
 ## 🐛 Bug Fixes
- * Ensure group audio-only calls don't switch on the webcam on join ([\#20234](https://github.com/vector-im/element-web/pull/20234)). Fixes #20212.
+ * Ensure group audio-only calls don't switch on the webcam on join ([\#20234](https://github.com/element-hq/element-web/pull/20234)). Fixes #20212.
  * Fix wrongly wrapping code blocks, breaking line numbers ([\#7507](https://github.com/matrix-org/matrix-react-sdk/pull/7507)). Fixes #20316.
  * Set header buttons to no phase when right panel is closed ([\#7506](https://github.com/matrix-org/matrix-react-sdk/pull/7506)).
  * Fix active Jitsi calls (and other active widgets) not being visible on screen, by showing them in PiP if they are not visible in any other container ([\#7435](https://github.com/matrix-org/matrix-react-sdk/pull/7435)). Fixes #15169 and #20275.
@@ -2779,7 +2779,7 @@ Changes in [1.9.9](https://github.com/vector-im/element-web/releases/tag/v1.9.9)
  * Fix room join spinner in room list header ([\#7364](https://github.com/matrix-org/matrix-react-sdk/pull/7364)). Fixes #20139.
  * Fix room search sometimes not opening spotlight ([\#7363](https://github.com/matrix-org/matrix-react-sdk/pull/7363)). Fixes matrix-org/element-web-rageshakes#7288.
 
-Changes in [1.9.9-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.9.9-rc.1) (2022-01-11)
+Changes in [1.9.9-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.9.9-rc.1) (2022-01-11)
 =======================================================================================================
 
 ## ✨ Features
@@ -2810,7 +2810,7 @@ Changes in [1.9.9-rc.1](https://github.com/vector-im/element-web/releases/tag/v1
  * Tweak FacePile tooltip to include whether or not you are included ([\#7367](https://github.com/matrix-org/matrix-react-sdk/pull/7367)). Fixes #17278.
 
 ## 🐛 Bug Fixes
- * Ensure group audio-only calls don't switch on the webcam on join ([\#20234](https://github.com/vector-im/element-web/pull/20234)). Fixes #20212.
+ * Ensure group audio-only calls don't switch on the webcam on join ([\#20234](https://github.com/element-hq/element-web/pull/20234)). Fixes #20212.
  * Fix wrongly wrapping code blocks, breaking line numbers ([\#7507](https://github.com/matrix-org/matrix-react-sdk/pull/7507)). Fixes #20316.
  * Set header buttons to no phase when right panel is closed ([\#7506](https://github.com/matrix-org/matrix-react-sdk/pull/7506)).
  * Fix active Jitsi calls (and other active widgets) not being visible on screen, by showing them in PiP if they are not visible in any other container ([\#7435](https://github.com/matrix-org/matrix-react-sdk/pull/7435)). Fixes #15169 and #20275.
@@ -2878,13 +2878,13 @@ Changes in [1.9.9-rc.1](https://github.com/vector-im/element-web/releases/tag/v1
  * Fix room join spinner in room list header ([\#7364](https://github.com/matrix-org/matrix-react-sdk/pull/7364)). Fixes #20139.
  * Fix room search sometimes not opening spotlight ([\#7363](https://github.com/matrix-org/matrix-react-sdk/pull/7363)). Fixes matrix-org/element-web-rageshakes#7288.
 
-Changes in [1.9.8](https://github.com/vector-im/element-web/releases/tag/v1.9.8) (2021-12-20)
+Changes in [1.9.8](https://github.com/element-hq/element-web/releases/tag/v1.9.8) (2021-12-20)
 =============================================================================================
 
 ## ✨ Features
- * Include Vietnamese language ([\#20029](https://github.com/vector-im/element-web/pull/20029)).
- * Simple static location sharing ([\#19754](https://github.com/vector-im/element-web/pull/19754)).
- * Add support for the Indonesian language ([\#20032](https://github.com/vector-im/element-web/pull/20032)). Fixes #20030. Contributed by @Linerly.
+ * Include Vietnamese language ([\#20029](https://github.com/element-hq/element-web/pull/20029)).
+ * Simple static location sharing ([\#19754](https://github.com/element-hq/element-web/pull/19754)).
+ * Add support for the Indonesian language ([\#20032](https://github.com/element-hq/element-web/pull/20032)). Fixes #20030. Contributed by @Linerly.
  * Always unhide widgets on layout change (pinning a widget) ([\#7299](https://github.com/matrix-org/matrix-react-sdk/pull/7299)).
  * Update status message in the member list and user info panel when it is changed ([\#7338](https://github.com/matrix-org/matrix-react-sdk/pull/7338)). Fixes #20127. Contributed by @SimonBrandner.
  * Iterate space panel toggle collapse interaction ([\#7335](https://github.com/matrix-org/matrix-react-sdk/pull/7335)). Fixes #20079.
@@ -2959,13 +2959,13 @@ Changes in [1.9.8](https://github.com/vector-im/element-web/releases/tag/v1.9.8)
  * Fix automatic space switching wrongly going via Home for room aliases ([\#7247](https://github.com/matrix-org/matrix-react-sdk/pull/7247)). Fixes #19974.
  * Fix links being parsed as markdown links improperly ([\#7200](https://github.com/matrix-org/matrix-react-sdk/pull/7200)). Contributed by @Palid.
 
-Changes in [1.9.8-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.9.8-rc.1) (2021-12-14)
+Changes in [1.9.8-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.9.8-rc.1) (2021-12-14)
 =======================================================================================================
 
 ## ✨ Features
- * Include Vietnamese language ([\#20029](https://github.com/vector-im/element-web/pull/20029)).
- * Simple static location sharing ([\#19754](https://github.com/vector-im/element-web/pull/19754)).
- * Add support for the Indonesian language ([\#20032](https://github.com/vector-im/element-web/pull/20032)). Fixes #20030. Contributed by @Linerly.
+ * Include Vietnamese language ([\#20029](https://github.com/element-hq/element-web/pull/20029)).
+ * Simple static location sharing ([\#19754](https://github.com/element-hq/element-web/pull/19754)).
+ * Add support for the Indonesian language ([\#20032](https://github.com/element-hq/element-web/pull/20032)). Fixes #20030. Contributed by @Linerly.
  * Always unhide widgets on layout change (pinning a widget) ([\#7299](https://github.com/matrix-org/matrix-react-sdk/pull/7299)).
  * Update status message in the member list and user info panel when it is changed ([\#7338](https://github.com/matrix-org/matrix-react-sdk/pull/7338)). Fixes #20127. Contributed by @SimonBrandner.
  * Iterate space panel toggle collapse interaction ([\#7335](https://github.com/matrix-org/matrix-react-sdk/pull/7335)). Fixes #20079.
@@ -3039,13 +3039,13 @@ Changes in [1.9.8-rc.1](https://github.com/vector-im/element-web/releases/tag/v1
  * Fix automatic space switching wrongly going via Home for room aliases ([\#7247](https://github.com/matrix-org/matrix-react-sdk/pull/7247)). Fixes #19974.
  * Fix links being parsed as markdown links improperly ([\#7200](https://github.com/matrix-org/matrix-react-sdk/pull/7200)). Contributed by @Palid.
 
-Changes in [1.9.7](https://github.com/vector-im/element-web/releases/tag/v1.9.7) (2021-12-13)
+Changes in [1.9.7](https://github.com/element-hq/element-web/releases/tag/v1.9.7) (2021-12-13)
 =============================================================================================
 
  * Security release with updated version of Olm to fix https://matrix.org/blog/2021/12/03/pre-disclosure-upcoming-security-release-of-libolm-and-matrix-js-sdk
  * Fix a crash on logout
 
-Changes in [1.9.6](https://github.com/vector-im/element-web/releases/tag/v1.9.6) (2021-12-06)
+Changes in [1.9.6](https://github.com/element-hq/element-web/releases/tag/v1.9.6) (2021-12-06)
 =============================================================================================
 
 ## ✨ Features
@@ -3062,7 +3062,7 @@ Changes in [1.9.6](https://github.com/vector-im/element-web/releases/tag/v1.9.6)
  * Show room context details in forward dialog ([\#7162](https://github.com/matrix-org/matrix-react-sdk/pull/7162)). Fixes #19793.
  * Remove chevrons from RoomSummaryCard_Button ([\#7137](https://github.com/matrix-org/matrix-react-sdk/pull/7137)). Fixes #19644.
  * Disable op/deop commands where user has no permissions ([\#7161](https://github.com/matrix-org/matrix-react-sdk/pull/7161)). Fixes #15390.
- * Add option to change the size of images/videos in the timeline ([\#7017](https://github.com/matrix-org/matrix-react-sdk/pull/7017)). Fixes vector-im/element-meta#49 #1520 and #19498.
+ * Add option to change the size of images/videos in the timeline ([\#7017](https://github.com/matrix-org/matrix-react-sdk/pull/7017)). Fixes element-hq/element-meta#49 #1520 and #19498.
 
 ## 🐛 Bug Fixes
  * Fix left panel glow in Safari ([\#7236](https://github.com/matrix-org/matrix-react-sdk/pull/7236)). Fixes #19863.
@@ -3088,12 +3088,12 @@ Changes in [1.9.6](https://github.com/vector-im/element-web/releases/tag/v1.9.6)
  * Room Context Menu should respond to tag changes ([\#7154](https://github.com/matrix-org/matrix-react-sdk/pull/7154)). Fixes #19776.
  * Fix an edge case when trying to join an upgraded room ([\#7159](https://github.com/matrix-org/matrix-react-sdk/pull/7159)).
 
-Changes in [1.9.6-rc.2](https://github.com/vector-im/element-web/releases/tag/v1.9.6-rc.2) (2021-12-01)
+Changes in [1.9.6-rc.2](https://github.com/element-hq/element-web/releases/tag/v1.9.6-rc.2) (2021-12-01)
 =======================================================================================================
 
  * Fixed release from correct branch
 
-Changes in [1.9.6-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.9.6-rc.1) (2021-11-30)
+Changes in [1.9.6-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.9.6-rc.1) (2021-11-30)
 =======================================================================================================
 
 ## ✨ Features
@@ -3111,7 +3111,7 @@ Changes in [1.9.6-rc.1](https://github.com/vector-im/element-web/releases/tag/v1
  * Show room context details in forward dialog ([\#7162](https://github.com/matrix-org/matrix-react-sdk/pull/7162)). Fixes #19793 and #19793.
  * Remove chevrons from RoomSummaryCard_Button ([\#7137](https://github.com/matrix-org/matrix-react-sdk/pull/7137)). Fixes #19644 and #19644.
  * Disable op/deop commands where user has no permissions ([\#7161](https://github.com/matrix-org/matrix-react-sdk/pull/7161)). Fixes #15390 and #15390.
- * Add option to change the size of images/videos in the timeline ([\#7017](https://github.com/matrix-org/matrix-react-sdk/pull/7017)). Fixes vector-im/element-meta#49, #1520 #19498 and vector-im/element-meta#49.
+ * Add option to change the size of images/videos in the timeline ([\#7017](https://github.com/matrix-org/matrix-react-sdk/pull/7017)). Fixes element-hq/element-meta#49, #1520 #19498 and element-hq/element-meta#49.
 
 ## 🐛 Bug Fixes
  * Fix links being parsed as markdown links improperly ([\#7200](https://github.com/matrix-org/matrix-react-sdk/pull/7200)).
@@ -3138,7 +3138,7 @@ Changes in [1.9.6-rc.1](https://github.com/vector-im/element-web/releases/tag/v1
  * Room Context Menu should respond to tag changes ([\#7154](https://github.com/matrix-org/matrix-react-sdk/pull/7154)). Fixes #19776.
  * Fix an edge case when trying to join an upgraded room ([\#7159](https://github.com/matrix-org/matrix-react-sdk/pull/7159)).
 
-Changes in [1.9.5](https://github.com/vector-im/element-web/releases/tag/v1.9.5) (2021-11-22)
+Changes in [1.9.5](https://github.com/element-hq/element-web/releases/tag/v1.9.5) (2021-11-22)
 =============================================================================================
 
 ## ✨ Features
@@ -3174,7 +3174,7 @@ Changes in [1.9.5](https://github.com/vector-im/element-web/releases/tag/v1.9.5)
  * Use device IDs for nameless devices in device list ([\#7081](https://github.com/matrix-org/matrix-react-sdk/pull/7081)). Fixes #19608 and #19608.
  * Don't re-sort rooms on no-op RoomUpdateCause.PossibleTagChange ([\#7053](https://github.com/matrix-org/matrix-react-sdk/pull/7053)). Contributed by @bradtgmurray.
 
-Changes in [1.9.5-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.9.5-rc.1) (2021-11-17)
+Changes in [1.9.5-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.9.5-rc.1) (2021-11-17)
 =======================================================================================================
 
 ## ✨ Features
@@ -3210,7 +3210,7 @@ Changes in [1.9.5-rc.1](https://github.com/vector-im/element-web/releases/tag/v1
  * Use device IDs for nameless devices in device list ([\#7081](https://github.com/matrix-org/matrix-react-sdk/pull/7081)). Fixes #19608 and #19608.
  * Don't re-sort rooms on no-op RoomUpdateCause.PossibleTagChange ([\#7053](https://github.com/matrix-org/matrix-react-sdk/pull/7053)). Contributed by @bradtgmurray.
 
-Changes in [1.9.4](https://github.com/vector-im/element-web/releases/tag/v1.9.4) (2021-11-08)
+Changes in [1.9.4](https://github.com/element-hq/element-web/releases/tag/v1.9.4) (2021-11-08)
 =============================================================================================
 
 ## ✨ Features
@@ -3267,7 +3267,7 @@ Changes in [1.9.4](https://github.com/vector-im/element-web/releases/tag/v1.9.4)
  * Fix space panel name overflowing ([\#6995](https://github.com/matrix-org/matrix-react-sdk/pull/6995)). Fixes #19455 and #19455.
  * Fix conflicting CSS on syntax highlighted blocks ([\#6991](https://github.com/matrix-org/matrix-react-sdk/pull/6991)). Fixes #19445 and #19445.
 
-Changes in [1.9.3](https://github.com/vector-im/element-desktop/releases/tag/v1.9.3) (2021-10-25)
+Changes in [1.9.3](https://github.com/element-hq/element-desktop/releases/tag/v1.9.3) (2021-10-25)
 =================================================================================================
 
 ## ✨ Features
@@ -3309,20 +3309,20 @@ Changes in [1.9.3](https://github.com/vector-im/element-desktop/releases/tag/v1.
  * Fix spaces keyboard shortcuts not working for last space ([\#6909](https://github.com/matrix-org/matrix-react-sdk/pull/6909)). Fixes #19255 and #19255.
  * Use fallback avatar only for DMs with 2 people. ([\#6895](https://github.com/matrix-org/matrix-react-sdk/pull/6895)). Fixes #18747 and #18747. Contributed by [andybalaam](https://github.com/andybalaam).
 
-Changes in [1.9.3-rc.3](https://github.com/vector-im/element-desktop/releases/tag/v1.9.3-rc.3) (2021-10-25)
+Changes in [1.9.3-rc.3](https://github.com/element-hq/element-desktop/releases/tag/v1.9.3-rc.3) (2021-10-25)
 ===========================================================================================================
 
 ## 🐛 Bug Fixes
- * Remove highlightjs CSS ([\#19483](https://github.com/vector-im/element-web/pull/19483)). Fixes vector-im/element-web#19476
+ * Remove highlightjs CSS ([\#19483](https://github.com/element-hq/element-web/pull/19483)). Fixes element-hq/element-web#19476
 
 
-Changes in [1.9.3-rc.2](https://github.com/vector-im/element-desktop/releases/tag/v1.9.3-rc.2) (2021-10-20)
+Changes in [1.9.3-rc.2](https://github.com/element-hq/element-desktop/releases/tag/v1.9.3-rc.2) (2021-10-20)
 ===========================================================================================================
 
 ## 🐛 Bug Fixes
- * Fix conflicting CSS on syntax highlighted blocks ([\#6991](https://github.com/matrix-org/matrix-react-sdk/pull/6991)). Fixes vector-im/element-web#19445
+ * Fix conflicting CSS on syntax highlighted blocks ([\#6991](https://github.com/matrix-org/matrix-react-sdk/pull/6991)). Fixes element-hq/element-web#19445
 
-Changes in [1.9.3-rc.1](https://github.com/vector-im/element-desktop/releases/tag/v1.9.3-rc.1) (2021-10-19)
+Changes in [1.9.3-rc.1](https://github.com/element-hq/element-desktop/releases/tag/v1.9.3-rc.1) (2021-10-19)
 ===========================================================================================================
 
 ## ✨ Features
@@ -3364,13 +3364,13 @@ Changes in [1.9.3-rc.1](https://github.com/vector-im/element-desktop/releases/ta
  * Fix spaces keyboard shortcuts not working for last space ([\#6909](https://github.com/matrix-org/matrix-react-sdk/pull/6909)). Fixes #19255 and #19255.
  * Use fallback avatar only for DMs with 2 people. ([\#6895](https://github.com/matrix-org/matrix-react-sdk/pull/6895)). Fixes #18747 and #18747. Contributed by [andybalaam](https://github.com/andybalaam).
 
-Changes in [1.9.2](https://github.com/vector-im/element-desktop/releases/tag/v1.9.2) (2021-10-12)
+Changes in [1.9.2](https://github.com/element-hq/element-desktop/releases/tag/v1.9.2) (2021-10-12)
 =================================================================================================
 
 ## 🐛 Bug Fixes
  * Upgrade to matrix-js-sdk#14.0.1
 
-Changes in [1.9.1](https://github.com/vector-im/element-desktop/releases/tag/v1.9.1) (2021-10-11)
+Changes in [1.9.1](https://github.com/element-hq/element-desktop/releases/tag/v1.9.1) (2021-10-11)
 =================================================================================================
 
 ## ✨ Features
@@ -3398,12 +3398,12 @@ Changes in [1.9.1](https://github.com/vector-im/element-desktop/releases/tag/v1.
  * Fix spacing for message composer buttons ([\#6852](https://github.com/matrix-org/matrix-react-sdk/pull/6852)). Fixes #18999 and #18999.
  * Always show root event of a thread in room's timeline ([\#6842](https://github.com/matrix-org/matrix-react-sdk/pull/6842)). Fixes #19016 and #19016.
 
-Changes in [1.9.1-rc.2](https://github.com/vector-im/element-desktop/releases/tag/v1.9.1-rc.2) (2021-10-08)
+Changes in [1.9.1-rc.2](https://github.com/element-hq/element-desktop/releases/tag/v1.9.1-rc.2) (2021-10-08)
 ===========================================================================================================
 
 ## 🐛 Bug Fixes
 
-Changes in [1.9.1-rc.1](https://github.com/vector-im/element-desktop/releases/tag/v1.9.1-rc.1) (2021-10-04)
+Changes in [1.9.1-rc.1](https://github.com/element-hq/element-desktop/releases/tag/v1.9.1-rc.1) (2021-10-04)
 ===========================================================================================================
 
 ## ✨ Features
@@ -3430,11 +3430,11 @@ Changes in [1.9.1-rc.1](https://github.com/vector-im/element-desktop/releases/ta
  * Fix spacing for message composer buttons ([\#6852](https://github.com/matrix-org/matrix-react-sdk/pull/6852)). Fixes #18999 and #18999.
  * Always show root event of a thread in room's timeline ([\#6842](https://github.com/matrix-org/matrix-react-sdk/pull/6842)). Fixes #19016 and #19016.
 
-Changes in [1.9.0](https://github.com/vector-im/element-desktop/releases/tag/v1.9.0) (2021-09-27)
+Changes in [1.9.0](https://github.com/element-hq/element-desktop/releases/tag/v1.9.0) (2021-09-27)
 =================================================================================================
 
 ## ✨ Features
- * Fix space keyboard shortcuts conflicting with native zoom shortcuts ([\#19037](https://github.com/vector-im/element-web/pull/19037)). Fixes #18481 and undefined/element-web#18481.
+ * Fix space keyboard shortcuts conflicting with native zoom shortcuts ([\#19037](https://github.com/element-hq/element-web/pull/19037)). Fixes #18481 and undefined/element-web#18481.
  * Say Joining space instead of Joining room where we know its a space ([\#6818](https://github.com/matrix-org/matrix-react-sdk/pull/6818)). Fixes #19064 and #19064.
  * Add warning that some spaces may not be relinked to the newly upgraded room ([\#6805](https://github.com/matrix-org/matrix-react-sdk/pull/6805)). Fixes #18858 and #18858.
  * Delabs Spaces, iterate some copy and move communities/space toggle to preferences ([\#6594](https://github.com/matrix-org/matrix-react-sdk/pull/6594)). Fixes #18088, #18524 #18088 and #18088.
@@ -3479,17 +3479,17 @@ Changes in [1.9.0](https://github.com/vector-im/element-desktop/releases/tag/v1.
  * Use cursor:pointer on space panel buttons ([\#6770](https://github.com/matrix-org/matrix-react-sdk/pull/6770)). Fixes #18951 and #18951.
  * Fix regressed tab view buttons in space update toast ([\#6761](https://github.com/matrix-org/matrix-react-sdk/pull/6761)). Fixes #18781 and #18781.
 
-Changes in [1.8.6-rc.2](https://github.com/vector-im/element-desktop/releases/tag/v1.8.6-rc.2) (2021-09-22)
+Changes in [1.8.6-rc.2](https://github.com/element-hq/element-desktop/releases/tag/v1.8.6-rc.2) (2021-09-22)
 ===========================================================================================================
 
 ## 🐛 Bug Fixes
  * Fix spacing for message composer buttons ([\#6854](https://github.com/matrix-org/matrix-react-sdk/pull/6854)).
 
-Changes in [1.8.6-rc.1](https://github.com/vector-im/element-desktop/releases/tag/v1.8.6-rc.1) (2021-09-21)
+Changes in [1.8.6-rc.1](https://github.com/element-hq/element-desktop/releases/tag/v1.8.6-rc.1) (2021-09-21)
 ===========================================================================================================
 
 ## ✨ Features
- * Fix space keyboard shortcuts conflicting with native zoom shortcuts ([\#19037](https://github.com/vector-im/element-web/pull/19037)). Fixes #18481 and undefined/element-web#18481.
+ * Fix space keyboard shortcuts conflicting with native zoom shortcuts ([\#19037](https://github.com/element-hq/element-web/pull/19037)). Fixes #18481 and undefined/element-web#18481.
  * Say Joining space instead of Joining room where we know its a space ([\#6818](https://github.com/matrix-org/matrix-react-sdk/pull/6818)). Fixes #19064 and #19064.
  * Add warning that some spaces may not be relinked to the newly upgraded room ([\#6805](https://github.com/matrix-org/matrix-react-sdk/pull/6805)). Fixes #18858 and #18858.
  * Delabs Spaces, iterate some copy and move communities/space toggle to preferences ([\#6594](https://github.com/matrix-org/matrix-react-sdk/pull/6594)). Fixes #18088, #18524 #18088 and #18088.
@@ -3535,7 +3535,7 @@ Changes in [1.8.6-rc.1](https://github.com/vector-im/element-desktop/releases/ta
  * Use cursor:pointer on space panel buttons ([\#6770](https://github.com/matrix-org/matrix-react-sdk/pull/6770)). Fixes #18951 and #18951.
  * Fix regressed tab view buttons in space update toast ([\#6761](https://github.com/matrix-org/matrix-react-sdk/pull/6761)). Fixes #18781 and #18781.
 
-Changes in [1.8.5](https://github.com/vector-im/element-desktop/releases/tag/v1.8.5) (2021-09-14)
+Changes in [1.8.5](https://github.com/element-hq/element-desktop/releases/tag/v1.8.5) (2021-09-14)
 =================================================================================================
 
 ## ✨ Features
@@ -3594,18 +3594,18 @@ Changes in [1.8.5](https://github.com/vector-im/element-desktop/releases/tag/v1.
  * Fix codeblock formatting with syntax highlighting on ([\#6681](https://github.com/matrix-org/matrix-react-sdk/pull/6681)). Fixes #18739 #18365 and #18739. Contributed by [SimonBrandner](https://github.com/SimonBrandner).
  * Add padding to the Add button in the notification settings ([\#6665](https://github.com/matrix-org/matrix-react-sdk/pull/6665)). Fixes #18706 and #18706. Contributed by [SimonBrandner](https://github.com/SimonBrandner).
 
-Changes in [1.8.4](https://github.com/vector-im/element-web/releases/tag/v1.8.4) (2021-09-13)
+Changes in [1.8.4](https://github.com/element-hq/element-web/releases/tag/v1.8.4) (2021-09-13)
 =================================================================================================
 
 ## 🔒 SECURITY FIXES
  * Fix a security issue with message key sharing. See https://matrix.org/blog/2021/09/13/vulnerability-disclosure-key-sharing
    for details.
 
-Changes in [1.8.2](https://github.com/vector-im/element-desktop/releases/tag/v1.8.2) (2021-08-31)
+Changes in [1.8.2](https://github.com/element-hq/element-desktop/releases/tag/v1.8.2) (2021-08-31)
 =================================================================================================
 
 ## ✨ Features
- * Documentation for sentry config ([\#18608](https://github.com/vector-im/element-web/pull/18608)). Contributed by [novocaine](https://github.com/novocaine).
+ * Documentation for sentry config ([\#18608](https://github.com/element-hq/element-web/pull/18608)). Contributed by [novocaine](https://github.com/novocaine).
  * [Release]Increase general app performance by optimizing layers ([\#6672](https://github.com/matrix-org/matrix-react-sdk/pull/6672)). Fixes #18730 and #18730. Contributed by [Palid](https://github.com/Palid).
  * Add a warning on E2EE rooms if you try to make them public ([\#5698](https://github.com/matrix-org/matrix-react-sdk/pull/5698)). Contributed by [SimonBrandner](https://github.com/SimonBrandner).
  * Allow pagination of the space hierarchy and use new APIs ([\#6507](https://github.com/matrix-org/matrix-react-sdk/pull/6507)). Fixes #18089 and #18427.
@@ -3646,13 +3646,13 @@ Changes in [1.8.2](https://github.com/vector-im/element-desktop/releases/tag/v1.
  * Remove tiny scrollbar dot from code blocks ([\#6596](https://github.com/matrix-org/matrix-react-sdk/pull/6596)). Fixes #18474. Contributed by [SimonBrandner](https://github.com/SimonBrandner).
  * Improve handling of pills in the composer ([\#6353](https://github.com/matrix-org/matrix-react-sdk/pull/6353)). Fixes #10134 #10896 and #15037. Contributed by [SimonBrandner](https://github.com/SimonBrandner).
 
-Changes in [1.8.1](https://github.com/vector-im/element-desktop/releases/tag/v1.8.1) (2021-08-17)
+Changes in [1.8.1](https://github.com/element-hq/element-desktop/releases/tag/v1.8.1) (2021-08-17)
 =================================================================================================
 
 ## 🐛 Bug Fixes
  * Fix multiple VoIP regressions ([matrix-org/matrix-js-sdk#1860](https://github.com/matrix-org/matrix-js-sdk/pull/1860)).
 
-Changes in [1.8.0](https://github.com/vector-im/element-desktop/releases/tag/v1.8.0) (2021-08-16)
+Changes in [1.8.0](https://github.com/element-hq/element-desktop/releases/tag/v1.8.0) (2021-08-16)
 =================================================================================================
 
 ## ✨ Features
@@ -3676,7 +3676,7 @@ Changes in [1.8.0](https://github.com/vector-im/element-desktop/releases/tag/v1.
  * Add support for screen sharing in 1:1 calls ([\#5992](https://github.com/matrix-org/matrix-react-sdk/pull/5992)). Contributed by [SimonBrandner](https://github.com/SimonBrandner).
 
 ## 🐛 Bug Fixes
- * Dismiss electron download toast when clicking Open ([\#18267](https://github.com/vector-im/element-web/pull/18267)). Fixes #18266.
+ * Dismiss electron download toast when clicking Open ([\#18267](https://github.com/element-hq/element-web/pull/18267)). Fixes #18266.
  * [Release] Fix glare related regressions ([\#6622](https://github.com/matrix-org/matrix-react-sdk/pull/6622)). Contributed by [SimonBrandner](https://github.com/SimonBrandner).
  * [Release] Fix PiP of held calls ([\#6612](https://github.com/matrix-org/matrix-react-sdk/pull/6612)). Contributed by [SimonBrandner](https://github.com/SimonBrandner).
  * [Release] Fix toast colors ([\#6607](https://github.com/matrix-org/matrix-react-sdk/pull/6607)). Contributed by [SimonBrandner](https://github.com/SimonBrandner).
@@ -3718,12 +3718,12 @@ Changes in [1.8.0](https://github.com/vector-im/element-desktop/releases/tag/v1.
  * Fix grecaptcha regression ([\#6503](https://github.com/matrix-org/matrix-react-sdk/pull/6503)). Fixes #18284. Contributed by [Palid](https://github.com/Palid).
  * Fix compatibility with accounts where the security passphrase was created on a mobile device ([\#1819](https://github.com/matrix-org/matrix-js-sdk/pull/1819)).
 
-Changes in [1.7.34](https://github.com/vector-im/element-desktop/releases/tag/v1.7.34) (2021-08-02)
+Changes in [1.7.34](https://github.com/element-hq/element-desktop/releases/tag/v1.7.34) (2021-08-02)
 ===================================================================================================
 
 ## 🔒 SECURITY FIXES
  * Sanitize untrusted variables from message previews before translation
-   Fixes vector-im/element-web#18314
+   Fixes element-hq/element-web#18314
 
 ## ✨ Features
  * Fix editing of `<sub>` & `<sup`> & `<u>`
@@ -3764,15 +3764,15 @@ Changes in [1.7.34](https://github.com/vector-im/element-desktop/releases/tag/v1
    Fixes #18008
  * Improve reply rendering
    [\#3553](https://github.com/matrix-org/matrix-react-sdk/pull/3553)
-   Fixes vector-im/riot-web#9217, vector-im/riot-web#7633, vector-im/riot-web#7530, vector-im/riot-web#7169, vector-im/riot-web#7151, vector-im/riot-web#6692 vector-im/riot-web#6579 and #17440
+   Fixes element-hq/riot-web#9217, element-hq/riot-web#7633, element-hq/riot-web#7530, element-hq/riot-web#7169, element-hq/riot-web#7151, element-hq/riot-web#6692 element-hq/riot-web#6579 and #17440
  * Improve performance of room name calculation
    [\#1801](https://github.com/matrix-org/matrix-js-sdk/pull/1801)
 
 ## 🐛 Bug Fixes
  * Fix browser history getting stuck looping back to the same room
-   [\#18053](https://github.com/vector-im/element-web/pull/18053)
+   [\#18053](https://github.com/element-hq/element-web/pull/18053)
  * Fix space shortcuts on layouts with non-English keys in the places of numbers
-   [\#17780](https://github.com/vector-im/element-web/pull/17780)
+   [\#17780](https://github.com/element-hq/element-web/pull/17780)
    Fixes #17776
  * Fix CreateRoomDialog exploding when making public room outside of a space
    [\#6493](https://github.com/matrix-org/matrix-react-sdk/pull/6493)
@@ -3844,131 +3844,131 @@ Changes in [1.7.34](https://github.com/vector-im/element-desktop/releases/tag/v1
  * Cache feature_spaces\* flags to improve performance
    [\#6381](https://github.com/matrix-org/matrix-react-sdk/pull/6381)
 
-Changes in [1.7.33](https://github.com/vector-im/element-web/releases/tag/v1.7.33) (2021-07-19)
+Changes in [1.7.33](https://github.com/element-hq/element-web/releases/tag/v1.7.33) (2021-07-19)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.33-rc.1...v1.7.33)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.33-rc.1...v1.7.33)
 
  * No changes from rc.1
 
-Changes in [1.7.33-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.33-rc.1) (2021-07-14)
+Changes in [1.7.33-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.33-rc.1) (2021-07-14)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.32...v1.7.33-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.32...v1.7.33-rc.1)
 
  * Translations update from Weblate
-   [\#17991](https://github.com/vector-im/element-web/pull/17991)
+   [\#17991](https://github.com/element-hq/element-web/pull/17991)
  * Revert "Don't run nginx as root in docker"
-   [\#17990](https://github.com/vector-im/element-web/pull/17990)
+   [\#17990](https://github.com/element-hq/element-web/pull/17990)
  * Don't run nginx as root in docker
-   [\#17927](https://github.com/vector-im/element-web/pull/17927)
+   [\#17927](https://github.com/element-hq/element-web/pull/17927)
  * Add VS Code to gitignore
-   [\#17982](https://github.com/vector-im/element-web/pull/17982)
+   [\#17982](https://github.com/element-hq/element-web/pull/17982)
  * Remove canvas native dependencies from Dockerfile
-   [\#17973](https://github.com/vector-im/element-web/pull/17973)
+   [\#17973](https://github.com/element-hq/element-web/pull/17973)
  * Remove node-canvas devDependency
-   [\#17967](https://github.com/vector-im/element-web/pull/17967)
+   [\#17967](https://github.com/element-hq/element-web/pull/17967)
  * Add `reskindex` to development steps
-   [\#17926](https://github.com/vector-im/element-web/pull/17926)
+   [\#17926](https://github.com/element-hq/element-web/pull/17926)
  * Update Modernizr and stop it from polluting classes on the html tag
-   [\#17921](https://github.com/vector-im/element-web/pull/17921)
+   [\#17921](https://github.com/element-hq/element-web/pull/17921)
  * Convert a few files to TS
-   [\#17895](https://github.com/vector-im/element-web/pull/17895)
+   [\#17895](https://github.com/element-hq/element-web/pull/17895)
  * Do not generate a lockfile when running in CI
-   [\#17902](https://github.com/vector-im/element-web/pull/17902)
+   [\#17902](https://github.com/element-hq/element-web/pull/17902)
  * Fix lockfile to match listed dependencies
-   [\#17888](https://github.com/vector-im/element-web/pull/17888)
+   [\#17888](https://github.com/element-hq/element-web/pull/17888)
  * Remove PostCSS calc() processing
-   [\#17856](https://github.com/vector-im/element-web/pull/17856)
+   [\#17856](https://github.com/element-hq/element-web/pull/17856)
  * Make issue template styling more consistent and improve PR template
-   [\#17691](https://github.com/vector-im/element-web/pull/17691)
+   [\#17691](https://github.com/element-hq/element-web/pull/17691)
  * Update jsrsasign to ^10.2.0 (Includes fix for CVE-2021-30246)
-   [\#17170](https://github.com/vector-im/element-web/pull/17170)
+   [\#17170](https://github.com/element-hq/element-web/pull/17170)
  * Migrate to `eslint-plugin-matrix-org`
-   [\#17847](https://github.com/vector-im/element-web/pull/17847)
+   [\#17847](https://github.com/element-hq/element-web/pull/17847)
  * Remove spurious overflow: auto on #matrixchat element
-   [\#17647](https://github.com/vector-im/element-web/pull/17647)
+   [\#17647](https://github.com/element-hq/element-web/pull/17647)
  * Enhance security by disallowing CSP object-src rule
-   [\#17818](https://github.com/vector-im/element-web/pull/17818)
+   [\#17818](https://github.com/element-hq/element-web/pull/17818)
 
-Changes in [1.7.32](https://github.com/vector-im/element-web/releases/tag/v1.7.32) (2021-07-05)
+Changes in [1.7.32](https://github.com/element-hq/element-web/releases/tag/v1.7.32) (2021-07-05)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.32-rc.1...v1.7.32)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.32-rc.1...v1.7.32)
 
  * No changes from rc.1
 
-Changes in [1.7.32-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.32-rc.1) (2021-06-29)
+Changes in [1.7.32-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.32-rc.1) (2021-06-29)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.31...v1.7.32-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.31...v1.7.32-rc.1)
 
  * Update to react-sdk v3.25.0-rc.1 and js-sdk v12.0.1-rc.1
  * Translations update from Weblate
-   [\#17832](https://github.com/vector-im/element-web/pull/17832)
+   [\#17832](https://github.com/element-hq/element-web/pull/17832)
  * Fix canvas-filter-polyfill mock path
-   [\#17785](https://github.com/vector-im/element-web/pull/17785)
+   [\#17785](https://github.com/element-hq/element-web/pull/17785)
  * Mock context-filter-polyfill for app-tests
-   [\#17774](https://github.com/vector-im/element-web/pull/17774)
+   [\#17774](https://github.com/element-hq/element-web/pull/17774)
  * Add libera.chat to default room directory
-   [\#17772](https://github.com/vector-im/element-web/pull/17772)
+   [\#17772](https://github.com/element-hq/element-web/pull/17772)
  * Improve typing of Event Index Manager / Seshat
-   [\#17704](https://github.com/vector-im/element-web/pull/17704)
+   [\#17704](https://github.com/element-hq/element-web/pull/17704)
  * Bump dns-packet from 1.3.1 to 1.3.4
-   [\#17478](https://github.com/vector-im/element-web/pull/17478)
+   [\#17478](https://github.com/element-hq/element-web/pull/17478)
  * Update matrix-widget-api to fix build issues
-   [\#17747](https://github.com/vector-im/element-web/pull/17747)
+   [\#17747](https://github.com/element-hq/element-web/pull/17747)
  * Fix whitespace in Dockerfile
-   [\#17742](https://github.com/vector-im/element-web/pull/17742)
+   [\#17742](https://github.com/element-hq/element-web/pull/17742)
  * Upgrade @types/react and @types/react-dom
-   [\#17723](https://github.com/vector-im/element-web/pull/17723)
+   [\#17723](https://github.com/element-hq/element-web/pull/17723)
  * Spaces keyboard shortcuts first cut
-   [\#17457](https://github.com/vector-im/element-web/pull/17457)
+   [\#17457](https://github.com/element-hq/element-web/pull/17457)
  * Labs: feature_report_to_moderators
-   [\#17694](https://github.com/vector-im/element-web/pull/17694)
+   [\#17694](https://github.com/element-hq/element-web/pull/17694)
 
-Changes in [1.7.31](https://github.com/vector-im/element-web/releases/tag/v1.7.31) (2021-06-21)
+Changes in [1.7.31](https://github.com/element-hq/element-web/releases/tag/v1.7.31) (2021-06-21)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.31-rc.1...v1.7.31)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.31-rc.1...v1.7.31)
 
  * Upgrade to React SDK 3.24.0 and JS SDK 12.0.0
 
-Changes in [1.7.31-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.31-rc.1) (2021-06-15)
+Changes in [1.7.31-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.31-rc.1) (2021-06-15)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.30...v1.7.31-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.30...v1.7.31-rc.1)
 
  * Upgrade to React SDK 3.24.0-rc.1 and JS SDK 12.0.0-rc.1
  * Translations update from Weblate
-   [\#17655](https://github.com/vector-im/element-web/pull/17655)
+   [\#17655](https://github.com/element-hq/element-web/pull/17655)
  * Upgrade matrix-react-test-utils for React 17 peer deps
-   [\#17653](https://github.com/vector-im/element-web/pull/17653)
+   [\#17653](https://github.com/element-hq/element-web/pull/17653)
  * Fix lint errors in Webpack config
-   [\#17626](https://github.com/vector-im/element-web/pull/17626)
+   [\#17626](https://github.com/element-hq/element-web/pull/17626)
  * Preload only `woff2` fonts
-   [\#17614](https://github.com/vector-im/element-web/pull/17614)
+   [\#17614](https://github.com/element-hq/element-web/pull/17614)
  * ⚛️ Upgrade to React@17
-   [\#17601](https://github.com/vector-im/element-web/pull/17601)
+   [\#17601](https://github.com/element-hq/element-web/pull/17601)
 
-Changes in [1.7.30](https://github.com/vector-im/element-web/releases/tag/v1.7.30) (2021-06-07)
+Changes in [1.7.30](https://github.com/element-hq/element-web/releases/tag/v1.7.30) (2021-06-07)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.30-rc.1...v1.7.30)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.30-rc.1...v1.7.30)
 
  * Upgrade to React SDK 3.23.0 and JS SDK 11.2.0
 
-Changes in [1.7.30-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.30-rc.1) (2021-06-01)
+Changes in [1.7.30-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.30-rc.1) (2021-06-01)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.29...v1.7.30-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.29...v1.7.30-rc.1)
 
  * Upgrade to React SDK 3.23.0-rc.1 and JS SDK 11.2.0-rc.1
  * Translations update from Weblate
-   [\#17526](https://github.com/vector-im/element-web/pull/17526)
+   [\#17526](https://github.com/element-hq/element-web/pull/17526)
  * Add Modernizr test for Promise.allSettled given js-sdk and react-sdk depend
    on it
-   [\#17464](https://github.com/vector-im/element-web/pull/17464)
+   [\#17464](https://github.com/element-hq/element-web/pull/17464)
  * Bump libolm dependency, and update package name.
-   [\#17433](https://github.com/vector-im/element-web/pull/17433)
+   [\#17433](https://github.com/element-hq/element-web/pull/17433)
  * Remove logo spinner
-   [\#17423](https://github.com/vector-im/element-web/pull/17423)
+   [\#17423](https://github.com/element-hq/element-web/pull/17423)
 
-Changes in [1.7.29](https://github.com/vector-im/element-web/releases/tag/v1.7.29) (2021-05-24)
+Changes in [1.7.29](https://github.com/element-hq/element-web/releases/tag/v1.7.29) (2021-05-24)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.29-rc.1...v1.7.29)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.29-rc.1...v1.7.29)
 
 ## Security notice
 
@@ -3981,31 +3981,31 @@ and to control that function's local variables.
 
  * Upgrade to React SDK 3.22.0 and JS SDK 11.1.0
  * [Release] Bump libolm dependency, and update package name
-   [\#17456](https://github.com/vector-im/element-web/pull/17456)
+   [\#17456](https://github.com/element-hq/element-web/pull/17456)
 
-Changes in [1.7.29-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.29-rc.1) (2021-05-19)
+Changes in [1.7.29-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.29-rc.1) (2021-05-19)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.28...v1.7.29-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.28...v1.7.29-rc.1)
 
  * Upgrade to React SDK 3.22.0-rc.1 and JS SDK 11.1.0-rc.1
  * Translations update from Weblate
-   [\#17384](https://github.com/vector-im/element-web/pull/17384)
+   [\#17384](https://github.com/element-hq/element-web/pull/17384)
  * Prevent minification of `.html` files
-   [\#17349](https://github.com/vector-im/element-web/pull/17349)
+   [\#17349](https://github.com/element-hq/element-web/pull/17349)
  * Update matrix-widget-api/react-sdk dependency reference
-   [\#17346](https://github.com/vector-im/element-web/pull/17346)
+   [\#17346](https://github.com/element-hq/element-web/pull/17346)
  * Add `yarn start:https`
-   [\#16989](https://github.com/vector-im/element-web/pull/16989)
+   [\#16989](https://github.com/element-hq/element-web/pull/16989)
  * Translations update from Weblate
-   [\#17239](https://github.com/vector-im/element-web/pull/17239)
+   [\#17239](https://github.com/element-hq/element-web/pull/17239)
  * Remove "in development" flag from voice messages labs documentation
-   [\#17204](https://github.com/vector-im/element-web/pull/17204)
+   [\#17204](https://github.com/element-hq/element-web/pull/17204)
  * Add required webpack+jest config to load Safari support modules
-   [\#17193](https://github.com/vector-im/element-web/pull/17193)
+   [\#17193](https://github.com/element-hq/element-web/pull/17193)
 
-Changes in [1.7.28](https://github.com/vector-im/element-web/releases/tag/v1.7.28) (2021-05-17)
+Changes in [1.7.28](https://github.com/element-hq/element-web/releases/tag/v1.7.28) (2021-05-17)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.28-rc.1...v1.7.28)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.28-rc.1...v1.7.28)
 
 ## Security notice
 
@@ -4022,173 +4022,173 @@ this via Matrix's Security Disclosure Policy.
 
  * Upgrade to React SDK 3.21.0 and JS SDK 11.0.0
 
-Changes in [1.7.28-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.28-rc.1) (2021-05-11)
+Changes in [1.7.28-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.28-rc.1) (2021-05-11)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.27...v1.7.28-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.27...v1.7.28-rc.1)
 
  * Upgrade to React SDK 3.21.0-rc.1 and JS SDK 11.0.0-rc.1
  * Switch back to release version of `sanitize-html`
-   [\#17231](https://github.com/vector-im/element-web/pull/17231)
+   [\#17231](https://github.com/element-hq/element-web/pull/17231)
  * Bump url-parse from 1.4.7 to 1.5.1
-   [\#17199](https://github.com/vector-im/element-web/pull/17199)
+   [\#17199](https://github.com/element-hq/element-web/pull/17199)
  * Bump lodash from 4.17.20 to 4.17.21
-   [\#17205](https://github.com/vector-im/element-web/pull/17205)
+   [\#17205](https://github.com/element-hq/element-web/pull/17205)
  * Bump hosted-git-info from 2.8.8 to 2.8.9
-   [\#17219](https://github.com/vector-im/element-web/pull/17219)
+   [\#17219](https://github.com/element-hq/element-web/pull/17219)
  * Disable host checking on the webpack dev server
-   [\#17194](https://github.com/vector-im/element-web/pull/17194)
+   [\#17194](https://github.com/element-hq/element-web/pull/17194)
  * Bump ua-parser-js from 0.7.23 to 0.7.24
-   [\#17190](https://github.com/vector-im/element-web/pull/17190)
+   [\#17190](https://github.com/element-hq/element-web/pull/17190)
 
-Changes in [1.7.27](https://github.com/vector-im/element-web/releases/tag/v1.7.27) (2021-05-10)
+Changes in [1.7.27](https://github.com/element-hq/element-web/releases/tag/v1.7.27) (2021-05-10)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.27-rc.1...v1.7.27)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.27-rc.1...v1.7.27)
 
  * Upgrade to React SDK 3.20.0 and JS SDK 10.1.0
 
-Changes in [1.7.27-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.27-rc.1) (2021-05-04)
+Changes in [1.7.27-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.27-rc.1) (2021-05-04)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.26...v1.7.27-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.26...v1.7.27-rc.1)
 
  * Upgrade to React SDK 3.20.0-rc.1 and JS SDK 10.1.0-rc.1
  * Translations update from Weblate
-   [\#17160](https://github.com/vector-im/element-web/pull/17160)
+   [\#17160](https://github.com/element-hq/element-web/pull/17160)
  * Document option for obeying asserted identity
-   [\#17008](https://github.com/vector-im/element-web/pull/17008)
+   [\#17008](https://github.com/element-hq/element-web/pull/17008)
  * Implement IPC call to Electron to set language
-   [\#17052](https://github.com/vector-im/element-web/pull/17052)
+   [\#17052](https://github.com/element-hq/element-web/pull/17052)
  * Convert Vector skin react components to Typescript
-   [\#17061](https://github.com/vector-im/element-web/pull/17061)
+   [\#17061](https://github.com/element-hq/element-web/pull/17061)
  * Add code quality review policy
-   [\#16980](https://github.com/vector-im/element-web/pull/16980)
+   [\#16980](https://github.com/element-hq/element-web/pull/16980)
  * Register RecorderWorklet from react-sdk
-   [\#17013](https://github.com/vector-im/element-web/pull/17013)
+   [\#17013](https://github.com/element-hq/element-web/pull/17013)
  * Preload Inter font to avoid FOIT on slow connections
-   [\#17039](https://github.com/vector-im/element-web/pull/17039)
+   [\#17039](https://github.com/element-hq/element-web/pull/17039)
  * Disable `postcss-calc`'s noisy `warnWhenCannotResolve` option
-   [\#17041](https://github.com/vector-im/element-web/pull/17041)
+   [\#17041](https://github.com/element-hq/element-web/pull/17041)
 
-Changes in [1.7.26](https://github.com/vector-im/element-web/releases/tag/v1.7.26) (2021-04-26)
+Changes in [1.7.26](https://github.com/element-hq/element-web/releases/tag/v1.7.26) (2021-04-26)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.26-rc.1...v1.7.26)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.26-rc.1...v1.7.26)
 
  * Upgrade to React SDK 3.19.0 and JS SDK 10.0.0
 
-Changes in [1.7.26-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.26-rc.1) (2021-04-21)
+Changes in [1.7.26-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.26-rc.1) (2021-04-21)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.25...v1.7.26-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.25...v1.7.26-rc.1)
 
  * Upgrade to React SDK 3.19.0-rc.1 and JS SDK 10.0.0-rc.1
  * Translations update from Weblate
-   [\#17031](https://github.com/vector-im/element-web/pull/17031)
+   [\#17031](https://github.com/element-hq/element-web/pull/17031)
  * Bump ssri from 6.0.1 to 6.0.2
-   [\#17010](https://github.com/vector-im/element-web/pull/17010)
+   [\#17010](https://github.com/element-hq/element-web/pull/17010)
  * Fix `NODE_ENV` value for CI environments
-   [\#17003](https://github.com/vector-im/element-web/pull/17003)
+   [\#17003](https://github.com/element-hq/element-web/pull/17003)
  * Use React production mode in CI builds
-   [\#16969](https://github.com/vector-im/element-web/pull/16969)
+   [\#16969](https://github.com/element-hq/element-web/pull/16969)
  * Labs documentation for DND mode
-   [\#16962](https://github.com/vector-im/element-web/pull/16962)
+   [\#16962](https://github.com/element-hq/element-web/pull/16962)
  * Rename blackboxing to new option ignore list
-   [\#16965](https://github.com/vector-im/element-web/pull/16965)
+   [\#16965](https://github.com/element-hq/element-web/pull/16965)
  * Remove velocity-animate from lockfile
-   [\#16963](https://github.com/vector-im/element-web/pull/16963)
+   [\#16963](https://github.com/element-hq/element-web/pull/16963)
  * Add mobile download link configuration
-   [\#16890](https://github.com/vector-im/element-web/pull/16890)
+   [\#16890](https://github.com/element-hq/element-web/pull/16890)
  * Switch develop to not-staging Scalar by default
-   [\#16883](https://github.com/vector-im/element-web/pull/16883)
+   [\#16883](https://github.com/element-hq/element-web/pull/16883)
  * Support a config option to skip login/welcome and go to SSO
-   [\#16880](https://github.com/vector-im/element-web/pull/16880)
+   [\#16880](https://github.com/element-hq/element-web/pull/16880)
 
-Changes in [1.7.25](https://github.com/vector-im/element-web/releases/tag/v1.7.25) (2021-04-12)
+Changes in [1.7.25](https://github.com/element-hq/element-web/releases/tag/v1.7.25) (2021-04-12)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.25-rc.1...v1.7.25)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.25-rc.1...v1.7.25)
 
  * Upgrade to React SDK 3.18.0 and JS SDK 9.11.0
 
-Changes in [1.7.25-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.25-rc.1) (2021-04-07)
+Changes in [1.7.25-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.25-rc.1) (2021-04-07)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.24...v1.7.25-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.24...v1.7.25-rc.1)
 
  * Upgrade to React SDK 3.18.0-rc.1 and JS SDK 9.11.0-rc.1
  * Translations update from Weblate
-   [\#16882](https://github.com/vector-im/element-web/pull/16882)
+   [\#16882](https://github.com/element-hq/element-web/pull/16882)
  * Revert "Docker image: serve pre-compressed assets using gzip_static"
-   [\#16838](https://github.com/vector-im/element-web/pull/16838)
+   [\#16838](https://github.com/element-hq/element-web/pull/16838)
  * Move native node modules documentation to element-desktop
-   [\#16814](https://github.com/vector-im/element-web/pull/16814)
+   [\#16814](https://github.com/element-hq/element-web/pull/16814)
  * Add user settings for warn before exit
-   [\#16781](https://github.com/vector-im/element-web/pull/16781)
+   [\#16781](https://github.com/element-hq/element-web/pull/16781)
  * Change ISSUE_TEMPLATE bold lines to proper headers
-   [\#16768](https://github.com/vector-im/element-web/pull/16768)
+   [\#16768](https://github.com/element-hq/element-web/pull/16768)
  * Add example for deployment into Kubernetes
-   [\#16447](https://github.com/vector-im/element-web/pull/16447)
+   [\#16447](https://github.com/element-hq/element-web/pull/16447)
  * Create bare-bones `PULL_REQUEST_TEMPLATE.md`
-   [\#16770](https://github.com/vector-im/element-web/pull/16770)
+   [\#16770](https://github.com/element-hq/element-web/pull/16770)
  * Add webpack config and labs flag docs for voice messages
-   [\#16705](https://github.com/vector-im/element-web/pull/16705)
+   [\#16705](https://github.com/element-hq/element-web/pull/16705)
 
-Changes in [1.7.24](https://github.com/vector-im/element-web/releases/tag/v1.7.24) (2021-03-29)
+Changes in [1.7.24](https://github.com/element-hq/element-web/releases/tag/v1.7.24) (2021-03-29)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.24-rc.1...v1.7.24)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.24-rc.1...v1.7.24)
 
  * Upgrade to React SDK 3.17.0 and JS SDK 9.10.0
 
-Changes in [1.7.24-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.24-rc.1) (2021-03-25)
+Changes in [1.7.24-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.24-rc.1) (2021-03-25)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.23...v1.7.24-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.23...v1.7.24-rc.1)
 
  * Upgrade to React SDK 3.17.0-rc.2 and JS SDK 9.10.0-rc.1
  * Translations update from Weblate
-   [\#16766](https://github.com/vector-im/element-web/pull/16766)
+   [\#16766](https://github.com/element-hq/element-web/pull/16766)
  * Docker image: serve pre-compressed assets using gzip_static
-   [\#16698](https://github.com/vector-im/element-web/pull/16698)
+   [\#16698](https://github.com/element-hq/element-web/pull/16698)
  * Fix style lint issues
-   [\#16732](https://github.com/vector-im/element-web/pull/16732)
+   [\#16732](https://github.com/element-hq/element-web/pull/16732)
  * Updated expected webpack output in setup guide
-   [\#16740](https://github.com/vector-im/element-web/pull/16740)
+   [\#16740](https://github.com/element-hq/element-web/pull/16740)
  * Docs for `loginForWelcome`
-   [\#16468](https://github.com/vector-im/element-web/pull/16468)
+   [\#16468](https://github.com/element-hq/element-web/pull/16468)
  * Disable rageshake persistence if no logs would be submitted
-   [\#16697](https://github.com/vector-im/element-web/pull/16697)
+   [\#16697](https://github.com/element-hq/element-web/pull/16697)
 
-Changes in [1.7.23](https://github.com/vector-im/element-web/releases/tag/v1.7.23) (2021-03-15)
+Changes in [1.7.23](https://github.com/element-hq/element-web/releases/tag/v1.7.23) (2021-03-15)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.23-rc.1...v1.7.23)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.23-rc.1...v1.7.23)
 
  * Upgrade to React SDK 3.16.0 and JS SDK 9.9.0
 
-Changes in [1.7.23-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.23-rc.1) (2021-03-10)
+Changes in [1.7.23-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.23-rc.1) (2021-03-10)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.22...v1.7.23-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.22...v1.7.23-rc.1)
 
  * Upgrade to React SDK 3.16.0-rc.2 and JS SDK 9.9.0-rc.1
  * Translations update from Weblate
-   [\#16655](https://github.com/vector-im/element-web/pull/16655)
+   [\#16655](https://github.com/element-hq/element-web/pull/16655)
  * Improve docs for customisations
-   [\#16652](https://github.com/vector-im/element-web/pull/16652)
+   [\#16652](https://github.com/element-hq/element-web/pull/16652)
  * Update triage guide to match the new label scheme
-   [\#16612](https://github.com/vector-im/element-web/pull/16612)
+   [\#16612](https://github.com/element-hq/element-web/pull/16612)
  * Remove a couple useless 'use strict' calls
-   [\#16650](https://github.com/vector-im/element-web/pull/16650)
+   [\#16650](https://github.com/element-hq/element-web/pull/16650)
  * Remove old conferencing doc
-   [\#16648](https://github.com/vector-im/element-web/pull/16648)
+   [\#16648](https://github.com/element-hq/element-web/pull/16648)
  * Bump elliptic from 6.5.3 to 6.5.4
-   [\#16644](https://github.com/vector-im/element-web/pull/16644)
+   [\#16644](https://github.com/element-hq/element-web/pull/16644)
  * Add option for audio live streaming
-   [\#16604](https://github.com/vector-im/element-web/pull/16604)
+   [\#16604](https://github.com/element-hq/element-web/pull/16604)
  * Update velocity-animate dependency
-   [\#16605](https://github.com/vector-im/element-web/pull/16605)
+   [\#16605](https://github.com/element-hq/element-web/pull/16605)
  * Add Edge to the supported tier
-   [\#16611](https://github.com/vector-im/element-web/pull/16611)
+   [\#16611](https://github.com/element-hq/element-web/pull/16611)
  * Add multi language spell check
-   [\#15851](https://github.com/vector-im/element-web/pull/15851)
+   [\#15851](https://github.com/element-hq/element-web/pull/15851)
  * Document feature_spaces
-   [\#16538](https://github.com/vector-im/element-web/pull/16538)
+   [\#16538](https://github.com/element-hq/element-web/pull/16538)
 
-Changes in [1.7.22](https://github.com/vector-im/element-web/releases/tag/v1.7.22) (2021-03-01)
+Changes in [1.7.22](https://github.com/element-hq/element-web/releases/tag/v1.7.22) (2021-03-01)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.22-rc.1...v1.7.22)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.22-rc.1...v1.7.22)
 
 ## Security notice
 
@@ -4203,395 +4203,395 @@ possible for a malicious document to access user messages and secrets. Thanks to
 
  * Upgrade to React SDK 3.15.0 and JS SDK 9.8.0
 
-Changes in [1.7.22-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.22-rc.1) (2021-02-24)
+Changes in [1.7.22-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.22-rc.1) (2021-02-24)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.21...v1.7.22-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.21...v1.7.22-rc.1)
 
  * Upgrade to React SDK 3.15.0-rc.1 and JS SDK 9.8.0-rc.1
  * Translations update from Weblate
-   [\#16529](https://github.com/vector-im/element-web/pull/16529)
+   [\#16529](https://github.com/element-hq/element-web/pull/16529)
  * Add hostSignup config for element.io clients
-   [\#16515](https://github.com/vector-im/element-web/pull/16515)
+   [\#16515](https://github.com/element-hq/element-web/pull/16515)
  * VoIP virtual rooms, mkII
-   [\#16442](https://github.com/vector-im/element-web/pull/16442)
+   [\#16442](https://github.com/element-hq/element-web/pull/16442)
  * Jitsi widget: Read room name from query parameters
-   [\#16456](https://github.com/vector-im/element-web/pull/16456)
+   [\#16456](https://github.com/element-hq/element-web/pull/16456)
  * fix / sso: make sure to delete only loginToken after redirect
-   [\#16415](https://github.com/vector-im/element-web/pull/16415)
+   [\#16415](https://github.com/element-hq/element-web/pull/16415)
  * Disable Countly
-   [\#16433](https://github.com/vector-im/element-web/pull/16433)
+   [\#16433](https://github.com/element-hq/element-web/pull/16433)
 
-Changes in [1.7.21](https://github.com/vector-im/element-web/releases/tag/v1.7.21) (2021-02-16)
+Changes in [1.7.21](https://github.com/element-hq/element-web/releases/tag/v1.7.21) (2021-02-16)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.21-rc.1...v1.7.21)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.21-rc.1...v1.7.21)
 
  * Upgrade to React SDK 3.14.0 and JS SDK 9.7.0
 
-Changes in [1.7.21-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.21-rc.1) (2021-02-10)
+Changes in [1.7.21-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.21-rc.1) (2021-02-10)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.20...v1.7.21-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.20...v1.7.21-rc.1)
 
  * Upgrade to React SDK 3.14.0-rc.1 and JS SDK 9.7.0-rc.1
  * Translations update from Weblate
-   [\#16427](https://github.com/vector-im/element-web/pull/16427)
+   [\#16427](https://github.com/element-hq/element-web/pull/16427)
  * Add RegExp dotAll feature test
-   [\#16408](https://github.com/vector-im/element-web/pull/16408)
+   [\#16408](https://github.com/element-hq/element-web/pull/16408)
  * Fix Electron type merging
-   [\#16405](https://github.com/vector-im/element-web/pull/16405)
+   [\#16405](https://github.com/element-hq/element-web/pull/16405)
  * README: remove Jenkins reference
-   [\#16381](https://github.com/vector-im/element-web/pull/16381)
+   [\#16381](https://github.com/element-hq/element-web/pull/16381)
  * Enable PostCSS Calc in webpack builds
-   [\#16307](https://github.com/vector-im/element-web/pull/16307)
+   [\#16307](https://github.com/element-hq/element-web/pull/16307)
  * Add configuration security best practices to the README.
-   [\#16367](https://github.com/vector-im/element-web/pull/16367)
+   [\#16367](https://github.com/element-hq/element-web/pull/16367)
  * Upgrade matrix-widget-api
-   [\#16347](https://github.com/vector-im/element-web/pull/16347)
+   [\#16347](https://github.com/element-hq/element-web/pull/16347)
 
-Changes in [1.7.20](https://github.com/vector-im/element-web/releases/tag/v1.7.20) (2021-02-04)
+Changes in [1.7.20](https://github.com/element-hq/element-web/releases/tag/v1.7.20) (2021-02-04)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.19...v1.7.20)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.19...v1.7.20)
 
  * Upgrade to React SDK 3.13.1
 
-Changes in [1.7.19](https://github.com/vector-im/element-web/releases/tag/v1.7.19) (2021-02-03)
+Changes in [1.7.19](https://github.com/element-hq/element-web/releases/tag/v1.7.19) (2021-02-03)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.19-rc.1...v1.7.19)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.19-rc.1...v1.7.19)
 
  * Upgrade to React SDK 3.13.0 and JS SDK 9.6.0
  * [Release] Upgrade matrix-widget-api
-   [\#16348](https://github.com/vector-im/element-web/pull/16348)
+   [\#16348](https://github.com/element-hq/element-web/pull/16348)
 
-Changes in [1.7.19-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.19-rc.1) (2021-01-29)
+Changes in [1.7.19-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.19-rc.1) (2021-01-29)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.18...v1.7.19-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.18...v1.7.19-rc.1)
 
  * Upgrade to React SDK 3.13.0-rc.1 and JS SDK 9.6.0-rc.1
  * Translations update from Weblate
-   [\#16314](https://github.com/vector-im/element-web/pull/16314)
+   [\#16314](https://github.com/element-hq/element-web/pull/16314)
  * Use history replaceState instead of redirect for SSO flow
-   [\#16292](https://github.com/vector-im/element-web/pull/16292)
+   [\#16292](https://github.com/element-hq/element-web/pull/16292)
  * Document the mobile guide toast option
-   [\#16301](https://github.com/vector-im/element-web/pull/16301)
+   [\#16301](https://github.com/element-hq/element-web/pull/16301)
  * Update widget-api to beta.12
-   [\#16303](https://github.com/vector-im/element-web/pull/16303)
+   [\#16303](https://github.com/element-hq/element-web/pull/16303)
  * Upgrade deps 2021-01
-   [\#16294](https://github.com/vector-im/element-web/pull/16294)
+   [\#16294](https://github.com/element-hq/element-web/pull/16294)
  * Move to newer base image for Docker builds
-   [\#16275](https://github.com/vector-im/element-web/pull/16275)
+   [\#16275](https://github.com/element-hq/element-web/pull/16275)
  * Docs for the VoIP translate pattern option
-   [\#16236](https://github.com/vector-im/element-web/pull/16236)
+   [\#16236](https://github.com/element-hq/element-web/pull/16236)
  * Fix Riot->Element in permalinkPrefix docs
-   [\#16227](https://github.com/vector-im/element-web/pull/16227)
+   [\#16227](https://github.com/element-hq/element-web/pull/16227)
  * Supply server_name for optional federation-capable Jitsi auth
-   [\#16215](https://github.com/vector-im/element-web/pull/16215)
+   [\#16215](https://github.com/element-hq/element-web/pull/16215)
  * Fix Widget API version confusion
-   [\#16212](https://github.com/vector-im/element-web/pull/16212)
+   [\#16212](https://github.com/element-hq/element-web/pull/16212)
  * Add Hebrew language
-   [\#16210](https://github.com/vector-im/element-web/pull/16210)
+   [\#16210](https://github.com/element-hq/element-web/pull/16210)
  * Update widget-api to beta 11
-   [\#16177](https://github.com/vector-im/element-web/pull/16177)
+   [\#16177](https://github.com/element-hq/element-web/pull/16177)
  * Fix develop Docker builds
-   [\#16192](https://github.com/vector-im/element-web/pull/16192)
+   [\#16192](https://github.com/element-hq/element-web/pull/16192)
  * Skip the service worker for Electron
-   [\#16157](https://github.com/vector-im/element-web/pull/16157)
+   [\#16157](https://github.com/element-hq/element-web/pull/16157)
  * Use isolated IPC API
-   [\#16137](https://github.com/vector-im/element-web/pull/16137)
+   [\#16137](https://github.com/element-hq/element-web/pull/16137)
 
-Changes in [1.7.18](https://github.com/vector-im/element-web/releases/tag/v1.7.18) (2021-01-26)
+Changes in [1.7.18](https://github.com/element-hq/element-web/releases/tag/v1.7.18) (2021-01-26)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.17...v1.7.18)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.17...v1.7.18)
 
  * Upgrade to React SDK 3.12.1 and JS SDK 9.5.1
 
-Changes in [1.7.17](https://github.com/vector-im/element-web/releases/tag/v1.7.17) (2021-01-18)
+Changes in [1.7.17](https://github.com/element-hq/element-web/releases/tag/v1.7.17) (2021-01-18)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.17-rc.1...v1.7.17)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.17-rc.1...v1.7.17)
 
  * Upgrade to React SDK 3.12.0 and JS SDK 9.5.0
 
-Changes in [1.7.17-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.17-rc.1) (2021-01-13)
+Changes in [1.7.17-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.17-rc.1) (2021-01-13)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.16...v1.7.17-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.16...v1.7.17-rc.1)
 
  * Upgrade to React SDK 3.12.0-rc.1 and JS SDK 9.5.0-rc.1
  * Translations update from Weblate
-   [\#16131](https://github.com/vector-im/element-web/pull/16131)
+   [\#16131](https://github.com/element-hq/element-web/pull/16131)
  * webplatform: Fix notification closing
-   [\#16028](https://github.com/vector-im/element-web/pull/16028)
+   [\#16028](https://github.com/element-hq/element-web/pull/16028)
  * Stop building code and types for Element layer
-   [\#15999](https://github.com/vector-im/element-web/pull/15999)
+   [\#15999](https://github.com/element-hq/element-web/pull/15999)
 
-Changes in [1.7.16](https://github.com/vector-im/element-web/releases/tag/v1.7.16) (2020-12-21)
+Changes in [1.7.16](https://github.com/element-hq/element-web/releases/tag/v1.7.16) (2020-12-21)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.16-rc.1...v1.7.16)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.16-rc.1...v1.7.16)
 
  * Upgrade to React SDK 3.11.1 and JS SDK 9.4.1
 
-Changes in [1.7.16-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.16-rc.1) (2020-12-16)
+Changes in [1.7.16-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.16-rc.1) (2020-12-16)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.15...v1.7.16-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.15...v1.7.16-rc.1)
 
  * Upgrade to React SDK 3.11.0-rc.2 and JS SDK 9.4.0-rc.2
  * Translations update from Weblate
-   [\#15979](https://github.com/vector-im/element-web/pull/15979)
+   [\#15979](https://github.com/element-hq/element-web/pull/15979)
  * Bump ini from 1.3.5 to 1.3.7
-   [\#15949](https://github.com/vector-im/element-web/pull/15949)
+   [\#15949](https://github.com/element-hq/element-web/pull/15949)
  * Document pull request previews
-   [\#15937](https://github.com/vector-im/element-web/pull/15937)
+   [\#15937](https://github.com/element-hq/element-web/pull/15937)
  * Improve asset path for KaTeX fonts
-   [\#15939](https://github.com/vector-im/element-web/pull/15939)
+   [\#15939](https://github.com/element-hq/element-web/pull/15939)
  * Fix an important semicolon
-   [\#15912](https://github.com/vector-im/element-web/pull/15912)
+   [\#15912](https://github.com/element-hq/element-web/pull/15912)
  * Bump highlight.js from 10.1.2 to 10.4.1
-   [\#15898](https://github.com/vector-im/element-web/pull/15898)
+   [\#15898](https://github.com/element-hq/element-web/pull/15898)
  * Add gitter.im to room directory
-   [\#15894](https://github.com/vector-im/element-web/pull/15894)
+   [\#15894](https://github.com/element-hq/element-web/pull/15894)
  * Extend Platform to support idpId for SSO flows
-   [\#15771](https://github.com/vector-im/element-web/pull/15771)
+   [\#15771](https://github.com/element-hq/element-web/pull/15771)
  * Include KaTeX CSS as a dependency
-   [\#15843](https://github.com/vector-im/element-web/pull/15843)
+   [\#15843](https://github.com/element-hq/element-web/pull/15843)
 
-Changes in [1.7.15](https://github.com/vector-im/element-web/releases/tag/v1.7.15) (2020-12-07)
+Changes in [1.7.15](https://github.com/element-hq/element-web/releases/tag/v1.7.15) (2020-12-07)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.15-rc.1...v1.7.15)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.15-rc.1...v1.7.15)
 
  * Upgrade to React SDK 3.10.0 and JS SDK 9.3.0
 
-Changes in [1.7.15-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.15-rc.1) (2020-12-02)
+Changes in [1.7.15-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.15-rc.1) (2020-12-02)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.14...v1.7.15-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.14...v1.7.15-rc.1)
 
  * Upgrade to React SDK 3.10.0-rc.1 and JS SDK 9.3.0-rc.1
  * Include KaTeX CSS as a dependency
-   [\#15843](https://github.com/vector-im/element-web/pull/15843)
+   [\#15843](https://github.com/element-hq/element-web/pull/15843)
  * Translations update from Weblate
-   [\#15884](https://github.com/vector-im/element-web/pull/15884)
+   [\#15884](https://github.com/element-hq/element-web/pull/15884)
  * added katex.min.css to webpack for math support (main PR in matrix-react-
    sdk)
-   [\#15277](https://github.com/vector-im/element-web/pull/15277)
+   [\#15277](https://github.com/element-hq/element-web/pull/15277)
  * Rebrand package name and other details
-   [\#15828](https://github.com/vector-im/element-web/pull/15828)
+   [\#15828](https://github.com/element-hq/element-web/pull/15828)
  * Bump highlight.js from 9.18.1 to 10.1.2
-   [\#15819](https://github.com/vector-im/element-web/pull/15819)
+   [\#15819](https://github.com/element-hq/element-web/pull/15819)
  * Update branding of packaging artifacts
-   [\#15810](https://github.com/vector-im/element-web/pull/15810)
+   [\#15810](https://github.com/element-hq/element-web/pull/15810)
  * Update the react-sdk reference in the lockfile
-   [\#15814](https://github.com/vector-im/element-web/pull/15814)
+   [\#15814](https://github.com/element-hq/element-web/pull/15814)
  * Update widget API for good measure in Element Web
-   [\#15812](https://github.com/vector-im/element-web/pull/15812)
+   [\#15812](https://github.com/element-hq/element-web/pull/15812)
  * Stop publishing Element to NPM
-   [\#15811](https://github.com/vector-im/element-web/pull/15811)
+   [\#15811](https://github.com/element-hq/element-web/pull/15811)
  * Add inotify instance limit info to README
-   [\#15795](https://github.com/vector-im/element-web/pull/15795)
+   [\#15795](https://github.com/element-hq/element-web/pull/15795)
 
-Changes in [1.7.14](https://github.com/vector-im/element-web/releases/tag/v1.7.14) (2020-11-23)
+Changes in [1.7.14](https://github.com/element-hq/element-web/releases/tag/v1.7.14) (2020-11-23)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.14-rc.1...v1.7.14)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.14-rc.1...v1.7.14)
 
  * Upgrade to React SDK 3.9.0 and JS SDK 9.2.0
 
-Changes in [1.7.14-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.14-rc.1) (2020-11-18)
+Changes in [1.7.14-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.14-rc.1) (2020-11-18)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.13...v1.7.14-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.13...v1.7.14-rc.1)
 
  * Upgrade to React SDK 3.9.0-rc.1 and JS SDK 9.2.0-rc.1
  * Translations update from Weblate
-   [\#15767](https://github.com/vector-im/element-web/pull/15767)
+   [\#15767](https://github.com/element-hq/element-web/pull/15767)
  * Update the widget-api for element-web
-   [\#15717](https://github.com/vector-im/element-web/pull/15717)
+   [\#15717](https://github.com/element-hq/element-web/pull/15717)
 
-Changes in [1.7.13](https://github.com/vector-im/element-web/releases/tag/v1.7.13) (2020-11-09)
+Changes in [1.7.13](https://github.com/element-hq/element-web/releases/tag/v1.7.13) (2020-11-09)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.13-rc.1...v1.7.13)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.13-rc.1...v1.7.13)
 
  * Upgrade to React SDK 3.8.0 and JS SDK 9.1.0
 
-Changes in [1.7.13-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.13-rc.1) (2020-11-04)
+Changes in [1.7.13-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.13-rc.1) (2020-11-04)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.12...v1.7.13-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.12...v1.7.13-rc.1)
 
  * Upgrade to React SDK 3.8.0-rc.1 and JS SDK 9.1.0-rc.1
  * Translations update from Weblate
-   [\#15644](https://github.com/vector-im/element-web/pull/15644)
+   [\#15644](https://github.com/element-hq/element-web/pull/15644)
  * Add countly experiment to develop/nightly configs
-   [\#15614](https://github.com/vector-im/element-web/pull/15614)
+   [\#15614](https://github.com/element-hq/element-web/pull/15614)
  * Add documentation for new UIFeature flag regarding room history settings
-   [\#15592](https://github.com/vector-im/element-web/pull/15592)
+   [\#15592](https://github.com/element-hq/element-web/pull/15592)
  * Rename Docker repo in docs
-   [\#15590](https://github.com/vector-im/element-web/pull/15590)
+   [\#15590](https://github.com/element-hq/element-web/pull/15590)
  * Fix Jitsi regressions with custom themes
-   [\#15575](https://github.com/vector-im/element-web/pull/15575)
+   [\#15575](https://github.com/element-hq/element-web/pull/15575)
 
-Changes in [1.7.12](https://github.com/vector-im/element-web/releases/tag/v1.7.12) (2020-10-28)
+Changes in [1.7.12](https://github.com/element-hq/element-web/releases/tag/v1.7.12) (2020-10-28)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.11...v1.7.12)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.11...v1.7.12)
 
  * Upgrade to React SDK 3.7.1 and JS SDK 9.0.1
  * [Release] Fix Jitsi regressions with custom themes
-   [\#15577](https://github.com/vector-im/element-web/pull/15577)
+   [\#15577](https://github.com/element-hq/element-web/pull/15577)
 
-Changes in [1.7.11](https://github.com/vector-im/element-web/releases/tag/v1.7.11) (2020-10-26)
+Changes in [1.7.11](https://github.com/element-hq/element-web/releases/tag/v1.7.11) (2020-10-26)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.11-rc.1...v1.7.11)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.11-rc.1...v1.7.11)
 
  * Upgrade to React SDK 3.7.0 and JS SDK 9.0.0
 
-Changes in [1.7.11-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.11-rc.1) (2020-10-21)
+Changes in [1.7.11-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.11-rc.1) (2020-10-21)
 =========================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.10...v1.7.11-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.10...v1.7.11-rc.1)
 
  * Upgrade to React SDK 3.7.0-rc.2 and JS SDK 9.0.0-rc.1
  * Update Weblate URL
-   [\#15516](https://github.com/vector-im/element-web/pull/15516)
+   [\#15516](https://github.com/element-hq/element-web/pull/15516)
  * Translations update from Weblate
-   [\#15517](https://github.com/vector-im/element-web/pull/15517)
+   [\#15517](https://github.com/element-hq/element-web/pull/15517)
  * Jitsi accept theme variable and restyle
-   [\#15499](https://github.com/vector-im/element-web/pull/15499)
+   [\#15499](https://github.com/element-hq/element-web/pull/15499)
  * Skip editor confirmation of upgrades
-   [\#15506](https://github.com/vector-im/element-web/pull/15506)
+   [\#15506](https://github.com/element-hq/element-web/pull/15506)
  * Adjust for new widget messaging APIs
-   [\#15495](https://github.com/vector-im/element-web/pull/15495)
+   [\#15495](https://github.com/element-hq/element-web/pull/15495)
  * Use HTTPS_PROXY environment variable for downloading external_api.min…
-   [\#15479](https://github.com/vector-im/element-web/pull/15479)
+   [\#15479](https://github.com/element-hq/element-web/pull/15479)
  * Document customisation points
-   [\#15475](https://github.com/vector-im/element-web/pull/15475)
+   [\#15475](https://github.com/element-hq/element-web/pull/15475)
  * Don't fatally end the Jitsi widget when it's not being used as a widget
-   [\#15466](https://github.com/vector-im/element-web/pull/15466)
+   [\#15466](https://github.com/element-hq/element-web/pull/15466)
  * electron-platform: Pass the user/devce id pair when initializing the event
    index.
-   [\#15455](https://github.com/vector-im/element-web/pull/15455)
+   [\#15455](https://github.com/element-hq/element-web/pull/15455)
 
-Changes in [1.7.10](https://github.com/vector-im/element-web/releases/tag/v1.7.10) (2020-10-20)
+Changes in [1.7.10](https://github.com/element-hq/element-web/releases/tag/v1.7.10) (2020-10-20)
 ===============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.9...v1.7.10)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.9...v1.7.10)
 
  * [Release] Adjust for new widget messaging APIs
-   [\#15497](https://github.com/vector-im/element-web/pull/15497)
+   [\#15497](https://github.com/element-hq/element-web/pull/15497)
  * Upgrade to React SDK 3.6.1
 
-Changes in [1.7.9](https://github.com/vector-im/element-web/releases/tag/v1.7.9) (2020-10-12)
+Changes in [1.7.9](https://github.com/element-hq/element-web/releases/tag/v1.7.9) (2020-10-12)
 =============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.9-rc.1...v1.7.9)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.9-rc.1...v1.7.9)
 
  * Upgrade to React SDK 3.6.0 and JS SDK 8.5.0
 
-Changes in [1.7.9-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.9-rc.1) (2020-10-07)
+Changes in [1.7.9-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.9-rc.1) (2020-10-07)
 =======================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.8...v1.7.9-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.8...v1.7.9-rc.1)
 
  * Upgrade to React SDK 3.6.0-rc.1 and JS SDK 8.5.0-rc.1
  * Update from Weblate
-   [\#15406](https://github.com/vector-im/element-web/pull/15406)
+   [\#15406](https://github.com/element-hq/element-web/pull/15406)
  * Update Jest and JSDOM
-   [\#15402](https://github.com/vector-im/element-web/pull/15402)
+   [\#15402](https://github.com/element-hq/element-web/pull/15402)
  * Add support for dehydration/fallback keys
-   [\#15398](https://github.com/vector-im/element-web/pull/15398)
+   [\#15398](https://github.com/element-hq/element-web/pull/15398)
  * Remove riot-bot from sample config
-   [\#15376](https://github.com/vector-im/element-web/pull/15376)
+   [\#15376](https://github.com/element-hq/element-web/pull/15376)
  * Switch to using the Widget API SDK for Jitsi widgets
-   [\#15102](https://github.com/vector-im/element-web/pull/15102)
+   [\#15102](https://github.com/element-hq/element-web/pull/15102)
  * Remove workbox
-   [\#15352](https://github.com/vector-im/element-web/pull/15352)
+   [\#15352](https://github.com/element-hq/element-web/pull/15352)
  * Disable workbox when running in webpack dev server, not in dev mode
-   [\#15345](https://github.com/vector-im/element-web/pull/15345)
+   [\#15345](https://github.com/element-hq/element-web/pull/15345)
  * Update Riot -> Element in contribute.json
-   [\#15326](https://github.com/vector-im/element-web/pull/15326)
+   [\#15326](https://github.com/element-hq/element-web/pull/15326)
  * Update Riot -> Element in redeploy.py
-   [\#15336](https://github.com/vector-im/element-web/pull/15336)
+   [\#15336](https://github.com/element-hq/element-web/pull/15336)
  * Update Riot -> Element in docs/feature-flags.md
-   [\#15325](https://github.com/vector-im/element-web/pull/15325)
+   [\#15325](https://github.com/element-hq/element-web/pull/15325)
  * Update Riot -> Element in element.io/README.md
-   [\#15327](https://github.com/vector-im/element-web/pull/15327)
+   [\#15327](https://github.com/element-hq/element-web/pull/15327)
  * Update Riot -> Element in VectorAuthFooter
-   [\#15328](https://github.com/vector-im/element-web/pull/15328)
+   [\#15328](https://github.com/element-hq/element-web/pull/15328)
  * Update Riot -> Element in VectorEmbeddedPage
-   [\#15329](https://github.com/vector-im/element-web/pull/15329)
+   [\#15329](https://github.com/element-hq/element-web/pull/15329)
  * Update Riot -> Element in docs/review.md
-   [\#15330](https://github.com/vector-im/element-web/pull/15330)
+   [\#15330](https://github.com/element-hq/element-web/pull/15330)
  * Update Riot -> Element in welcome.html
-   [\#15332](https://github.com/vector-im/element-web/pull/15332)
+   [\#15332](https://github.com/element-hq/element-web/pull/15332)
  * Update Riot -> Element in issues-burndown.pl
-   [\#15333](https://github.com/vector-im/element-web/pull/15333)
+   [\#15333](https://github.com/element-hq/element-web/pull/15333)
  * Update Riot -> Element in redeploy.py
-   [\#15334](https://github.com/vector-im/element-web/pull/15334)
+   [\#15334](https://github.com/element-hq/element-web/pull/15334)
  * Update Riot -> Element in index.ts
-   [\#15335](https://github.com/vector-im/element-web/pull/15335)
+   [\#15335](https://github.com/element-hq/element-web/pull/15335)
  * Update Riot -> Element Web in issue templates
-   [\#15324](https://github.com/vector-im/element-web/pull/15324)
+   [\#15324](https://github.com/element-hq/element-web/pull/15324)
  * Give the Jitsi widget an icon to help with discovery
-   [\#15316](https://github.com/vector-im/element-web/pull/15316)
+   [\#15316](https://github.com/element-hq/element-web/pull/15316)
  * Jitsi widget wrapper updates for hangup button
-   [\#15219](https://github.com/vector-im/element-web/pull/15219)
+   [\#15219](https://github.com/element-hq/element-web/pull/15219)
  * Tidy up Service Worker, only run Workbox in production
-   [\#15271](https://github.com/vector-im/element-web/pull/15271)
+   [\#15271](https://github.com/element-hq/element-web/pull/15271)
  * Remove conference handler
-   [\#15274](https://github.com/vector-im/element-web/pull/15274)
+   [\#15274](https://github.com/element-hq/element-web/pull/15274)
  * Rebrand the webpack pipeline for Element
-   [\#15266](https://github.com/vector-im/element-web/pull/15266)
+   [\#15266](https://github.com/element-hq/element-web/pull/15266)
  * Replace dummy sw.js with pre-caching and runtime-caching workbox SW
-   [\#15196](https://github.com/vector-im/element-web/pull/15196)
+   [\#15196](https://github.com/element-hq/element-web/pull/15196)
 
-Changes in [1.7.8](https://github.com/vector-im/element-web/releases/tag/v1.7.8) (2020-09-28)
+Changes in [1.7.8](https://github.com/element-hq/element-web/releases/tag/v1.7.8) (2020-09-28)
 =============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.8-rc.1...v1.7.8)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.8-rc.1...v1.7.8)
 
  * Upgrade to React SDK 3.5.0 and JS SDK 8.4.1
 
-Changes in [1.7.8-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.8-rc.1) (2020-09-23)
+Changes in [1.7.8-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.8-rc.1) (2020-09-23)
 =======================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.7...v1.7.8-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.7...v1.7.8-rc.1)
 
  * Upgrade to React SDK 3.5.0-rc.1 and JS SDK 8.4.0-rc.1
  * Update from Weblate
-   [\#15262](https://github.com/vector-im/element-web/pull/15262)
+   [\#15262](https://github.com/element-hq/element-web/pull/15262)
  * Upgrade sanitize-html
-   [\#15260](https://github.com/vector-im/element-web/pull/15260)
+   [\#15260](https://github.com/element-hq/element-web/pull/15260)
  * Document config for preferring Secure Backup setup methods
-   [\#15251](https://github.com/vector-im/element-web/pull/15251)
+   [\#15251](https://github.com/element-hq/element-web/pull/15251)
  * Add end-user documentation for UI features
-   [\#15190](https://github.com/vector-im/element-web/pull/15190)
+   [\#15190](https://github.com/element-hq/element-web/pull/15190)
  * Update git checkout instructions
-   [\#15218](https://github.com/vector-im/element-web/pull/15218)
+   [\#15218](https://github.com/element-hq/element-web/pull/15218)
  * If no bug_report_endpoint_url, hide rageshaking from the App
-   [\#15201](https://github.com/vector-im/element-web/pull/15201)
+   [\#15201](https://github.com/element-hq/element-web/pull/15201)
  * Bump node-fetch from 2.6.0 to 2.6.1
-   [\#15153](https://github.com/vector-im/element-web/pull/15153)
+   [\#15153](https://github.com/element-hq/element-web/pull/15153)
  * Remove references to Travis CI
-   [\#15137](https://github.com/vector-im/element-web/pull/15137)
+   [\#15137](https://github.com/element-hq/element-web/pull/15137)
  * Fix onNewScreen to use replace when going from roomId->roomAlias
-   [\#15127](https://github.com/vector-im/element-web/pull/15127)
+   [\#15127](https://github.com/element-hq/element-web/pull/15127)
  * Enable Estonian in language menu
-   [\#15136](https://github.com/vector-im/element-web/pull/15136)
+   [\#15136](https://github.com/element-hq/element-web/pull/15136)
 
-Changes in [1.7.7](https://github.com/vector-im/element-web/releases/tag/v1.7.7) (2020-09-14)
+Changes in [1.7.7](https://github.com/element-hq/element-web/releases/tag/v1.7.7) (2020-09-14)
 =============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.6...v1.7.7)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.6...v1.7.7)
 
  * Upgrade to React SDK 3.4.1
 
-Changes in [1.7.6](https://github.com/vector-im/element-web/releases/tag/v1.7.6) (2020-09-14)
+Changes in [1.7.6](https://github.com/element-hq/element-web/releases/tag/v1.7.6) (2020-09-14)
 =============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.6-rc.1...v1.7.6)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.6-rc.1...v1.7.6)
 
  * Upgrade to React SDK 3.4.0 and JS SDK 8.3.0
 
-Changes in [1.7.6-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.6-rc.1) (2020-09-09)
+Changes in [1.7.6-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.6-rc.1) (2020-09-09)
 =======================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.5...v1.7.6-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.5...v1.7.6-rc.1)
 
  * Upgrade to React SDK 3.4.0-rc.1 and JS SDK 8.3.0-rc.1
  * Update from Weblate
-   [\#15125](https://github.com/vector-im/element-web/pull/15125)
+   [\#15125](https://github.com/element-hq/element-web/pull/15125)
  * Support usage of Jitsi widgets with "openidtoken-jwt" auth
-   [\#15114](https://github.com/vector-im/element-web/pull/15114)
+   [\#15114](https://github.com/element-hq/element-web/pull/15114)
  * Fix eslint ts override tsx matching and delint
-   [\#15064](https://github.com/vector-im/element-web/pull/15064)
+   [\#15064](https://github.com/element-hq/element-web/pull/15064)
  * Add testing to review guidelines
-   [\#15050](https://github.com/vector-im/element-web/pull/15050)
+   [\#15050](https://github.com/element-hq/element-web/pull/15050)
 
-Changes in [1.7.5](https://github.com/vector-im/element-web/releases/tag/v1.7.5) (2020-09-01)
+Changes in [1.7.5](https://github.com/element-hq/element-web/releases/tag/v1.7.5) (2020-09-01)
 =============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.5-rc.1...v1.7.5)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.5-rc.1...v1.7.5)
 
 ## Security notice
 
@@ -4603,62 +4603,62 @@ Security Disclosure Policy.
 
  * Upgrade to React SDK 3.3.0 and JS SDK 8.2.0
 
-Changes in [1.7.5-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.5-rc.1) (2020-08-26)
+Changes in [1.7.5-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.5-rc.1) (2020-08-26)
 =======================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.4...v1.7.5-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.4...v1.7.5-rc.1)
 
  * Upgrade to React SDK 3.3.0-rc.1 and JS SDK 8.2.0-rc.1
  * Update from Weblate
-   [\#15045](https://github.com/vector-im/element-web/pull/15045)
+   [\#15045](https://github.com/element-hq/element-web/pull/15045)
  * Document .well-known E2EE secure backup setting
-   [\#15003](https://github.com/vector-im/element-web/pull/15003)
+   [\#15003](https://github.com/element-hq/element-web/pull/15003)
  * Add docs for communities v2 prototyping feature flag
-   [\#15013](https://github.com/vector-im/element-web/pull/15013)
+   [\#15013](https://github.com/element-hq/element-web/pull/15013)
  * Update links in README.md to point to Element
-   [\#14973](https://github.com/vector-im/element-web/pull/14973)
+   [\#14973](https://github.com/element-hq/element-web/pull/14973)
  * Make kabyle translation available
-   [\#15027](https://github.com/vector-im/element-web/pull/15027)
+   [\#15027](https://github.com/element-hq/element-web/pull/15027)
  * Change Riot to Element in readme
-   [\#15016](https://github.com/vector-im/element-web/pull/15016)
+   [\#15016](https://github.com/element-hq/element-web/pull/15016)
  * Update links to element in the readme
-   [\#15014](https://github.com/vector-im/element-web/pull/15014)
+   [\#15014](https://github.com/element-hq/element-web/pull/15014)
  * Link to Element in F-Droid as well
-   [\#15002](https://github.com/vector-im/element-web/pull/15002)
+   [\#15002](https://github.com/element-hq/element-web/pull/15002)
  * Settings v3: Update documentation and configs for new feature flag behaviour
-   [\#14986](https://github.com/vector-im/element-web/pull/14986)
+   [\#14986](https://github.com/element-hq/element-web/pull/14986)
  * Update jitsi.md with Element Android details
-   [\#14952](https://github.com/vector-im/element-web/pull/14952)
+   [\#14952](https://github.com/element-hq/element-web/pull/14952)
  * TypeScript: enable es2019 lib for newer definitions
-   [\#14983](https://github.com/vector-im/element-web/pull/14983)
+   [\#14983](https://github.com/element-hq/element-web/pull/14983)
  * Add reaction preview labs flags to develop
-   [\#14979](https://github.com/vector-im/element-web/pull/14979)
+   [\#14979](https://github.com/element-hq/element-web/pull/14979)
  * Document new labs tweaks
-   [\#14958](https://github.com/vector-im/element-web/pull/14958)
+   [\#14958](https://github.com/element-hq/element-web/pull/14958)
 
-Changes in [1.7.4](https://github.com/vector-im/element-web/releases/tag/v1.7.4) (2020-08-17)
+Changes in [1.7.4](https://github.com/element-hq/element-web/releases/tag/v1.7.4) (2020-08-17)
 =============================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.4-rc.1...v1.7.4)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.4-rc.1...v1.7.4)
 
  * Upgrade to React SDK 3.2.0 and JS SDK 8.1.0
 
-Changes in [1.7.4-rc.1](https://github.com/vector-im/element-web/releases/tag/v1.7.4-rc.1) (2020-08-13)
+Changes in [1.7.4-rc.1](https://github.com/element-hq/element-web/releases/tag/v1.7.4-rc.1) (2020-08-13)
 =======================================================================================================
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.3...v1.7.4-rc.1)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.3...v1.7.4-rc.1)
 
  * Upgrade to React SDK 3.2.0-rc.1 and JS SDK 8.1.0-rc.1
  * Update policy links to element.io
-   [\#14905](https://github.com/vector-im/element-web/pull/14905)
+   [\#14905](https://github.com/element-hq/element-web/pull/14905)
  * Update from Weblate
-   [\#14949](https://github.com/vector-im/element-web/pull/14949)
+   [\#14949](https://github.com/element-hq/element-web/pull/14949)
  * Try to close notification on all platforms which support it, not just
    electron
-   [\#14939](https://github.com/vector-im/element-web/pull/14939)
+   [\#14939](https://github.com/element-hq/element-web/pull/14939)
  * Update bug report submission URL
-   [\#14903](https://github.com/vector-im/element-web/pull/14903)
+   [\#14903](https://github.com/element-hq/element-web/pull/14903)
  * Fix arm docker build
-   [\#14522](https://github.com/vector-im/element-web/pull/14522)
+   [\#14522](https://github.com/element-hq/element-web/pull/14522)
 
-Changes in [1.7.3](https://github.com/vector-im/element-web/releases/tag/v1.7.3) (2020-08-05)
+Changes in [1.7.3](https://github.com/element-hq/element-web/releases/tag/v1.7.3) (2020-08-05)
 =============================================================================================
 
 ## Security notice
@@ -4674,184 +4674,184 @@ SakiiR for responsibly disclosing this via Matrix's Security Disclosure Policy.
 
 ## All changes
 
-[Full Changelog](https://github.com/vector-im/element-web/compare/v1.7.3-rc.1...v1.7.3)
+[Full Changelog](https://github.com/element-hq/element-web/compare/v1.7.3-rc.1...v1.7.3)
 
  * Upgrade to React SDK 3.1.0 and JS SDK 8.0.1
 
-Changes in [1.7.3-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.7.3-rc.1) (2020-07-31)
+Changes in [1.7.3-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.7.3-rc.1) (2020-07-31)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.7.2...v1.7.3-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.7.2...v1.7.3-rc.1)
 
  * Upgrade to React SDK 3.1.0-rc.1 and JS SDK 8.0.1-rc.1
  * Make Lojban translation available
-   [\#14703](https://github.com/vector-im/riot-web/pull/14703)
+   [\#14703](https://github.com/element-hq/riot-web/pull/14703)
  * Update from Weblate
-   [\#14841](https://github.com/vector-im/riot-web/pull/14841)
+   [\#14841](https://github.com/element-hq/riot-web/pull/14841)
  * Remove redundant lint dependencies
-   [\#14810](https://github.com/vector-im/riot-web/pull/14810)
+   [\#14810](https://github.com/element-hq/riot-web/pull/14810)
  * Bump elliptic from 6.5.2 to 6.5.3
-   [\#14826](https://github.com/vector-im/riot-web/pull/14826)
+   [\#14826](https://github.com/element-hq/riot-web/pull/14826)
  * Update mobile config intercept URL
-   [\#14796](https://github.com/vector-im/riot-web/pull/14796)
+   [\#14796](https://github.com/element-hq/riot-web/pull/14796)
  * Fix typo in https://
-   [\#14791](https://github.com/vector-im/riot-web/pull/14791)
+   [\#14791](https://github.com/element-hq/riot-web/pull/14791)
 
-Changes in [1.7.2](https://github.com/vector-im/riot-web/releases/tag/v1.7.2) (2020-07-27)
+Changes in [1.7.2](https://github.com/element-hq/riot-web/releases/tag/v1.7.2) (2020-07-27)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.7.1...v1.7.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.7.1...v1.7.2)
 
  * Upgrade to React SDK 3.0.0 and JS SDK 8.0.0
  * Update from Weblate
-   [\#14778](https://github.com/vector-im/riot-web/pull/14778)
+   [\#14778](https://github.com/element-hq/riot-web/pull/14778)
  * Capitalize letters
-   [\#14566](https://github.com/vector-im/riot-web/pull/14566)
+   [\#14566](https://github.com/element-hq/riot-web/pull/14566)
  * Configure eslint package and fix lint issues
-   [\#14673](https://github.com/vector-im/riot-web/pull/14673)
+   [\#14673](https://github.com/element-hq/riot-web/pull/14673)
  * Riot → Element
-   [\#14581](https://github.com/vector-im/riot-web/pull/14581)
+   [\#14581](https://github.com/element-hq/riot-web/pull/14581)
  * Remove labs info for the new room list
-   [\#14603](https://github.com/vector-im/riot-web/pull/14603)
+   [\#14603](https://github.com/element-hq/riot-web/pull/14603)
  * Convince Webpack to use development on CI
-   [\#14593](https://github.com/vector-im/riot-web/pull/14593)
+   [\#14593](https://github.com/element-hq/riot-web/pull/14593)
  * Move dev dep to the right place
-   [\#14572](https://github.com/vector-im/riot-web/pull/14572)
+   [\#14572](https://github.com/element-hq/riot-web/pull/14572)
  * Bump lodash from 4.17.15 to 4.17.19
-   [\#14552](https://github.com/vector-im/riot-web/pull/14552)
+   [\#14552](https://github.com/element-hq/riot-web/pull/14552)
  * Update all mobile links to match marketing site
-   [\#14541](https://github.com/vector-im/riot-web/pull/14541)
+   [\#14541](https://github.com/element-hq/riot-web/pull/14541)
 
-Changes in [1.7.1](https://github.com/vector-im/riot-web/releases/tag/v1.7.1) (2020-07-16)
+Changes in [1.7.1](https://github.com/element-hq/riot-web/releases/tag/v1.7.1) (2020-07-16)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.7.0...v1.7.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.7.0...v1.7.1)
 
  * Upgrade to React SDK 2.10.1
  * Fix SSO session ID paramater
-   [\#14544](https://github.com/vector-im/riot-web/pull/14544)
+   [\#14544](https://github.com/element-hq/riot-web/pull/14544)
  * Run pngcrush on vector-icons
-   [\#14488](https://github.com/vector-im/riot-web/pull/14488)
+   [\#14488](https://github.com/element-hq/riot-web/pull/14488)
  * Fix hosting signup link
-   [\#14502](https://github.com/vector-im/riot-web/pull/14502)
+   [\#14502](https://github.com/element-hq/riot-web/pull/14502)
  * Use the right protocol for SSO URLs
-   [\#14513](https://github.com/vector-im/riot-web/pull/14513)
+   [\#14513](https://github.com/element-hq/riot-web/pull/14513)
  * Fix mstile-310x150 by renaming it
-   [\#14485](https://github.com/vector-im/riot-web/pull/14485)
+   [\#14485](https://github.com/element-hq/riot-web/pull/14485)
  * Update blog and twitter links to point to Element
-   [\#14478](https://github.com/vector-im/riot-web/pull/14478)
+   [\#14478](https://github.com/element-hq/riot-web/pull/14478)
 
-Changes in [1.7.0](https://github.com/vector-im/riot-web/releases/tag/v1.7.0) (2020-07-15)
+Changes in [1.7.0](https://github.com/element-hq/riot-web/releases/tag/v1.7.0) (2020-07-15)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.8...v1.7.0)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.8...v1.7.0)
 
  * App name changed from Riot to Element
  * Upgrade to React SDK 2.10.0
  * Remove redundant enum
-   [\#14472](https://github.com/vector-im/riot-web/pull/14472)
+   [\#14472](https://github.com/element-hq/riot-web/pull/14472)
  * Remove font scaling from labs
-   [\#14355](https://github.com/vector-im/riot-web/pull/14355)
+   [\#14355](https://github.com/element-hq/riot-web/pull/14355)
  * Update documentation and remove labs flag for new room list
-   [\#14375](https://github.com/vector-im/riot-web/pull/14375)
+   [\#14375](https://github.com/element-hq/riot-web/pull/14375)
  * Update from Weblate
-   [\#14434](https://github.com/vector-im/riot-web/pull/14434)
+   [\#14434](https://github.com/element-hq/riot-web/pull/14434)
  * Release the irc layout from labs
-   [\#14350](https://github.com/vector-im/riot-web/pull/14350)
+   [\#14350](https://github.com/element-hq/riot-web/pull/14350)
  * Fix welcomeBackgroundUrl array causing background to change during use
-   [\#14368](https://github.com/vector-im/riot-web/pull/14368)
+   [\#14368](https://github.com/element-hq/riot-web/pull/14368)
  * Be more explicit about type when calling platform startUpdater
-   [\#14299](https://github.com/vector-im/riot-web/pull/14299)
+   [\#14299](https://github.com/element-hq/riot-web/pull/14299)
 
-Changes in [1.6.8](https://github.com/vector-im/riot-web/releases/tag/v1.6.8) (2020-07-03)
+Changes in [1.6.8](https://github.com/element-hq/riot-web/releases/tag/v1.6.8) (2020-07-03)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.8-rc.1...v1.6.8)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.8-rc.1...v1.6.8)
 
  * Upgrade to JS SDK 7.1.0 and React SDK 2.9.0
 
-Changes in [1.6.8-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.6.8-rc.1) (2020-07-01)
+Changes in [1.6.8-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.6.8-rc.1) (2020-07-01)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.7...v1.6.8-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.7...v1.6.8-rc.1)
 
  * Upgrade to JS SDK 7.1.0-rc.1 and React SDK 2.9.0-rc.1
  * Update from Weblate
-   [\#14282](https://github.com/vector-im/riot-web/pull/14282)
+   [\#14282](https://github.com/element-hq/riot-web/pull/14282)
  * Show a download completed toast in electron
-   [\#14248](https://github.com/vector-im/riot-web/pull/14248)
+   [\#14248](https://github.com/element-hq/riot-web/pull/14248)
  * Add the new spinner feature labs flag
-   [\#14213](https://github.com/vector-im/riot-web/pull/14213)
+   [\#14213](https://github.com/element-hq/riot-web/pull/14213)
  * Fix loading-test for SSO plaf changes
-   [\#14212](https://github.com/vector-im/riot-web/pull/14212)
+   [\#14212](https://github.com/element-hq/riot-web/pull/14212)
  * Fix spelling on startup error page
-   [\#14199](https://github.com/vector-im/riot-web/pull/14199)
+   [\#14199](https://github.com/element-hq/riot-web/pull/14199)
  * Document fonts in custom theme
-   [\#14175](https://github.com/vector-im/riot-web/pull/14175)
+   [\#14175](https://github.com/element-hq/riot-web/pull/14175)
  * Update from Weblate
-   [\#14129](https://github.com/vector-im/riot-web/pull/14129)
+   [\#14129](https://github.com/element-hq/riot-web/pull/14129)
  * ElectronPlatform: Implement the isRoomIndexed method.
-   [\#13957](https://github.com/vector-im/riot-web/pull/13957)
+   [\#13957](https://github.com/element-hq/riot-web/pull/13957)
  * ElectronPlatform: Add support to set and get the index user version.
-   [\#14080](https://github.com/vector-im/riot-web/pull/14080)
+   [\#14080](https://github.com/element-hq/riot-web/pull/14080)
  * Mark the new room list as ready for general testing
-   [\#14102](https://github.com/vector-im/riot-web/pull/14102)
+   [\#14102](https://github.com/element-hq/riot-web/pull/14102)
 
-Changes in [1.6.7](https://github.com/vector-im/riot-web/releases/tag/v1.6.7) (2020-06-29)
+Changes in [1.6.7](https://github.com/element-hq/riot-web/releases/tag/v1.6.7) (2020-06-29)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.6...v1.6.7)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.6...v1.6.7)
 
  * Upgrade to React SDK 2.8.1
 
-Changes in [1.6.6](https://github.com/vector-im/riot-web/releases/tag/v1.6.6) (2020-06-23)
+Changes in [1.6.6](https://github.com/element-hq/riot-web/releases/tag/v1.6.6) (2020-06-23)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.6-rc.1...v1.6.6)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.6-rc.1...v1.6.6)
 
  * Upgrade to JS SDK 7.0.0 and React SDK 2.8.0
 
-Changes in [1.6.6-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.6.6-rc.1) (2020-06-17)
+Changes in [1.6.6-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.6.6-rc.1) (2020-06-17)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.5...v1.6.6-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.5...v1.6.6-rc.1)
 
  * Upgrade to JS SDK 7.0.0-rc.1 and React SDK 2.8.0-rc.1
  * Update from Weblate
-   [\#14067](https://github.com/vector-im/riot-web/pull/14067)
+   [\#14067](https://github.com/element-hq/riot-web/pull/14067)
  * Update from Weblate
-   [\#14032](https://github.com/vector-im/riot-web/pull/14032)
+   [\#14032](https://github.com/element-hq/riot-web/pull/14032)
  * Attempt to fix decoder ring for relative hosted riots
-   [\#13987](https://github.com/vector-im/riot-web/pull/13987)
+   [\#13987](https://github.com/element-hq/riot-web/pull/13987)
  * Upgrade deps
-   [\#13952](https://github.com/vector-im/riot-web/pull/13952)
+   [\#13952](https://github.com/element-hq/riot-web/pull/13952)
  * Fix riot-desktop manual update check getting stuck on Downloading...
-   [\#13946](https://github.com/vector-im/riot-web/pull/13946)
+   [\#13946](https://github.com/element-hq/riot-web/pull/13946)
  * Bump websocket-extensions from 0.1.3 to 0.1.4
-   [\#13943](https://github.com/vector-im/riot-web/pull/13943)
+   [\#13943](https://github.com/element-hq/riot-web/pull/13943)
  * Add e2ee-default:false docs
-   [\#13914](https://github.com/vector-im/riot-web/pull/13914)
+   [\#13914](https://github.com/element-hq/riot-web/pull/13914)
  * make IPC calls to get pickle key
-   [\#13846](https://github.com/vector-im/riot-web/pull/13846)
+   [\#13846](https://github.com/element-hq/riot-web/pull/13846)
  * fix loading test for new sso pattern
-   [\#13913](https://github.com/vector-im/riot-web/pull/13913)
+   [\#13913](https://github.com/element-hq/riot-web/pull/13913)
  * Fix login loop where the sso flow returns to `#/login`
-   [\#13889](https://github.com/vector-im/riot-web/pull/13889)
+   [\#13889](https://github.com/element-hq/riot-web/pull/13889)
  * Fix typo in docs
-   [\#13905](https://github.com/vector-im/riot-web/pull/13905)
+   [\#13905](https://github.com/element-hq/riot-web/pull/13905)
  * Remove cross-signing from labs
-   [\#13904](https://github.com/vector-im/riot-web/pull/13904)
+   [\#13904](https://github.com/element-hq/riot-web/pull/13904)
  * Add PWA Platform with PWA-specific badge controls
-   [\#13890](https://github.com/vector-im/riot-web/pull/13890)
+   [\#13890](https://github.com/element-hq/riot-web/pull/13890)
  * Modernizr check for subtle crypto as we require it all over the place
-   [\#13828](https://github.com/vector-im/riot-web/pull/13828)
+   [\#13828](https://github.com/element-hq/riot-web/pull/13828)
 
-Changes in [1.6.5](https://github.com/vector-im/riot-web/releases/tag/v1.6.5) (2020-06-16)
+Changes in [1.6.5](https://github.com/element-hq/riot-web/releases/tag/v1.6.5) (2020-06-16)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.4...v1.6.5)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.4...v1.6.5)
 
 * Upgrade to JS SDK 6.2.2 and React SDK 2.7.2
 
-Changes in [1.6.4](https://github.com/vector-im/riot-web/releases/tag/v1.6.4) (2020-06-05)
+Changes in [1.6.4](https://github.com/element-hq/riot-web/releases/tag/v1.6.4) (2020-06-05)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.3...v1.6.4)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.3...v1.6.4)
 
 * Upgrade to JS SDK 6.2.1 and React SDK 2.7.1
 
-Changes in [1.6.3](https://github.com/vector-im/riot-web/releases/tag/v1.6.3) (2020-06-04)
+Changes in [1.6.3](https://github.com/element-hq/riot-web/releases/tag/v1.6.3) (2020-06-04)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.3-rc.1...v1.6.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.3-rc.1...v1.6.3)
 
 ## Security notice
 
@@ -4860,243 +4860,243 @@ Riot Web 1.6.3 fixes a vulnerability in single sign-on (SSO) deployments where R
 ## All changes
 
  * Fix login loop where the sso flow returns to `#/login` to release
-   [\#13915](https://github.com/vector-im/riot-web/pull/13915)
+   [\#13915](https://github.com/element-hq/riot-web/pull/13915)
 
-Changes in [1.6.3-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.6.3-rc.1) (2020-06-02)
+Changes in [1.6.3-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.6.3-rc.1) (2020-06-02)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.2...v1.6.3-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.2...v1.6.3-rc.1)
 
  * Upgrade to JS SDK 6.2.0-rc.1 and React SDK 2.7.0-rc.2
  * Get rid of welcome.html's Chat with Riot Bot button
-   [\#13842](https://github.com/vector-im/riot-web/pull/13842)
+   [\#13842](https://github.com/element-hq/riot-web/pull/13842)
  * Update from Weblate
-   [\#13886](https://github.com/vector-im/riot-web/pull/13886)
+   [\#13886](https://github.com/element-hq/riot-web/pull/13886)
  * Allow deferring of Update Toast until the next morning
-   [\#13864](https://github.com/vector-im/riot-web/pull/13864)
+   [\#13864](https://github.com/element-hq/riot-web/pull/13864)
  * Give contextual feedback for manual update check instead of banner
-   [\#13862](https://github.com/vector-im/riot-web/pull/13862)
+   [\#13862](https://github.com/element-hq/riot-web/pull/13862)
  * Add app-load doc
-   [\#13834](https://github.com/vector-im/riot-web/pull/13834)
+   [\#13834](https://github.com/element-hq/riot-web/pull/13834)
  * Update Modular hosting link
-   [\#13777](https://github.com/vector-im/riot-web/pull/13777)
+   [\#13777](https://github.com/element-hq/riot-web/pull/13777)
  * Replace New Version Bar with a Toast
-   [\#13776](https://github.com/vector-im/riot-web/pull/13776)
+   [\#13776](https://github.com/element-hq/riot-web/pull/13776)
  * Remove webpack-build-notifier from lockfile
-   [\#13814](https://github.com/vector-im/riot-web/pull/13814)
+   [\#13814](https://github.com/element-hq/riot-web/pull/13814)
  *  Add media queries and mobile viewport (#12142)
-   [\#13818](https://github.com/vector-im/riot-web/pull/13818)
+   [\#13818](https://github.com/element-hq/riot-web/pull/13818)
  * Fix @types/react conflict in matrix-react-sdk
-   [\#13809](https://github.com/vector-im/riot-web/pull/13809)
+   [\#13809](https://github.com/element-hq/riot-web/pull/13809)
  * Fix manual update checking, super in arrow funcs doesn't work
-   [\#13808](https://github.com/vector-im/riot-web/pull/13808)
+   [\#13808](https://github.com/element-hq/riot-web/pull/13808)
  * Update from Weblate
-   [\#13806](https://github.com/vector-im/riot-web/pull/13806)
+   [\#13806](https://github.com/element-hq/riot-web/pull/13806)
  * Convert platforms to Typescript
-   [\#13756](https://github.com/vector-im/riot-web/pull/13756)
+   [\#13756](https://github.com/element-hq/riot-web/pull/13756)
  * Fix EventEmitter typescript signature in node typings
-   [\#13764](https://github.com/vector-im/riot-web/pull/13764)
+   [\#13764](https://github.com/element-hq/riot-web/pull/13764)
  * Add docs and labs flag for new room list implementation
-   [\#13675](https://github.com/vector-im/riot-web/pull/13675)
+   [\#13675](https://github.com/element-hq/riot-web/pull/13675)
  * Add font scaling labs setting.
-   [\#13352](https://github.com/vector-im/riot-web/pull/13352)
+   [\#13352](https://github.com/element-hq/riot-web/pull/13352)
  * Add labs flag for alternate message layouts
-   [\#13350](https://github.com/vector-im/riot-web/pull/13350)
+   [\#13350](https://github.com/element-hq/riot-web/pull/13350)
  * Move dispatcher references in support of TypeScript conversion
-   [\#13666](https://github.com/vector-im/riot-web/pull/13666)
+   [\#13666](https://github.com/element-hq/riot-web/pull/13666)
  * Update from Weblate
-   [\#13704](https://github.com/vector-im/riot-web/pull/13704)
+   [\#13704](https://github.com/element-hq/riot-web/pull/13704)
  * Replace favico.js dependency with simplified variant grown from it
-   [\#13649](https://github.com/vector-im/riot-web/pull/13649)
+   [\#13649](https://github.com/element-hq/riot-web/pull/13649)
  * Remove Electron packaging scripts
-   [\#13688](https://github.com/vector-im/riot-web/pull/13688)
+   [\#13688](https://github.com/element-hq/riot-web/pull/13688)
  * Fix postcss order to allow mixin variables to work
-   [\#13674](https://github.com/vector-im/riot-web/pull/13674)
+   [\#13674](https://github.com/element-hq/riot-web/pull/13674)
  * Pass screenAfterLogin through SSO in the callback url
-   [\#13650](https://github.com/vector-im/riot-web/pull/13650)
+   [\#13650](https://github.com/element-hq/riot-web/pull/13650)
 
-Changes in [1.6.2](https://github.com/vector-im/riot-web/releases/tag/v1.6.2) (2020-05-22)
+Changes in [1.6.2](https://github.com/element-hq/riot-web/releases/tag/v1.6.2) (2020-05-22)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.1...v1.6.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.1...v1.6.2)
 
  * Upgrade to React SDK 2.6.1
 
-Changes in [1.6.1](https://github.com/vector-im/riot-web/releases/tag/v1.6.1) (2020-05-19)
+Changes in [1.6.1](https://github.com/element-hq/riot-web/releases/tag/v1.6.1) (2020-05-19)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.1-rc.1...v1.6.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.1-rc.1...v1.6.1)
 
  * Upgrade to React SDK 2.6.0 and JS SDK 6.1.0
 
-Changes in [1.6.1-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.6.1-rc.1) (2020-05-14)
+Changes in [1.6.1-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.6.1-rc.1) (2020-05-14)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.0...v1.6.1-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.0...v1.6.1-rc.1)
 
  * Upgrade to React SDK 2.6.0-rc.1 and JS SDK 6.1.0-rc.1
  * Update from Weblate
-   [\#13673](https://github.com/vector-im/riot-web/pull/13673)
+   [\#13673](https://github.com/element-hq/riot-web/pull/13673)
  * Add notranslate class to matrixchat to prevent translation by Google
    Translate
-   [\#13669](https://github.com/vector-im/riot-web/pull/13669)
+   [\#13669](https://github.com/element-hq/riot-web/pull/13669)
  * Added Anchor Link to the development of matrix sdk
-   [\#13638](https://github.com/vector-im/riot-web/pull/13638)
+   [\#13638](https://github.com/element-hq/riot-web/pull/13638)
  * Prefetch the formatting button mask svg images
-   [\#13631](https://github.com/vector-im/riot-web/pull/13631)
+   [\#13631](https://github.com/element-hq/riot-web/pull/13631)
  * use a different image in previews
-   [\#13488](https://github.com/vector-im/riot-web/pull/13488)
+   [\#13488](https://github.com/element-hq/riot-web/pull/13488)
  * Update from Weblate
-   [\#13625](https://github.com/vector-im/riot-web/pull/13625)
+   [\#13625](https://github.com/element-hq/riot-web/pull/13625)
  * Remove electron_app as we now have riot-desktop repo
-   [\#13544](https://github.com/vector-im/riot-web/pull/13544)
+   [\#13544](https://github.com/element-hq/riot-web/pull/13544)
  * add new images for PWA icons
-   [\#13556](https://github.com/vector-im/riot-web/pull/13556)
+   [\#13556](https://github.com/element-hq/riot-web/pull/13556)
  * Remove unused feature flag from config
-   [\#13504](https://github.com/vector-im/riot-web/pull/13504)
+   [\#13504](https://github.com/element-hq/riot-web/pull/13504)
  * Update from Weblate
-   [\#13486](https://github.com/vector-im/riot-web/pull/13486)
+   [\#13486](https://github.com/element-hq/riot-web/pull/13486)
  * Developer tool: convert rageshake error locations back to sourcecode
    locations
-   [\#13357](https://github.com/vector-im/riot-web/pull/13357)
+   [\#13357](https://github.com/element-hq/riot-web/pull/13357)
  * App load tweaks, improve error pages
-   [\#13329](https://github.com/vector-im/riot-web/pull/13329)
+   [\#13329](https://github.com/element-hq/riot-web/pull/13329)
  * Tweak default device name to be more compact
-   [\#13465](https://github.com/vector-im/riot-web/pull/13465)
+   [\#13465](https://github.com/element-hq/riot-web/pull/13465)
  * Tweak default device name on macOS
-   [\#13460](https://github.com/vector-im/riot-web/pull/13460)
+   [\#13460](https://github.com/element-hq/riot-web/pull/13460)
  * Update docs with custom theming changes
-   [\#13406](https://github.com/vector-im/riot-web/pull/13406)
+   [\#13406](https://github.com/element-hq/riot-web/pull/13406)
  * Update from Weblate
-   [\#13395](https://github.com/vector-im/riot-web/pull/13395)
+   [\#13395](https://github.com/element-hq/riot-web/pull/13395)
  * Remove docs and config for invite only padlocks
-   [\#13374](https://github.com/vector-im/riot-web/pull/13374)
+   [\#13374](https://github.com/element-hq/riot-web/pull/13374)
  * Revert "Add font scaling labs setting."
-   [\#13351](https://github.com/vector-im/riot-web/pull/13351)
+   [\#13351](https://github.com/element-hq/riot-web/pull/13351)
  * Expand feature flag docs to cover additional release channels
-   [\#13341](https://github.com/vector-im/riot-web/pull/13341)
+   [\#13341](https://github.com/element-hq/riot-web/pull/13341)
  * Optimized image assets by recompressing without affecting quality.
-   [\#13034](https://github.com/vector-im/riot-web/pull/13034)
+   [\#13034](https://github.com/element-hq/riot-web/pull/13034)
  * Add font scaling labs setting.
-   [\#13199](https://github.com/vector-im/riot-web/pull/13199)
+   [\#13199](https://github.com/element-hq/riot-web/pull/13199)
  * Remove encrypted message search feature flag
-   [\#13325](https://github.com/vector-im/riot-web/pull/13325)
+   [\#13325](https://github.com/element-hq/riot-web/pull/13325)
  * Fix `default_federate` settting description
-   [\#13312](https://github.com/vector-im/riot-web/pull/13312)
+   [\#13312](https://github.com/element-hq/riot-web/pull/13312)
  * Clarify that the .well-known method for Jitsi isn't available yet
-   [\#13314](https://github.com/vector-im/riot-web/pull/13314)
+   [\#13314](https://github.com/element-hq/riot-web/pull/13314)
  * add config option to tsc resolveJsonModule
-   [\#13296](https://github.com/vector-im/riot-web/pull/13296)
+   [\#13296](https://github.com/element-hq/riot-web/pull/13296)
  * Fix dispatcher import to be extension agnostic
-   [\#13297](https://github.com/vector-im/riot-web/pull/13297)
+   [\#13297](https://github.com/element-hq/riot-web/pull/13297)
  * Document more config options in config.md (fixes #13089)
-   [\#13260](https://github.com/vector-im/riot-web/pull/13260)
+   [\#13260](https://github.com/element-hq/riot-web/pull/13260)
  * Fix tests post-js-sdk-filters change
-   [\#13295](https://github.com/vector-im/riot-web/pull/13295)
+   [\#13295](https://github.com/element-hq/riot-web/pull/13295)
  * Make Jitsi download script a JS script
-   [\#13227](https://github.com/vector-im/riot-web/pull/13227)
+   [\#13227](https://github.com/element-hq/riot-web/pull/13227)
  * Use matrix-react-sdk type extensions as a base
-   [\#13271](https://github.com/vector-im/riot-web/pull/13271)
+   [\#13271](https://github.com/element-hq/riot-web/pull/13271)
  * Allow Riot Web to randomly pick welcome backgrounds
-   [\#13235](https://github.com/vector-im/riot-web/pull/13235)
+   [\#13235](https://github.com/element-hq/riot-web/pull/13235)
  * Update cross-signing feature docs and document fallback procedures
-   [\#13224](https://github.com/vector-im/riot-web/pull/13224)
+   [\#13224](https://github.com/element-hq/riot-web/pull/13224)
 
-Changes in [1.6.0](https://github.com/vector-im/riot-web/releases/tag/v1.6.0) (2020-05-05)
+Changes in [1.6.0](https://github.com/element-hq/riot-web/releases/tag/v1.6.0) (2020-05-05)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.0-rc.6...v1.6.0)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.0-rc.6...v1.6.0)
 
  * Cross-signing and E2EE by default for DMs and private rooms enabled
  * Upgrade to React SDK 2.5.0 and JS SDK 6.0.0
 
-Changes in [1.6.0-rc.6](https://github.com/vector-im/riot-web/releases/tag/v1.6.0-rc.6) (2020-05-01)
+Changes in [1.6.0-rc.6](https://github.com/element-hq/riot-web/releases/tag/v1.6.0-rc.6) (2020-05-01)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.0-rc.5...v1.6.0-rc.6)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.0-rc.5...v1.6.0-rc.6)
 
  * Upgrade to React SDK 2.5.0-rc.6 and JS SDK 6.0.0-rc.2
 
-Changes in [1.6.0-rc.5](https://github.com/vector-im/riot-web/releases/tag/v1.6.0-rc.5) (2020-04-30)
+Changes in [1.6.0-rc.5](https://github.com/element-hq/riot-web/releases/tag/v1.6.0-rc.5) (2020-04-30)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.0-rc.4...v1.6.0-rc.5)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.0-rc.4...v1.6.0-rc.5)
 
  * Upgrade to React SDK 2.5.0-rc.5 and JS SDK 6.0.0-rc.1
  * Remove feature flag docs from docs on release
-   [\#13375](https://github.com/vector-im/riot-web/pull/13375)
+   [\#13375](https://github.com/element-hq/riot-web/pull/13375)
 
-Changes in [1.6.0-rc.4](https://github.com/vector-im/riot-web/releases/tag/v1.6.0-rc.4) (2020-04-23)
+Changes in [1.6.0-rc.4](https://github.com/element-hq/riot-web/releases/tag/v1.6.0-rc.4) (2020-04-23)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.0-rc.3...v1.6.0-rc.4)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.0-rc.3...v1.6.0-rc.4)
 
  * Upgrade to React SDK 2.5.0-rc.4 and JS SDK 5.3.1-rc.4
 
-Changes in [1.6.0-rc.3](https://github.com/vector-im/riot-web/releases/tag/v1.6.0-rc.3) (2020-04-17)
+Changes in [1.6.0-rc.3](https://github.com/element-hq/riot-web/releases/tag/v1.6.0-rc.3) (2020-04-17)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.0-rc.2...v1.6.0-rc.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.0-rc.2...v1.6.0-rc.3)
 
  * Upgrade to React SDK 2.5.0-rc.3 and JS SDK 5.3.1-rc.3
 
-Changes in [1.6.0-rc.2](https://github.com/vector-im/riot-web/releases/tag/v1.6.0-rc.2) (2020-04-16)
+Changes in [1.6.0-rc.2](https://github.com/element-hq/riot-web/releases/tag/v1.6.0-rc.2) (2020-04-16)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.6.0-rc.1...v1.6.0-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.6.0-rc.1...v1.6.0-rc.2)
 
  * Upgrade to React SDK 2.5.0-rc.2 and JS SDK 5.3.1-rc.2
  * Enable cross-signing / E2EE by default for DM without config changes
 
-Changes in [1.6.0-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.6.0-rc.1) (2020-04-15)
+Changes in [1.6.0-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.6.0-rc.1) (2020-04-15)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.16-rc.1...v1.6.0-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.16-rc.1...v1.6.0-rc.1)
 
  * Enable cross-signing / E2EE by default for DM on release
-   [\#13179](https://github.com/vector-im/riot-web/pull/13179)
+   [\#13179](https://github.com/element-hq/riot-web/pull/13179)
  * Upgrade to React SDK 2.5.0-rc.1 and JS SDK 5.3.1-rc.1
  * Add instruction to resolve the inotify watch limit issue
-   [\#13128](https://github.com/vector-im/riot-web/pull/13128)
+   [\#13128](https://github.com/element-hq/riot-web/pull/13128)
  * docs: labs: add a pointer to config.md
-   [\#13149](https://github.com/vector-im/riot-web/pull/13149)
+   [\#13149](https://github.com/element-hq/riot-web/pull/13149)
  * Fix Electron SSO handling to support multiple profiles
-   [\#13028](https://github.com/vector-im/riot-web/pull/13028)
+   [\#13028](https://github.com/element-hq/riot-web/pull/13028)
  * Add riot-desktop shortcuts for forward/back matching browsers&slack
-   [\#13133](https://github.com/vector-im/riot-web/pull/13133)
+   [\#13133](https://github.com/element-hq/riot-web/pull/13133)
  * Allow rageshake to fail in init
-   [\#13164](https://github.com/vector-im/riot-web/pull/13164)
+   [\#13164](https://github.com/element-hq/riot-web/pull/13164)
  * Fix broken yarn install link in README.md
-   [\#13125](https://github.com/vector-im/riot-web/pull/13125)
+   [\#13125](https://github.com/element-hq/riot-web/pull/13125)
  * fix build:jitsi scripts crash caused by a missing folder
-   [\#13122](https://github.com/vector-im/riot-web/pull/13122)
+   [\#13122](https://github.com/element-hq/riot-web/pull/13122)
  * App load order changes to catch errors better
-   [\#13095](https://github.com/vector-im/riot-web/pull/13095)
+   [\#13095](https://github.com/element-hq/riot-web/pull/13095)
  * Upgrade deps
-   [\#13080](https://github.com/vector-im/riot-web/pull/13080)
+   [\#13080](https://github.com/element-hq/riot-web/pull/13080)
 
-Changes in [1.5.16-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.5.16-rc.1) (2020-04-08)
+Changes in [1.5.16-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.5.16-rc.1) (2020-04-08)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.15...v1.5.16-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.15...v1.5.16-rc.1)
 
  * Upgrade React SDK to 2.4.0-rc.1 and JS SDK to 5.3.0-rc.1
  * Update from Weblate
-   [\#13078](https://github.com/vector-im/riot-web/pull/13078)
+   [\#13078](https://github.com/element-hq/riot-web/pull/13078)
  * Mention Jitsi support at the .well-known level in Jitsi docs
-   [\#13047](https://github.com/vector-im/riot-web/pull/13047)
+   [\#13047](https://github.com/element-hq/riot-web/pull/13047)
  * Add new default home page fallback
-   [\#13049](https://github.com/vector-im/riot-web/pull/13049)
+   [\#13049](https://github.com/element-hq/riot-web/pull/13049)
  * App load order tweaks for code splitting
-   [\#13032](https://github.com/vector-im/riot-web/pull/13032)
+   [\#13032](https://github.com/element-hq/riot-web/pull/13032)
  * Add some docs about Jitsi widgets and Jitsi configuration
-   [\#13027](https://github.com/vector-im/riot-web/pull/13027)
+   [\#13027](https://github.com/element-hq/riot-web/pull/13027)
  * Bump minimist from 1.2.2 to 1.2.3 in /electron_app
-   [\#13030](https://github.com/vector-im/riot-web/pull/13030)
+   [\#13030](https://github.com/element-hq/riot-web/pull/13030)
  * Fix Electron mac-specific shortcut being registered on Web too.
-   [\#13020](https://github.com/vector-im/riot-web/pull/13020)
+   [\#13020](https://github.com/element-hq/riot-web/pull/13020)
  * Add a console warning that errors from Jitsi Meet are fine
-   [\#12968](https://github.com/vector-im/riot-web/pull/12968)
+   [\#12968](https://github.com/element-hq/riot-web/pull/12968)
  * Fix popout support for jitsi widgets
-   [\#12975](https://github.com/vector-im/riot-web/pull/12975)
+   [\#12975](https://github.com/element-hq/riot-web/pull/12975)
  * Some grammar and clarifications
-   [\#12925](https://github.com/vector-im/riot-web/pull/12925)
+   [\#12925](https://github.com/element-hq/riot-web/pull/12925)
  * Don't immediately remove notifications from notification trays
-   [\#12861](https://github.com/vector-im/riot-web/pull/12861)
+   [\#12861](https://github.com/element-hq/riot-web/pull/12861)
  * Remove welcome user from config
-   [\#12894](https://github.com/vector-im/riot-web/pull/12894)
+   [\#12894](https://github.com/element-hq/riot-web/pull/12894)
 
-Changes in [1.5.15](https://github.com/vector-im/riot-web/releases/tag/v1.5.15) (2020-04-01)
+Changes in [1.5.15](https://github.com/element-hq/riot-web/releases/tag/v1.5.15) (2020-04-01)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.14...v1.5.15)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.14...v1.5.15)
 
 ## Security notice
 
@@ -5108,234 +5108,234 @@ It is important to purge any copies of Riot 1.5.14 so that the vulnerable `jitsi
 
  * Upgrade React SDK to 2.3.1 for Jitsi fixes
  * Fix popout support for jitsi widgets
-   [\#12980](https://github.com/vector-im/riot-web/pull/12980)
+   [\#12980](https://github.com/element-hq/riot-web/pull/12980)
 
-Changes in [1.5.14](https://github.com/vector-im/riot-web/releases/tag/v1.5.14) (2020-03-30)
+Changes in [1.5.14](https://github.com/element-hq/riot-web/releases/tag/v1.5.14) (2020-03-30)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.14-rc.1...v1.5.14)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.14-rc.1...v1.5.14)
 
  * Upgrade JS SDK to 5.2.0 and React SDK to 2.3.0
 
-Changes in [1.5.14-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.5.14-rc.1) (2020-03-26)
+Changes in [1.5.14-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.5.14-rc.1) (2020-03-26)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.13...v1.5.14-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.13...v1.5.14-rc.1)
 
  * Upgrade JS SDK to 5.2.0-rc.1 and React SDK to 2.3.0-rc.1
  * Update from Weblate
-   [\#12890](https://github.com/vector-im/riot-web/pull/12890)
+   [\#12890](https://github.com/element-hq/riot-web/pull/12890)
  * App load tweaks
-   [\#12869](https://github.com/vector-im/riot-web/pull/12869)
+   [\#12869](https://github.com/element-hq/riot-web/pull/12869)
  * Add review policy doc
-   [\#12730](https://github.com/vector-im/riot-web/pull/12730)
+   [\#12730](https://github.com/element-hq/riot-web/pull/12730)
  * Fix artifact searching in redeployer
-   [\#12875](https://github.com/vector-im/riot-web/pull/12875)
+   [\#12875](https://github.com/element-hq/riot-web/pull/12875)
  * Fix Jitsi wrapper being large by getting the config from elsewhere
-   [\#12845](https://github.com/vector-im/riot-web/pull/12845)
+   [\#12845](https://github.com/element-hq/riot-web/pull/12845)
  * Add webpack stats which will be used by CI and stored to artifacts
-   [\#12832](https://github.com/vector-im/riot-web/pull/12832)
+   [\#12832](https://github.com/element-hq/riot-web/pull/12832)
  * Revert "Remove useless app preloading from Jitsi widget wrapper"
-   [\#12842](https://github.com/vector-im/riot-web/pull/12842)
+   [\#12842](https://github.com/element-hq/riot-web/pull/12842)
  * Remove useless app preloading from Jitsi widget wrapper
-   [\#12836](https://github.com/vector-im/riot-web/pull/12836)
+   [\#12836](https://github.com/element-hq/riot-web/pull/12836)
  * Update from Weblate
-   [\#12829](https://github.com/vector-im/riot-web/pull/12829)
+   [\#12829](https://github.com/element-hq/riot-web/pull/12829)
  * Fix version for Docker builds
-   [\#12799](https://github.com/vector-im/riot-web/pull/12799)
+   [\#12799](https://github.com/element-hq/riot-web/pull/12799)
  * Register Mac electron specific Cmd+, shortcut to User Settings
-   [\#12800](https://github.com/vector-im/riot-web/pull/12800)
+   [\#12800](https://github.com/element-hq/riot-web/pull/12800)
  * Use a local widget wrapper for Jitsi calls
-   [\#12780](https://github.com/vector-im/riot-web/pull/12780)
+   [\#12780](https://github.com/element-hq/riot-web/pull/12780)
  * Delete shortcuts.md
-   [\#12786](https://github.com/vector-im/riot-web/pull/12786)
+   [\#12786](https://github.com/element-hq/riot-web/pull/12786)
  * Remove remainders of gemini-scrollbar and react-gemini-scrollbar
-   [\#12756](https://github.com/vector-im/riot-web/pull/12756)
+   [\#12756](https://github.com/element-hq/riot-web/pull/12756)
  * Update electron to v7.1.14
-   [\#12762](https://github.com/vector-im/riot-web/pull/12762)
+   [\#12762](https://github.com/element-hq/riot-web/pull/12762)
  * Add url tests to Modernizr
-   [\#12735](https://github.com/vector-im/riot-web/pull/12735)
+   [\#12735](https://github.com/element-hq/riot-web/pull/12735)
  * ElectronPlatform: Add support to remove events from the event index.
-   [\#12703](https://github.com/vector-im/riot-web/pull/12703)
+   [\#12703](https://github.com/element-hq/riot-web/pull/12703)
  * Bump minimist from 1.2.0 to 1.2.2 in /electron_app
-   [\#12744](https://github.com/vector-im/riot-web/pull/12744)
+   [\#12744](https://github.com/element-hq/riot-web/pull/12744)
  * Add docs and flag for custom theme support
-   [\#12731](https://github.com/vector-im/riot-web/pull/12731)
+   [\#12731](https://github.com/element-hq/riot-web/pull/12731)
  * Declare jsx in tsconfig for IDEs
-   [\#12716](https://github.com/vector-im/riot-web/pull/12716)
+   [\#12716](https://github.com/element-hq/riot-web/pull/12716)
  * Remove stuff that yarn install doesn't think we need
-   [\#12713](https://github.com/vector-im/riot-web/pull/12713)
+   [\#12713](https://github.com/element-hq/riot-web/pull/12713)
  * yarn upgrade
-   [\#12691](https://github.com/vector-im/riot-web/pull/12691)
+   [\#12691](https://github.com/element-hq/riot-web/pull/12691)
  * Support TypeScript for React components
-   [\#12696](https://github.com/vector-im/riot-web/pull/12696)
+   [\#12696](https://github.com/element-hq/riot-web/pull/12696)
 
-Changes in [1.5.13](https://github.com/vector-im/riot-web/releases/tag/v1.5.13) (2020-03-17)
+Changes in [1.5.13](https://github.com/element-hq/riot-web/releases/tag/v1.5.13) (2020-03-17)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.13-rc.1...v1.5.13)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.13-rc.1...v1.5.13)
 
  * Upgrade to JS SDK 5.1.1 and React SDK 2.2.3
 
-Changes in [1.5.13-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.5.13-rc.1) (2020-03-11)
+Changes in [1.5.13-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.5.13-rc.1) (2020-03-11)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.12...v1.5.13-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.12...v1.5.13-rc.1)
 
  * Update from Weblate
-   [\#12688](https://github.com/vector-im/riot-web/pull/12688)
+   [\#12688](https://github.com/element-hq/riot-web/pull/12688)
  * Fix Docker image version for develop builds
-   [\#12670](https://github.com/vector-im/riot-web/pull/12670)
+   [\#12670](https://github.com/element-hq/riot-web/pull/12670)
  * docker: optimize custom sdk builds
-   [\#12612](https://github.com/vector-im/riot-web/pull/12612)
+   [\#12612](https://github.com/element-hq/riot-web/pull/12612)
  * riot-desktop open SSO in browser so user doesn't have to auth twice
-   [\#12590](https://github.com/vector-im/riot-web/pull/12590)
+   [\#12590](https://github.com/element-hq/riot-web/pull/12590)
  * Fix SSO flows for electron 8.0.2 by re-breaking will-navigate
-   [\#12585](https://github.com/vector-im/riot-web/pull/12585)
+   [\#12585](https://github.com/element-hq/riot-web/pull/12585)
  * index.html: Place noscript on top of the page
-   [\#12563](https://github.com/vector-im/riot-web/pull/12563)
+   [\#12563](https://github.com/element-hq/riot-web/pull/12563)
  * Remove will-navigate comment after Electron fix
-   [\#12561](https://github.com/vector-im/riot-web/pull/12561)
+   [\#12561](https://github.com/element-hq/riot-web/pull/12561)
  * Update loading test for JS SDK IDB change
-   [\#12552](https://github.com/vector-im/riot-web/pull/12552)
+   [\#12552](https://github.com/element-hq/riot-web/pull/12552)
  * Upgrade deps
-   [\#12528](https://github.com/vector-im/riot-web/pull/12528)
+   [\#12528](https://github.com/element-hq/riot-web/pull/12528)
 
-Changes in [1.5.12](https://github.com/vector-im/riot-web/releases/tag/v1.5.12) (2020-03-04)
+Changes in [1.5.12](https://github.com/element-hq/riot-web/releases/tag/v1.5.12) (2020-03-04)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.11...v1.5.12)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.11...v1.5.12)
 
  * Upgrade to React SDK 2.2.1
  * Revert to Electron 7.1.12 to fix Arch Linux tray icon
  * Fix image download links so they open in a new tab
 
-Changes in [1.5.11](https://github.com/vector-im/riot-web/releases/tag/v1.5.11) (2020-03-02)
+Changes in [1.5.11](https://github.com/element-hq/riot-web/releases/tag/v1.5.11) (2020-03-02)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.11-rc.1...v1.5.11)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.11-rc.1...v1.5.11)
 
  * Upgrade to JS SDK 5.1.0 and React SDK 2.2.0
  * Fix SSO flows for Electron 8.0.2 by disabling will-navigate
-   [\#12585](https://github.com/vector-im/riot-web/pull/12585)
+   [\#12585](https://github.com/element-hq/riot-web/pull/12585)
 
-Changes in [1.5.11-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.5.11-rc.1) (2020-02-26)
+Changes in [1.5.11-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.5.11-rc.1) (2020-02-26)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.10...v1.5.11-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.10...v1.5.11-rc.1)
 
  * Upgrade to JS SDK 5.1.0-rc.1 and React SDK 2.2.0-rc.1
  * Change Windows signing to warning when missing token
-   [\#12523](https://github.com/vector-im/riot-web/pull/12523)
+   [\#12523](https://github.com/element-hq/riot-web/pull/12523)
  * Modernizr remove t3st/es6/contains
-   [\#12524](https://github.com/vector-im/riot-web/pull/12524)
+   [\#12524](https://github.com/element-hq/riot-web/pull/12524)
  * Switch out any eval-using Modernizr rules
-   [\#12519](https://github.com/vector-im/riot-web/pull/12519)
+   [\#12519](https://github.com/element-hq/riot-web/pull/12519)
  * Update from Weblate
-   [\#12522](https://github.com/vector-im/riot-web/pull/12522)
+   [\#12522](https://github.com/element-hq/riot-web/pull/12522)
  * Notify electron of language changes
-   [\#12487](https://github.com/vector-im/riot-web/pull/12487)
+   [\#12487](https://github.com/element-hq/riot-web/pull/12487)
  * Relax macOS notarisation check to print a warning
-   [\#12503](https://github.com/vector-im/riot-web/pull/12503)
+   [\#12503](https://github.com/element-hq/riot-web/pull/12503)
  * Clarify supported tier means desktop OSes
-   [\#12486](https://github.com/vector-im/riot-web/pull/12486)
+   [\#12486](https://github.com/element-hq/riot-web/pull/12486)
  * Use noreferrer in addition to noopener for edge case browsers
-   [\#12477](https://github.com/vector-im/riot-web/pull/12477)
+   [\#12477](https://github.com/element-hq/riot-web/pull/12477)
  * Document start / end composer shortcuts
-   [\#12466](https://github.com/vector-im/riot-web/pull/12466)
+   [\#12466](https://github.com/element-hq/riot-web/pull/12466)
  * Update from Weblate
-   [\#12480](https://github.com/vector-im/riot-web/pull/12480)
+   [\#12480](https://github.com/element-hq/riot-web/pull/12480)
  * Remove buildkite pipeline
-   [\#12464](https://github.com/vector-im/riot-web/pull/12464)
+   [\#12464](https://github.com/element-hq/riot-web/pull/12464)
  * Remove exec so release script continues
-   [\#12435](https://github.com/vector-im/riot-web/pull/12435)
+   [\#12435](https://github.com/element-hq/riot-web/pull/12435)
  * Use Persistent Storage where possible
-   [\#12425](https://github.com/vector-im/riot-web/pull/12425)
+   [\#12425](https://github.com/element-hq/riot-web/pull/12425)
 
-Changes in [1.5.10](https://github.com/vector-im/riot-web/releases/tag/v1.5.10) (2020-02-19)
+Changes in [1.5.10](https://github.com/element-hq/riot-web/releases/tag/v1.5.10) (2020-02-19)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.9...v1.5.10)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.9...v1.5.10)
 
  * Get rid of dependence on usercontent.riot.im
-   [\#12292](https://github.com/vector-im/riot-web/pull/12292)
+   [\#12292](https://github.com/element-hq/riot-web/pull/12292)
  * Add experimental support tier
-   [\#12377](https://github.com/vector-im/riot-web/pull/12377)
+   [\#12377](https://github.com/element-hq/riot-web/pull/12377)
 
-Changes in [1.5.9](https://github.com/vector-im/riot-web/releases/tag/v1.5.9) (2020-02-17)
+Changes in [1.5.9](https://github.com/element-hq/riot-web/releases/tag/v1.5.9) (2020-02-17)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.9-rc.1...v1.5.9)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.9-rc.1...v1.5.9)
 
  * Automate SDK dep upgrades for release
-   [\#12374](https://github.com/vector-im/riot-web/pull/12374)
+   [\#12374](https://github.com/element-hq/riot-web/pull/12374)
 
-Changes in [1.5.9-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.5.9-rc.1) (2020-02-13)
+Changes in [1.5.9-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.5.9-rc.1) (2020-02-13)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.8...v1.5.9-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.8...v1.5.9-rc.1)
 
  * Upgrade JS SDK to 5.0.0-rc.1 and React SDK 2.1.0-rc.2
  * Update from Weblate
-   [\#12354](https://github.com/vector-im/riot-web/pull/12354)
+   [\#12354](https://github.com/element-hq/riot-web/pull/12354)
  * Add top left menu shortcut
-   [\#12310](https://github.com/vector-im/riot-web/pull/12310)
+   [\#12310](https://github.com/element-hq/riot-web/pull/12310)
  * Remove modernizr rules for features on which we only soft depend
-   [\#12272](https://github.com/vector-im/riot-web/pull/12272)
+   [\#12272](https://github.com/element-hq/riot-web/pull/12272)
  * Embed CSP meta tag and stop using script-src unsafe-inline
-   [\#12258](https://github.com/vector-im/riot-web/pull/12258)
+   [\#12258](https://github.com/element-hq/riot-web/pull/12258)
  * Add contribute.json
-   [\#12251](https://github.com/vector-im/riot-web/pull/12251)
+   [\#12251](https://github.com/element-hq/riot-web/pull/12251)
  * Improve Browser checks
-   [\#12232](https://github.com/vector-im/riot-web/pull/12232)
+   [\#12232](https://github.com/element-hq/riot-web/pull/12232)
  * Document padlock flag
-   [\#12173](https://github.com/vector-im/riot-web/pull/12173)
+   [\#12173](https://github.com/element-hq/riot-web/pull/12173)
  * Enable cross-signing on /develop
-   [\#12126](https://github.com/vector-im/riot-web/pull/12126)
+   [\#12126](https://github.com/element-hq/riot-web/pull/12126)
  * Switch back to legacy decorators
-   [\#12110](https://github.com/vector-im/riot-web/pull/12110)
+   [\#12110](https://github.com/element-hq/riot-web/pull/12110)
  * Update babel targets
-   [\#12102](https://github.com/vector-im/riot-web/pull/12102)
+   [\#12102](https://github.com/element-hq/riot-web/pull/12102)
  * Install deps for linting
-   [\#12076](https://github.com/vector-im/riot-web/pull/12076)
+   [\#12076](https://github.com/element-hq/riot-web/pull/12076)
  * Update from Weblate
-   [\#12062](https://github.com/vector-im/riot-web/pull/12062)
+   [\#12062](https://github.com/element-hq/riot-web/pull/12062)
  * Change to minimal Webpack output
-   [\#12049](https://github.com/vector-im/riot-web/pull/12049)
+   [\#12049](https://github.com/element-hq/riot-web/pull/12049)
  * Remove docs for new invite dialog labs feature
-   [\#12015](https://github.com/vector-im/riot-web/pull/12015)
+   [\#12015](https://github.com/element-hq/riot-web/pull/12015)
  * ElectronPlatform: Add the indexSize method.
-   [\#11529](https://github.com/vector-im/riot-web/pull/11529)
+   [\#11529](https://github.com/element-hq/riot-web/pull/11529)
  * ElectronPlatform: Add the ability to load file events from the event index
-   [\#11907](https://github.com/vector-im/riot-web/pull/11907)
+   [\#11907](https://github.com/element-hq/riot-web/pull/11907)
  * Fix the remainder of the cookie links
-   [\#12008](https://github.com/vector-im/riot-web/pull/12008)
+   [\#12008](https://github.com/element-hq/riot-web/pull/12008)
  * Use bash in Docker scripts
-   [\#12001](https://github.com/vector-im/riot-web/pull/12001)
+   [\#12001](https://github.com/element-hq/riot-web/pull/12001)
  * Use debian to build the Docker image
-   [\#11999](https://github.com/vector-im/riot-web/pull/11999)
+   [\#11999](https://github.com/element-hq/riot-web/pull/11999)
  * Update cookie policy urls on /app and /develop config.json
-   [\#11998](https://github.com/vector-im/riot-web/pull/11998)
+   [\#11998](https://github.com/element-hq/riot-web/pull/11998)
  * BuildKite: Only deploy to /develop if everything else passed
-   [\#11996](https://github.com/vector-im/riot-web/pull/11996)
+   [\#11996](https://github.com/element-hq/riot-web/pull/11996)
  * Add docs for admin report content message
-   [\#11995](https://github.com/vector-im/riot-web/pull/11995)
+   [\#11995](https://github.com/element-hq/riot-web/pull/11995)
  * Load as little as possible in index.js for the skinner
-   [\#11959](https://github.com/vector-im/riot-web/pull/11959)
+   [\#11959](https://github.com/element-hq/riot-web/pull/11959)
  * Fix webpack config (by stealing Dave's config)
-   [\#11956](https://github.com/vector-im/riot-web/pull/11956)
+   [\#11956](https://github.com/element-hq/riot-web/pull/11956)
  * Force Jest to resolve the js-sdk and react-sdk to src directories
-   [\#11954](https://github.com/vector-im/riot-web/pull/11954)
+   [\#11954](https://github.com/element-hq/riot-web/pull/11954)
  * Fix build to not babel modules inside js/react sdk
-   [\#11949](https://github.com/vector-im/riot-web/pull/11949)
+   [\#11949](https://github.com/element-hq/riot-web/pull/11949)
  * Fix webpack to babel js-sdk & react-sdk but no other deps
-   [\#11944](https://github.com/vector-im/riot-web/pull/11944)
+   [\#11944](https://github.com/element-hq/riot-web/pull/11944)
 
-Changes in [1.5.8](https://github.com/vector-im/riot-web/releases/tag/v1.5.8) (2020-01-27)
+Changes in [1.5.8](https://github.com/element-hq/riot-web/releases/tag/v1.5.8) (2020-01-27)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.8-rc.2...v1.5.8)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.8-rc.2...v1.5.8)
 
  * Fixes for alias display and copy / paste on composer
 
-Changes in [1.5.8-rc.2](https://github.com/vector-im/riot-web/releases/tag/v1.5.8-rc.2) (2020-01-22)
+Changes in [1.5.8-rc.2](https://github.com/element-hq/riot-web/releases/tag/v1.5.8-rc.2) (2020-01-22)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.8-rc.1...v1.5.8-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.8-rc.1...v1.5.8-rc.2)
 
  * Fix incorrect version of react-sdk
 
-Changes in [1.5.8-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.5.8-rc.1) (2020-01-22)
+Changes in [1.5.8-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.5.8-rc.1) (2020-01-22)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.7...v1.5.8-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.7...v1.5.8-rc.1)
 
 This version contains an upgrade to the cryptography database
 version. Once users run this version, their session's indexeddb
@@ -5344,1515 +5344,1515 @@ be able to read it. Users will have to log out and log in if
 the version of Riot is downgraded back to a previous version.
 
  * Fix webpack config (by stealing Dave's config)
-   [\#11994](https://github.com/vector-im/riot-web/pull/11994)
+   [\#11994](https://github.com/element-hq/riot-web/pull/11994)
  * Fix webpack to babel js-sdk & react-sdk but no other deps
-   [\#11947](https://github.com/vector-im/riot-web/pull/11947)
+   [\#11947](https://github.com/element-hq/riot-web/pull/11947)
  * Update from Weblate
-   [\#11934](https://github.com/vector-im/riot-web/pull/11934)
+   [\#11934](https://github.com/element-hq/riot-web/pull/11934)
  * Fix rageshake post-sourcemaps
-   [\#11926](https://github.com/vector-im/riot-web/pull/11926)
+   [\#11926](https://github.com/element-hq/riot-web/pull/11926)
  * Fix yarn start concurrent commands
-   [\#11895](https://github.com/vector-im/riot-web/pull/11895)
+   [\#11895](https://github.com/element-hq/riot-web/pull/11895)
  * Run the react-sdk reskindexer for developers
-   [\#11894](https://github.com/vector-im/riot-web/pull/11894)
+   [\#11894](https://github.com/element-hq/riot-web/pull/11894)
  * Update labs documentation for feature_ftue_dms given new scope
-   [\#11893](https://github.com/vector-im/riot-web/pull/11893)
+   [\#11893](https://github.com/element-hq/riot-web/pull/11893)
  * Fix indentation on webpack config and make sourcemapped files legible
-   [\#11892](https://github.com/vector-im/riot-web/pull/11892)
+   [\#11892](https://github.com/element-hq/riot-web/pull/11892)
  * Remove spinner check
-   [\#11891](https://github.com/vector-im/riot-web/pull/11891)
+   [\#11891](https://github.com/element-hq/riot-web/pull/11891)
  * Don't minifiy builds of develop through CI packaging
-   [\#11867](https://github.com/vector-im/riot-web/pull/11867)
+   [\#11867](https://github.com/element-hq/riot-web/pull/11867)
  * Use Jest for tests
-   [\#11869](https://github.com/vector-im/riot-web/pull/11869)
+   [\#11869](https://github.com/element-hq/riot-web/pull/11869)
  * Support application/wasm in Docker image
-   [\#11858](https://github.com/vector-im/riot-web/pull/11858)
+   [\#11858](https://github.com/element-hq/riot-web/pull/11858)
  * Fix sourcemaps by refactoring the build system
-   [\#11843](https://github.com/vector-im/riot-web/pull/11843)
+   [\#11843](https://github.com/element-hq/riot-web/pull/11843)
  * Disable event indexing on develop
-   [\#11850](https://github.com/vector-im/riot-web/pull/11850)
+   [\#11850](https://github.com/element-hq/riot-web/pull/11850)
  * Updated blog url
-   [\#11792](https://github.com/vector-im/riot-web/pull/11792)
+   [\#11792](https://github.com/element-hq/riot-web/pull/11792)
  * Enable and document presence in room list feature flag
-   [\#11829](https://github.com/vector-im/riot-web/pull/11829)
+   [\#11829](https://github.com/element-hq/riot-web/pull/11829)
  * Add stub service worker so users can install on desktop with Chrome
-   [\#11774](https://github.com/vector-im/riot-web/pull/11774)
+   [\#11774](https://github.com/element-hq/riot-web/pull/11774)
  * Update from Weblate
-   [\#11826](https://github.com/vector-im/riot-web/pull/11826)
+   [\#11826](https://github.com/element-hq/riot-web/pull/11826)
  * Sourcemaps: develop -> feature branch
-   [\#11802](https://github.com/vector-im/riot-web/pull/11802)
+   [\#11802](https://github.com/element-hq/riot-web/pull/11802)
  * Update build scripts for new process
-   [\#11801](https://github.com/vector-im/riot-web/pull/11801)
+   [\#11801](https://github.com/element-hq/riot-web/pull/11801)
  * Make the webpack config work for us
-   [\#11712](https://github.com/vector-im/riot-web/pull/11712)
+   [\#11712](https://github.com/element-hq/riot-web/pull/11712)
  * Updates URL for Electron Command Line Switches
-   [\#11810](https://github.com/vector-im/riot-web/pull/11810)
+   [\#11810](https://github.com/element-hq/riot-web/pull/11810)
  * Import from src/ for the react-sdk and js-sdk
-   [\#11714](https://github.com/vector-im/riot-web/pull/11714)
+   [\#11714](https://github.com/element-hq/riot-web/pull/11714)
  * Convert components to ES6 exports
-   [\#11713](https://github.com/vector-im/riot-web/pull/11713)
+   [\#11713](https://github.com/element-hq/riot-web/pull/11713)
  * Remove now-retired package.json property
-   [\#11660](https://github.com/vector-im/riot-web/pull/11660)
+   [\#11660](https://github.com/element-hq/riot-web/pull/11660)
 
-Changes in [1.5.7](https://github.com/vector-im/riot-web/releases/tag/v1.5.7) (2020-01-13)
+Changes in [1.5.7](https://github.com/element-hq/riot-web/releases/tag/v1.5.7) (2020-01-13)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.7-rc.2...v1.5.7)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.7-rc.2...v1.5.7)
 
  * Enable and document presence in room list feature flag
-   [\#11830](https://github.com/vector-im/riot-web/pull/11830)
+   [\#11830](https://github.com/element-hq/riot-web/pull/11830)
 
-Changes in [1.5.7-rc.2](https://github.com/vector-im/riot-web/releases/tag/v1.5.7-rc.2) (2020-01-08)
+Changes in [1.5.7-rc.2](https://github.com/element-hq/riot-web/releases/tag/v1.5.7-rc.2) (2020-01-08)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.7-rc.1...v1.5.7-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.7-rc.1...v1.5.7-rc.2)
 
  * Update to react-sdk rc.2 to fix build
 
-Changes in [1.5.7-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.5.7-rc.1) (2020-01-06)
+Changes in [1.5.7-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.5.7-rc.1) (2020-01-06)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.6...v1.5.7-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.6...v1.5.7-rc.1)
 
  * Update from Weblate
-   [\#11784](https://github.com/vector-im/riot-web/pull/11784)
+   [\#11784](https://github.com/element-hq/riot-web/pull/11784)
  * Add docs for feature_bridge_state flag
-   [\#11778](https://github.com/vector-im/riot-web/pull/11778)
+   [\#11778](https://github.com/element-hq/riot-web/pull/11778)
  * Add docs for feature_ftue_dms flag
-   [\#11758](https://github.com/vector-im/riot-web/pull/11758)
+   [\#11758](https://github.com/element-hq/riot-web/pull/11758)
  * Fix version file for Docker images
-   [\#11721](https://github.com/vector-im/riot-web/pull/11721)
+   [\#11721](https://github.com/element-hq/riot-web/pull/11721)
  * Add accelerators to context menu options like cut&paste in electron
-   [\#11690](https://github.com/vector-im/riot-web/pull/11690)
+   [\#11690](https://github.com/element-hq/riot-web/pull/11690)
  * electron-main: Provide a better error message if Seshat isn't installed.
-   [\#11691](https://github.com/vector-im/riot-web/pull/11691)
+   [\#11691](https://github.com/element-hq/riot-web/pull/11691)
  * Update from Weblate
-   [\#11672](https://github.com/vector-im/riot-web/pull/11672)
+   [\#11672](https://github.com/element-hq/riot-web/pull/11672)
  * Remove babel-plugin-transform-async-to-bluebird
-   [\#11662](https://github.com/vector-im/riot-web/pull/11662)
+   [\#11662](https://github.com/element-hq/riot-web/pull/11662)
  * Clarify which versions of what we support
-   [\#11658](https://github.com/vector-im/riot-web/pull/11658)
+   [\#11658](https://github.com/element-hq/riot-web/pull/11658)
  * Remove the code that calls the origin migrator
-   [\#11631](https://github.com/vector-im/riot-web/pull/11631)
+   [\#11631](https://github.com/element-hq/riot-web/pull/11631)
  * yarn upgrade
-   [\#11617](https://github.com/vector-im/riot-web/pull/11617)
+   [\#11617](https://github.com/element-hq/riot-web/pull/11617)
  * Remove draft-js dependency
-   [\#11616](https://github.com/vector-im/riot-web/pull/11616)
+   [\#11616](https://github.com/element-hq/riot-web/pull/11616)
 
-Changes in [1.5.6](https://github.com/vector-im/riot-web/releases/tag/v1.5.6) (2019-12-09)
+Changes in [1.5.6](https://github.com/element-hq/riot-web/releases/tag/v1.5.6) (2019-12-09)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.6-rc.1...v1.5.6)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.6-rc.1...v1.5.6)
 
  * No changes since rc.1
 
-Changes in [1.5.6-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.5.6-rc.1) (2019-12-04)
+Changes in [1.5.6-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.5.6-rc.1) (2019-12-04)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.5...v1.5.6-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.5...v1.5.6-rc.1)
 
  * Update Lithuanian language name
-   [\#11599](https://github.com/vector-im/riot-web/pull/11599)
+   [\#11599](https://github.com/element-hq/riot-web/pull/11599)
  * Enable more languages
-   [\#11592](https://github.com/vector-im/riot-web/pull/11592)
+   [\#11592](https://github.com/element-hq/riot-web/pull/11592)
  * Fix Docker build for develop and publish a /version file
-   [\#11588](https://github.com/vector-im/riot-web/pull/11588)
+   [\#11588](https://github.com/element-hq/riot-web/pull/11588)
  * Remove unused translations
-   [\#11540](https://github.com/vector-im/riot-web/pull/11540)
+   [\#11540](https://github.com/element-hq/riot-web/pull/11540)
  * Update from Weblate
-   [\#11591](https://github.com/vector-im/riot-web/pull/11591)
+   [\#11591](https://github.com/element-hq/riot-web/pull/11591)
  * Update riot.im enable_presence_by_hs_url for new matrix.org client URL
-   [\#11565](https://github.com/vector-im/riot-web/pull/11565)
+   [\#11565](https://github.com/element-hq/riot-web/pull/11565)
  * Remove mention of vector.im as default identity server on mobile guide
-   [\#11544](https://github.com/vector-im/riot-web/pull/11544)
+   [\#11544](https://github.com/element-hq/riot-web/pull/11544)
  * Clean up and standardise app config
-   [\#11549](https://github.com/vector-im/riot-web/pull/11549)
+   [\#11549](https://github.com/element-hq/riot-web/pull/11549)
  * make it clear that seshat requires electron-build-env (at least on macOS)
-   [\#11527](https://github.com/vector-im/riot-web/pull/11527)
+   [\#11527](https://github.com/element-hq/riot-web/pull/11527)
  * Add postcss-easings
-   [\#11521](https://github.com/vector-im/riot-web/pull/11521)
+   [\#11521](https://github.com/element-hq/riot-web/pull/11521)
  * ElectronPlatform: Add support for a event index using Seshat.
-   [\#11125](https://github.com/vector-im/riot-web/pull/11125)
+   [\#11125](https://github.com/element-hq/riot-web/pull/11125)
  * Sign all of the Windows executable files
-   [\#11516](https://github.com/vector-im/riot-web/pull/11516)
+   [\#11516](https://github.com/element-hq/riot-web/pull/11516)
  * Clarify that cross-signing is in development
-   [\#11493](https://github.com/vector-im/riot-web/pull/11493)
+   [\#11493](https://github.com/element-hq/riot-web/pull/11493)
  * get rid of bluebird
-   [\#11301](https://github.com/vector-im/riot-web/pull/11301)
+   [\#11301](https://github.com/element-hq/riot-web/pull/11301)
  * Update from Weblate
-   [\#11488](https://github.com/vector-im/riot-web/pull/11488)
+   [\#11488](https://github.com/element-hq/riot-web/pull/11488)
  * Add note in README about self-hosted riot installs requiring custom caching
    headers
-   [\#8702](https://github.com/vector-im/riot-web/pull/8702)
+   [\#8702](https://github.com/element-hq/riot-web/pull/8702)
  * De-dup theming code
-   [\#11445](https://github.com/vector-im/riot-web/pull/11445)
+   [\#11445](https://github.com/element-hq/riot-web/pull/11445)
  * Add eslint-plugin-jest because we inherit js-sdk's eslintrc and it wants
-   [\#11448](https://github.com/vector-im/riot-web/pull/11448)
+   [\#11448](https://github.com/element-hq/riot-web/pull/11448)
 
-Changes in [1.5.5](https://github.com/vector-im/riot-web/releases/tag/v1.5.5) (2019-11-27)
+Changes in [1.5.5](https://github.com/element-hq/riot-web/releases/tag/v1.5.5) (2019-11-27)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.4...v1.5.5)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.4...v1.5.5)
 
 * Upgrade to JS SDK 2.5.4 to relax identity server discovery and E2EE debugging
 * Upgrade to React SDK 1.7.4 to fix override behaviour of themes
 * Clarify that cross-signing is in development
 * Sign all of the Windows executable files
 
-Changes in [1.5.4](https://github.com/vector-im/riot-web/releases/tag/v1.5.4) (2019-11-25)
+Changes in [1.5.4](https://github.com/element-hq/riot-web/releases/tag/v1.5.4) (2019-11-25)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.4-rc.2...v1.5.4)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.4-rc.2...v1.5.4)
 
  * No changes since rc.2
 
-Changes in [1.5.4-rc.2](https://github.com/vector-im/riot-web/releases/tag/v1.5.4-rc.2) (2019-11-22)
+Changes in [1.5.4-rc.2](https://github.com/element-hq/riot-web/releases/tag/v1.5.4-rc.2) (2019-11-22)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.4-rc.1...v1.5.4-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.4-rc.1...v1.5.4-rc.2)
 
  * react-sdk rc.2 to fix an error in Safari and some cosmetic
    bugs
 
-Changes in [1.5.4-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.5.4-rc.1) (2019-11-20)
+Changes in [1.5.4-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.5.4-rc.1) (2019-11-20)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.3...v1.5.4-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.3...v1.5.4-rc.1)
 
  * Add doc for custom themes
-   [\#11444](https://github.com/vector-im/riot-web/pull/11444)
+   [\#11444](https://github.com/element-hq/riot-web/pull/11444)
  * Use new theme API in react-sdk
-   [\#11442](https://github.com/vector-im/riot-web/pull/11442)
+   [\#11442](https://github.com/element-hq/riot-web/pull/11442)
  * preload warning triangle
-   [\#11441](https://github.com/vector-im/riot-web/pull/11441)
+   [\#11441](https://github.com/element-hq/riot-web/pull/11441)
  * Update from Weblate
-   [\#11440](https://github.com/vector-im/riot-web/pull/11440)
+   [\#11440](https://github.com/element-hq/riot-web/pull/11440)
  * Add entitlements file for mic & camera permissions on macOS
-   [\#11435](https://github.com/vector-im/riot-web/pull/11435)
+   [\#11435](https://github.com/element-hq/riot-web/pull/11435)
  * Fix error/exception in electron signing script
-   [\#11429](https://github.com/vector-im/riot-web/pull/11429)
+   [\#11429](https://github.com/element-hq/riot-web/pull/11429)
  * Merge the `feature_user_info_panel` flag into `feature_dm_verification`
-   [\#11426](https://github.com/vector-im/riot-web/pull/11426)
+   [\#11426](https://github.com/element-hq/riot-web/pull/11426)
  * Let the user's homeserver config override the build config
-   [\#11409](https://github.com/vector-im/riot-web/pull/11409)
+   [\#11409](https://github.com/element-hq/riot-web/pull/11409)
  * Add cross-signing labs flag to develop and document
-   [\#11408](https://github.com/vector-im/riot-web/pull/11408)
+   [\#11408](https://github.com/element-hq/riot-web/pull/11408)
  * Update from Weblate
-   [\#11405](https://github.com/vector-im/riot-web/pull/11405)
+   [\#11405](https://github.com/element-hq/riot-web/pull/11405)
  * Trigger a theme change on startup, not just a tint change
-   [\#11381](https://github.com/vector-im/riot-web/pull/11381)
+   [\#11381](https://github.com/element-hq/riot-web/pull/11381)
  * Perform favicon updates twice in Chrome
-   [\#11375](https://github.com/vector-im/riot-web/pull/11375)
+   [\#11375](https://github.com/element-hq/riot-web/pull/11375)
  * Add labs documentation for Mjolnir
-   [\#11275](https://github.com/vector-im/riot-web/pull/11275)
+   [\#11275](https://github.com/element-hq/riot-web/pull/11275)
  * Add description of user info feature in labs doc
-   [\#11360](https://github.com/vector-im/riot-web/pull/11360)
+   [\#11360](https://github.com/element-hq/riot-web/pull/11360)
  * Update from Weblate
-   [\#11359](https://github.com/vector-im/riot-web/pull/11359)
+   [\#11359](https://github.com/element-hq/riot-web/pull/11359)
  * Add DM verification feature to labs.md
-   [\#11356](https://github.com/vector-im/riot-web/pull/11356)
+   [\#11356](https://github.com/element-hq/riot-web/pull/11356)
  * Add feature_dm_verification to labs
-   [\#11355](https://github.com/vector-im/riot-web/pull/11355)
+   [\#11355](https://github.com/element-hq/riot-web/pull/11355)
  * Document feature flag process
-   [\#11341](https://github.com/vector-im/riot-web/pull/11341)
+   [\#11341](https://github.com/element-hq/riot-web/pull/11341)
  * Remove unused feature flags
-   [\#11343](https://github.com/vector-im/riot-web/pull/11343)
+   [\#11343](https://github.com/element-hq/riot-web/pull/11343)
 
-Changes in [1.5.3](https://github.com/vector-im/riot-web/releases/tag/v1.5.3) (2019-11-06)
+Changes in [1.5.3](https://github.com/element-hq/riot-web/releases/tag/v1.5.3) (2019-11-06)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.2...v1.5.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.2...v1.5.3)
 
  * Remove the 'auto hide menu bar' option on Mac
-   [\#11326](https://github.com/vector-im/riot-web/pull/11326)
+   [\#11326](https://github.com/element-hq/riot-web/pull/11326)
  * Expose feature_user_info_panel on riot.im/develop
-   [\#11304](https://github.com/vector-im/riot-web/pull/11304)
+   [\#11304](https://github.com/element-hq/riot-web/pull/11304)
  * Upgrade electron-notarize
-   [\#11312](https://github.com/vector-im/riot-web/pull/11312)
+   [\#11312](https://github.com/element-hq/riot-web/pull/11312)
  * Fix close window behaviour on Macos
-   [\#11309](https://github.com/vector-im/riot-web/pull/11309)
+   [\#11309](https://github.com/element-hq/riot-web/pull/11309)
  * Merge: Add dependency to eslint-plugin-react-hooks as react-sdk did
-   [\#11307](https://github.com/vector-im/riot-web/pull/11307)
+   [\#11307](https://github.com/element-hq/riot-web/pull/11307)
  * Add dependency to eslint-plugin-react-hooks as react-sdk did
-   [\#11306](https://github.com/vector-im/riot-web/pull/11306)
+   [\#11306](https://github.com/element-hq/riot-web/pull/11306)
  * Update from Weblate
-   [\#11300](https://github.com/vector-im/riot-web/pull/11300)
+   [\#11300](https://github.com/element-hq/riot-web/pull/11300)
 
-Changes in [1.5.2](https://github.com/vector-im/riot-web/releases/tag/v1.5.2) (2019-11-04)
+Changes in [1.5.2](https://github.com/element-hq/riot-web/releases/tag/v1.5.2) (2019-11-04)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.1...v1.5.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.1...v1.5.2)
 
  * Fix close window behaviour on Macos
-   [\#11311](https://github.com/vector-im/riot-web/pull/11311)
+   [\#11311](https://github.com/element-hq/riot-web/pull/11311)
 
-Changes in [1.5.1](https://github.com/vector-im/riot-web/releases/tag/v1.5.1) (2019-11-04)
+Changes in [1.5.1](https://github.com/element-hq/riot-web/releases/tag/v1.5.1) (2019-11-04)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.1-rc.2...v1.5.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.1-rc.2...v1.5.1)
 
  * No changes since rc.2
 
-Changes in [1.5.1-rc.2](https://github.com/vector-im/riot-web/releases/tag/v1.5.1-rc.2) (2019-11-01)
+Changes in [1.5.1-rc.2](https://github.com/element-hq/riot-web/releases/tag/v1.5.1-rc.2) (2019-11-01)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.1-rc.1...v1.5.1-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.1-rc.1...v1.5.1-rc.2)
 
  * Updated react-sdk with fix for bug that caused room filtering to
    omit results.
 
-Changes in [1.5.1-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.5.1-rc.1) (2019-10-30)
+Changes in [1.5.1-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.5.1-rc.1) (2019-10-30)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.0...v1.5.1-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.0...v1.5.1-rc.1)
 
  * Add ability to hide tray icon on non-Mac (which has no tray icon)
-   [\#11258](https://github.com/vector-im/riot-web/pull/11258)
+   [\#11258](https://github.com/element-hq/riot-web/pull/11258)
  * Fix bug preventing display from sleeping after a call
-   [\#11264](https://github.com/vector-im/riot-web/pull/11264)
+   [\#11264](https://github.com/element-hq/riot-web/pull/11264)
  * Remove mention of CI scripts from docs
-   [\#11257](https://github.com/vector-im/riot-web/pull/11257)
+   [\#11257](https://github.com/element-hq/riot-web/pull/11257)
  * Fix skinning replaces being broken since being rewritten as React FC's
-   [\#11254](https://github.com/vector-im/riot-web/pull/11254)
+   [\#11254](https://github.com/element-hq/riot-web/pull/11254)
  * Update config docs about identity servers
-   [\#11249](https://github.com/vector-im/riot-web/pull/11249)
+   [\#11249](https://github.com/element-hq/riot-web/pull/11249)
  * Remove unneeded help about identity servers
-   [\#11248](https://github.com/vector-im/riot-web/pull/11248)
+   [\#11248](https://github.com/element-hq/riot-web/pull/11248)
  * Update from Weblate
-   [\#11243](https://github.com/vector-im/riot-web/pull/11243)
+   [\#11243](https://github.com/element-hq/riot-web/pull/11243)
  * Update sample config for new matrix.org CS API URL
-   [\#11207](https://github.com/vector-im/riot-web/pull/11207)
+   [\#11207](https://github.com/element-hq/riot-web/pull/11207)
  * clarify where the e2e tests are located
-   [\#11115](https://github.com/vector-im/riot-web/pull/11115)
+   [\#11115](https://github.com/element-hq/riot-web/pull/11115)
  * Update from Weblate
-   [\#11171](https://github.com/vector-im/riot-web/pull/11171)
+   [\#11171](https://github.com/element-hq/riot-web/pull/11171)
  * Prevent referrers from being sent
-   [\#6155](https://github.com/vector-im/riot-web/pull/6155)
+   [\#6155](https://github.com/element-hq/riot-web/pull/6155)
  * Add darkModeSupport to allow dark themed title bar.
-   [\#11140](https://github.com/vector-im/riot-web/pull/11140)
+   [\#11140](https://github.com/element-hq/riot-web/pull/11140)
  * Fix the label of Turkish language
-   [\#11124](https://github.com/vector-im/riot-web/pull/11124)
+   [\#11124](https://github.com/element-hq/riot-web/pull/11124)
  * Update default HS config to match well-known
-   [\#11112](https://github.com/vector-im/riot-web/pull/11112)
+   [\#11112](https://github.com/element-hq/riot-web/pull/11112)
 
-Changes in [1.5.0](https://github.com/vector-im/riot-web/releases/tag/v1.5.0) (2019-10-18)
+Changes in [1.5.0](https://github.com/element-hq/riot-web/releases/tag/v1.5.0) (2019-10-18)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.5.0-rc.1...v1.5.0)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.5.0-rc.1...v1.5.0)
 
  * Upgrade to JS SDK v2.4.2 and React SDK v1.7.0
  * Port Windows signing and macOS notarization to release
-   [\#11158](https://github.com/vector-im/riot-web/pull/11158)
+   [\#11158](https://github.com/element-hq/riot-web/pull/11158)
  * Sign main Windows executable
-   [\#11126](https://github.com/vector-im/riot-web/pull/11126)
+   [\#11126](https://github.com/element-hq/riot-web/pull/11126)
  * Notarise the macOS app
-   [\#11119](https://github.com/vector-im/riot-web/pull/11119)
+   [\#11119](https://github.com/element-hq/riot-web/pull/11119)
 
-Changes in [1.5.0-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.5.0-rc.1) (2019-10-09)
+Changes in [1.5.0-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.5.0-rc.1) (2019-10-09)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.4.2...v1.5.0-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.4.2...v1.5.0-rc.1)
 
  * Update from Weblate
-   [\#11104](https://github.com/vector-im/riot-web/pull/11104)
+   [\#11104](https://github.com/element-hq/riot-web/pull/11104)
  * Bump Olm to 3.1.4 for olm_session_describe
-   [\#11103](https://github.com/vector-im/riot-web/pull/11103)
+   [\#11103](https://github.com/element-hq/riot-web/pull/11103)
  * Enable Webpack production mode for start:js:prod
-   [\#11098](https://github.com/vector-im/riot-web/pull/11098)
+   [\#11098](https://github.com/element-hq/riot-web/pull/11098)
  * add settingDefaults to sample config
-   [\#9919](https://github.com/vector-im/riot-web/pull/9919)
+   [\#9919](https://github.com/element-hq/riot-web/pull/9919)
  * Add config.json copy instruction to 'Development' as well
-   [\#11062](https://github.com/vector-im/riot-web/pull/11062)
+   [\#11062](https://github.com/element-hq/riot-web/pull/11062)
  * Revert "Run yarn upgrade"
-   [\#11055](https://github.com/vector-im/riot-web/pull/11055)
+   [\#11055](https://github.com/element-hq/riot-web/pull/11055)
  * Run yarn upgrade
-   [\#11050](https://github.com/vector-im/riot-web/pull/11050)
+   [\#11050](https://github.com/element-hq/riot-web/pull/11050)
  * Request persistent storage on Electron
-   [\#11052](https://github.com/vector-im/riot-web/pull/11052)
+   [\#11052](https://github.com/element-hq/riot-web/pull/11052)
  * Remove docs for CIDER feature
-   [\#11047](https://github.com/vector-im/riot-web/pull/11047)
+   [\#11047](https://github.com/element-hq/riot-web/pull/11047)
 
-Changes in [1.4.2](https://github.com/vector-im/riot-web/releases/tag/v1.4.2) (2019-10-04)
+Changes in [1.4.2](https://github.com/element-hq/riot-web/releases/tag/v1.4.2) (2019-10-04)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.4.2-rc.1...v1.4.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.4.2-rc.1...v1.4.2)
 
  * Document troubleshooting for memory leaks and getting profiles
-   [\#11031](https://github.com/vector-im/riot-web/pull/11031)
+   [\#11031](https://github.com/element-hq/riot-web/pull/11031)
 
-Changes in [1.4.2-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.4.2-rc.1) (2019-10-02)
+Changes in [1.4.2-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.4.2-rc.1) (2019-10-02)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.4.1...v1.4.2-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.4.1...v1.4.2-rc.1)
 
  * Custom themes MVP
-   [\#11017](https://github.com/vector-im/riot-web/pull/11017)
+   [\#11017](https://github.com/element-hq/riot-web/pull/11017)
  * Document permalinkPrefix setting
-   [\#11007](https://github.com/vector-im/riot-web/pull/11007)
+   [\#11007](https://github.com/element-hq/riot-web/pull/11007)
 
-Changes in [1.4.1](https://github.com/vector-im/riot-web/releases/tag/v1.4.1) (2019-10-01)
+Changes in [1.4.1](https://github.com/element-hq/riot-web/releases/tag/v1.4.1) (2019-10-01)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.4.0...v1.4.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.4.0...v1.4.1)
 
  * Upgrade to React SDK 1.6.1 to fix critical
-   [blank screen issue](https://github.com/vector-im/riot-web/issues/10983)
+   [blank screen issue](https://github.com/element-hq/riot-web/issues/10983)
  * Upgrade to JS SDK 2.4.1 to to ignore crypto events with empty content
  * Update from Weblate
-   [\#11010](https://github.com/vector-im/riot-web/pull/11010)
+   [\#11010](https://github.com/element-hq/riot-web/pull/11010)
  * Update from Weblate
-   [\#11001](https://github.com/vector-im/riot-web/pull/11001)
+   [\#11001](https://github.com/element-hq/riot-web/pull/11001)
  * Upgrade deps
-   [\#10980](https://github.com/vector-im/riot-web/pull/10980)
+   [\#10980](https://github.com/element-hq/riot-web/pull/10980)
 
-Changes in [1.4.0](https://github.com/vector-im/riot-web/releases/tag/v1.4.0) (2019-09-27)
+Changes in [1.4.0](https://github.com/element-hq/riot-web/releases/tag/v1.4.0) (2019-09-27)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.4.0-rc.2...v1.4.0)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.4.0-rc.2...v1.4.0)
 
 * Many improvements related to privacy and user control of identity services and integration managers
 * Upgrade to React SDK 1.6.0 and JS SDK 2.4.0
 
-Changes in [1.4.0-rc.2](https://github.com/vector-im/riot-web/releases/tag/v1.4.0-rc.2) (2019-09-26)
+Changes in [1.4.0-rc.2](https://github.com/element-hq/riot-web/releases/tag/v1.4.0-rc.2) (2019-09-26)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.4.0-rc.1...v1.4.0-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.4.0-rc.1...v1.4.0-rc.2)
 
  * Upgrade to React SDK 1.6.0-rc.2
  * Work around Yarn confusion with `react-gemini-scrollbar` package
 
-Changes in [1.4.0-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.4.0-rc.1) (2019-09-25)
+Changes in [1.4.0-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.4.0-rc.1) (2019-09-25)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.3.6...v1.4.0-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.3.6...v1.4.0-rc.1)
 
  * Upgrade to React SDK 1.6.0-rc.1 and JS SDK 2.4.0-rc.1
  * Update from Weblate
-   [\#10961](https://github.com/vector-im/riot-web/pull/10961)
+   [\#10961](https://github.com/element-hq/riot-web/pull/10961)
  * Don't log query parameters as they may contain secrets
-   [\#10929](https://github.com/vector-im/riot-web/pull/10929)
+   [\#10929](https://github.com/element-hq/riot-web/pull/10929)
  * Document more shortcuts
-   [\#10906](https://github.com/vector-im/riot-web/pull/10906)
+   [\#10906](https://github.com/element-hq/riot-web/pull/10906)
  * Point to #develop and use the same gemini-scrollbar version as the react-sdk
-   [\#10893](https://github.com/vector-im/riot-web/pull/10893)
+   [\#10893](https://github.com/element-hq/riot-web/pull/10893)
  * Tweak lock file to pull in only one React version
-   [\#10874](https://github.com/vector-im/riot-web/pull/10874)
+   [\#10874](https://github.com/element-hq/riot-web/pull/10874)
  * document disable_custom_urls
-   [\#10844](https://github.com/vector-im/riot-web/pull/10844)
+   [\#10844](https://github.com/element-hq/riot-web/pull/10844)
  * Install guide tweaks
-   [\#10838](https://github.com/vector-im/riot-web/pull/10838)
+   [\#10838](https://github.com/element-hq/riot-web/pull/10838)
  * Switch to React 16
-   [\#10480](https://github.com/vector-im/riot-web/pull/10480)
+   [\#10480](https://github.com/element-hq/riot-web/pull/10480)
  * Update install guide
-   [\#10810](https://github.com/vector-im/riot-web/pull/10810)
+   [\#10810](https://github.com/element-hq/riot-web/pull/10810)
  * Clarify that HTTPS is not just needed for VoIP
-   [\#6146](https://github.com/vector-im/riot-web/pull/6146)
+   [\#6146](https://github.com/element-hq/riot-web/pull/6146)
  * Bump eslint-utils from 1.4.0 to 1.4.2
-   [\#10692](https://github.com/vector-im/riot-web/pull/10692)
+   [\#10692](https://github.com/element-hq/riot-web/pull/10692)
  * Add docs for tabbed integration managers labs flag
-   [\#10641](https://github.com/vector-im/riot-web/pull/10641)
+   [\#10641](https://github.com/element-hq/riot-web/pull/10641)
  * Change integrations_widgets_urls default configuration
-   [\#10656](https://github.com/vector-im/riot-web/pull/10656)
+   [\#10656](https://github.com/element-hq/riot-web/pull/10656)
  * Add docs for the CIDER composer flag
-   [\#10638](https://github.com/vector-im/riot-web/pull/10638)
+   [\#10638](https://github.com/element-hq/riot-web/pull/10638)
  * add cider composer labs flag
-   [\#10626](https://github.com/vector-im/riot-web/pull/10626)
+   [\#10626](https://github.com/element-hq/riot-web/pull/10626)
  * Upgrade to Electron 6.0.3
-   [\#10601](https://github.com/vector-im/riot-web/pull/10601)
+   [\#10601](https://github.com/element-hq/riot-web/pull/10601)
  * Upgrade to Electron 6
-   [\#10596](https://github.com/vector-im/riot-web/pull/10596)
+   [\#10596](https://github.com/element-hq/riot-web/pull/10596)
  * Update from Weblate
-   [\#10591](https://github.com/vector-im/riot-web/pull/10591)
+   [\#10591](https://github.com/element-hq/riot-web/pull/10591)
  * Upgrade electron-builder to 21.2.0
-   [\#10579](https://github.com/vector-im/riot-web/pull/10579)
+   [\#10579](https://github.com/element-hq/riot-web/pull/10579)
  * Set SUID bit on chrome-sandbox for Debian
-   [\#10580](https://github.com/vector-im/riot-web/pull/10580)
+   [\#10580](https://github.com/element-hq/riot-web/pull/10580)
  * Load config.json before loading language so default can apply
-   [\#10551](https://github.com/vector-im/riot-web/pull/10551)
+   [\#10551](https://github.com/element-hq/riot-web/pull/10551)
  * Bump matrix-react-test-utils for React 16 compatibility
-   [\#10543](https://github.com/vector-im/riot-web/pull/10543)
+   [\#10543](https://github.com/element-hq/riot-web/pull/10543)
  * Add --help to electron app
-   [\#10530](https://github.com/vector-im/riot-web/pull/10530)
+   [\#10530](https://github.com/element-hq/riot-web/pull/10530)
  * Allow setting electron autoHideMenuBar and persist it
-   [\#10503](https://github.com/vector-im/riot-web/pull/10503)
+   [\#10503](https://github.com/element-hq/riot-web/pull/10503)
  * Upgrade dependencies
-   [\#10475](https://github.com/vector-im/riot-web/pull/10475)
+   [\#10475](https://github.com/element-hq/riot-web/pull/10475)
 
-Changes in [1.3.6](https://github.com/vector-im/riot-web/releases/tag/v1.3.6) (2019-09-19)
+Changes in [1.3.6](https://github.com/element-hq/riot-web/releases/tag/v1.3.6) (2019-09-19)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.3.5...v1.3.6)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.3.5...v1.3.6)
 
  * Fix origin migrator for SSO logins
-   [\#10920](https://github.com/vector-im/riot-web/pull/10920)
+   [\#10920](https://github.com/element-hq/riot-web/pull/10920)
 
-Changes in [1.3.5](https://github.com/vector-im/riot-web/releases/tag/v1.3.5) (2019-09-16)
+Changes in [1.3.5](https://github.com/element-hq/riot-web/releases/tag/v1.3.5) (2019-09-16)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.3.5-rc.3...v1.3.5)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.3.5-rc.3...v1.3.5)
 
  * Updated js-sdk and react-sdk for some more minor bugfixes
 
-Changes in [1.3.5-rc.3](https://github.com/vector-im/riot-web/releases/tag/v1.3.5-rc.3) (2019-09-13)
+Changes in [1.3.5-rc.3](https://github.com/element-hq/riot-web/releases/tag/v1.3.5-rc.3) (2019-09-13)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.3.5-rc.2...v1.3.5-rc.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.3.5-rc.2...v1.3.5-rc.3)
 
  * js-sdk rc.1 to include report API
 
-Changes in [1.3.5-rc.2](https://github.com/vector-im/riot-web/releases/tag/v1.3.5-rc.2) (2019-09-13)
+Changes in [1.3.5-rc.2](https://github.com/element-hq/riot-web/releases/tag/v1.3.5-rc.2) (2019-09-13)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.3.5-rc.1...v1.3.5-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.3.5-rc.1...v1.3.5-rc.2)
 
  * Pull in more fixes from react-sdk rc.2
 
-Changes in [1.3.5-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.3.5-rc.1) (2019-09-12)
+Changes in [1.3.5-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.3.5-rc.1) (2019-09-12)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.3.4...v1.3.5-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.3.4...v1.3.5-rc.1)
 
  * Cosmetic fixes from react-sdk rc.1
 
-Changes in [1.3.4](https://github.com/vector-im/riot-web/releases/tag/v1.3.4) (2019-09-12)
+Changes in [1.3.4](https://github.com/element-hq/riot-web/releases/tag/v1.3.4) (2019-09-12)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.3.4-rc.1...v1.3.4)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.3.4-rc.1...v1.3.4)
 
  * Updated react-sdk and tweaks to mobile install guide
 
-Changes in [1.3.4-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.3.4-rc.1) (2019-09-11)
+Changes in [1.3.4-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.3.4-rc.1) (2019-09-11)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.3.3...v1.3.4-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.3.3...v1.3.4-rc.1)
 
  * Update install guide
-   [\#10831](https://github.com/vector-im/riot-web/pull/10831)
+   [\#10831](https://github.com/element-hq/riot-web/pull/10831)
 
-Changes in [1.3.3](https://github.com/vector-im/riot-web/releases/tag/v1.3.3) (2019-08-16)
+Changes in [1.3.3](https://github.com/element-hq/riot-web/releases/tag/v1.3.3) (2019-08-16)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.3.2...v1.3.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.3.2...v1.3.3)
 
  * Linux-only release to fix sandboxing with Electron 5 on Debian
-   [\#10580](https://github.com/vector-im/riot-web/pull/10580)
+   [\#10580](https://github.com/element-hq/riot-web/pull/10580)
 
-Changes in [1.3.2](https://github.com/vector-im/riot-web/releases/tag/v1.3.2) (2019-08-05)
+Changes in [1.3.2](https://github.com/element-hq/riot-web/releases/tag/v1.3.2) (2019-08-05)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.3.1...v1.3.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.3.1...v1.3.2)
 
  * Updated react-sdk for deactivated account error message on login
 
-Changes in [1.3.1](https://github.com/vector-im/riot-web/releases/tag/v1.3.1) (2019-08-05)
+Changes in [1.3.1](https://github.com/element-hq/riot-web/releases/tag/v1.3.1) (2019-08-05)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.3.1-rc.1...v1.3.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.3.1-rc.1...v1.3.1)
 
  * Updated js-sdk for notifications fix and react-sdk for registration fix
 
-Changes in [1.3.1-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.3.1-rc.1) (2019-07-31)
+Changes in [1.3.1-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.3.1-rc.1) (2019-07-31)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.3.0...v1.3.1-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.3.0...v1.3.1-rc.1)
 
  * Upgrade to JS SDK 2.3.0-rc.1 and React SDK 1.5.0-rc.1
  * Update from Weblate
-   [\#10436](https://github.com/vector-im/riot-web/pull/10436)
+   [\#10436](https://github.com/element-hq/riot-web/pull/10436)
  * Describe our existing features better in documentation
-   [\#10418](https://github.com/vector-im/riot-web/pull/10418)
+   [\#10418](https://github.com/element-hq/riot-web/pull/10418)
  * Upgrade to Electron 5
-   [\#10392](https://github.com/vector-im/riot-web/pull/10392)
+   [\#10392](https://github.com/element-hq/riot-web/pull/10392)
  * Remove edits and reactions feature flags from docs and config
-   [\#10363](https://github.com/vector-im/riot-web/pull/10363)
+   [\#10363](https://github.com/element-hq/riot-web/pull/10363)
  * Cachebust config file requests
-   [\#10349](https://github.com/vector-im/riot-web/pull/10349)
+   [\#10349](https://github.com/element-hq/riot-web/pull/10349)
  * Convert install-app-deps to subcommand
-   [\#10334](https://github.com/vector-im/riot-web/pull/10334)
+   [\#10334](https://github.com/element-hq/riot-web/pull/10334)
  * Add riot.im configuration files
-   [\#10327](https://github.com/vector-im/riot-web/pull/10327)
+   [\#10327](https://github.com/element-hq/riot-web/pull/10327)
  * Require descriptions in mxSendRageshake and remove infinite loop in issue
    templates
-   [\#10321](https://github.com/vector-im/riot-web/pull/10321)
+   [\#10321](https://github.com/element-hq/riot-web/pull/10321)
  * Remove unused disable_identity_server config flag
-   [\#10322](https://github.com/vector-im/riot-web/pull/10322)
+   [\#10322](https://github.com/element-hq/riot-web/pull/10322)
  * Verify i18n in CI
-   [\#10320](https://github.com/vector-im/riot-web/pull/10320)
+   [\#10320](https://github.com/element-hq/riot-web/pull/10320)
 
-Changes in [1.3.0](https://github.com/vector-im/riot-web/releases/tag/v1.3.0) (2019-07-18)
+Changes in [1.3.0](https://github.com/element-hq/riot-web/releases/tag/v1.3.0) (2019-07-18)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.3.0-rc.3...v1.3.0)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.3.0-rc.3...v1.3.0)
 
  * Upgrade to React SDK 1.4.0 and JS SDK 2.2.0
  * Message editing and reactions features enabled
  * Remove edits and reactions feature flags from docs and config
-   [\#10365](https://github.com/vector-im/riot-web/pull/10365)
+   [\#10365](https://github.com/element-hq/riot-web/pull/10365)
 
-Changes in [1.3.0-rc.3](https://github.com/vector-im/riot-web/releases/tag/v1.3.0-rc.3) (2019-07-15)
+Changes in [1.3.0-rc.3](https://github.com/element-hq/riot-web/releases/tag/v1.3.0-rc.3) (2019-07-15)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.3.0-rc.2...v1.3.0-rc.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.3.0-rc.2...v1.3.0-rc.3)
 
  * Update to react-sdk rc.3 to fix a bug where a room admin could generate a room
    that would cause Riot to error, and some stuck notifications.
 
-Changes in [1.3.0-rc.2](https://github.com/vector-im/riot-web/releases/tag/v1.3.0-rc.2) (2019-07-12)
+Changes in [1.3.0-rc.2](https://github.com/element-hq/riot-web/releases/tag/v1.3.0-rc.2) (2019-07-12)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.3.0-rc.1...v1.3.0-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.3.0-rc.1...v1.3.0-rc.2)
 
  * Upgrade to React SDK 1.4.0-rc.2 and JS SDK 2.2.0-rc.2
  * Fix regression from Riot 1.3.0-rc.1 when listing devices in user settings
 
-Changes in [1.3.0-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.3.0-rc.1) (2019-07-12)
+Changes in [1.3.0-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.3.0-rc.1) (2019-07-12)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.2.4...v1.3.0-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.2.4...v1.3.0-rc.1)
 
  * Upgrade to React SDK 1.4.0-rc.1 and JS SDK 2.2.0-rc.1
  * Update from Weblate
-   [\#10328](https://github.com/vector-im/riot-web/pull/10328)
+   [\#10328](https://github.com/element-hq/riot-web/pull/10328)
  * Upgrade dependencies
-   [\#10308](https://github.com/vector-im/riot-web/pull/10308)
+   [\#10308](https://github.com/element-hq/riot-web/pull/10308)
  * Upgrade dependencies
-   [\#10260](https://github.com/vector-im/riot-web/pull/10260)
+   [\#10260](https://github.com/element-hq/riot-web/pull/10260)
 
-Changes in [1.2.4](https://github.com/vector-im/riot-web/releases/tag/v1.2.4) (2019-07-11)
+Changes in [1.2.4](https://github.com/element-hq/riot-web/releases/tag/v1.2.4) (2019-07-11)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.2.3...v1.2.4)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.2.3...v1.2.4)
 
  * Upgrade to React SDK 1.3.1 and JS SDK 2.1.1
  * Upgrade lodash dependencies
  * JS SDK 2.1.1 includes a fix for ephemeral event processing
  * React SDK 1.3.1 includes a fix for account deactivation
 
-Changes in [1.2.3](https://github.com/vector-im/riot-web/releases/tag/v1.2.3) (2019-07-08)
+Changes in [1.2.3](https://github.com/element-hq/riot-web/releases/tag/v1.2.3) (2019-07-08)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.2.3-rc.1...v1.2.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.2.3-rc.1...v1.2.3)
 
  * Upgrade to React SDK 1.3.0 and JS SDK 2.1.0
  * JS SDK 2.1.0 includes a fix for an exception whilst syncing
 
-Changes in [1.2.3-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.2.3-rc.1) (2019-07-03)
+Changes in [1.2.3-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.2.3-rc.1) (2019-07-03)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.2.2...v1.2.3-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.2.2...v1.2.3-rc.1)
 
  * Change update URL to match new host
-   [\#10247](https://github.com/vector-im/riot-web/pull/10247)
+   [\#10247](https://github.com/element-hq/riot-web/pull/10247)
  * Update from Weblate
-   [\#10219](https://github.com/vector-im/riot-web/pull/10219)
+   [\#10219](https://github.com/element-hq/riot-web/pull/10219)
  * Extract configuration docs to separate file
-   [\#10195](https://github.com/vector-im/riot-web/pull/10195)
+   [\#10195](https://github.com/element-hq/riot-web/pull/10195)
  * Add e2e/warning.svg to preload
-   [\#10197](https://github.com/vector-im/riot-web/pull/10197)
+   [\#10197](https://github.com/element-hq/riot-web/pull/10197)
  * Fix Electron vector: links
-   [\#10196](https://github.com/vector-im/riot-web/pull/10196)
+   [\#10196](https://github.com/element-hq/riot-web/pull/10196)
  * Display a red box of anger for config syntax errors
-   [\#10193](https://github.com/vector-im/riot-web/pull/10193)
+   [\#10193](https://github.com/element-hq/riot-web/pull/10193)
  * Move config-getting to VectorBasePlatform
-   [\#10181](https://github.com/vector-im/riot-web/pull/10181)
+   [\#10181](https://github.com/element-hq/riot-web/pull/10181)
  * Update from Weblate
-   [\#10124](https://github.com/vector-im/riot-web/pull/10124)
+   [\#10124](https://github.com/element-hq/riot-web/pull/10124)
  * Fix default Electron window and tray icons
-   [\#10097](https://github.com/vector-im/riot-web/pull/10097)
+   [\#10097](https://github.com/element-hq/riot-web/pull/10097)
 
-Changes in [1.2.2](https://github.com/vector-im/riot-web/releases/tag/v1.2.2) (2019-06-19)
+Changes in [1.2.2](https://github.com/element-hq/riot-web/releases/tag/v1.2.2) (2019-06-19)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.2.2-rc.2...v1.2.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.2.2-rc.2...v1.2.2)
 
  No changes since rc.2
 
-Changes in [1.2.2-rc.2](https://github.com/vector-im/riot-web/releases/tag/v1.2.2-rc.2) (2019-06-18)
+Changes in [1.2.2-rc.2](https://github.com/element-hq/riot-web/releases/tag/v1.2.2-rc.2) (2019-06-18)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.2.2-rc.1...v1.2.2-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.2.2-rc.1...v1.2.2-rc.2)
 
  * Update to react-sdk and js-sdk rc.2 for registration fixes,
    redaction local echo fix and removing unnecessary calls
    to the integration manager.
 
-Changes in [1.2.2-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.2.2-rc.1) (2019-06-12)
+Changes in [1.2.2-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.2.2-rc.1) (2019-06-12)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.2.1...v1.2.2-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.2.1...v1.2.2-rc.1)
 
  * Update from Weblate
-   [\#10012](https://github.com/vector-im/riot-web/pull/10012)
+   [\#10012](https://github.com/element-hq/riot-web/pull/10012)
  * Add funding details for GitHub sponsor button
-   [\#9982](https://github.com/vector-im/riot-web/pull/9982)
+   [\#9982](https://github.com/element-hq/riot-web/pull/9982)
  * Do not fail on server liveliness checks during startup
-   [\#9960](https://github.com/vector-im/riot-web/pull/9960)
+   [\#9960](https://github.com/element-hq/riot-web/pull/9960)
  * Hide guest functions on the welcome page if not logged in
-   [\#9957](https://github.com/vector-im/riot-web/pull/9957)
+   [\#9957](https://github.com/element-hq/riot-web/pull/9957)
  * Add Albanian and West Flemish languages
-   [\#9953](https://github.com/vector-im/riot-web/pull/9953)
+   [\#9953](https://github.com/element-hq/riot-web/pull/9953)
  * Update from Weblate
-   [\#9951](https://github.com/vector-im/riot-web/pull/9951)
+   [\#9951](https://github.com/element-hq/riot-web/pull/9951)
  * Add docs for defaultCountryCode
-   [\#9927](https://github.com/vector-im/riot-web/pull/9927)
+   [\#9927](https://github.com/element-hq/riot-web/pull/9927)
  * Use the user's pre-existing HS when config validation fails
-   [\#9892](https://github.com/vector-im/riot-web/pull/9892)
+   [\#9892](https://github.com/element-hq/riot-web/pull/9892)
  * Low bandwidth mode
-   [\#9909](https://github.com/vector-im/riot-web/pull/9909)
+   [\#9909](https://github.com/element-hq/riot-web/pull/9909)
  * Fix Twemoji loading on Windows dev machines
-   [\#9869](https://github.com/vector-im/riot-web/pull/9869)
+   [\#9869](https://github.com/element-hq/riot-web/pull/9869)
  * Base Docker image on nginx:alpine, not the larger nginx:latest
-   [\#9848](https://github.com/vector-im/riot-web/pull/9848)
+   [\#9848](https://github.com/element-hq/riot-web/pull/9848)
  * Validate homeserver configuration prior to loading the app
-   [\#9779](https://github.com/vector-im/riot-web/pull/9779)
+   [\#9779](https://github.com/element-hq/riot-web/pull/9779)
  * Show resolved homeserver configuration on the mobile guide
-   [\#9726](https://github.com/vector-im/riot-web/pull/9726)
+   [\#9726](https://github.com/element-hq/riot-web/pull/9726)
  * Flag the validated config as the default config
-   [\#9721](https://github.com/vector-im/riot-web/pull/9721)
+   [\#9721](https://github.com/element-hq/riot-web/pull/9721)
  * Clarify comment on is_url and hs_url handling
-   [\#9719](https://github.com/vector-im/riot-web/pull/9719)
+   [\#9719](https://github.com/element-hq/riot-web/pull/9719)
  * Validate default homeserver config before loading the app
-   [\#9496](https://github.com/vector-im/riot-web/pull/9496)
+   [\#9496](https://github.com/element-hq/riot-web/pull/9496)
 
-Changes in [1.2.1](https://github.com/vector-im/riot-web/releases/tag/v1.2.1) (2019-05-31)
+Changes in [1.2.1](https://github.com/element-hq/riot-web/releases/tag/v1.2.1) (2019-05-31)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.2.0...v1.2.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.2.0...v1.2.1)
 
  * Upgrade JS SDK to 2.0.0 and React SDK to 1.2.1 to fix key backup and native emoji height
 
-Changes in [1.2.0](https://github.com/vector-im/riot-web/releases/tag/v1.2.0) (2019-05-29)
+Changes in [1.2.0](https://github.com/element-hq/riot-web/releases/tag/v1.2.0) (2019-05-29)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.2.0-rc.1...v1.2.0)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.2.0-rc.1...v1.2.0)
 
  * Upgrade to JS SDK v1.2.0 and React SDK v1.2.0 to fix some regressions
 
-Changes in [1.2.0-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.2.0-rc.1) (2019-05-23)
+Changes in [1.2.0-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.2.0-rc.1) (2019-05-23)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.1.2...v1.2.0-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.1.2...v1.2.0-rc.1)
 
  * Update from Weblate
-   [\#9802](https://github.com/vector-im/riot-web/pull/9802)
+   [\#9802](https://github.com/element-hq/riot-web/pull/9802)
  * remove emojione
-   [\#9766](https://github.com/vector-im/riot-web/pull/9766)
+   [\#9766](https://github.com/element-hq/riot-web/pull/9766)
  * Make Dockerfile work for develop and other branches
-   [\#9736](https://github.com/vector-im/riot-web/pull/9736)
+   [\#9736](https://github.com/element-hq/riot-web/pull/9736)
  * add description of new labs feature for message editing
-   [\#9728](https://github.com/vector-im/riot-web/pull/9728)
+   [\#9728](https://github.com/element-hq/riot-web/pull/9728)
  * Remove karma junit output
-   [\#9628](https://github.com/vector-im/riot-web/pull/9628)
+   [\#9628](https://github.com/element-hq/riot-web/pull/9628)
  * yarn upgrade
-   [\#9626](https://github.com/vector-im/riot-web/pull/9626)
+   [\#9626](https://github.com/element-hq/riot-web/pull/9626)
  * Respond quickly to buildkite pokes
-   [\#9617](https://github.com/vector-im/riot-web/pull/9617)
+   [\#9617](https://github.com/element-hq/riot-web/pull/9617)
  * Delay creating the `Favico` instance
-   [\#9616](https://github.com/vector-im/riot-web/pull/9616)
+   [\#9616](https://github.com/element-hq/riot-web/pull/9616)
  * Add reactions feature to config sample
-   [\#9598](https://github.com/vector-im/riot-web/pull/9598)
+   [\#9598](https://github.com/element-hq/riot-web/pull/9598)
 
-Changes in [1.1.2](https://github.com/vector-im/riot-web/releases/tag/v1.1.2) (2019-05-15)
+Changes in [1.1.2](https://github.com/element-hq/riot-web/releases/tag/v1.1.2) (2019-05-15)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.1.1...v1.1.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.1.1...v1.1.2)
 
  * react-sdk v1.1.2 to fix single sign-on and GIF autoplaying
 
-Changes in [1.1.1](https://github.com/vector-im/riot-web/releases/tag/v1.1.1) (2019-05-14)
+Changes in [1.1.1](https://github.com/element-hq/riot-web/releases/tag/v1.1.1) (2019-05-14)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.1.0...v1.1.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.1.0...v1.1.1)
 
  * react-sdk v1.1.1 to fix regressions with registration
 
-Changes in [1.1.0](https://github.com/vector-im/riot-web/releases/tag/v1.1.0) (2019-05-07)
+Changes in [1.1.0](https://github.com/element-hq/riot-web/releases/tag/v1.1.0) (2019-05-07)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.1.0-rc.1...v1.1.0)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.1.0-rc.1...v1.1.0)
 
  * Add Dockerfile
-   [\#9632](https://github.com/vector-im/riot-web/pull/9632)
+   [\#9632](https://github.com/element-hq/riot-web/pull/9632)
  * Add Dockerfile (part 2)
-   [\#9426](https://github.com/vector-im/riot-web/pull/9426)
+   [\#9426](https://github.com/element-hq/riot-web/pull/9426)
  * Add new scalar staging url
-   [\#9601](https://github.com/vector-im/riot-web/pull/9601)
+   [\#9601](https://github.com/element-hq/riot-web/pull/9601)
 
-Changes in [1.1.0-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.1.0-rc.1) (2019-04-30)
+Changes in [1.1.0-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.1.0-rc.1) (2019-04-30)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.0.8...v1.1.0-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.0.8...v1.1.0-rc.1)
 
  * Convert redeploy.py to buildkite
-   [\#9577](https://github.com/vector-im/riot-web/pull/9577)
+   [\#9577](https://github.com/element-hq/riot-web/pull/9577)
  * Add package step to buildkite pipeline
-   [\#9568](https://github.com/vector-im/riot-web/pull/9568)
+   [\#9568](https://github.com/element-hq/riot-web/pull/9568)
  * Don't fail if there's no local config to remove
-   [\#9571](https://github.com/vector-im/riot-web/pull/9571)
+   [\#9571](https://github.com/element-hq/riot-web/pull/9571)
  * Change jenkins script to package script
-   [\#9567](https://github.com/vector-im/riot-web/pull/9567)
+   [\#9567](https://github.com/element-hq/riot-web/pull/9567)
  * Remove config.json from package dir
-   [\#9555](https://github.com/vector-im/riot-web/pull/9555)
+   [\#9555](https://github.com/element-hq/riot-web/pull/9555)
  * use the release version of olm 3.1.0
-   [\#9550](https://github.com/vector-im/riot-web/pull/9550)
+   [\#9550](https://github.com/element-hq/riot-web/pull/9550)
  * Fix default for --include arg
-   [\#9517](https://github.com/vector-im/riot-web/pull/9517)
+   [\#9517](https://github.com/element-hq/riot-web/pull/9517)
  * update installation instructions with new repo
-   [\#9500](https://github.com/vector-im/riot-web/pull/9500)
+   [\#9500](https://github.com/element-hq/riot-web/pull/9500)
  * Use packages.matrix.org for Olm
-   [\#9498](https://github.com/vector-im/riot-web/pull/9498)
+   [\#9498](https://github.com/element-hq/riot-web/pull/9498)
  * Add separate platform electron build commands
-   [\#9412](https://github.com/vector-im/riot-web/pull/9412)
+   [\#9412](https://github.com/element-hq/riot-web/pull/9412)
  * Add support for custom profile directory
-   [\#9408](https://github.com/vector-im/riot-web/pull/9408)
+   [\#9408](https://github.com/element-hq/riot-web/pull/9408)
  * Improved mobile install guide
-   [\#9410](https://github.com/vector-im/riot-web/pull/9410)
+   [\#9410](https://github.com/element-hq/riot-web/pull/9410)
  * Remove vector-electron-desktop from README
-   [\#9404](https://github.com/vector-im/riot-web/pull/9404)
+   [\#9404](https://github.com/element-hq/riot-web/pull/9404)
  * Update from Weblate
-   [\#9398](https://github.com/vector-im/riot-web/pull/9398)
+   [\#9398](https://github.com/element-hq/riot-web/pull/9398)
  * bump olm version to 3.1.0-pre3
-   [\#9392](https://github.com/vector-im/riot-web/pull/9392)
+   [\#9392](https://github.com/element-hq/riot-web/pull/9392)
  * Add expiration to mobile guide cookie
-   [\#9383](https://github.com/vector-im/riot-web/pull/9383)
+   [\#9383](https://github.com/element-hq/riot-web/pull/9383)
  * Fix autolaunch setting appearing toggled off
-   [\#9368](https://github.com/vector-im/riot-web/pull/9368)
+   [\#9368](https://github.com/element-hq/riot-web/pull/9368)
  * Don't try to save files the user didn't want to save
-   [\#9352](https://github.com/vector-im/riot-web/pull/9352)
+   [\#9352](https://github.com/element-hq/riot-web/pull/9352)
  * Setup crypto store for restore session tests
-   [\#9325](https://github.com/vector-im/riot-web/pull/9325)
+   [\#9325](https://github.com/element-hq/riot-web/pull/9325)
  * Update from Weblate
-   [\#9333](https://github.com/vector-im/riot-web/pull/9333)
+   [\#9333](https://github.com/element-hq/riot-web/pull/9333)
  * Add "Save image as..." button to context menu on images
-   [\#9326](https://github.com/vector-im/riot-web/pull/9326)
+   [\#9326](https://github.com/element-hq/riot-web/pull/9326)
  * Configure auth footer links through Riot config
-   [\#9297](https://github.com/vector-im/riot-web/pull/9297)
+   [\#9297](https://github.com/element-hq/riot-web/pull/9297)
 
-Changes in [1.0.8](https://github.com/vector-im/riot-web/releases/tag/v1.0.8) (2019-04-16)
+Changes in [1.0.8](https://github.com/element-hq/riot-web/releases/tag/v1.0.8) (2019-04-16)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.0.7...v1.0.8)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.0.7...v1.0.8)
 
  * No changes in this release. This is the same code as v1.0.7 from our new clean-room
    packaging and signing infrastructure.
 
-Changes in [1.0.7](https://github.com/vector-im/riot-web/releases/tag/v1.0.7) (2019-04-08)
+Changes in [1.0.7](https://github.com/element-hq/riot-web/releases/tag/v1.0.7) (2019-04-08)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.0.6...v1.0.7)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.0.6...v1.0.7)
 
  * Hotfix: bump js-sdk to 1.0.4, see https://github.com/matrix-org/matrix-js-sdk/releases/tag/v1.0.4
 
-Changes in [1.0.6](https://github.com/vector-im/riot-web/releases/tag/v1.0.6) (2019-04-01)
+Changes in [1.0.6](https://github.com/element-hq/riot-web/releases/tag/v1.0.6) (2019-04-01)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.0.6-rc.1...v1.0.6)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.0.6-rc.1...v1.0.6)
 
  * Add "Save image as..." button to context menu on images
-   [\#9327](https://github.com/vector-im/riot-web/pull/9327)
+   [\#9327](https://github.com/element-hq/riot-web/pull/9327)
 
-Changes in [1.0.6-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.0.6-rc.1) (2019-03-27)
+Changes in [1.0.6-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.0.6-rc.1) (2019-03-27)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.0.5...v1.0.6-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.0.5...v1.0.6-rc.1)
 
  * Use `on_logged_in` action in tests
-   [\#9279](https://github.com/vector-im/riot-web/pull/9279)
+   [\#9279](https://github.com/element-hq/riot-web/pull/9279)
  * Convert away from `Promise.defer`
-   [\#9278](https://github.com/vector-im/riot-web/pull/9278)
+   [\#9278](https://github.com/element-hq/riot-web/pull/9278)
  * update react-sdk version in yarn lockfile
-   [\#9233](https://github.com/vector-im/riot-web/pull/9233)
+   [\#9233](https://github.com/element-hq/riot-web/pull/9233)
  * "Render simple counters in room header" details
-   [\#9154](https://github.com/vector-im/riot-web/pull/9154)
+   [\#9154](https://github.com/element-hq/riot-web/pull/9154)
  * Use medium agents for the more resource intensive builds
-   [\#9238](https://github.com/vector-im/riot-web/pull/9238)
+   [\#9238](https://github.com/element-hq/riot-web/pull/9238)
  * Add log grouping to buildkite
-   [\#9223](https://github.com/vector-im/riot-web/pull/9223)
+   [\#9223](https://github.com/element-hq/riot-web/pull/9223)
  * Switch to `git` protocol for CI dependencies
-   [\#9222](https://github.com/vector-im/riot-web/pull/9222)
+   [\#9222](https://github.com/element-hq/riot-web/pull/9222)
  * Support CI for matching branches on forks
-   [\#9212](https://github.com/vector-im/riot-web/pull/9212)
+   [\#9212](https://github.com/element-hq/riot-web/pull/9212)
  * Update from Weblate
-   [\#9199](https://github.com/vector-im/riot-web/pull/9199)
+   [\#9199](https://github.com/element-hq/riot-web/pull/9199)
  * Declare the officially supported browsers in the README
-   [\#9177](https://github.com/vector-im/riot-web/pull/9177)
+   [\#9177](https://github.com/element-hq/riot-web/pull/9177)
  * Document some desktop app things
-   [\#9011](https://github.com/vector-im/riot-web/pull/9011)
+   [\#9011](https://github.com/element-hq/riot-web/pull/9011)
  * Use Buildkite for CI
-   [\#9165](https://github.com/vector-im/riot-web/pull/9165)
+   [\#9165](https://github.com/element-hq/riot-web/pull/9165)
  * Update version number in issue templates
-   [\#9170](https://github.com/vector-im/riot-web/pull/9170)
+   [\#9170](https://github.com/element-hq/riot-web/pull/9170)
  * Remove node 8.x from the build matrix
-   [\#9159](https://github.com/vector-im/riot-web/pull/9159)
+   [\#9159](https://github.com/element-hq/riot-web/pull/9159)
  * Update Electron help menu link
-   [\#9157](https://github.com/vector-im/riot-web/pull/9157)
+   [\#9157](https://github.com/element-hq/riot-web/pull/9157)
 
-Changes in [1.0.5](https://github.com/vector-im/riot-web/releases/tag/v1.0.5) (2019-03-21)
+Changes in [1.0.5](https://github.com/element-hq/riot-web/releases/tag/v1.0.5) (2019-03-21)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.0.4...v1.0.5)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.0.4...v1.0.5)
 
- * Hotfix for [\#9205](https://github.com/vector-im/riot-web/issues/9205) disabling jump prevention for typing notifications, while we're reworking this functionally to enable it again soon.
+ * Hotfix for [\#9205](https://github.com/element-hq/riot-web/issues/9205) disabling jump prevention for typing notifications, while we're reworking this functionally to enable it again soon.
 
-Changes in [1.0.4](https://github.com/vector-im/riot-web/releases/tag/v1.0.4) (2019-03-18)
+Changes in [1.0.4](https://github.com/element-hq/riot-web/releases/tag/v1.0.4) (2019-03-18)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.0.4-rc.1...v1.0.4)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.0.4-rc.1...v1.0.4)
 
  * No changes since rc.1
 
-Changes in [1.0.4-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.0.4-rc.1) (2019-03-13)
+Changes in [1.0.4-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.0.4-rc.1) (2019-03-13)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.0.3...v1.0.4-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.0.3...v1.0.4-rc.1)
 
  * Update from Weblate
-   [\#9152](https://github.com/vector-im/riot-web/pull/9152)
+   [\#9152](https://github.com/element-hq/riot-web/pull/9152)
  * Use modern Yarn version on Travis CI
-   [\#9151](https://github.com/vector-im/riot-web/pull/9151)
+   [\#9151](https://github.com/element-hq/riot-web/pull/9151)
  * Switch to `yarn` for dependency management
-   [\#9132](https://github.com/vector-im/riot-web/pull/9132)
+   [\#9132](https://github.com/element-hq/riot-web/pull/9132)
  * Update from Weblate
-   [\#9104](https://github.com/vector-im/riot-web/pull/9104)
+   [\#9104](https://github.com/element-hq/riot-web/pull/9104)
  * Don't copy the 32 bit linux deb
-   [\#9075](https://github.com/vector-im/riot-web/pull/9075)
+   [\#9075](https://github.com/element-hq/riot-web/pull/9075)
  * Change olm dependency to normal dep
-   [\#9068](https://github.com/vector-im/riot-web/pull/9068)
+   [\#9068](https://github.com/element-hq/riot-web/pull/9068)
  * Add modular.im hosting link to electron app config
-   [\#9047](https://github.com/vector-im/riot-web/pull/9047)
+   [\#9047](https://github.com/element-hq/riot-web/pull/9047)
  * Nudge karma to 3.1.2
-   [\#8991](https://github.com/vector-im/riot-web/pull/8991)
+   [\#8991](https://github.com/element-hq/riot-web/pull/8991)
  * Add support for localConfig at $appData/config.json.
-   [\#8983](https://github.com/vector-im/riot-web/pull/8983)
+   [\#8983](https://github.com/element-hq/riot-web/pull/8983)
 
-Changes in [1.0.3](https://github.com/vector-im/riot-web/releases/tag/v1.0.3) (2019-03-06)
+Changes in [1.0.3](https://github.com/element-hq/riot-web/releases/tag/v1.0.3) (2019-03-06)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.0.2...v1.0.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.0.2...v1.0.3)
 
  * react-sdk 1.0.3 to fix ctrl+k shortcut and room list bugs
 
-Changes in [1.0.2](https://github.com/vector-im/riot-web/releases/tag/v1.0.2) (2019-03-06)
+Changes in [1.0.2](https://github.com/element-hq/riot-web/releases/tag/v1.0.2) (2019-03-06)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.0.2-rc.3...v1.0.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.0.2-rc.3...v1.0.2)
 
  * New react-sdk for minor hosting link fixes
 
-Changes in [1.0.2-rc.3](https://github.com/vector-im/riot-web/releases/tag/v1.0.2-rc.3) (2019-03-05)
+Changes in [1.0.2-rc.3](https://github.com/element-hq/riot-web/releases/tag/v1.0.2-rc.3) (2019-03-05)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.0.2-rc.2...v1.0.2-rc.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.0.2-rc.2...v1.0.2-rc.3)
 
  * Add modular.im hosting link to electron app config
-   [\#9051](https://github.com/vector-im/riot-web/pull/9051)
+   [\#9051](https://github.com/element-hq/riot-web/pull/9051)
 
-Changes in [1.0.2-rc.2](https://github.com/vector-im/riot-web/releases/tag/v1.0.2-rc.2) (2019-03-01)
+Changes in [1.0.2-rc.2](https://github.com/element-hq/riot-web/releases/tag/v1.0.2-rc.2) (2019-03-01)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.0.2-rc.1...v1.0.2-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.0.2-rc.1...v1.0.2-rc.2)
 
  * Update to react-sdk rc.3
 
-Changes in [1.0.2-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.0.2-rc.1) (2019-03-01)
+Changes in [1.0.2-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.0.2-rc.1) (2019-03-01)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.0.1...v1.0.2-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.0.1...v1.0.2-rc.1)
 
  * Set a require alias for the webapp directory
-   [\#9014](https://github.com/vector-im/riot-web/pull/9014)
+   [\#9014](https://github.com/element-hq/riot-web/pull/9014)
  * Update from Weblate.
-   [\#8973](https://github.com/vector-im/riot-web/pull/8973)
+   [\#8973](https://github.com/element-hq/riot-web/pull/8973)
  * set chrome path for travis CI explicitly
-   [\#8987](https://github.com/vector-im/riot-web/pull/8987)
+   [\#8987](https://github.com/element-hq/riot-web/pull/8987)
  * Updated install spinner
-   [\#8984](https://github.com/vector-im/riot-web/pull/8984)
+   [\#8984](https://github.com/element-hq/riot-web/pull/8984)
  * Allow disabling update mechanism
-   [\#8911](https://github.com/vector-im/riot-web/pull/8911)
+   [\#8911](https://github.com/element-hq/riot-web/pull/8911)
  * Allow configuration of whether closing window closes or minimizes to tray
-   [\#8908](https://github.com/vector-im/riot-web/pull/8908)
+   [\#8908](https://github.com/element-hq/riot-web/pull/8908)
  * Fix language file path for Jenkins
-   [\#8854](https://github.com/vector-im/riot-web/pull/8854)
+   [\#8854](https://github.com/element-hq/riot-web/pull/8854)
  * Document and recommend `default_server_name`
-   [\#8832](https://github.com/vector-im/riot-web/pull/8832)
+   [\#8832](https://github.com/element-hq/riot-web/pull/8832)
  * Cache busting for icons & language files
-   [\#8710](https://github.com/vector-im/riot-web/pull/8710)
+   [\#8710](https://github.com/element-hq/riot-web/pull/8710)
  * Remove redesign issue template
-   [\#8722](https://github.com/vector-im/riot-web/pull/8722)
+   [\#8722](https://github.com/element-hq/riot-web/pull/8722)
  * Make scripts/make-icons.sh work on linux
-   [\#8550](https://github.com/vector-im/riot-web/pull/8550)
+   [\#8550](https://github.com/element-hq/riot-web/pull/8550)
 
-Changes in [1.0.1](https://github.com/vector-im/riot-web/releases/tag/v1.0.1) (2019-02-15)
+Changes in [1.0.1](https://github.com/element-hq/riot-web/releases/tag/v1.0.1) (2019-02-15)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.0.0...v1.0.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.0.0...v1.0.1)
 
 
-Changes in [1.0.0](https://github.com/vector-im/riot-web/releases/tag/v1.0.0) (2019-02-14)
+Changes in [1.0.0](https://github.com/element-hq/riot-web/releases/tag/v1.0.0) (2019-02-14)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.0.0-rc.2...v1.0.0)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.0.0-rc.2...v1.0.0)
 
  * Add snipping lines to welcome page without guests
-   [\#8634](https://github.com/vector-im/riot-web/pull/8634)
+   [\#8634](https://github.com/element-hq/riot-web/pull/8634)
  * Add home page to fix loading tests
-   [\#8625](https://github.com/vector-im/riot-web/pull/8625)
+   [\#8625](https://github.com/element-hq/riot-web/pull/8625)
 
-Changes in [1.0.0-rc.2](https://github.com/vector-im/riot-web/releases/tag/v1.0.0-rc.2) (2019-02-14)
+Changes in [1.0.0-rc.2](https://github.com/element-hq/riot-web/releases/tag/v1.0.0-rc.2) (2019-02-14)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v1.0.0-rc.1...v1.0.0-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v1.0.0-rc.1...v1.0.0-rc.2)
 
  * Update from Weblate.
-   [\#8615](https://github.com/vector-im/riot-web/pull/8615)
+   [\#8615](https://github.com/element-hq/riot-web/pull/8615)
  * Replace favicon assets to ones with transparent backgrounds
-   [\#8600](https://github.com/vector-im/riot-web/pull/8600)
+   [\#8600](https://github.com/element-hq/riot-web/pull/8600)
  * Refreshed icons
-   [\#8594](https://github.com/vector-im/riot-web/pull/8594)
+   [\#8594](https://github.com/element-hq/riot-web/pull/8594)
  * Fix order of fetch-develop-deps / npm install
-   [\#8566](https://github.com/vector-im/riot-web/pull/8566)
+   [\#8566](https://github.com/element-hq/riot-web/pull/8566)
  * Revive building dark theme
-   [\#8540](https://github.com/vector-im/riot-web/pull/8540)
+   [\#8540](https://github.com/element-hq/riot-web/pull/8540)
  * Update from Weblate.
-   [\#8546](https://github.com/vector-im/riot-web/pull/8546)
+   [\#8546](https://github.com/element-hq/riot-web/pull/8546)
  * Repair app loading tests after welcome page
-   [\#8525](https://github.com/vector-im/riot-web/pull/8525)
+   [\#8525](https://github.com/element-hq/riot-web/pull/8525)
  * Support configurable welcome background and logo
-   [\#8528](https://github.com/vector-im/riot-web/pull/8528)
+   [\#8528](https://github.com/element-hq/riot-web/pull/8528)
  * Update from Weblate.
-   [\#8518](https://github.com/vector-im/riot-web/pull/8518)
+   [\#8518](https://github.com/element-hq/riot-web/pull/8518)
  * Document `embeddedPages` configuration
-   [\#8514](https://github.com/vector-im/riot-web/pull/8514)
+   [\#8514](https://github.com/element-hq/riot-web/pull/8514)
  * README.md : Syntax Coloring
-   [\#8502](https://github.com/vector-im/riot-web/pull/8502)
+   [\#8502](https://github.com/element-hq/riot-web/pull/8502)
 
-Changes in [1.0.0-rc.1](https://github.com/vector-im/riot-web/releases/tag/v1.0.0-rc.1) (2019-02-08)
+Changes in [1.0.0-rc.1](https://github.com/element-hq/riot-web/releases/tag/v1.0.0-rc.1) (2019-02-08)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.17.9...v1.0.0-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.17.9...v1.0.0-rc.1)
 
  * Update from Weblate.
-   [\#8475](https://github.com/vector-im/riot-web/pull/8475)
+   [\#8475](https://github.com/element-hq/riot-web/pull/8475)
  * Add configurable welcome page
-   [\#8466](https://github.com/vector-im/riot-web/pull/8466)
+   [\#8466](https://github.com/element-hq/riot-web/pull/8466)
  * fix app tests after force enabling lazy loading + removing feature flag
-   [\#8464](https://github.com/vector-im/riot-web/pull/8464)
+   [\#8464](https://github.com/element-hq/riot-web/pull/8464)
  * Allow Electron to zoom with CommandOrControl+=
-   [\#8381](https://github.com/vector-im/riot-web/pull/8381)
+   [\#8381](https://github.com/element-hq/riot-web/pull/8381)
  * Hide sign in / create account for logged in users
-   [\#8368](https://github.com/vector-im/riot-web/pull/8368)
+   [\#8368](https://github.com/element-hq/riot-web/pull/8368)
  * Fix home page link target
-   [\#8365](https://github.com/vector-im/riot-web/pull/8365)
+   [\#8365](https://github.com/element-hq/riot-web/pull/8365)
  * Add auth background image and update Riot logo
-   [\#8364](https://github.com/vector-im/riot-web/pull/8364)
+   [\#8364](https://github.com/element-hq/riot-web/pull/8364)
  * New homepage
-   [\#8363](https://github.com/vector-im/riot-web/pull/8363)
+   [\#8363](https://github.com/element-hq/riot-web/pull/8363)
  * Spell homeserver correctly
-   [\#8358](https://github.com/vector-im/riot-web/pull/8358)
+   [\#8358](https://github.com/element-hq/riot-web/pull/8358)
  * Merge redesign into develop
-   [\#8321](https://github.com/vector-im/riot-web/pull/8321)
+   [\#8321](https://github.com/element-hq/riot-web/pull/8321)
  * Disable room directory test because it doesn't work
-   [\#8318](https://github.com/vector-im/riot-web/pull/8318)
+   [\#8318](https://github.com/element-hq/riot-web/pull/8318)
  * Tweak auth overflow on Windows and Linux
-   [\#8307](https://github.com/vector-im/riot-web/pull/8307)
+   [\#8307](https://github.com/element-hq/riot-web/pull/8307)
  * Clean up Custom Server Help dialog
-   [\#8296](https://github.com/vector-im/riot-web/pull/8296)
+   [\#8296](https://github.com/element-hq/riot-web/pull/8296)
  * Cache-bust olm.wasm
-   [\#8283](https://github.com/vector-im/riot-web/pull/8283)
+   [\#8283](https://github.com/element-hq/riot-web/pull/8283)
  * Completely disable other themes for now (#8277)
-   [\#8280](https://github.com/vector-im/riot-web/pull/8280)
+   [\#8280](https://github.com/element-hq/riot-web/pull/8280)
  * Remove support for team servers
-   [\#8271](https://github.com/vector-im/riot-web/pull/8271)
+   [\#8271](https://github.com/element-hq/riot-web/pull/8271)
  * Add target="_blank" to footer links
-   [\#8248](https://github.com/vector-im/riot-web/pull/8248)
+   [\#8248](https://github.com/element-hq/riot-web/pull/8248)
  * Fix device names on desktop
-   [\#8241](https://github.com/vector-im/riot-web/pull/8241)
+   [\#8241](https://github.com/element-hq/riot-web/pull/8241)
  * Fix literal &lt/&gt in notifications
-   [\#8238](https://github.com/vector-im/riot-web/pull/8238)
+   [\#8238](https://github.com/element-hq/riot-web/pull/8238)
  * Fix registration nextLink on desktop
-   [\#8239](https://github.com/vector-im/riot-web/pull/8239)
+   [\#8239](https://github.com/element-hq/riot-web/pull/8239)
  * Add returns to fetch-develop-deps
-   [\#8233](https://github.com/vector-im/riot-web/pull/8233)
+   [\#8233](https://github.com/element-hq/riot-web/pull/8233)
  * Update electron builder
-   [\#8231](https://github.com/vector-im/riot-web/pull/8231)
+   [\#8231](https://github.com/element-hq/riot-web/pull/8231)
  * Try fetching more branches for PRs
-   [\#8225](https://github.com/vector-im/riot-web/pull/8225)
+   [\#8225](https://github.com/element-hq/riot-web/pull/8225)
  * Use content hashing for font and image URLs
-   [\#8159](https://github.com/vector-im/riot-web/pull/8159)
+   [\#8159](https://github.com/element-hq/riot-web/pull/8159)
  * Develop->Experimental
-   [\#8156](https://github.com/vector-im/riot-web/pull/8156)
+   [\#8156](https://github.com/element-hq/riot-web/pull/8156)
  * Update from Weblate.
-   [\#8150](https://github.com/vector-im/riot-web/pull/8150)
+   [\#8150](https://github.com/element-hq/riot-web/pull/8150)
  * Correct the copying of e-mail addresses in the electron app
-   [\#8124](https://github.com/vector-im/riot-web/pull/8124)
+   [\#8124](https://github.com/element-hq/riot-web/pull/8124)
  * Start documenting keyboard shortcuts
-   [\#7165](https://github.com/vector-im/riot-web/pull/7165)
+   [\#7165](https://github.com/element-hq/riot-web/pull/7165)
  * Update issue templates
-   [\#7948](https://github.com/vector-im/riot-web/pull/7948)
+   [\#7948](https://github.com/element-hq/riot-web/pull/7948)
  * Added new colour var to all themes
-   [\#7927](https://github.com/vector-im/riot-web/pull/7927)
+   [\#7927](https://github.com/element-hq/riot-web/pull/7927)
  * Redesign: apply changes from dharma theme to status theme
-   [\#7541](https://github.com/vector-im/riot-web/pull/7541)
+   [\#7541](https://github.com/element-hq/riot-web/pull/7541)
  * Redesign: ignore setting and always show dharma theme for now
-   [\#7540](https://github.com/vector-im/riot-web/pull/7540)
+   [\#7540](https://github.com/element-hq/riot-web/pull/7540)
 
-Changes in [0.17.9](https://github.com/vector-im/riot-web/releases/tag/v0.17.9) (2019-01-22)
+Changes in [0.17.9](https://github.com/element-hq/riot-web/releases/tag/v0.17.9) (2019-01-22)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.17.9-rc.1...v0.17.9)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.17.9-rc.1...v0.17.9)
 
  * Bugfix in react-sdk for setting DM rooms
 
-Changes in [0.17.9-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.17.9-rc.1) (2019-01-17)
+Changes in [0.17.9-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.17.9-rc.1) (2019-01-17)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.17.8...v0.17.9-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.17.8...v0.17.9-rc.1)
 
  * Merge develop into experimental
-   [\#8003](https://github.com/vector-im/riot-web/pull/8003)
+   [\#8003](https://github.com/element-hq/riot-web/pull/8003)
  * Electron: Load app from custom protocol
-   [\#7943](https://github.com/vector-im/riot-web/pull/7943)
+   [\#7943](https://github.com/element-hq/riot-web/pull/7943)
  * Fix the IndexedDB worker
-   [\#7920](https://github.com/vector-im/riot-web/pull/7920)
+   [\#7920](https://github.com/element-hq/riot-web/pull/7920)
  * Make clear that the Debian package is for desktop
-   [\#7919](https://github.com/vector-im/riot-web/pull/7919)
+   [\#7919](https://github.com/element-hq/riot-web/pull/7919)
  * Run the Desktop app in a sandbox
-   [\#7907](https://github.com/vector-im/riot-web/pull/7907)
+   [\#7907](https://github.com/element-hq/riot-web/pull/7907)
  * Update to new electron single instance API
-   [\#7908](https://github.com/vector-im/riot-web/pull/7908)
+   [\#7908](https://github.com/element-hq/riot-web/pull/7908)
  * Update the tests to match https://github.com/matrix-org/matrix-react-
    sdk/pull/2340
-   [\#7834](https://github.com/vector-im/riot-web/pull/7834)
+   [\#7834](https://github.com/element-hq/riot-web/pull/7834)
 
-Changes in [0.17.8](https://github.com/vector-im/riot-web/releases/tag/v0.17.8) (2018-12-10)
+Changes in [0.17.8](https://github.com/element-hq/riot-web/releases/tag/v0.17.8) (2018-12-10)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.17.8-rc.1...v0.17.8)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.17.8-rc.1...v0.17.8)
 
  * No changes since rc.1
 
-Changes in [0.17.8-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.17.8-rc.1) (2018-12-06)
+Changes in [0.17.8-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.17.8-rc.1) (2018-12-06)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.17.7...v0.17.8-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.17.7...v0.17.8-rc.1)
 
  * Update from Weblate.
-   [\#7784](https://github.com/vector-im/riot-web/pull/7784)
+   [\#7784](https://github.com/element-hq/riot-web/pull/7784)
  * Add a function to send a rageshake from the console
-   [\#7755](https://github.com/vector-im/riot-web/pull/7755)
+   [\#7755](https://github.com/element-hq/riot-web/pull/7755)
  * Re-apply "Run lint on travis builds and use modern node versions"
-   [\#7738](https://github.com/vector-im/riot-web/pull/7738)
+   [\#7738](https://github.com/element-hq/riot-web/pull/7738)
  * Revert "Run lint on travis builds and use modern node versions"
-   [\#7737](https://github.com/vector-im/riot-web/pull/7737)
+   [\#7737](https://github.com/element-hq/riot-web/pull/7737)
  * Run lint on travis builds and use modern node versions
-   [\#7490](https://github.com/vector-im/riot-web/pull/7490)
+   [\#7490](https://github.com/element-hq/riot-web/pull/7490)
  * Fix missing js-sdk logging
-   [\#7736](https://github.com/vector-im/riot-web/pull/7736)
+   [\#7736](https://github.com/element-hq/riot-web/pull/7736)
  * Add $accent-color-50pct as a CSS variable to the Status theme
-   [\#7710](https://github.com/vector-im/riot-web/pull/7710)
+   [\#7710](https://github.com/element-hq/riot-web/pull/7710)
 
-Changes in [0.17.7](https://github.com/vector-im/riot-web/releases/tag/v0.17.7) (2018-11-22)
+Changes in [0.17.7](https://github.com/element-hq/riot-web/releases/tag/v0.17.7) (2018-11-22)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.17.6...v0.17.7)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.17.6...v0.17.7)
 
  * Warning when crypto DB is too new to use.
  * Fix missing entries from js-sdk in rageshake logs
 
-Changes in [0.17.6](https://github.com/vector-im/riot-web/releases/tag/v0.17.6) (2018-11-19)
+Changes in [0.17.6](https://github.com/element-hq/riot-web/releases/tag/v0.17.6) (2018-11-19)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.17.6-rc.2...v0.17.6)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.17.6-rc.2...v0.17.6)
 
  * No changes since rc.2
 
-Changes in [0.17.6-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.17.6-rc.2) (2018-11-15)
+Changes in [0.17.6-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.17.6-rc.2) (2018-11-15)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.17.6-rc.1...v0.17.6-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.17.6-rc.1...v0.17.6-rc.2)
 
  * Update to js-sdk 0.14 and react-sdk rc.2. rc.1 was broken as it was built against
    js-sdk 0.13 which does not use the new Olm 3.0 API.
 
-Changes in [0.17.6-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.17.6-rc.1) (2018-11-15)
+Changes in [0.17.6-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.17.6-rc.1) (2018-11-15)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.17.5...v0.17.6-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.17.5...v0.17.6-rc.1)
 
  * Update from Weblate.
-   [\#7708](https://github.com/vector-im/riot-web/pull/7708)
+   [\#7708](https://github.com/element-hq/riot-web/pull/7708)
  * Add Japanese (#7599)
-   [\#7673](https://github.com/vector-im/riot-web/pull/7673)
+   [\#7673](https://github.com/element-hq/riot-web/pull/7673)
  * Allow Webpack dev server to listen to all interfaces
-   [\#7674](https://github.com/vector-im/riot-web/pull/7674)
+   [\#7674](https://github.com/element-hq/riot-web/pull/7674)
  * Remove the request-only stuff we don't need anymore
-   [\#7637](https://github.com/vector-im/riot-web/pull/7637)
+   [\#7637](https://github.com/element-hq/riot-web/pull/7637)
  * Correct the author of the electron app
-   [\#7615](https://github.com/vector-im/riot-web/pull/7615)
+   [\#7615](https://github.com/element-hq/riot-web/pull/7615)
  * Mock fs, tls, and net to support request in the browser
-   [\#7552](https://github.com/vector-im/riot-web/pull/7552)
+   [\#7552](https://github.com/element-hq/riot-web/pull/7552)
  * Update chokidar to transitively get newer fsevents
-   [\#7598](https://github.com/vector-im/riot-web/pull/7598)
+   [\#7598](https://github.com/element-hq/riot-web/pull/7598)
  * Support WebAssembly version of Olm
-   [\#7385](https://github.com/vector-im/riot-web/pull/7385)
+   [\#7385](https://github.com/element-hq/riot-web/pull/7385)
 
-Changes in [0.17.5](https://github.com/vector-im/riot-web/releases/tag/v0.17.5) (2018-11-13)
+Changes in [0.17.5](https://github.com/element-hq/riot-web/releases/tag/v0.17.5) (2018-11-13)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.17.4...v0.17.5)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.17.4...v0.17.5)
 
  * Include change that was supposed to be included in orevious version
 
-Changes in [0.17.4](https://github.com/vector-im/riot-web/releases/tag/v0.17.4) (2018-11-13)
+Changes in [0.17.4](https://github.com/element-hq/riot-web/releases/tag/v0.17.4) (2018-11-13)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.17.3...v0.17.4)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.17.3...v0.17.4)
 
  * Add banner with login/register links for users who aren't logged in
 
-Changes in [0.17.3](https://github.com/vector-im/riot-web/releases/tag/v0.17.3) (2018-10-29)
+Changes in [0.17.3](https://github.com/element-hq/riot-web/releases/tag/v0.17.3) (2018-10-29)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.17.3-rc.1...v0.17.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.17.3-rc.1...v0.17.3)
 
  * Fix for autocompleting text emoji from react-sdk v0.14.2
 
-Changes in [0.17.3-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.17.3-rc.1) (2018-10-24)
+Changes in [0.17.3-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.17.3-rc.1) (2018-10-24)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.17.2...v0.17.3-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.17.2...v0.17.3-rc.1)
 
  * Update from Weblate.
-   [\#7549](https://github.com/vector-im/riot-web/pull/7549)
+   [\#7549](https://github.com/element-hq/riot-web/pull/7549)
  * Don't set tags on notifications
-   [\#7518](https://github.com/vector-im/riot-web/pull/7518)
+   [\#7518](https://github.com/element-hq/riot-web/pull/7518)
  * Update to latest electron builder
-   [\#7498](https://github.com/vector-im/riot-web/pull/7498)
+   [\#7498](https://github.com/element-hq/riot-web/pull/7498)
  * Fix Tinter.setTheme to not fire using Firefox
-   [\#6831](https://github.com/vector-im/riot-web/pull/6831)
+   [\#6831](https://github.com/element-hq/riot-web/pull/6831)
 
-Changes in [0.17.2](https://github.com/vector-im/riot-web/releases/tag/v0.17.2) (2018-10-19)
+Changes in [0.17.2](https://github.com/element-hq/riot-web/releases/tag/v0.17.2) (2018-10-19)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.17.1...v0.17.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.17.1...v0.17.2)
 
  * Update react-sdk version to "Apply the user's tint once the MatrixClientPeg is moderately ready"
  * Electron: don't set tags on notifications
-   [\#7518](https://github.com/vector-im/riot-web/pull/7518)
+   [\#7518](https://github.com/element-hq/riot-web/pull/7518)
 
-Changes in [0.17.1](https://github.com/vector-im/riot-web/releases/tag/v0.17.1) (2018-10-18)
+Changes in [0.17.1](https://github.com/element-hq/riot-web/releases/tag/v0.17.1) (2018-10-18)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.17.0...v0.17.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.17.0...v0.17.1)
 
  * Stop electron crashing
-   [\#7517](https://github.com/vector-im/riot-web/pull/7517)
+   [\#7517](https://github.com/element-hq/riot-web/pull/7517)
 
-Changes in [0.17.0](https://github.com/vector-im/riot-web/releases/tag/v0.17.0) (2018-10-16)
+Changes in [0.17.0](https://github.com/element-hq/riot-web/releases/tag/v0.17.0) (2018-10-16)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.17.0-rc.1...v0.17.0)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.17.0-rc.1...v0.17.0)
 
  * Phased rollout of lazyloading
-   [\#7503](https://github.com/vector-im/riot-web/pull/7503)
+   [\#7503](https://github.com/element-hq/riot-web/pull/7503)
  * Update to latest electron builder
-   [\#7501](https://github.com/vector-im/riot-web/pull/7501)
+   [\#7501](https://github.com/element-hq/riot-web/pull/7501)
 
-Changes in [0.17.0-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.17.0-rc.1) (2018-10-11)
+Changes in [0.17.0-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.17.0-rc.1) (2018-10-11)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.16.5...v0.17.0-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.16.5...v0.17.0-rc.1)
 
  * Revert "also commit the lock file when bumping version as it is now
    committed to the repo"
-   [\#7483](https://github.com/vector-im/riot-web/pull/7483)
+   [\#7483](https://github.com/element-hq/riot-web/pull/7483)
  * Update from Weblate.
-   [\#7478](https://github.com/vector-im/riot-web/pull/7478)
+   [\#7478](https://github.com/element-hq/riot-web/pull/7478)
  *  Fix riot-web Promise.defer warnings (#7409)
-   [\#7444](https://github.com/vector-im/riot-web/pull/7444)
+   [\#7444](https://github.com/element-hq/riot-web/pull/7444)
  * Use HTTPS cloning for riot-web too
-   [\#7459](https://github.com/vector-im/riot-web/pull/7459)
+   [\#7459](https://github.com/element-hq/riot-web/pull/7459)
  * Disable webpack-dev-server auto reload
-   [\#7463](https://github.com/vector-im/riot-web/pull/7463)
+   [\#7463](https://github.com/element-hq/riot-web/pull/7463)
  * Silence bluebird warnings
-   [\#7462](https://github.com/vector-im/riot-web/pull/7462)
+   [\#7462](https://github.com/element-hq/riot-web/pull/7462)
  * Fix reskindex on matrix-react-side not being called if using build script
-   [\#7443](https://github.com/vector-im/riot-web/pull/7443)
+   [\#7443](https://github.com/element-hq/riot-web/pull/7443)
  * Fix double-closed tags
-   [\#7454](https://github.com/vector-im/riot-web/pull/7454)
+   [\#7454](https://github.com/element-hq/riot-web/pull/7454)
  * Document how to turn off Piwik and bug reports (#6738)
-   [\#7435](https://github.com/vector-im/riot-web/pull/7435)
+   [\#7435](https://github.com/element-hq/riot-web/pull/7435)
  * also commit the lock file when bumping version as it is now committed to the
    repo
-   [\#7429](https://github.com/vector-im/riot-web/pull/7429)
+   [\#7429](https://github.com/element-hq/riot-web/pull/7429)
  * Update a bunch of deps
-   [\#7393](https://github.com/vector-im/riot-web/pull/7393)
+   [\#7393](https://github.com/element-hq/riot-web/pull/7393)
  * Don't show mobile guide if deep linking
-   [\#7415](https://github.com/vector-im/riot-web/pull/7415)
+   [\#7415](https://github.com/element-hq/riot-web/pull/7415)
  * Don't show custom server bit on matrix.org
-   [\#7408](https://github.com/vector-im/riot-web/pull/7408)
+   [\#7408](https://github.com/element-hq/riot-web/pull/7408)
  * Update Webpack to version 4
-   [\#6620](https://github.com/vector-im/riot-web/pull/6620)
+   [\#6620](https://github.com/element-hq/riot-web/pull/6620)
  * Webpack4
-   [\#7387](https://github.com/vector-im/riot-web/pull/7387)
+   [\#7387](https://github.com/element-hq/riot-web/pull/7387)
 
-Changes in [0.16.6](https://github.com/vector-im/riot-web/releases/tag/v0.16.6) (2018-10-08)
+Changes in [0.16.6](https://github.com/element-hq/riot-web/releases/tag/v0.16.6) (2018-10-08)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.16.5...v0.16.6)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.16.5...v0.16.6)
 
  * Update to matrix-react-sdk v0.13.6
 
-Changes in [0.16.5](https://github.com/vector-im/riot-web/releases/tag/v0.16.5) (2018-10-01)
+Changes in [0.16.5](https://github.com/element-hq/riot-web/releases/tag/v0.16.5) (2018-10-01)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.16.5-rc.1...v0.16.5)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.16.5-rc.1...v0.16.5)
 
  * Don't show mobile guide if deep linking
-   [\#7415](https://github.com/vector-im/riot-web/pull/7415)
+   [\#7415](https://github.com/element-hq/riot-web/pull/7415)
  * Don't show custom server bit on matrix.org
-   [\#7408](https://github.com/vector-im/riot-web/pull/7408)
+   [\#7408](https://github.com/element-hq/riot-web/pull/7408)
 
-Changes in [0.16.5-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.16.5-rc.1) (2018-09-27)
+Changes in [0.16.5-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.16.5-rc.1) (2018-09-27)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.16.4...v0.16.5-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.16.4...v0.16.5-rc.1)
 
  * Update from Weblate.
-   [\#7395](https://github.com/vector-im/riot-web/pull/7395)
+   [\#7395](https://github.com/element-hq/riot-web/pull/7395)
  * Reduce the number of terminals required to build riot-web to 1
-   [\#7355](https://github.com/vector-im/riot-web/pull/7355)
+   [\#7355](https://github.com/element-hq/riot-web/pull/7355)
  * Small typo in release notes v0.16.3
-   [\#7274](https://github.com/vector-im/riot-web/pull/7274)
+   [\#7274](https://github.com/element-hq/riot-web/pull/7274)
 
-Changes in [0.16.4](https://github.com/vector-im/riot-web/releases/tag/v0.16.4) (2018-09-10)
+Changes in [0.16.4](https://github.com/element-hq/riot-web/releases/tag/v0.16.4) (2018-09-10)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.16.4-rc.1...v0.16.4)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.16.4-rc.1...v0.16.4)
 
  * No changes since rc.1
 
-Changes in [0.16.4-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.16.4-rc.1) (2018-09-07)
+Changes in [0.16.4-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.16.4-rc.1) (2018-09-07)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.16.3...v0.16.4-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.16.3...v0.16.4-rc.1)
 
  * Update from Weblate.
-   [\#7296](https://github.com/vector-im/riot-web/pull/7296)
+   [\#7296](https://github.com/element-hq/riot-web/pull/7296)
  * Fix config not loading & mobileguide script being loaded in riot
-   [\#7288](https://github.com/vector-im/riot-web/pull/7288)
+   [\#7288](https://github.com/element-hq/riot-web/pull/7288)
  * Instructions for installing mobile apps
-   [\#7272](https://github.com/vector-im/riot-web/pull/7272)
+   [\#7272](https://github.com/element-hq/riot-web/pull/7272)
  * Tidy up index.js
-   [\#7265](https://github.com/vector-im/riot-web/pull/7265)
+   [\#7265](https://github.com/element-hq/riot-web/pull/7265)
 
-Changes in [0.16.3](https://github.com/vector-im/riot-web/releases/tag/v0.16.3) (2018-09-03)
+Changes in [0.16.3](https://github.com/element-hq/riot-web/releases/tag/v0.16.3) (2018-09-03)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.16.3-rc.2...v0.16.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.16.3-rc.2...v0.16.3)
 
  * SECURITY FIX: This version (and release candidates) pull in an upstream security
    fix from electron to fix CVE-2018-15685. Electron users should update as soon as
    possible. Riot-web run outside of Electron is unaffected.
 
-Changes in [0.16.3-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.16.3-rc.2) (2018-08-31)
+Changes in [0.16.3-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.16.3-rc.2) (2018-08-31)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.16.3-rc.1...v0.16.3-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.16.3-rc.1...v0.16.3-rc.2)
 
  * Update js-sdk to fix an exception causing the room list to become unresponsive.
 
-Changes in [0.16.3-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.16.3-rc.1) (2018-08-30)
+Changes in [0.16.3-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.16.3-rc.1) (2018-08-30)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.16.2...v0.16.3-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.16.2...v0.16.3-rc.1)
 
  * Update from Weblate.
-   [\#7245](https://github.com/vector-im/riot-web/pull/7245)
+   [\#7245](https://github.com/element-hq/riot-web/pull/7245)
  * Revert "Remove package-lock.json for now"
-   [\#7128](https://github.com/vector-im/riot-web/pull/7128)
+   [\#7128](https://github.com/element-hq/riot-web/pull/7128)
  * Remove package-lock.json for now
-   [\#7115](https://github.com/vector-im/riot-web/pull/7115)
+   [\#7115](https://github.com/element-hq/riot-web/pull/7115)
 
-Changes in [0.16.2](https://github.com/vector-im/riot-web/releases/tag/v0.16.2) (2018-08-23)
+Changes in [0.16.2](https://github.com/element-hq/riot-web/releases/tag/v0.16.2) (2018-08-23)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.16.1...v0.16.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.16.1...v0.16.2)
 
  * Support new server notices format
 
-Changes in [0.16.1](https://github.com/vector-im/riot-web/releases/tag/v0.16.1) (2018-08-20)
+Changes in [0.16.1](https://github.com/element-hq/riot-web/releases/tag/v0.16.1) (2018-08-20)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.16.1-rc.1...v0.16.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.16.1-rc.1...v0.16.1)
 
  * No changes since rc.1
 
-Changes in [0.16.1-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.16.1-rc.1) (2018-08-16)
+Changes in [0.16.1-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.16.1-rc.1) (2018-08-16)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.16.0...v0.16.1-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.16.0...v0.16.1-rc.1)
 
  * Update from Weblate.
-   [\#7178](https://github.com/vector-im/riot-web/pull/7178)
+   [\#7178](https://github.com/element-hq/riot-web/pull/7178)
  * CSS for MAU warning bar
-   [\#7152](https://github.com/vector-im/riot-web/pull/7152)
+   [\#7152](https://github.com/element-hq/riot-web/pull/7152)
  * CSS for user limit error
-   [\#7139](https://github.com/vector-im/riot-web/pull/7139)
+   [\#7139](https://github.com/element-hq/riot-web/pull/7139)
  * Unpin sanitize-html
-   [\#7132](https://github.com/vector-im/riot-web/pull/7132)
+   [\#7132](https://github.com/element-hq/riot-web/pull/7132)
  * Pin sanitize-html to 0.18.2
-   [\#7129](https://github.com/vector-im/riot-web/pull/7129)
+   [\#7129](https://github.com/element-hq/riot-web/pull/7129)
 
-Changes in [0.16.0](https://github.com/vector-im/riot-web/releases/tag/v0.16.0) (2018-07-30)
+Changes in [0.16.0](https://github.com/element-hq/riot-web/releases/tag/v0.16.0) (2018-07-30)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.16.0-rc.2...v0.16.0)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.16.0-rc.2...v0.16.0)
 
 * Update react-sdk version for bugfixes with Jitsi widgets and the new composer
 
-Changes in [0.16.0-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.16.0-rc.2) (2018-07-24)
+Changes in [0.16.0-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.16.0-rc.2) (2018-07-24)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.16.0-rc.1...v0.16.0-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.16.0-rc.1...v0.16.0-rc.2)
 
  * Update to react-sdk rc.2 to remove Jitsi conference calling from labs
 
-Changes in [0.16.0-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.16.0-rc.1) (2018-07-24)
+Changes in [0.16.0-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.16.0-rc.1) (2018-07-24)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.7...v0.16.0-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.7...v0.16.0-rc.1)
 
  * Update from Weblate.
-   [\#7082](https://github.com/vector-im/riot-web/pull/7082)
+   [\#7082](https://github.com/element-hq/riot-web/pull/7082)
  * Sample config for jitsi integration URL
-   [\#7055](https://github.com/vector-im/riot-web/pull/7055)
+   [\#7055](https://github.com/element-hq/riot-web/pull/7055)
 
-Changes in [0.15.7](https://github.com/vector-im/riot-web/releases/tag/v0.15.7) (2018-07-09)
+Changes in [0.15.7](https://github.com/element-hq/riot-web/releases/tag/v0.15.7) (2018-07-09)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.7-rc.2...v0.15.7)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.7-rc.2...v0.15.7)
 
  * No changes since rc.2
 
-Changes in [0.15.7-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.15.7-rc.2) (2018-07-06)
+Changes in [0.15.7-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.15.7-rc.2) (2018-07-06)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.7-rc.1...v0.15.7-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.7-rc.1...v0.15.7-rc.2)
 
  * Update react-sdk and js-sdk
 
-Changes in [0.15.7-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.15.7-rc.1) (2018-07-04)
+Changes in [0.15.7-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.15.7-rc.1) (2018-07-04)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.6...v0.15.7-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.6...v0.15.7-rc.1)
 
  * add override for colour of room tile text within memberinfo (unreadable)
-   [\#6889](https://github.com/vector-im/riot-web/pull/6889)
+   [\#6889](https://github.com/element-hq/riot-web/pull/6889)
 
-Changes in [0.15.6](https://github.com/vector-im/riot-web/releases/tag/v0.15.6) (2018-06-29)
+Changes in [0.15.6](https://github.com/element-hq/riot-web/releases/tag/v0.15.6) (2018-06-29)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.6-rc.2...v0.15.6)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.6-rc.2...v0.15.6)
 
  * Pull in bug fixes from react-sdk
 
-Changes in [0.15.6-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.15.6-rc.2) (2018-06-22)
+Changes in [0.15.6-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.15.6-rc.2) (2018-06-22)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.6-rc.1...v0.15.6-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.6-rc.1...v0.15.6-rc.2)
 
  * Update to react-sdk rc.2 for fix to slash commands
 
-Changes in [0.15.6-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.15.6-rc.1) (2018-06-21)
+Changes in [0.15.6-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.15.6-rc.1) (2018-06-21)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.5...v0.15.6-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.5...v0.15.6-rc.1)
 
  * Update from Weblate.
-   [\#6915](https://github.com/vector-im/riot-web/pull/6915)
+   [\#6915](https://github.com/element-hq/riot-web/pull/6915)
  * [electron] Fix desktop app --hidden flag
-   [\#6805](https://github.com/vector-im/riot-web/pull/6805)
+   [\#6805](https://github.com/element-hq/riot-web/pull/6805)
 
-Changes in [0.15.5](https://github.com/vector-im/riot-web/releases/tag/v0.15.5) (2018-06-12)
+Changes in [0.15.5](https://github.com/element-hq/riot-web/releases/tag/v0.15.5) (2018-06-12)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.5-rc.1...v0.15.5)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.5-rc.1...v0.15.5)
 
  * No changes since rc.1
 
-Changes in [0.15.5-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.15.5-rc.1) (2018-06-06)
+Changes in [0.15.5-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.15.5-rc.1) (2018-06-06)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.4...v0.15.5-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.4...v0.15.5-rc.1)
 
  * Update from Weblate.
-   [\#6846](https://github.com/vector-im/riot-web/pull/6846)
+   [\#6846](https://github.com/element-hq/riot-web/pull/6846)
 
-Changes in [0.15.4](https://github.com/vector-im/riot-web/releases/tag/v0.15.4) (2018-05-25)
+Changes in [0.15.4](https://github.com/element-hq/riot-web/releases/tag/v0.15.4) (2018-05-25)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.4-rc.1...v0.15.4)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.4-rc.1...v0.15.4)
 
  * Add cookie policy link to desktop app config
 
-Changes in [0.15.4-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.15.4-rc.1) (2018-05-24)
+Changes in [0.15.4-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.15.4-rc.1) (2018-05-24)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.3...v0.15.4-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.3...v0.15.4-rc.1)
 
  * Update from Weblate.
-   [\#6792](https://github.com/vector-im/riot-web/pull/6792)
+   [\#6792](https://github.com/element-hq/riot-web/pull/6792)
  * Hide URL options for e2e blob: URL images
-   [\#6765](https://github.com/vector-im/riot-web/pull/6765)
+   [\#6765](https://github.com/element-hq/riot-web/pull/6765)
  * Fix right click menu in electron
-   [\#6763](https://github.com/vector-im/riot-web/pull/6763)
+   [\#6763](https://github.com/element-hq/riot-web/pull/6763)
  * Update to electron 2.0.1
-   [\#6764](https://github.com/vector-im/riot-web/pull/6764)
+   [\#6764](https://github.com/element-hq/riot-web/pull/6764)
  * Add instructions for changing translated strings
-   [\#6528](https://github.com/vector-im/riot-web/pull/6528)
+   [\#6528](https://github.com/element-hq/riot-web/pull/6528)
 
-Changes in [0.15.3](https://github.com/vector-im/riot-web/releases/tag/v0.15.3) (2018-05-18)
+Changes in [0.15.3](https://github.com/element-hq/riot-web/releases/tag/v0.15.3) (2018-05-18)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.2...v0.15.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.2...v0.15.3)
 
  * Fix right click menu in electron
-   [\#6763](https://github.com/vector-im/riot-web/pull/6763)
+   [\#6763](https://github.com/element-hq/riot-web/pull/6763)
  * Update to electron 2.0.1
-   [\#6764](https://github.com/vector-im/riot-web/pull/6764)
+   [\#6764](https://github.com/element-hq/riot-web/pull/6764)
  * Hide URL options for e2e blob: URL images
-   [\#6765](https://github.com/vector-im/riot-web/pull/6765)
+   [\#6765](https://github.com/element-hq/riot-web/pull/6765)
 
-Changes in [0.15.2](https://github.com/vector-im/riot-web/releases/tag/v0.15.2) (2018-05-17)
+Changes in [0.15.2](https://github.com/element-hq/riot-web/releases/tag/v0.15.2) (2018-05-17)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.1...v0.15.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.1...v0.15.2)
 
  * Update to matrix-react-sdk v0.12.5 to fix image size jumps
 
-Changes in [0.15.1](https://github.com/vector-im/riot-web/releases/tag/v0.15.1) (2018-05-16)
+Changes in [0.15.1](https://github.com/element-hq/riot-web/releases/tag/v0.15.1) (2018-05-16)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.0...v0.15.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.0...v0.15.1)
 
  * Fix package-lock.json which was causing errors building the Electron app
  * Update Electron version
 
-Changes in [0.15.0](https://github.com/vector-im/riot-web/releases/tag/v0.15.0) (2018-05-16)
+Changes in [0.15.0](https://github.com/element-hq/riot-web/releases/tag/v0.15.0) (2018-05-16)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.0-rc.6...v0.15.0)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.0-rc.6...v0.15.0)
 
  * No changes since rc.6
 
-Changes in [0.15.0-rc.6](https://github.com/vector-im/riot-web/releases/tag/v0.15.0-rc.6) (2018-05-15)
+Changes in [0.15.0-rc.6](https://github.com/element-hq/riot-web/releases/tag/v0.15.0-rc.6) (2018-05-15)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.0-rc.5...v0.15.0-rc.6)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.0-rc.5...v0.15.0-rc.6)
 
  * Update to matrix-react-sdk 0.12.4-rc.6
 
-Changes in [0.15.0-rc.5](https://github.com/vector-im/riot-web/releases/tag/v0.15.0-rc.5) (2018-05-15)
+Changes in [0.15.0-rc.5](https://github.com/element-hq/riot-web/releases/tag/v0.15.0-rc.5) (2018-05-15)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.0-rc.4...v0.15.0-rc.5)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.0-rc.4...v0.15.0-rc.5)
 
  * Update to matrix-react-sdk 0.12.4-rc.5
 
-Changes in [0.15.0-rc.4](https://github.com/vector-im/riot-web/releases/tag/v0.15.0-rc.4) (2018-05-14)
+Changes in [0.15.0-rc.4](https://github.com/element-hq/riot-web/releases/tag/v0.15.0-rc.4) (2018-05-14)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.0-rc.3...v0.15.0-rc.4)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.0-rc.3...v0.15.0-rc.4)
 
  * Update from Weblate.
-   [\#6726](https://github.com/vector-im/riot-web/pull/6726)
+   [\#6726](https://github.com/element-hq/riot-web/pull/6726)
  * Update to matrix-react-sdk 0.12.4-rc.4
 
-Changes in [0.15.0-rc.3](https://github.com/vector-im/riot-web/releases/tag/v0.15.0-rc.3) (2018-05-11)
+Changes in [0.15.0-rc.3](https://github.com/element-hq/riot-web/releases/tag/v0.15.0-rc.3) (2018-05-11)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.0-rc.2...v0.15.0-rc.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.0-rc.2...v0.15.0-rc.3)
 
  * Update to matrix-react-sdk 0.12.4-rc.3
 
-Changes in [0.15.0-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.15.0-rc.2) (2018-05-09)
+Changes in [0.15.0-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.15.0-rc.2) (2018-05-09)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.15.0-rc.1...v0.15.0-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.15.0-rc.1...v0.15.0-rc.2)
 
  * Update to matrix-react-sdk 0.12.4-rc.2
 
-Changes in [0.15.0-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.15.0-rc.1) (2018-05-09)
+Changes in [0.15.0-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.15.0-rc.1) (2018-05-09)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.14.3-rc.1...v0.15.0-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.14.3-rc.1...v0.15.0-rc.1)
 
  * No changes since 0.14.3-rc.1
 
-Changes in [0.14.3-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.14.3-rc.1) (2018-05-09)
+Changes in [0.14.3-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.14.3-rc.1) (2018-05-09)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.14.2...v0.14.3-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.14.2...v0.14.3-rc.1)
 
  * Update from Weblate.
-   [\#6688](https://github.com/vector-im/riot-web/pull/6688)
+   [\#6688](https://github.com/element-hq/riot-web/pull/6688)
  * Don't show presence on matrix.org
-   [\#6638](https://github.com/vector-im/riot-web/pull/6638)
+   [\#6638](https://github.com/element-hq/riot-web/pull/6638)
  * Enforce loading babel-polyfill first
-   [\#6625](https://github.com/vector-im/riot-web/pull/6625)
+   [\#6625](https://github.com/element-hq/riot-web/pull/6625)
  * Update hoek
-   [\#6624](https://github.com/vector-im/riot-web/pull/6624)
+   [\#6624](https://github.com/element-hq/riot-web/pull/6624)
  * Fix args in the release wrapper script
-   [\#6614](https://github.com/vector-im/riot-web/pull/6614)
+   [\#6614](https://github.com/element-hq/riot-web/pull/6614)
 
-Changes in [0.14.2](https://github.com/vector-im/riot-web/releases/tag/v0.14.2) (2018-04-30)
+Changes in [0.14.2](https://github.com/element-hq/riot-web/releases/tag/v0.14.2) (2018-04-30)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.14.2-rc.3...v0.14.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.14.2-rc.3...v0.14.2)
 
  * No changes since rc.3
 
-Changes in [0.14.2-rc.3](https://github.com/vector-im/riot-web/releases/tag/v0.14.2-rc.3) (2018-04-26)
+Changes in [0.14.2-rc.3](https://github.com/element-hq/riot-web/releases/tag/v0.14.2-rc.3) (2018-04-26)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.14.2-rc.2...v0.14.2-rc.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.14.2-rc.2...v0.14.2-rc.3)
 
  * Fix CSS dependency versions to be the same as those in react-sdk to fix
    left panel header positions.
 
-Changes in [0.14.2-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.14.2-rc.2) (2018-04-26)
+Changes in [0.14.2-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.14.2-rc.2) (2018-04-26)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.14.2-rc.1...v0.14.2-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.14.2-rc.1...v0.14.2-rc.2)
 
  * Fix Download of attachments in e2e encrypted rooms in Firefox
 
-Changes in [0.14.2-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.14.2-rc.1) (2018-04-25)
+Changes in [0.14.2-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.14.2-rc.1) (2018-04-25)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.14.1...v0.14.2-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.14.1...v0.14.2-rc.1)
 
  * Update from Weblate.
-   [\#6602](https://github.com/vector-im/riot-web/pull/6602)
+   [\#6602](https://github.com/element-hq/riot-web/pull/6602)
  * Add readme bit on cross-origin renderer
-   [\#6600](https://github.com/vector-im/riot-web/pull/6600)
+   [\#6600](https://github.com/element-hq/riot-web/pull/6600)
  * Update from Weblate.
-   [\#6573](https://github.com/vector-im/riot-web/pull/6573)
+   [\#6573](https://github.com/element-hq/riot-web/pull/6573)
  * Copy media from react-sdk
-   [\#6588](https://github.com/vector-im/riot-web/pull/6588)
+   [\#6588](https://github.com/element-hq/riot-web/pull/6588)
  * Fix favicon
-   [\#6580](https://github.com/vector-im/riot-web/pull/6580)
+   [\#6580](https://github.com/element-hq/riot-web/pull/6580)
  * Update from Weblate.
-   [\#6569](https://github.com/vector-im/riot-web/pull/6569)
+   [\#6569](https://github.com/element-hq/riot-web/pull/6569)
  * move everything not explicitly riot (or status) branded into matrix-react-
    sdk
-   [\#6500](https://github.com/vector-im/riot-web/pull/6500)
+   [\#6500](https://github.com/element-hq/riot-web/pull/6500)
  * Remove presence management
-   [\#5881](https://github.com/vector-im/riot-web/pull/5881)
+   [\#5881](https://github.com/element-hq/riot-web/pull/5881)
  * change vector-web repo to riot-web in changelog
-   [\#6480](https://github.com/vector-im/riot-web/pull/6480)
+   [\#6480](https://github.com/element-hq/riot-web/pull/6480)
  * Update from Weblate.
-   [\#6473](https://github.com/vector-im/riot-web/pull/6473)
+   [\#6473](https://github.com/element-hq/riot-web/pull/6473)
  * Bump source-map-loader version to avoid bug /w inline base64 maps
-   [\#6472](https://github.com/vector-im/riot-web/pull/6472)
+   [\#6472](https://github.com/element-hq/riot-web/pull/6472)
  * Add CSS for new group admin radio button
-   [\#6415](https://github.com/vector-im/riot-web/pull/6415)
+   [\#6415](https://github.com/element-hq/riot-web/pull/6415)
  * Rxl881/sticker picker styling
-   [\#6447](https://github.com/vector-im/riot-web/pull/6447)
+   [\#6447](https://github.com/element-hq/riot-web/pull/6447)
  * Stickerpacks
-   [\#6242](https://github.com/vector-im/riot-web/pull/6242)
+   [\#6242](https://github.com/element-hq/riot-web/pull/6242)
  * Force gemini on HomePage
-   [\#6368](https://github.com/vector-im/riot-web/pull/6368)
+   [\#6368](https://github.com/element-hq/riot-web/pull/6368)
  * Rename the Riot-Web Translations Room
-   [\#6348](https://github.com/vector-im/riot-web/pull/6348)
+   [\#6348](https://github.com/element-hq/riot-web/pull/6348)
  * Add disable-presence-by-hs option to sample config
-   [\#6350](https://github.com/vector-im/riot-web/pull/6350)
+   [\#6350](https://github.com/element-hq/riot-web/pull/6350)
  * Reword the BugReportDialog.js as per @lampholder
-   [\#6354](https://github.com/vector-im/riot-web/pull/6354)
+   [\#6354](https://github.com/element-hq/riot-web/pull/6354)
 
-Changes in [0.14.1](https://github.com/vector-im/riot-web/releases/tag/v0.14.1) (2018-04-12)
+Changes in [0.14.1](https://github.com/element-hq/riot-web/releases/tag/v0.14.1) (2018-04-12)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.14.0...v0.14.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.14.0...v0.14.1)
 
  * Remove presence management feature from labs
  * Fix an issue where Riot would fail to load at all if certain
@@ -6860,250 +6860,250 @@ Changes in [0.14.1](https://github.com/vector-im/riot-web/releases/tag/v0.14.1) 
  * Fix an issue where e2e cryptography could be disabled due to
    a migration error.
 
-Changes in [0.14.0](https://github.com/vector-im/riot-web/releases/tag/v0.14.0) (2018-04-11)
+Changes in [0.14.0](https://github.com/element-hq/riot-web/releases/tag/v0.14.0) (2018-04-11)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.14.0-rc.6...v0.14.0)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.14.0-rc.6...v0.14.0)
 
  * Cosmetic changes for group UI
 
-Changes in [0.14.0-rc.6](https://github.com/vector-im/riot-web/releases/tag/v0.14.0-rc.6) (2018-04-09)
+Changes in [0.14.0-rc.6](https://github.com/element-hq/riot-web/releases/tag/v0.14.0-rc.6) (2018-04-09)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.14.0-rc.5...v0.14.0-rc.6)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.14.0-rc.5...v0.14.0-rc.6)
 
  * Bump react-sdk to [rc.6](https://github.com/matrix-org/matrix-react-sdk/releases/tag/v0.12.0-rc.6)
 
-Changes in [0.14.0-rc.5](https://github.com/vector-im/riot-web/releases/tag/v0.14.0-rc.5) (2018-04-09)
+Changes in [0.14.0-rc.5](https://github.com/element-hq/riot-web/releases/tag/v0.14.0-rc.5) (2018-04-09)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.14.0-rc.4...v0.14.0-rc.5)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.14.0-rc.4...v0.14.0-rc.5)
 
 * Add CSS for new control to set group join policy
 
-Changes in [0.14.0-rc.4](https://github.com/vector-im/riot-web/releases/tag/v0.14.0-rc.4) (2018-03-22)
+Changes in [0.14.0-rc.4](https://github.com/element-hq/riot-web/releases/tag/v0.14.0-rc.4) (2018-03-22)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.14.0-rc.3...v0.14.0-rc.4)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.14.0-rc.3...v0.14.0-rc.4)
 
  * Fix tagging rooms as direct messages
 
-Changes in [0.14.0-rc.3](https://github.com/vector-im/riot-web/releases/tag/v0.14.0-rc.3) (2018-03-20)
+Changes in [0.14.0-rc.3](https://github.com/element-hq/riot-web/releases/tag/v0.14.0-rc.3) (2018-03-20)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.14.0-rc.2...v0.14.0-rc.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.14.0-rc.2...v0.14.0-rc.3)
 
  * Fix a bug where the badge on a room tile would not update
    when a room was read from a different device.
 
-Changes in [0.14.0-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.14.0-rc.2) (2018-03-19)
+Changes in [0.14.0-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.14.0-rc.2) (2018-03-19)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.14.0-rc.1...v0.14.0-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.14.0-rc.1...v0.14.0-rc.2)
 
  * Take TagPanel out of labs
-   [\#6347](https://github.com/vector-im/riot-web/pull/6347)
+   [\#6347](https://github.com/element-hq/riot-web/pull/6347)
  * Add languages (czech, galician and serbian)
-   [\#6343](https://github.com/vector-im/riot-web/pull/6343)
+   [\#6343](https://github.com/element-hq/riot-web/pull/6343)
 
-Changes in [0.14.0-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.14.0-rc.1) (2018-03-19)
+Changes in [0.14.0-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.14.0-rc.1) (2018-03-19)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.13.5...v0.14.0-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.13.5...v0.14.0-rc.1)
 
  * Force update RoomSubList after reading a room
-   [\#6342](https://github.com/vector-im/riot-web/pull/6342)
+   [\#6342](https://github.com/element-hq/riot-web/pull/6342)
  * Ensure entire LeftPanel is faded when settings open
-   [\#6340](https://github.com/vector-im/riot-web/pull/6340)
+   [\#6340](https://github.com/element-hq/riot-web/pull/6340)
  * Update from Weblate.
-   [\#6330](https://github.com/vector-im/riot-web/pull/6330)
+   [\#6330](https://github.com/element-hq/riot-web/pull/6330)
  * Implement a simple shouldComponentUpdate for DNDRoomTile
-   [\#6313](https://github.com/vector-im/riot-web/pull/6313)
+   [\#6313](https://github.com/element-hq/riot-web/pull/6313)
  * Remove og:image with status.im URL
-   [\#6317](https://github.com/vector-im/riot-web/pull/6317)
+   [\#6317](https://github.com/element-hq/riot-web/pull/6317)
  * Add change delay warning in GroupView settings
-   [\#6316](https://github.com/vector-im/riot-web/pull/6316)
+   [\#6316](https://github.com/element-hq/riot-web/pull/6316)
  * Correctly position mx_TagPanel_clearButton
-   [\#6289](https://github.com/vector-im/riot-web/pull/6289)
+   [\#6289](https://github.com/element-hq/riot-web/pull/6289)
  * Fix gap between avatar and border
-   [\#6290](https://github.com/vector-im/riot-web/pull/6290)
+   [\#6290](https://github.com/element-hq/riot-web/pull/6290)
  * Fix bug where cannot send group invite on GroupMemberInfo phase
-   [\#6303](https://github.com/vector-im/riot-web/pull/6303)
+   [\#6303](https://github.com/element-hq/riot-web/pull/6303)
  * Fix themeing bug with Firefox where "disabled" ignored
-   [\#6301](https://github.com/vector-im/riot-web/pull/6301)
+   [\#6301](https://github.com/element-hq/riot-web/pull/6301)
  * Changes for E2E "fudge-button"
-   [\#6288](https://github.com/vector-im/riot-web/pull/6288)
+   [\#6288](https://github.com/element-hq/riot-web/pull/6288)
  * Make sure mx_TagPanel_tagTileContainer occupies full height
-   [\#6286](https://github.com/vector-im/riot-web/pull/6286)
+   [\#6286](https://github.com/element-hq/riot-web/pull/6286)
  * Add transparent CSS class for RoomTile
-   [\#6281](https://github.com/vector-im/riot-web/pull/6281)
+   [\#6281](https://github.com/element-hq/riot-web/pull/6281)
  * Fix crash; fs event received /w langauge file empty
-   [\#6273](https://github.com/vector-im/riot-web/pull/6273)
+   [\#6273](https://github.com/element-hq/riot-web/pull/6273)
  * Add setting to disable TagPanel
-   [\#6269](https://github.com/vector-im/riot-web/pull/6269)
+   [\#6269](https://github.com/element-hq/riot-web/pull/6269)
  * CSS for my groups microcopy
-   [\#6257](https://github.com/vector-im/riot-web/pull/6257)
+   [\#6257](https://github.com/element-hq/riot-web/pull/6257)
  * Add Bulgarian to the list of languages
-   [\#6246](https://github.com/vector-im/riot-web/pull/6246)
+   [\#6246](https://github.com/element-hq/riot-web/pull/6246)
  * Make media dropdown wider
-   [\#6245](https://github.com/vector-im/riot-web/pull/6245)
+   [\#6245](https://github.com/element-hq/riot-web/pull/6245)
  * Make dropdowns with long options degrade more gracefully
-   [\#6244](https://github.com/vector-im/riot-web/pull/6244)
+   [\#6244](https://github.com/element-hq/riot-web/pull/6244)
  * Fix un-tinted "View Community" icon in TagTile context menu
-   [\#6223](https://github.com/vector-im/riot-web/pull/6223)
+   [\#6223](https://github.com/element-hq/riot-web/pull/6223)
  * Fix RoomDropTarget and emptySubListTip to have containers
-   [\#6160](https://github.com/vector-im/riot-web/pull/6160)
+   [\#6160](https://github.com/element-hq/riot-web/pull/6160)
  * Fix syntax error of wrong use of self-closing HTML tag
-   [\#6154](https://github.com/vector-im/riot-web/pull/6154)
+   [\#6154](https://github.com/element-hq/riot-web/pull/6154)
  * Use translucent black for RoomSubList bg to fix tinting
-   [\#6227](https://github.com/vector-im/riot-web/pull/6227)
+   [\#6227](https://github.com/element-hq/riot-web/pull/6227)
  * CSS for changing "R" to "X" for clearing group filter
-   [\#6216](https://github.com/vector-im/riot-web/pull/6216)
+   [\#6216](https://github.com/element-hq/riot-web/pull/6216)
  * CSS for new global TagPanel filter
-   [\#6187](https://github.com/vector-im/riot-web/pull/6187)
+   [\#6187](https://github.com/element-hq/riot-web/pull/6187)
  * Separate the middle panel from the room list
-   [\#6194](https://github.com/vector-im/riot-web/pull/6194)
+   [\#6194](https://github.com/element-hq/riot-web/pull/6194)
  * Only use DNDRoomTile for editable sub lists
-   [\#6176](https://github.com/vector-im/riot-web/pull/6176)
+   [\#6176](https://github.com/element-hq/riot-web/pull/6176)
  * Adjust CSS to prevent scrollbars on message panel spinner
-   [\#6131](https://github.com/vector-im/riot-web/pull/6131)
+   [\#6131](https://github.com/element-hq/riot-web/pull/6131)
  * Implement riot-web side of dragging GroupTile avatars to TagPanel
-   [\#6143](https://github.com/vector-im/riot-web/pull/6143)
+   [\#6143](https://github.com/element-hq/riot-web/pull/6143)
  * Fix LeftPanel size being incorrect when TagPanel disabled
-   [\#6140](https://github.com/vector-im/riot-web/pull/6140)
+   [\#6140](https://github.com/element-hq/riot-web/pull/6140)
  * Fix TagPanel from collapsing to < 60px when LP collapsed
-   [\#6134](https://github.com/vector-im/riot-web/pull/6134)
+   [\#6134](https://github.com/element-hq/riot-web/pull/6134)
  * Temporary hack to constrain LLP container size.
-   [\#6138](https://github.com/vector-im/riot-web/pull/6138)
+   [\#6138](https://github.com/element-hq/riot-web/pull/6138)
  * Fix typo
-   [\#6137](https://github.com/vector-im/riot-web/pull/6137)
+   [\#6137](https://github.com/element-hq/riot-web/pull/6137)
  * Add context menu to TagPanel
-   [\#6127](https://github.com/vector-im/riot-web/pull/6127)
+   [\#6127](https://github.com/element-hq/riot-web/pull/6127)
  * Make room tagging flux-y
-   [\#6096](https://github.com/vector-im/riot-web/pull/6096)
+   [\#6096](https://github.com/element-hq/riot-web/pull/6096)
  * Move groups button to TagPanel
-   [\#6130](https://github.com/vector-im/riot-web/pull/6130)
+   [\#6130](https://github.com/element-hq/riot-web/pull/6130)
  * Fix long group name pushing settings cog into void
-   [\#6106](https://github.com/vector-im/riot-web/pull/6106)
+   [\#6106](https://github.com/element-hq/riot-web/pull/6106)
  * Fix horizontal scrollbar under certain circumstances
-   [\#6103](https://github.com/vector-im/riot-web/pull/6103)
+   [\#6103](https://github.com/element-hq/riot-web/pull/6103)
  * Split MImageBody into MFileBody to match JS Classes.
-   [\#6067](https://github.com/vector-im/riot-web/pull/6067)
+   [\#6067](https://github.com/element-hq/riot-web/pull/6067)
  * Add Catalan
-   [\#6040](https://github.com/vector-im/riot-web/pull/6040)
+   [\#6040](https://github.com/element-hq/riot-web/pull/6040)
  * Update from Weblate.
-   [\#5777](https://github.com/vector-im/riot-web/pull/5777)
+   [\#5777](https://github.com/element-hq/riot-web/pull/5777)
  * make FilteredList controlled, such that it can externally persist filter
-   [\#5718](https://github.com/vector-im/riot-web/pull/5718)
+   [\#5718](https://github.com/element-hq/riot-web/pull/5718)
  * Linear Rich Quoting
-   [\#6017](https://github.com/vector-im/riot-web/pull/6017)
+   [\#6017](https://github.com/element-hq/riot-web/pull/6017)
  * Highlight ViewSource and Devtools ViewSource
-   [\#5995](https://github.com/vector-im/riot-web/pull/5995)
+   [\#5995](https://github.com/element-hq/riot-web/pull/5995)
  * default url, not domain
-   [\#6022](https://github.com/vector-im/riot-web/pull/6022)
+   [\#6022](https://github.com/element-hq/riot-web/pull/6022)
  * T3chguy/num members tooltip
-   [\#5929](https://github.com/vector-im/riot-web/pull/5929)
+   [\#5929](https://github.com/element-hq/riot-web/pull/5929)
  * Swap RoomList to react-beautiful-dnd
-   [\#6008](https://github.com/vector-im/riot-web/pull/6008)
+   [\#6008](https://github.com/element-hq/riot-web/pull/6008)
  * CSS required as part of moving TagPanel from react-dnd to react-beautiful-
    dnd
-   [\#5992](https://github.com/vector-im/riot-web/pull/5992)
+   [\#5992](https://github.com/element-hq/riot-web/pull/5992)
  * fix&refactor DateSeparator and MessageTimestamp
-   [\#5984](https://github.com/vector-im/riot-web/pull/5984)
+   [\#5984](https://github.com/element-hq/riot-web/pull/5984)
  * Iterative fixes on Rich Quoting
-   [\#5978](https://github.com/vector-im/riot-web/pull/5978)
+   [\#5978](https://github.com/element-hq/riot-web/pull/5978)
  * move piwik whitelists to conf and add piwik config.json info to readme
-   [\#5653](https://github.com/vector-im/riot-web/pull/5653)
+   [\#5653](https://github.com/element-hq/riot-web/pull/5653)
  * Implement Rich Quoting/Replies
-   [\#5804](https://github.com/vector-im/riot-web/pull/5804)
+   [\#5804](https://github.com/element-hq/riot-web/pull/5804)
  * Change author
-   [\#5950](https://github.com/vector-im/riot-web/pull/5950)
+   [\#5950](https://github.com/element-hq/riot-web/pull/5950)
  * Revert "Add a &nbsp; after timestamp"
-   [\#5944](https://github.com/vector-im/riot-web/pull/5944)
+   [\#5944](https://github.com/element-hq/riot-web/pull/5944)
  * Add a &nbsp; after timestamp
-   [\#3046](https://github.com/vector-im/riot-web/pull/3046)
+   [\#3046](https://github.com/element-hq/riot-web/pull/3046)
  * Corrected language name
-   [\#5938](https://github.com/vector-im/riot-web/pull/5938)
+   [\#5938](https://github.com/element-hq/riot-web/pull/5938)
  * Hide Options button from copy to clipboard
-   [\#2892](https://github.com/vector-im/riot-web/pull/2892)
+   [\#2892](https://github.com/element-hq/riot-web/pull/2892)
  * Fix for `If riot is narrow enough, such that 'Send a message (unecrypted)'
    wraps to a second line, the timeline doesn't fit the window.`
-   [\#5900](https://github.com/vector-im/riot-web/pull/5900)
+   [\#5900](https://github.com/element-hq/riot-web/pull/5900)
  * Screenshot UI
-   [\#5849](https://github.com/vector-im/riot-web/pull/5849)
+   [\#5849](https://github.com/element-hq/riot-web/pull/5849)
  * add missing config.json entry such that scalar-staging widgets work
-   [\#5855](https://github.com/vector-im/riot-web/pull/5855)
+   [\#5855](https://github.com/element-hq/riot-web/pull/5855)
  * add dark theme styling to devtools input box
-   [\#5610](https://github.com/vector-im/riot-web/pull/5610)
+   [\#5610](https://github.com/element-hq/riot-web/pull/5610)
  * Fixes #1953 by adding oivoodoo as author
-   [\#5851](https://github.com/vector-im/riot-web/pull/5851)
+   [\#5851](https://github.com/element-hq/riot-web/pull/5851)
  * Instructions on security issues
-   [\#5824](https://github.com/vector-im/riot-web/pull/5824)
+   [\#5824](https://github.com/element-hq/riot-web/pull/5824)
  * Move DND wrapper to top level component
-   [\#5790](https://github.com/vector-im/riot-web/pull/5790)
+   [\#5790](https://github.com/element-hq/riot-web/pull/5790)
  * Widget title bar max / min visual cues.
-   [\#5786](https://github.com/vector-im/riot-web/pull/5786)
+   [\#5786](https://github.com/element-hq/riot-web/pull/5786)
  * Implement renumeration of ordered tags upon collision
-   [\#5759](https://github.com/vector-im/riot-web/pull/5759)
+   [\#5759](https://github.com/element-hq/riot-web/pull/5759)
  * Update imports for accessing KeyCode
-   [\#5751](https://github.com/vector-im/riot-web/pull/5751)
+   [\#5751](https://github.com/element-hq/riot-web/pull/5751)
  * Set html lang attribute from language setting
-   [\#5685](https://github.com/vector-im/riot-web/pull/5685)
+   [\#5685](https://github.com/element-hq/riot-web/pull/5685)
  * CSS for new TagPanel
-   [\#5723](https://github.com/vector-im/riot-web/pull/5723)
+   [\#5723](https://github.com/element-hq/riot-web/pull/5723)
  * getGroupStore no longer needs a matrix client
-   [\#5707](https://github.com/vector-im/riot-web/pull/5707)
+   [\#5707](https://github.com/element-hq/riot-web/pull/5707)
  * CSS required for moving group publication toggles to UserSettings
-   [\#5702](https://github.com/vector-im/riot-web/pull/5702)
+   [\#5702](https://github.com/element-hq/riot-web/pull/5702)
  * Make sure the SettingsStore is ready to load the theme before loading it
-   [\#5630](https://github.com/vector-im/riot-web/pull/5630)
+   [\#5630](https://github.com/element-hq/riot-web/pull/5630)
  * Add some aria-labels to RightPanel
-   [\#5661](https://github.com/vector-im/riot-web/pull/5661)
+   [\#5661](https://github.com/element-hq/riot-web/pull/5661)
  * Use badge count format for member count in RightPanel
-   [\#5657](https://github.com/vector-im/riot-web/pull/5657)
+   [\#5657](https://github.com/element-hq/riot-web/pull/5657)
  * Exclude the default language on page load
-   [\#5640](https://github.com/vector-im/riot-web/pull/5640)
+   [\#5640](https://github.com/element-hq/riot-web/pull/5640)
  * Use SettingsStore to get the default theme
-   [\#5615](https://github.com/vector-im/riot-web/pull/5615)
+   [\#5615](https://github.com/element-hq/riot-web/pull/5615)
  * Refactor translations
-   [\#5613](https://github.com/vector-im/riot-web/pull/5613)
+   [\#5613](https://github.com/element-hq/riot-web/pull/5613)
  * TintableSvgButton styling
-   [\#5605](https://github.com/vector-im/riot-web/pull/5605)
+   [\#5605](https://github.com/element-hq/riot-web/pull/5605)
  * Granular settings
-   [\#5468](https://github.com/vector-im/riot-web/pull/5468)
+   [\#5468](https://github.com/element-hq/riot-web/pull/5468)
  * CSS/components for custom presence controls
-   [\#5286](https://github.com/vector-im/riot-web/pull/5286)
+   [\#5286](https://github.com/element-hq/riot-web/pull/5286)
  * Set widget tile background colour
-   [\#5574](https://github.com/vector-im/riot-web/pull/5574)
+   [\#5574](https://github.com/element-hq/riot-web/pull/5574)
  * Widget styling tweaks
-   [\#5573](https://github.com/vector-im/riot-web/pull/5573)
+   [\#5573](https://github.com/element-hq/riot-web/pull/5573)
  * Center mixed content warnings in panel.
-   [\#5567](https://github.com/vector-im/riot-web/pull/5567)
+   [\#5567](https://github.com/element-hq/riot-web/pull/5567)
  * Status.im theme
-   [\#5578](https://github.com/vector-im/riot-web/pull/5578)
+   [\#5578](https://github.com/element-hq/riot-web/pull/5578)
 
-Changes in [0.13.5](https://github.com/vector-im/riot-web/releases/tag/v0.13.5) (2018-02-09)
+Changes in [0.13.5](https://github.com/element-hq/riot-web/releases/tag/v0.13.5) (2018-02-09)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.13.4...v0.13.5)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.13.4...v0.13.5)
 
  * SECURITY UPDATE: Sanitise URLs from 'external_url'. Thanks to walle303 for contacting
    us about this vulnerability.
 
-Changes in [0.13.4](https://github.com/vector-im/riot-web/releases/tag/v0.13.4) (2018-01-03)
+Changes in [0.13.4](https://github.com/element-hq/riot-web/releases/tag/v0.13.4) (2018-01-03)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.13.3...v0.13.4)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.13.3...v0.13.4)
 
  * Change config of riot.im electron build to fix some widgets not working. This only affects
    electron builds using the riot.im config - for all other builds, this is identical to
    v0.13.3.
 
-Changes in [0.13.3](https://github.com/vector-im/riot-web/releases/tag/v0.13.3) (2017-12-04)
+Changes in [0.13.3](https://github.com/element-hq/riot-web/releases/tag/v0.13.3) (2017-12-04)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.13.2...v0.13.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.13.2...v0.13.3)
 
  * Bump js-sdk, react-sdk version to pull in fix for [setting room publicity in a group](https://github.com/matrix-org/matrix-js-sdk/commit/aa3201ebb0fff5af2fb733080aa65ed1f7213de6).
 
-Changes in [0.13.2](https://github.com/vector-im/riot-web/releases/tag/v0.13.2) (2017-11-28)
+Changes in [0.13.2](https://github.com/element-hq/riot-web/releases/tag/v0.13.2) (2017-11-28)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.13.1...v0.13.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.13.1...v0.13.2)
 
 
-Changes in [0.13.1](https://github.com/vector-im/riot-web/releases/tag/v0.13.1) (2017-11-17)
+Changes in [0.13.1](https://github.com/element-hq/riot-web/releases/tag/v0.13.1) (2017-11-17)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.13.0...v0.13.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.13.0...v0.13.1)
 
  * SECURITY UPDATE: Fix the force TURN option for inbound calls. This option forced the use
    of TURN but only worked for outbound calls and not inbound calls. This means that if you
@@ -7111,483 +7111,483 @@ Changes in [0.13.1](https://github.com/vector-im/riot-web/releases/tag/v0.13.1) 
    have been revealed to the room if you accepted an incoming call.
  * Also adds the Slovak translation.
 
-Changes in [0.13.0](https://github.com/vector-im/riot-web/releases/tag/v0.13.0) (2017-11-15)
+Changes in [0.13.0](https://github.com/element-hq/riot-web/releases/tag/v0.13.0) (2017-11-15)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.13.0-rc.3...v0.13.0)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.13.0-rc.3...v0.13.0)
 
 
-Changes in [0.13.0-rc.3](https://github.com/vector-im/riot-web/releases/tag/v0.13.0-rc.3) (2017-11-14)
+Changes in [0.13.0-rc.3](https://github.com/element-hq/riot-web/releases/tag/v0.13.0-rc.3) (2017-11-14)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.13.0-rc.2...v0.13.0-rc.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.13.0-rc.2...v0.13.0-rc.3)
 
 
-Changes in [0.13.0-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.13.0-rc.2) (2017-11-10)
+Changes in [0.13.0-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.13.0-rc.2) (2017-11-10)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.13.0-rc.1...v0.13.0-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.13.0-rc.1...v0.13.0-rc.2)
 
  * Make groups a fully-fleged baked-in feature
-   [\#5566](https://github.com/vector-im/riot-web/pull/5566)
+   [\#5566](https://github.com/element-hq/riot-web/pull/5566)
 
-Changes in [0.13.0-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.13.0-rc.1) (2017-11-10)
+Changes in [0.13.0-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.13.0-rc.1) (2017-11-10)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.12.7...v0.13.0-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.12.7...v0.13.0-rc.1)
 
  * Fix app tile margins.
-   [\#5561](https://github.com/vector-im/riot-web/pull/5561)
+   [\#5561](https://github.com/element-hq/riot-web/pull/5561)
  * Fix wrapping of long room topics (and overlap with apps)
-   [\#5549](https://github.com/vector-im/riot-web/pull/5549)
+   [\#5549](https://github.com/element-hq/riot-web/pull/5549)
  * Don't display widget iframes whilst loading.
-   [\#5555](https://github.com/vector-im/riot-web/pull/5555)
+   [\#5555](https://github.com/element-hq/riot-web/pull/5555)
  * Update from Weblate.
-   [\#5558](https://github.com/vector-im/riot-web/pull/5558)
+   [\#5558](https://github.com/element-hq/riot-web/pull/5558)
  * Adjust CSS for GroupView
-   [\#5543](https://github.com/vector-im/riot-web/pull/5543)
+   [\#5543](https://github.com/element-hq/riot-web/pull/5543)
  * CSS for adding rooms to a group with visibility
-   [\#5546](https://github.com/vector-im/riot-web/pull/5546)
+   [\#5546](https://github.com/element-hq/riot-web/pull/5546)
  * CSS for pinned indicators
-   [\#5511](https://github.com/vector-im/riot-web/pull/5511)
+   [\#5511](https://github.com/element-hq/riot-web/pull/5511)
  * Implement general-purpose tooltip "(?)"-style
-   [\#5540](https://github.com/vector-im/riot-web/pull/5540)
+   [\#5540](https://github.com/element-hq/riot-web/pull/5540)
  * CSS for improving group creation UX, namely setting long description
-   [\#5535](https://github.com/vector-im/riot-web/pull/5535)
+   [\#5535](https://github.com/element-hq/riot-web/pull/5535)
  * CSS for room notif pills in composer
-   [\#5531](https://github.com/vector-im/riot-web/pull/5531)
+   [\#5531](https://github.com/element-hq/riot-web/pull/5531)
  * Do not init a group store when no groupId specified
-   [\#5520](https://github.com/vector-im/riot-web/pull/5520)
+   [\#5520](https://github.com/element-hq/riot-web/pull/5520)
  * CSS for new pinned events indicator
-   [\#5293](https://github.com/vector-im/riot-web/pull/5293)
+   [\#5293](https://github.com/element-hq/riot-web/pull/5293)
  * T3chguy/devtools 1
-   [\#5471](https://github.com/vector-im/riot-web/pull/5471)
+   [\#5471](https://github.com/element-hq/riot-web/pull/5471)
  * Use margin to separate "perms" in the room directory
-   [\#5498](https://github.com/vector-im/riot-web/pull/5498)
+   [\#5498](https://github.com/element-hq/riot-web/pull/5498)
  * Add CSS for CreateGroupDialog to give group ID input suffix and prefix style
-   [\#5505](https://github.com/vector-im/riot-web/pull/5505)
+   [\#5505](https://github.com/element-hq/riot-web/pull/5505)
  * Fix group invites such that they look similar to room invites
-   [\#5504](https://github.com/vector-im/riot-web/pull/5504)
+   [\#5504](https://github.com/element-hq/riot-web/pull/5504)
  * CSS for Your Communities scrollbar
-   [\#5501](https://github.com/vector-im/riot-web/pull/5501)
+   [\#5501](https://github.com/element-hq/riot-web/pull/5501)
  * Add toggle to alter visibility of room-group association
-   [\#5497](https://github.com/vector-im/riot-web/pull/5497)
+   [\#5497](https://github.com/element-hq/riot-web/pull/5497)
  * CSS for room notification pills
-   [\#5494](https://github.com/vector-im/riot-web/pull/5494)
+   [\#5494](https://github.com/element-hq/riot-web/pull/5494)
  * Implement simple GroupRoomInfo
-   [\#5493](https://github.com/vector-im/riot-web/pull/5493)
+   [\#5493](https://github.com/element-hq/riot-web/pull/5493)
  * Add back bottom border to widget title bar
-   [\#5458](https://github.com/vector-im/riot-web/pull/5458)
+   [\#5458](https://github.com/element-hq/riot-web/pull/5458)
  * Prevent group name looking clickable for non-members
-   [\#5478](https://github.com/vector-im/riot-web/pull/5478)
+   [\#5478](https://github.com/element-hq/riot-web/pull/5478)
  * Fix instanceof check, was checking against the Package rather than class
-   [\#5472](https://github.com/vector-im/riot-web/pull/5472)
+   [\#5472](https://github.com/element-hq/riot-web/pull/5472)
  * Use correct group store state when rendering "Invite to this community"
-   [\#5455](https://github.com/vector-im/riot-web/pull/5455)
+   [\#5455](https://github.com/element-hq/riot-web/pull/5455)
  * Leverages ES6 in Notifications
-   [\#5453](https://github.com/vector-im/riot-web/pull/5453)
+   [\#5453](https://github.com/element-hq/riot-web/pull/5453)
  * Re-PR #4412
-   [\#5437](https://github.com/vector-im/riot-web/pull/5437)
+   [\#5437](https://github.com/element-hq/riot-web/pull/5437)
  * fix comma error of features example
-   [\#5410](https://github.com/vector-im/riot-web/pull/5410)
+   [\#5410](https://github.com/element-hq/riot-web/pull/5410)
  * Devtools: make filtering case-insensitive
-   [\#5387](https://github.com/vector-im/riot-web/pull/5387)
+   [\#5387](https://github.com/element-hq/riot-web/pull/5387)
  * Highlight group members icon in group member info
-   [\#5432](https://github.com/vector-im/riot-web/pull/5432)
+   [\#5432](https://github.com/element-hq/riot-web/pull/5432)
  * Use CSS to stop greyed Right/LeftPanel UI from being interactable
-   [\#5422](https://github.com/vector-im/riot-web/pull/5422)
+   [\#5422](https://github.com/element-hq/riot-web/pull/5422)
  * CSS for preventing editing of UI requiring user privilege if user
    unprivileged
-   [\#5417](https://github.com/vector-im/riot-web/pull/5417)
+   [\#5417](https://github.com/element-hq/riot-web/pull/5417)
  * Only show UI for adding rooms/users to groups to privileged users
-   [\#5409](https://github.com/vector-im/riot-web/pull/5409)
+   [\#5409](https://github.com/element-hq/riot-web/pull/5409)
  * Only show "Invite to this community" when viewing group members
-   [\#5407](https://github.com/vector-im/riot-web/pull/5407)
+   [\#5407](https://github.com/element-hq/riot-web/pull/5407)
  * Add trash can icon for delete widget
-   [\#5397](https://github.com/vector-im/riot-web/pull/5397)
+   [\#5397](https://github.com/element-hq/riot-web/pull/5397)
  * CSS to improve MyGroups in general, and add placeholder
-   [\#5375](https://github.com/vector-im/riot-web/pull/5375)
+   [\#5375](https://github.com/element-hq/riot-web/pull/5375)
  * Rxl881/parallelshell
-   [\#4881](https://github.com/vector-im/riot-web/pull/4881)
+   [\#4881](https://github.com/element-hq/riot-web/pull/4881)
  * Custom server text was i18ned by key
-   [\#5371](https://github.com/vector-im/riot-web/pull/5371)
+   [\#5371](https://github.com/element-hq/riot-web/pull/5371)
  * Run prunei18n
-   [\#5370](https://github.com/vector-im/riot-web/pull/5370)
+   [\#5370](https://github.com/element-hq/riot-web/pull/5370)
  * Update from Weblate.
-   [\#5369](https://github.com/vector-im/riot-web/pull/5369)
+   [\#5369](https://github.com/element-hq/riot-web/pull/5369)
  * Add script to prune unused translations
-   [\#5339](https://github.com/vector-im/riot-web/pull/5339)
+   [\#5339](https://github.com/element-hq/riot-web/pull/5339)
  * CSS for improved MyGroups page
-   [\#5360](https://github.com/vector-im/riot-web/pull/5360)
+   [\#5360](https://github.com/element-hq/riot-web/pull/5360)
  * Add padding-right to Dialogs
-   [\#5346](https://github.com/vector-im/riot-web/pull/5346)
+   [\#5346](https://github.com/element-hq/riot-web/pull/5346)
  * Add div.warning and use the scss var
-   [\#5344](https://github.com/vector-im/riot-web/pull/5344)
+   [\#5344](https://github.com/element-hq/riot-web/pull/5344)
  * Groups->Communities
-   [\#5343](https://github.com/vector-im/riot-web/pull/5343)
+   [\#5343](https://github.com/element-hq/riot-web/pull/5343)
  * Make the 'add rooms' button clickable
-   [\#5342](https://github.com/vector-im/riot-web/pull/5342)
+   [\#5342](https://github.com/element-hq/riot-web/pull/5342)
  * Switch to gen-i18n script
-   [\#5338](https://github.com/vector-im/riot-web/pull/5338)
+   [\#5338](https://github.com/element-hq/riot-web/pull/5338)
  * Use _t as _t
-   [\#5334](https://github.com/vector-im/riot-web/pull/5334)
+   [\#5334](https://github.com/element-hq/riot-web/pull/5334)
  * fix groupview header editing visuals (pt 1)
-   [\#5330](https://github.com/vector-im/riot-web/pull/5330)
+   [\#5330](https://github.com/element-hq/riot-web/pull/5330)
  * bump version to prevent eslint errors
-   [\#5316](https://github.com/vector-im/riot-web/pull/5316)
+   [\#5316](https://github.com/element-hq/riot-web/pull/5316)
  * CSS for invited group members section
-   [\#5303](https://github.com/vector-im/riot-web/pull/5303)
+   [\#5303](https://github.com/element-hq/riot-web/pull/5303)
  * Handle long names in EntityTiles by overflowing correctly
-   [\#5302](https://github.com/vector-im/riot-web/pull/5302)
+   [\#5302](https://github.com/element-hq/riot-web/pull/5302)
  * Disable labs in electron
-   [\#5296](https://github.com/vector-im/riot-web/pull/5296)
+   [\#5296](https://github.com/element-hq/riot-web/pull/5296)
  * CSS for Modifying GroupView UI matrix-org/matrix-react-sdk#1475
-   [\#5295](https://github.com/vector-im/riot-web/pull/5295)
+   [\#5295](https://github.com/element-hq/riot-web/pull/5295)
  * Message/event pinning
-   [\#5142](https://github.com/vector-im/riot-web/pull/5142)
+   [\#5142](https://github.com/element-hq/riot-web/pull/5142)
  * Sorting of networks within a protocol based on name
-   [\#4054](https://github.com/vector-im/riot-web/pull/4054)
+   [\#4054](https://github.com/element-hq/riot-web/pull/4054)
  * allow hiding of notification body for privacy reasons
-   [\#4988](https://github.com/vector-im/riot-web/pull/4988)
+   [\#4988](https://github.com/element-hq/riot-web/pull/4988)
  * Don't use MXIDs on the lightbox if possible
-   [\#5281](https://github.com/vector-im/riot-web/pull/5281)
+   [\#5281](https://github.com/element-hq/riot-web/pull/5281)
  * CSS for lonely room message
-   [\#5267](https://github.com/vector-im/riot-web/pull/5267)
+   [\#5267](https://github.com/element-hq/riot-web/pull/5267)
  * Bring back dark theme code block border
-   [\#5037](https://github.com/vector-im/riot-web/pull/5037)
+   [\#5037](https://github.com/element-hq/riot-web/pull/5037)
  * CSS for remove avatar buttons
-   [\#5282](https://github.com/vector-im/riot-web/pull/5282)
+   [\#5282](https://github.com/element-hq/riot-web/pull/5282)
 
-Changes in [0.12.7](https://github.com/vector-im/riot-web/releases/tag/v0.12.7) (2017-10-16)
+Changes in [0.12.7](https://github.com/element-hq/riot-web/releases/tag/v0.12.7) (2017-10-16)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.12.7-rc.3...v0.12.7)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.12.7-rc.3...v0.12.7)
 
  * Released versions of react-sdk & js-sdk
 
-Changes in [0.12.7-rc.3](https://github.com/vector-im/riot-web/releases/tag/v0.12.7-rc.3) (2017-10-13)
+Changes in [0.12.7-rc.3](https://github.com/element-hq/riot-web/releases/tag/v0.12.7-rc.3) (2017-10-13)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.12.7-rc.2...v0.12.7-rc.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.12.7-rc.2...v0.12.7-rc.3)
 
  * Hide the join group button
-   [\#5275](https://github.com/vector-im/riot-web/pull/5275)
+   [\#5275](https://github.com/element-hq/riot-web/pull/5275)
 
-Changes in [0.12.7-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.12.7-rc.2) (2017-10-13)
+Changes in [0.12.7-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.12.7-rc.2) (2017-10-13)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.12.7-rc.1...v0.12.7-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.12.7-rc.1...v0.12.7-rc.2)
 
 
-Changes in [0.12.7-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.12.7-rc.1) (2017-10-13)
+Changes in [0.12.7-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.12.7-rc.1) (2017-10-13)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.12.6...v0.12.7-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.12.6...v0.12.7-rc.1)
 
  * switch to new logos, and use import rather than VAR
-   [\#5203](https://github.com/vector-im/riot-web/pull/5203)
+   [\#5203](https://github.com/element-hq/riot-web/pull/5203)
  * Clarify what an integrations server is
-   [\#5266](https://github.com/vector-im/riot-web/pull/5266)
+   [\#5266](https://github.com/element-hq/riot-web/pull/5266)
  * Update from Weblate.
-   [\#5269](https://github.com/vector-im/riot-web/pull/5269)
+   [\#5269](https://github.com/element-hq/riot-web/pull/5269)
  * Remove trailing comma in JSON
-   [\#5167](https://github.com/vector-im/riot-web/pull/5167)
+   [\#5167](https://github.com/element-hq/riot-web/pull/5167)
  * Added default_federate property
-   [\#3849](https://github.com/vector-im/riot-web/pull/3849)
+   [\#3849](https://github.com/element-hq/riot-web/pull/3849)
  * CSS for greying out login form
-   [\#5197](https://github.com/vector-im/riot-web/pull/5197)
+   [\#5197](https://github.com/element-hq/riot-web/pull/5197)
  * Fix bug that made sub list placeholders not show for ILAG etc.
-   [\#5164](https://github.com/vector-im/riot-web/pull/5164)
+   [\#5164](https://github.com/element-hq/riot-web/pull/5164)
  * Factor out EditableItemList component from AliasSettings
-   [\#5161](https://github.com/vector-im/riot-web/pull/5161)
+   [\#5161](https://github.com/element-hq/riot-web/pull/5161)
  * Mark and remove some translations
-   [\#5110](https://github.com/vector-im/riot-web/pull/5110)
+   [\#5110](https://github.com/element-hq/riot-web/pull/5110)
  * CSS for "remove" button on GroupRoomTile
-   [\#5141](https://github.com/vector-im/riot-web/pull/5141)
+   [\#5141](https://github.com/element-hq/riot-web/pull/5141)
  * Create basic icon for the GroupRoomList tab and adding rooms to groups
-   [\#5140](https://github.com/vector-im/riot-web/pull/5140)
+   [\#5140](https://github.com/element-hq/riot-web/pull/5140)
  * Add button to get to MyGroups
-   [\#5131](https://github.com/vector-im/riot-web/pull/5131)
+   [\#5131](https://github.com/element-hq/riot-web/pull/5131)
  * Remove `key` prop pass-thru on HeaderButton
-   [\#5137](https://github.com/vector-im/riot-web/pull/5137)
+   [\#5137](https://github.com/element-hq/riot-web/pull/5137)
  * Implement "Add room to group" feature
-   [\#5125](https://github.com/vector-im/riot-web/pull/5125)
+   [\#5125](https://github.com/element-hq/riot-web/pull/5125)
  * Add Jitsi screensharing support in electron app
-   [\#4967](https://github.com/vector-im/riot-web/pull/4967)
+   [\#4967](https://github.com/element-hq/riot-web/pull/4967)
  * Refactor right panel header buttons
-   [\#5117](https://github.com/vector-im/riot-web/pull/5117)
+   [\#5117](https://github.com/element-hq/riot-web/pull/5117)
  * CSS for publicity status & toggle button
-   [\#5104](https://github.com/vector-im/riot-web/pull/5104)
+   [\#5104](https://github.com/element-hq/riot-web/pull/5104)
  * CSS for "X" in top right of features users/rooms
-   [\#5103](https://github.com/vector-im/riot-web/pull/5103)
+   [\#5103](https://github.com/element-hq/riot-web/pull/5103)
  * Include Finnish translation
-   [\#5051](https://github.com/vector-im/riot-web/pull/5051)
+   [\#5051](https://github.com/element-hq/riot-web/pull/5051)
  * Redesign membership section of GroupView
-   [\#5096](https://github.com/vector-im/riot-web/pull/5096)
+   [\#5096](https://github.com/element-hq/riot-web/pull/5096)
  * Make --config accept globs
-   [\#5090](https://github.com/vector-im/riot-web/pull/5090)
+   [\#5090](https://github.com/element-hq/riot-web/pull/5090)
  * CSS for GroupView: Add a User
-   [\#5093](https://github.com/vector-im/riot-web/pull/5093)
+   [\#5093](https://github.com/element-hq/riot-web/pull/5093)
  * T3chguy/devtools 1
-   [\#5074](https://github.com/vector-im/riot-web/pull/5074)
+   [\#5074](https://github.com/element-hq/riot-web/pull/5074)
  * Alter opacity for flair
-   [\#5085](https://github.com/vector-im/riot-web/pull/5085)
+   [\#5085](https://github.com/element-hq/riot-web/pull/5085)
  * Fix ugly integ button
-   [\#5082](https://github.com/vector-im/riot-web/pull/5082)
+   [\#5082](https://github.com/element-hq/riot-web/pull/5082)
  * Group Membership UI
-   [\#4830](https://github.com/vector-im/riot-web/pull/4830)
+   [\#4830](https://github.com/element-hq/riot-web/pull/4830)
 
-Changes in [0.12.6](https://github.com/vector-im/riot-web/releases/tag/v0.12.6) (2017-09-21)
+Changes in [0.12.6](https://github.com/element-hq/riot-web/releases/tag/v0.12.6) (2017-09-21)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.12.5...v0.12.6)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.12.5...v0.12.6)
 
  * Use matrix-js-sdk v0.8.4 to fix build
 
-Changes in [0.12.5](https://github.com/vector-im/riot-web/releases/tag/v0.12.5) (2017-09-21)
+Changes in [0.12.5](https://github.com/element-hq/riot-web/releases/tag/v0.12.5) (2017-09-21)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.12.4...v0.12.5)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.12.4...v0.12.5)
 
  * Use react-sdk v0.10.5 to fix build
 
-Changes in [0.12.4](https://github.com/vector-im/riot-web/releases/tag/v0.12.4) (2017-09-20)
+Changes in [0.12.4](https://github.com/element-hq/riot-web/releases/tag/v0.12.4) (2017-09-20)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.12.4-rc.1...v0.12.4)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.12.4-rc.1...v0.12.4)
 
  * No changes
 
-Changes in [0.12.4-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.12.4-rc.1) (2017-09-19)
+Changes in [0.12.4-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.12.4-rc.1) (2017-09-19)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.12.3...v0.12.4-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.12.3...v0.12.4-rc.1)
 
  * Fix test for new behaviour of 'joining' flag
-   [\#5053](https://github.com/vector-im/riot-web/pull/5053)
+   [\#5053](https://github.com/element-hq/riot-web/pull/5053)
  * fix really dumb blunder/typo preventing system from going to sleep.
-   [\#5080](https://github.com/vector-im/riot-web/pull/5080)
+   [\#5080](https://github.com/element-hq/riot-web/pull/5080)
  * T3chguy/devtools
-   [\#4735](https://github.com/vector-im/riot-web/pull/4735)
+   [\#4735](https://github.com/element-hq/riot-web/pull/4735)
  * CSS for unignore button in UserSettings
-   [\#5042](https://github.com/vector-im/riot-web/pull/5042)
+   [\#5042](https://github.com/element-hq/riot-web/pull/5042)
  * Fix alias on home page for identity room
-   [\#5044](https://github.com/vector-im/riot-web/pull/5044)
+   [\#5044](https://github.com/element-hq/riot-web/pull/5044)
  * generic contextual menu for tooltip/responses
-   [\#4989](https://github.com/vector-im/riot-web/pull/4989)
+   [\#4989](https://github.com/element-hq/riot-web/pull/4989)
  * Update from Weblate.
-   [\#5018](https://github.com/vector-im/riot-web/pull/5018)
+   [\#5018](https://github.com/element-hq/riot-web/pull/5018)
  * Avoid re-rendering RoomList on room switch
-   [\#5015](https://github.com/vector-im/riot-web/pull/5015)
+   [\#5015](https://github.com/element-hq/riot-web/pull/5015)
  * Fix menu on change keyboard language issue #4345
-   [\#4623](https://github.com/vector-im/riot-web/pull/4623)
+   [\#4623](https://github.com/element-hq/riot-web/pull/4623)
  * Make isInvite default to false
-   [\#4999](https://github.com/vector-im/riot-web/pull/4999)
+   [\#4999](https://github.com/element-hq/riot-web/pull/4999)
  * Revert "Implement sticky date separators"
-   [\#4991](https://github.com/vector-im/riot-web/pull/4991)
+   [\#4991](https://github.com/element-hq/riot-web/pull/4991)
  * Implement sticky date separators
-   [\#4939](https://github.com/vector-im/riot-web/pull/4939)
+   [\#4939](https://github.com/element-hq/riot-web/pull/4939)
 
-Changes in [0.12.3](https://github.com/vector-im/riot-web/releases/tag/v0.12.3) (2017-09-06)
+Changes in [0.12.3](https://github.com/element-hq/riot-web/releases/tag/v0.12.3) (2017-09-06)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.12.3-rc.3...v0.12.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.12.3-rc.3...v0.12.3)
 
  * No changes
 
-Changes in [0.12.3-rc.3](https://github.com/vector-im/riot-web/releases/tag/v0.12.3-rc.3) (2017-09-05)
+Changes in [0.12.3-rc.3](https://github.com/element-hq/riot-web/releases/tag/v0.12.3-rc.3) (2017-09-05)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.12.3-rc.2...v0.12.3-rc.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.12.3-rc.2...v0.12.3-rc.3)
 
  * Fix plurals in translations
-   [\#4971](https://github.com/vector-im/riot-web/pull/4971)
+   [\#4971](https://github.com/element-hq/riot-web/pull/4971)
  * Update from Weblate.
-   [\#4968](https://github.com/vector-im/riot-web/pull/4968)
+   [\#4968](https://github.com/element-hq/riot-web/pull/4968)
 
-Changes in [0.12.3-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.12.3-rc.2) (2017-09-05)
+Changes in [0.12.3-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.12.3-rc.2) (2017-09-05)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.12.3-rc.1...v0.12.3-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.12.3-rc.1...v0.12.3-rc.2)
 
  * New react-sdk version to pull in new translations and fix some translation bugs.
 
 
-Changes in [0.12.3-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.12.3-rc.1) (2017-09-01)
+Changes in [0.12.3-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.12.3-rc.1) (2017-09-01)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.12.2...v0.12.3-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.12.2...v0.12.3-rc.1)
 
  * Fix overflowing login/register buttons on some languages issue #4804
-   [\#4858](https://github.com/vector-im/riot-web/pull/4858)
- * Update vector-im to riot-im on Login
-   [\#4943](https://github.com/vector-im/riot-web/pull/4943)
+   [\#4858](https://github.com/element-hq/riot-web/pull/4858)
+ * Update element-hq to riot-im on Login
+   [\#4943](https://github.com/element-hq/riot-web/pull/4943)
  * lets let people know that the bug report actually sent properly :)
-   [\#4910](https://github.com/vector-im/riot-web/pull/4910)
+   [\#4910](https://github.com/element-hq/riot-web/pull/4910)
  * another s/vector/riot/ in README
-   [\#4934](https://github.com/vector-im/riot-web/pull/4934)
+   [\#4934](https://github.com/element-hq/riot-web/pull/4934)
  * fix two room list regressions
-   [\#4907](https://github.com/vector-im/riot-web/pull/4907)
+   [\#4907](https://github.com/element-hq/riot-web/pull/4907)
 
-Changes in [0.12.2](https://github.com/vector-im/riot-web/releases/tag/v0.12.2) (2017-08-24)
+Changes in [0.12.2](https://github.com/element-hq/riot-web/releases/tag/v0.12.2) (2017-08-24)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.12.1...v0.12.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.12.1...v0.12.2)
 
  * Update react-sdk and js-sdk to fix bugs with incoming calls, messages and notifications
    in encrypted rooms.
 
-Changes in [0.12.1](https://github.com/vector-im/riot-web/releases/tag/v0.12.1) (2017-08-23)
+Changes in [0.12.1](https://github.com/element-hq/riot-web/releases/tag/v0.12.1) (2017-08-23)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.12.1-rc.1...v0.12.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.12.1-rc.1...v0.12.1)
 
  * [No changes]
 
-Changes in [0.12.1-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.12.1-rc.1) (2017-08-22)
+Changes in [0.12.1-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.12.1-rc.1) (2017-08-22)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.12.0-rc.2...v0.12.1-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.12.0-rc.2...v0.12.1-rc.1)
 
  * Update from Weblate.
-   [\#4832](https://github.com/vector-im/riot-web/pull/4832)
+   [\#4832](https://github.com/element-hq/riot-web/pull/4832)
  * Misc styling fixes.
-   [\#4826](https://github.com/vector-im/riot-web/pull/4826)
+   [\#4826](https://github.com/element-hq/riot-web/pull/4826)
  * Show / Hide apps icons
-   [\#4774](https://github.com/vector-im/riot-web/pull/4774)
+   [\#4774](https://github.com/element-hq/riot-web/pull/4774)
 
-Changes in [0.12.0-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.12.0-rc.1) (2017-08-16)
+Changes in [0.12.0-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.12.0-rc.1) (2017-08-16)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.11.4...v0.12.0-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.11.4...v0.12.0-rc.1)
 
  * Update from Weblate.
-   [\#4797](https://github.com/vector-im/riot-web/pull/4797)
+   [\#4797](https://github.com/element-hq/riot-web/pull/4797)
  * move focus-via-up/down cursors to LeftPanel
-   [\#4777](https://github.com/vector-im/riot-web/pull/4777)
+   [\#4777](https://github.com/element-hq/riot-web/pull/4777)
  * Remove userId property on RightPanel
-   [\#4775](https://github.com/vector-im/riot-web/pull/4775)
+   [\#4775](https://github.com/element-hq/riot-web/pull/4775)
  * Make member device info buttons fluid and stackable with flexbox
-   [\#4776](https://github.com/vector-im/riot-web/pull/4776)
+   [\#4776](https://github.com/element-hq/riot-web/pull/4776)
  * un-i18n Modal Analytics
-   [\#4688](https://github.com/vector-im/riot-web/pull/4688)
+   [\#4688](https://github.com/element-hq/riot-web/pull/4688)
  * Quote using innerText
-   [\#4773](https://github.com/vector-im/riot-web/pull/4773)
+   [\#4773](https://github.com/element-hq/riot-web/pull/4773)
  * Karma tweaks for riot-web
-   [\#4765](https://github.com/vector-im/riot-web/pull/4765)
+   [\#4765](https://github.com/element-hq/riot-web/pull/4765)
  * Fix typo with scripts/fetch-develop-deps.sh in Building From Source
-   [\#4764](https://github.com/vector-im/riot-web/pull/4764)
+   [\#4764](https://github.com/element-hq/riot-web/pull/4764)
  * Adjust CSS for optional avatars in pills
-   [\#4757](https://github.com/vector-im/riot-web/pull/4757)
+   [\#4757](https://github.com/element-hq/riot-web/pull/4757)
  * Fix crypto on develop
-   [\#4754](https://github.com/vector-im/riot-web/pull/4754)
+   [\#4754](https://github.com/element-hq/riot-web/pull/4754)
  * Fix signing key url in readme
-   [\#4464](https://github.com/vector-im/riot-web/pull/4464)
+   [\#4464](https://github.com/element-hq/riot-web/pull/4464)
  * update gitignore to allow .idea directory to exist in subdirs
-   [\#4749](https://github.com/vector-im/riot-web/pull/4749)
+   [\#4749](https://github.com/element-hq/riot-web/pull/4749)
  * tweak compact theme
-   [\#4665](https://github.com/vector-im/riot-web/pull/4665)
+   [\#4665](https://github.com/element-hq/riot-web/pull/4665)
  * Update draft-js from 0.10.1 to 0.11.0-alpha
-   [\#4740](https://github.com/vector-im/riot-web/pull/4740)
+   [\#4740](https://github.com/element-hq/riot-web/pull/4740)
  * electron support for mouse forward/back buttons in Windows
-   [\#4739](https://github.com/vector-im/riot-web/pull/4739)
+   [\#4739](https://github.com/element-hq/riot-web/pull/4739)
  * Update draft-js from 0.8.1 to 0.10.1
-   [\#4730](https://github.com/vector-im/riot-web/pull/4730)
+   [\#4730](https://github.com/element-hq/riot-web/pull/4730)
  * Make pills, emoji translucent when sending
-   [\#4693](https://github.com/vector-im/riot-web/pull/4693)
+   [\#4693](https://github.com/element-hq/riot-web/pull/4693)
  * Widget permissions styling and icon
-   [\#4690](https://github.com/vector-im/riot-web/pull/4690)
+   [\#4690](https://github.com/element-hq/riot-web/pull/4690)
  * CSS required for composer autoscroll
-   [\#4682](https://github.com/vector-im/riot-web/pull/4682)
+   [\#4682](https://github.com/element-hq/riot-web/pull/4682)
  * CSS for group edit UI
-   [\#4608](https://github.com/vector-im/riot-web/pull/4608)
+   [\#4608](https://github.com/element-hq/riot-web/pull/4608)
  * Fix a couple of minor errors in the room list
-   [\#4671](https://github.com/vector-im/riot-web/pull/4671)
+   [\#4671](https://github.com/element-hq/riot-web/pull/4671)
  * Styling for beta testing icon.
-   [\#4584](https://github.com/vector-im/riot-web/pull/4584)
+   [\#4584](https://github.com/element-hq/riot-web/pull/4584)
  * Increase the timeout for clearing indexeddbs
-   [\#4650](https://github.com/vector-im/riot-web/pull/4650)
+   [\#4650](https://github.com/element-hq/riot-web/pull/4650)
  * Make some adjustments to mx_UserPill and mx_RoomPill
-   [\#4597](https://github.com/vector-im/riot-web/pull/4597)
+   [\#4597](https://github.com/element-hq/riot-web/pull/4597)
  * Apply CSS to <pre> tags to distinguish them from each other
-   [\#4639](https://github.com/vector-im/riot-web/pull/4639)
+   [\#4639](https://github.com/element-hq/riot-web/pull/4639)
  * Use `catch` instead of `fail` to handle room tag error
-   [\#4643](https://github.com/vector-im/riot-web/pull/4643)
+   [\#4643](https://github.com/element-hq/riot-web/pull/4643)
  * CSS for decorated matrix.to links in the composer
-   [\#4583](https://github.com/vector-im/riot-web/pull/4583)
+   [\#4583](https://github.com/element-hq/riot-web/pull/4583)
  * Deflake the joining test
-   [\#4579](https://github.com/vector-im/riot-web/pull/4579)
+   [\#4579](https://github.com/element-hq/riot-web/pull/4579)
  * Bump react to 15.6 to fix build problems
-   [\#4577](https://github.com/vector-im/riot-web/pull/4577)
+   [\#4577](https://github.com/element-hq/riot-web/pull/4577)
  * Improve AppTile menu bar button styling.
-   [\#4567](https://github.com/vector-im/riot-web/pull/4567)
+   [\#4567](https://github.com/element-hq/riot-web/pull/4567)
  * Transform `async` functions to bluebird promises
-   [\#4572](https://github.com/vector-im/riot-web/pull/4572)
+   [\#4572](https://github.com/element-hq/riot-web/pull/4572)
  * use flushAllExpected in joining test
-   [\#4570](https://github.com/vector-im/riot-web/pull/4570)
+   [\#4570](https://github.com/element-hq/riot-web/pull/4570)
  * Switch riot-web to bluebird
-   [\#4565](https://github.com/vector-im/riot-web/pull/4565)
+   [\#4565](https://github.com/element-hq/riot-web/pull/4565)
  * loading tests: wait for login component
-   [\#4564](https://github.com/vector-im/riot-web/pull/4564)
+   [\#4564](https://github.com/element-hq/riot-web/pull/4564)
  * Remove CSS for the MessageComposerInputOld
-   [\#4568](https://github.com/vector-im/riot-web/pull/4568)
+   [\#4568](https://github.com/element-hq/riot-web/pull/4568)
  * Implement the focus_room_filter action
-   [\#4560](https://github.com/vector-im/riot-web/pull/4560)
+   [\#4560](https://github.com/element-hq/riot-web/pull/4560)
  * CSS for Rooms in Group View
-   [\#4530](https://github.com/vector-im/riot-web/pull/4530)
+   [\#4530](https://github.com/element-hq/riot-web/pull/4530)
  * more HomePage tweaks
-   [\#4557](https://github.com/vector-im/riot-web/pull/4557)
+   [\#4557](https://github.com/element-hq/riot-web/pull/4557)
  * Give HomePage an unmounted guard
-   [\#4556](https://github.com/vector-im/riot-web/pull/4556)
+   [\#4556](https://github.com/element-hq/riot-web/pull/4556)
  * Take RTE out of labs
-   [\#4500](https://github.com/vector-im/riot-web/pull/4500)
+   [\#4500](https://github.com/element-hq/riot-web/pull/4500)
  * CSS for Groups page
-   [\#4468](https://github.com/vector-im/riot-web/pull/4468)
+   [\#4468](https://github.com/element-hq/riot-web/pull/4468)
  * CSS for GroupView
-   [\#4442](https://github.com/vector-im/riot-web/pull/4442)
+   [\#4442](https://github.com/element-hq/riot-web/pull/4442)
  * remove unused class
-   [\#4525](https://github.com/vector-im/riot-web/pull/4525)
+   [\#4525](https://github.com/element-hq/riot-web/pull/4525)
  * Fix long words causing MessageComposer to widen
-   [\#4466](https://github.com/vector-im/riot-web/pull/4466)
+   [\#4466](https://github.com/element-hq/riot-web/pull/4466)
  * Add visual bell animation for RTE
-   [\#4516](https://github.com/vector-im/riot-web/pull/4516)
+   [\#4516](https://github.com/element-hq/riot-web/pull/4516)
  * Truncate auto-complete pills properly
-   [\#4502](https://github.com/vector-im/riot-web/pull/4502)
+   [\#4502](https://github.com/element-hq/riot-web/pull/4502)
  * Use chrome headless instead of phantomjs
-   [\#4512](https://github.com/vector-im/riot-web/pull/4512)
+   [\#4512](https://github.com/element-hq/riot-web/pull/4512)
  * Use external mock-request
-   [\#4489](https://github.com/vector-im/riot-web/pull/4489)
+   [\#4489](https://github.com/element-hq/riot-web/pull/4489)
  * fix Quote not closing contextual menu
-   [\#4443](https://github.com/vector-im/riot-web/pull/4443)
+   [\#4443](https://github.com/element-hq/riot-web/pull/4443)
  * Apply white-space: pre-wrap to mx_MEmoteBody
-   [\#4470](https://github.com/vector-im/riot-web/pull/4470)
+   [\#4470](https://github.com/element-hq/riot-web/pull/4470)
  * Add some style improvements to autocompletions
-   [\#4456](https://github.com/vector-im/riot-web/pull/4456)
+   [\#4456](https://github.com/element-hq/riot-web/pull/4456)
  * Styling for apps / widgets
-   [\#4447](https://github.com/vector-im/riot-web/pull/4447)
+   [\#4447](https://github.com/element-hq/riot-web/pull/4447)
  * Attempt to flush the rageshake logs on close
-   [\#4400](https://github.com/vector-im/riot-web/pull/4400)
+   [\#4400](https://github.com/element-hq/riot-web/pull/4400)
  * Update from Weblate.
-   [\#4401](https://github.com/vector-im/riot-web/pull/4401)
+   [\#4401](https://github.com/element-hq/riot-web/pull/4401)
  * improve update polling electron and provide a manual check for updates
    button
-   [\#4176](https://github.com/vector-im/riot-web/pull/4176)
+   [\#4176](https://github.com/element-hq/riot-web/pull/4176)
  * Fix load failure in firefox when indexedDB is disabled
-   [\#4395](https://github.com/vector-im/riot-web/pull/4395)
+   [\#4395](https://github.com/element-hq/riot-web/pull/4395)
  * Change missed 'Redact' to 'Remove' in ImageView.
-   [\#4362](https://github.com/vector-im/riot-web/pull/4362)
+   [\#4362](https://github.com/element-hq/riot-web/pull/4362)
  * explicit convert to nativeImage to stabilise trayIcon on Windows [Electron]
-   [\#4355](https://github.com/vector-im/riot-web/pull/4355)
+   [\#4355](https://github.com/element-hq/riot-web/pull/4355)
  * Use _tJsx for PasswordNagBar (because it has <u>)
-   [\#4373](https://github.com/vector-im/riot-web/pull/4373)
+   [\#4373](https://github.com/element-hq/riot-web/pull/4373)
  * Clean up some log outputs from the integ tests
-   [\#4376](https://github.com/vector-im/riot-web/pull/4376)
+   [\#4376](https://github.com/element-hq/riot-web/pull/4376)
  * CSS for redeisng of password warning
-   [\#4367](https://github.com/vector-im/riot-web/pull/4367)
+   [\#4367](https://github.com/element-hq/riot-web/pull/4367)
  * Give _t to PasswordNagBar, add CSS for UserSettings password warning
-   [\#4366](https://github.com/vector-im/riot-web/pull/4366)
+   [\#4366](https://github.com/element-hq/riot-web/pull/4366)
  * Update from Weblate.
-   [\#4361](https://github.com/vector-im/riot-web/pull/4361)
+   [\#4361](https://github.com/element-hq/riot-web/pull/4361)
  * Update from Weblate.
-   [\#4360](https://github.com/vector-im/riot-web/pull/4360)
+   [\#4360](https://github.com/element-hq/riot-web/pull/4360)
  * Test 'return-to-app' functionality
-   [\#4352](https://github.com/vector-im/riot-web/pull/4352)
+   [\#4352](https://github.com/element-hq/riot-web/pull/4352)
  * Update from Weblate.
-   [\#4354](https://github.com/vector-im/riot-web/pull/4354)
+   [\#4354](https://github.com/element-hq/riot-web/pull/4354)
  * onLoadCompleted is now onTokenLoginCompleted
-   [\#4335](https://github.com/vector-im/riot-web/pull/4335)
+   [\#4335](https://github.com/element-hq/riot-web/pull/4335)
  * Tweak tests to match updates to matrixchat
-   [\#4325](https://github.com/vector-im/riot-web/pull/4325)
+   [\#4325](https://github.com/element-hq/riot-web/pull/4325)
  * Update from Weblate.
-   [\#4346](https://github.com/vector-im/riot-web/pull/4346)
+   [\#4346](https://github.com/element-hq/riot-web/pull/4346)
  * change dispatcher forward_event signature
-   [\#4337](https://github.com/vector-im/riot-web/pull/4337)
+   [\#4337](https://github.com/element-hq/riot-web/pull/4337)
  * Add border on hover for code blocks
-   [\#4259](https://github.com/vector-im/riot-web/pull/4259)
+   [\#4259](https://github.com/element-hq/riot-web/pull/4259)
 
-Changes in [0.11.4](https://github.com/vector-im/riot-web/releases/tag/v0.11.4) (2017-06-22)
+Changes in [0.11.4](https://github.com/element-hq/riot-web/releases/tag/v0.11.4) (2017-06-22)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.11.3...v0.11.4)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.11.3...v0.11.4)
 
  * Update matrix-js-sdk and react-sdk to fix a regression where the
    background indexedb worker was disabled, failures to open indexeddb
@@ -7595,848 +7595,848 @@ Changes in [0.11.4](https://github.com/vector-im/riot-web/releases/tag/v0.11.4) 
    switching to rooms, and the inability to invite users with mixed case
    usernames.
 
-Changes in [0.11.3](https://github.com/vector-im/riot-web/releases/tag/v0.11.3) (2017-06-20)
+Changes in [0.11.3](https://github.com/element-hq/riot-web/releases/tag/v0.11.3) (2017-06-20)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.11.2...v0.11.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.11.2...v0.11.3)
 
  * Update to matrix-react-sdk 0.9.6 to fix infinite spinner bugs
    and some parts of the app that had missed translation.
 
-Changes in [0.11.2](https://github.com/vector-im/riot-web/releases/tag/v0.11.2) (2017-06-19)
+Changes in [0.11.2](https://github.com/element-hq/riot-web/releases/tag/v0.11.2) (2017-06-19)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.11.2-rc.2...v0.11.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.11.2-rc.2...v0.11.2)
 
  * Add more languages and translations
  * Add a 'register' button
 
-Changes in [0.11.2-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.11.2-rc.2) (2017-06-16)
+Changes in [0.11.2-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.11.2-rc.2) (2017-06-16)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.11.2-rc.1...v0.11.2-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.11.2-rc.1...v0.11.2-rc.2)
 
  * Update react-sdk to pull in fixes for URL previews, CAS
    login, h2 in markdown and CAPTCHA forms.
  * Enable Korean translation
  * Update from Weblate.
-   [\#4323](https://github.com/vector-im/riot-web/pull/4323)
+   [\#4323](https://github.com/element-hq/riot-web/pull/4323)
  * Fix h2 in markdown being weird
-   [\#4332](https://github.com/vector-im/riot-web/pull/4332)
+   [\#4332](https://github.com/element-hq/riot-web/pull/4332)
 
-Changes in [0.11.2-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.11.2-rc.1) (2017-06-15)
+Changes in [0.11.2-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.11.2-rc.1) (2017-06-15)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.11.1...v0.11.2-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.11.1...v0.11.2-rc.1)
 
  * Attempts to deflakify the joining test
-   [\#4313](https://github.com/vector-im/riot-web/pull/4313)
+   [\#4313](https://github.com/element-hq/riot-web/pull/4313)
  * Add a test for the login flow when there is a teamserver
-   [\#4315](https://github.com/vector-im/riot-web/pull/4315)
+   [\#4315](https://github.com/element-hq/riot-web/pull/4315)
  * Remove onload simulator from loading test
-   [\#4314](https://github.com/vector-im/riot-web/pull/4314)
+   [\#4314](https://github.com/element-hq/riot-web/pull/4314)
  * Update from Weblate.
-   [\#4305](https://github.com/vector-im/riot-web/pull/4305)
+   [\#4305](https://github.com/element-hq/riot-web/pull/4305)
  * Test that we handle stored mx_last_room_id correctly
-   [\#4292](https://github.com/vector-im/riot-web/pull/4292)
+   [\#4292](https://github.com/element-hq/riot-web/pull/4292)
  * Ask for email address after setting password for the first time
-   [\#4301](https://github.com/vector-im/riot-web/pull/4301)
+   [\#4301](https://github.com/element-hq/riot-web/pull/4301)
  * i18n for setting email after password flow
-   [\#4299](https://github.com/vector-im/riot-web/pull/4299)
+   [\#4299](https://github.com/element-hq/riot-web/pull/4299)
  * Update from Weblate.
-   [\#4290](https://github.com/vector-im/riot-web/pull/4290)
+   [\#4290](https://github.com/element-hq/riot-web/pull/4290)
  * Don't show the tooltips when filtering rooms
-   [\#4282](https://github.com/vector-im/riot-web/pull/4282)
+   [\#4282](https://github.com/element-hq/riot-web/pull/4282)
  * Update from Weblate.
-   [\#4272](https://github.com/vector-im/riot-web/pull/4272)
+   [\#4272](https://github.com/element-hq/riot-web/pull/4272)
  * Add missing VOIP Dropdown width
-   [\#4266](https://github.com/vector-im/riot-web/pull/4266)
+   [\#4266](https://github.com/element-hq/riot-web/pull/4266)
  * Update import and directory path in the Translations dev guide
-   [\#4261](https://github.com/vector-im/riot-web/pull/4261)
+   [\#4261](https://github.com/element-hq/riot-web/pull/4261)
  * Use Thai string for Thai in Language-Chooser
-   [\#4260](https://github.com/vector-im/riot-web/pull/4260)
+   [\#4260](https://github.com/element-hq/riot-web/pull/4260)
 
-Changes in [0.11.1](https://github.com/vector-im/riot-web/releases/tag/v0.11.1) (2017-06-14)
+Changes in [0.11.1](https://github.com/element-hq/riot-web/releases/tag/v0.11.1) (2017-06-14)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.11.0...v0.11.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.11.0...v0.11.1)
 
  * Update to react-sdk 0.9.4 to prompt to set an
    email address when setting a password and make
    DM guessing smarter.
 
-Changes in [0.11.0](https://github.com/vector-im/riot-web/releases/tag/v0.11.0) (2017-06-12)
+Changes in [0.11.0](https://github.com/element-hq/riot-web/releases/tag/v0.11.0) (2017-06-12)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.11.0-rc.2...v0.11.0)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.11.0-rc.2...v0.11.0)
 
  * More translations & minor fixes
 
-Changes in [0.11.0-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.11.0-rc.2) (2017-06-09)
+Changes in [0.11.0-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.11.0-rc.2) (2017-06-09)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.11.0-rc.1...v0.11.0-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.11.0-rc.1...v0.11.0-rc.2)
 
  * Update to matrix-react-sdk rc.2 which fixes the flux
    dependency version and an issue with the conference
    call bar translation.
 
 
-Changes in [0.11.0-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.11.0-rc.1) (2017-06-09)
+Changes in [0.11.0-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.11.0-rc.1) (2017-06-09)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.10.2...v0.11.0-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.10.2...v0.11.0-rc.1)
 
  * Update from Weblate.
-   [\#4258](https://github.com/vector-im/riot-web/pull/4258)
+   [\#4258](https://github.com/element-hq/riot-web/pull/4258)
  * Update from Weblate.
-   [\#4254](https://github.com/vector-im/riot-web/pull/4254)
+   [\#4254](https://github.com/element-hq/riot-web/pull/4254)
  * Update from Weblate.
-   [\#4253](https://github.com/vector-im/riot-web/pull/4253)
+   [\#4253](https://github.com/element-hq/riot-web/pull/4253)
  * Expect to see HTTP /join/#some:alias when we the view knows it
-   [\#4252](https://github.com/vector-im/riot-web/pull/4252)
+   [\#4252](https://github.com/element-hq/riot-web/pull/4252)
  * Update from Weblate.
-   [\#4250](https://github.com/vector-im/riot-web/pull/4250)
+   [\#4250](https://github.com/element-hq/riot-web/pull/4250)
  * add explicit import to utf8 polyfill and rip out unused imports
-   [\#4169](https://github.com/vector-im/riot-web/pull/4169)
+   [\#4169](https://github.com/element-hq/riot-web/pull/4169)
  * Added styling for copy to clipboard button
-   [\#4204](https://github.com/vector-im/riot-web/pull/4204)
+   [\#4204](https://github.com/element-hq/riot-web/pull/4204)
  * Update from Weblate.
-   [\#4231](https://github.com/vector-im/riot-web/pull/4231)
+   [\#4231](https://github.com/element-hq/riot-web/pull/4231)
  * Update from Weblate.
-   [\#4218](https://github.com/vector-im/riot-web/pull/4218)
+   [\#4218](https://github.com/element-hq/riot-web/pull/4218)
  * Update CSS for ChatInviteDialog
-   [\#4226](https://github.com/vector-im/riot-web/pull/4226)
+   [\#4226](https://github.com/element-hq/riot-web/pull/4226)
  * change electron -> electron_app which was previously missed
-   [\#4212](https://github.com/vector-im/riot-web/pull/4212)
+   [\#4212](https://github.com/element-hq/riot-web/pull/4212)
  * New guest access
-   [\#4039](https://github.com/vector-im/riot-web/pull/4039)
+   [\#4039](https://github.com/element-hq/riot-web/pull/4039)
  * Align message timestamp centrally about the avatar mid-point
-   [\#4219](https://github.com/vector-im/riot-web/pull/4219)
+   [\#4219](https://github.com/element-hq/riot-web/pull/4219)
  * Remove '/' from homepage URL
-   [\#4221](https://github.com/vector-im/riot-web/pull/4221)
+   [\#4221](https://github.com/element-hq/riot-web/pull/4221)
  * Chop off 'origin/'
-   [\#4220](https://github.com/vector-im/riot-web/pull/4220)
+   [\#4220](https://github.com/element-hq/riot-web/pull/4220)
  * Update from Weblate.
-   [\#4214](https://github.com/vector-im/riot-web/pull/4214)
+   [\#4214](https://github.com/element-hq/riot-web/pull/4214)
  * adjust alignment of message menu button in compact layout
-   [\#4211](https://github.com/vector-im/riot-web/pull/4211)
+   [\#4211](https://github.com/element-hq/riot-web/pull/4211)
  * Update from Weblate.
-   [\#4207](https://github.com/vector-im/riot-web/pull/4207)
+   [\#4207](https://github.com/element-hq/riot-web/pull/4207)
  * Fix Tests in ILAG
-   [\#4209](https://github.com/vector-im/riot-web/pull/4209)
+   [\#4209](https://github.com/element-hq/riot-web/pull/4209)
  * Update from Weblate.
-   [\#4197](https://github.com/vector-im/riot-web/pull/4197)
+   [\#4197](https://github.com/element-hq/riot-web/pull/4197)
  * Fix tests for new-guest-access
-   [\#4201](https://github.com/vector-im/riot-web/pull/4201)
+   [\#4201](https://github.com/element-hq/riot-web/pull/4201)
  * i18n for SetPasswordDialog
-   [\#4198](https://github.com/vector-im/riot-web/pull/4198)
+   [\#4198](https://github.com/element-hq/riot-web/pull/4198)
  * Update from Weblate.
-   [\#4193](https://github.com/vector-im/riot-web/pull/4193)
+   [\#4193](https://github.com/element-hq/riot-web/pull/4193)
  * to make the windows volume mixer not explode as it can't resize icons.
-   [\#4183](https://github.com/vector-im/riot-web/pull/4183)
+   [\#4183](https://github.com/element-hq/riot-web/pull/4183)
  * provide react devtools in electron dev runs
-   [\#4186](https://github.com/vector-im/riot-web/pull/4186)
+   [\#4186](https://github.com/element-hq/riot-web/pull/4186)
  * Fix DeprecationWarning
-   [\#4184](https://github.com/vector-im/riot-web/pull/4184)
+   [\#4184](https://github.com/element-hq/riot-web/pull/4184)
  * room link should be a matrix.to one
-   [\#4178](https://github.com/vector-im/riot-web/pull/4178)
+   [\#4178](https://github.com/element-hq/riot-web/pull/4178)
  * Update home.html
-   [\#4163](https://github.com/vector-im/riot-web/pull/4163)
+   [\#4163](https://github.com/element-hq/riot-web/pull/4163)
  * Add missing translation for room directory
-   [\#4160](https://github.com/vector-im/riot-web/pull/4160)
+   [\#4160](https://github.com/element-hq/riot-web/pull/4160)
  * i18n welcome
-   [\#4129](https://github.com/vector-im/riot-web/pull/4129)
+   [\#4129](https://github.com/element-hq/riot-web/pull/4129)
  * Tom welcome page
-   [\#4038](https://github.com/vector-im/riot-web/pull/4038)
+   [\#4038](https://github.com/element-hq/riot-web/pull/4038)
  * Fix some tests that expect Directory (they should expect HomePage)
-   [\#4076](https://github.com/vector-im/riot-web/pull/4076)
+   [\#4076](https://github.com/element-hq/riot-web/pull/4076)
  * Add "Login" button to RHS when user is a guest
-   [\#4037](https://github.com/vector-im/riot-web/pull/4037)
+   [\#4037](https://github.com/element-hq/riot-web/pull/4037)
  * Rejig the PaswordNagBar
-   [\#4026](https://github.com/vector-im/riot-web/pull/4026)
+   [\#4026](https://github.com/element-hq/riot-web/pull/4026)
  * Allow team server config to be missing
-   [\#4024](https://github.com/vector-im/riot-web/pull/4024)
+   [\#4024](https://github.com/element-hq/riot-web/pull/4024)
  * Remove GuestWarningBar
-   [\#4020](https://github.com/vector-im/riot-web/pull/4020)
+   [\#4020](https://github.com/element-hq/riot-web/pull/4020)
  * Make left panel better for new users (mk III)
-   [\#4023](https://github.com/vector-im/riot-web/pull/4023)
+   [\#4023](https://github.com/element-hq/riot-web/pull/4023)
  * Implement default welcome page and allow custom URL /w config
-   [\#4015](https://github.com/vector-im/riot-web/pull/4015)
+   [\#4015](https://github.com/element-hq/riot-web/pull/4015)
  * Add warm-fuzzy for successful password entry
-   [\#3989](https://github.com/vector-im/riot-web/pull/3989)
+   [\#3989](https://github.com/element-hq/riot-web/pull/3989)
  * autoFocus new password input in SetPasswordDialog
-   [\#3982](https://github.com/vector-im/riot-web/pull/3982)
+   [\#3982](https://github.com/element-hq/riot-web/pull/3982)
  * Implement dialog to set password
-   [\#3921](https://github.com/vector-im/riot-web/pull/3921)
+   [\#3921](https://github.com/element-hq/riot-web/pull/3921)
  * Replace NeedToRegister with SetMxId dialog
-   [\#3924](https://github.com/vector-im/riot-web/pull/3924)
+   [\#3924](https://github.com/element-hq/riot-web/pull/3924)
  * Add welcomeUserId to sample config
-   [\#3906](https://github.com/vector-im/riot-web/pull/3906)
+   [\#3906](https://github.com/element-hq/riot-web/pull/3906)
  * CSS for mxIdDialog redesign
-   [\#3885](https://github.com/vector-im/riot-web/pull/3885)
+   [\#3885](https://github.com/element-hq/riot-web/pull/3885)
  * Implement PasswordNagBar
-   [\#3817](https://github.com/vector-im/riot-web/pull/3817)
+   [\#3817](https://github.com/element-hq/riot-web/pull/3817)
  * CSS for new SetMxIdDialog
-   [\#3762](https://github.com/vector-im/riot-web/pull/3762)
+   [\#3762](https://github.com/element-hq/riot-web/pull/3762)
 
-Changes in [0.10.2](https://github.com/vector-im/riot-web/releases/tag/v0.10.2) (2017-06-06)
+Changes in [0.10.2](https://github.com/element-hq/riot-web/releases/tag/v0.10.2) (2017-06-06)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.10.1...v0.10.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.10.1...v0.10.2)
 
  * Hotfix for bugs where navigating straight to a URL like /#/login and
    and /#/forgot_password
 
 
-Changes in [0.10.1](https://github.com/vector-im/riot-web/releases/tag/v0.10.1) (2017-06-02)
+Changes in [0.10.1](https://github.com/element-hq/riot-web/releases/tag/v0.10.1) (2017-06-02)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.10.0...v0.10.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.10.0...v0.10.1)
 
  * Update to matrix-react-sdk 0.9.1 to fix i18n error which broke start chat in some circumstances
 
-Changes in [0.10.0](https://github.com/vector-im/riot-web/releases/tag/v0.10.0) (2017-06-02)
+Changes in [0.10.0](https://github.com/element-hq/riot-web/releases/tag/v0.10.0) (2017-06-02)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.10.0-rc.2...v0.10.0)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.10.0-rc.2...v0.10.0)
 
  * Update from Weblate.
-   [\#4152](https://github.com/vector-im/riot-web/pull/4152)
+   [\#4152](https://github.com/element-hq/riot-web/pull/4152)
 
-Changes in [0.10.0-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.10.0-rc.2) (2017-06-02)
+Changes in [0.10.0-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.10.0-rc.2) (2017-06-02)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.10.0-rc.1...v0.10.0-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.10.0-rc.1...v0.10.0-rc.2)
 
  * Update from Weblate.
-   [\#4150](https://github.com/vector-im/riot-web/pull/4150)
+   [\#4150](https://github.com/element-hq/riot-web/pull/4150)
  * styling for webrtc settings
-   [\#4019](https://github.com/vector-im/riot-web/pull/4019)
+   [\#4019](https://github.com/element-hq/riot-web/pull/4019)
  * Update from Weblate.
-   [\#4140](https://github.com/vector-im/riot-web/pull/4140)
+   [\#4140](https://github.com/element-hq/riot-web/pull/4140)
  * add styles for compact layout
-   [\#4132](https://github.com/vector-im/riot-web/pull/4132)
+   [\#4132](https://github.com/element-hq/riot-web/pull/4132)
  * Various tweaks to fetch-develop-deps
-   [\#4147](https://github.com/vector-im/riot-web/pull/4147)
+   [\#4147](https://github.com/element-hq/riot-web/pull/4147)
  * Don't try to build with node 6.0
-   [\#4145](https://github.com/vector-im/riot-web/pull/4145)
+   [\#4145](https://github.com/element-hq/riot-web/pull/4145)
  * Support 12hr time on DateSeparator
-   [\#4143](https://github.com/vector-im/riot-web/pull/4143)
+   [\#4143](https://github.com/element-hq/riot-web/pull/4143)
  * Update from Weblate.
-   [\#4137](https://github.com/vector-im/riot-web/pull/4137)
+   [\#4137](https://github.com/element-hq/riot-web/pull/4137)
  * Update from Weblate.
-   [\#4105](https://github.com/vector-im/riot-web/pull/4105)
+   [\#4105](https://github.com/element-hq/riot-web/pull/4105)
  * Update from Weblate.
-   [\#4094](https://github.com/vector-im/riot-web/pull/4094)
+   [\#4094](https://github.com/element-hq/riot-web/pull/4094)
  * Update from Weblate.
-   [\#4091](https://github.com/vector-im/riot-web/pull/4091)
+   [\#4091](https://github.com/element-hq/riot-web/pull/4091)
  * Update from Weblate.
-   [\#4089](https://github.com/vector-im/riot-web/pull/4089)
+   [\#4089](https://github.com/element-hq/riot-web/pull/4089)
  * Update from Weblate.
-   [\#4083](https://github.com/vector-im/riot-web/pull/4083)
+   [\#4083](https://github.com/element-hq/riot-web/pull/4083)
 
-Changes in [0.10.0-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.10.0-rc.1) (2017-06-01)
+Changes in [0.10.0-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.10.0-rc.1) (2017-06-01)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.10...v0.10.0-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.10...v0.10.0-rc.1)
 
  * basic electron profile support
-   [\#4030](https://github.com/vector-im/riot-web/pull/4030)
- * Finish translations for vector-im/riot-web
-   [\#4122](https://github.com/vector-im/riot-web/pull/4122)
+   [\#4030](https://github.com/element-hq/riot-web/pull/4030)
+ * Finish translations for element-hq/riot-web
+   [\#4122](https://github.com/element-hq/riot-web/pull/4122)
  * Translate src/vector
-   [\#4119](https://github.com/vector-im/riot-web/pull/4119)
+   [\#4119](https://github.com/element-hq/riot-web/pull/4119)
  * electron flashFrame was way too annoying
-   [\#4128](https://github.com/vector-im/riot-web/pull/4128)
+   [\#4128](https://github.com/element-hq/riot-web/pull/4128)
  * auto-launch support [Electron]
-   [\#4012](https://github.com/vector-im/riot-web/pull/4012)
+   [\#4012](https://github.com/element-hq/riot-web/pull/4012)
  * Show 12hr time on hover too
-   [\#4092](https://github.com/vector-im/riot-web/pull/4092)
+   [\#4092](https://github.com/element-hq/riot-web/pull/4092)
  * Translate src/notifications
-   [\#4087](https://github.com/vector-im/riot-web/pull/4087)
+   [\#4087](https://github.com/element-hq/riot-web/pull/4087)
  * Translate src/components/structures
-   [\#4084](https://github.com/vector-im/riot-web/pull/4084)
+   [\#4084](https://github.com/element-hq/riot-web/pull/4084)
  * Smaller font size on timestamp to better fit in the available space
-   [\#4085](https://github.com/vector-im/riot-web/pull/4085)
+   [\#4085](https://github.com/element-hq/riot-web/pull/4085)
  * Make travis run the build with several versions of node
-   [\#4079](https://github.com/vector-im/riot-web/pull/4079)
+   [\#4079](https://github.com/element-hq/riot-web/pull/4079)
  * Piwik Analytics
-   [\#4056](https://github.com/vector-im/riot-web/pull/4056)
+   [\#4056](https://github.com/element-hq/riot-web/pull/4056)
  * Update from Weblate.
-   [\#4077](https://github.com/vector-im/riot-web/pull/4077)
+   [\#4077](https://github.com/element-hq/riot-web/pull/4077)
  * managed to eat the eventStatus check, can't redact a local-echo etc
-   [\#4078](https://github.com/vector-im/riot-web/pull/4078)
+   [\#4078](https://github.com/element-hq/riot-web/pull/4078)
  * show redact in context menu only if has PL to/sent message
-   [\#3925](https://github.com/vector-im/riot-web/pull/3925)
+   [\#3925](https://github.com/element-hq/riot-web/pull/3925)
  * Update from Weblate.
-   [\#4064](https://github.com/vector-im/riot-web/pull/4064)
+   [\#4064](https://github.com/element-hq/riot-web/pull/4064)
  * Change redact -> remove to improve clarity
-   [\#3722](https://github.com/vector-im/riot-web/pull/3722)
+   [\#3722](https://github.com/element-hq/riot-web/pull/3722)
  * Update from Weblate.
-   [\#4058](https://github.com/vector-im/riot-web/pull/4058)
+   [\#4058](https://github.com/element-hq/riot-web/pull/4058)
  * Message Forwarding
-   [\#3688](https://github.com/vector-im/riot-web/pull/3688)
+   [\#3688](https://github.com/element-hq/riot-web/pull/3688)
  * Update from Weblate.
-   [\#4057](https://github.com/vector-im/riot-web/pull/4057)
+   [\#4057](https://github.com/element-hq/riot-web/pull/4057)
  * Fixed an input field's background color in dark theme
-   [\#4053](https://github.com/vector-im/riot-web/pull/4053)
+   [\#4053](https://github.com/element-hq/riot-web/pull/4053)
  * Update from Weblate.
-   [\#4051](https://github.com/vector-im/riot-web/pull/4051)
+   [\#4051](https://github.com/element-hq/riot-web/pull/4051)
  * Update from Weblate.
-   [\#4049](https://github.com/vector-im/riot-web/pull/4049)
+   [\#4049](https://github.com/element-hq/riot-web/pull/4049)
  * Update from Weblate.
-   [\#4048](https://github.com/vector-im/riot-web/pull/4048)
+   [\#4048](https://github.com/element-hq/riot-web/pull/4048)
  * Update from Weblate.
-   [\#4040](https://github.com/vector-im/riot-web/pull/4040)
+   [\#4040](https://github.com/element-hq/riot-web/pull/4040)
  * Update translating.md: Minor suggestions
-   [\#4041](https://github.com/vector-im/riot-web/pull/4041)
+   [\#4041](https://github.com/element-hq/riot-web/pull/4041)
  * tidy electron files, they weren't pwetty
-   [\#3993](https://github.com/vector-im/riot-web/pull/3993)
+   [\#3993](https://github.com/element-hq/riot-web/pull/3993)
  * Prevent Power Save when in call (Electron)
-   [\#3992](https://github.com/vector-im/riot-web/pull/3992)
+   [\#3992](https://github.com/element-hq/riot-web/pull/3992)
  * Translations!
-   [\#4035](https://github.com/vector-im/riot-web/pull/4035)
+   [\#4035](https://github.com/element-hq/riot-web/pull/4035)
  * Kieran gould/12hourtimestamp
-   [\#3961](https://github.com/vector-im/riot-web/pull/3961)
+   [\#3961](https://github.com/element-hq/riot-web/pull/3961)
  * Don't include src in the test resolve root
-   [\#4033](https://github.com/vector-im/riot-web/pull/4033)
+   [\#4033](https://github.com/element-hq/riot-web/pull/4033)
  * add moar context menus [Electron]
-   [\#4021](https://github.com/vector-im/riot-web/pull/4021)
+   [\#4021](https://github.com/element-hq/riot-web/pull/4021)
  * Add `Chat` to Linux app categories
-   [\#4022](https://github.com/vector-im/riot-web/pull/4022)
+   [\#4022](https://github.com/element-hq/riot-web/pull/4022)
  * add menu category for linux build of app
-   [\#3975](https://github.com/vector-im/riot-web/pull/3975)
+   [\#3975](https://github.com/element-hq/riot-web/pull/3975)
  * Electron Tray Improvements
-   [\#3909](https://github.com/vector-im/riot-web/pull/3909)
+   [\#3909](https://github.com/element-hq/riot-web/pull/3909)
  * More riot-web test deflakification
-   [\#3966](https://github.com/vector-im/riot-web/pull/3966)
+   [\#3966](https://github.com/element-hq/riot-web/pull/3966)
  * Script to fetch corresponding branches of dependent projects
-   [\#3945](https://github.com/vector-im/riot-web/pull/3945)
+   [\#3945](https://github.com/element-hq/riot-web/pull/3945)
  * Add type="text/css" to SVG logos
-   [\#3964](https://github.com/vector-im/riot-web/pull/3964)
+   [\#3964](https://github.com/element-hq/riot-web/pull/3964)
  * Fix some setState-after-unmount in roomdirectory
-   [\#3958](https://github.com/vector-im/riot-web/pull/3958)
+   [\#3958](https://github.com/element-hq/riot-web/pull/3958)
  * Attempt to deflakify joining test
-   [\#3956](https://github.com/vector-im/riot-web/pull/3956)
+   [\#3956](https://github.com/element-hq/riot-web/pull/3956)
 
-Changes in [0.9.10](https://github.com/vector-im/riot-web/releases/tag/v0.9.10) (2017-05-22)
+Changes in [0.9.10](https://github.com/element-hq/riot-web/releases/tag/v0.9.10) (2017-05-22)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.10-rc.1...v0.9.10)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.10-rc.1...v0.9.10)
 
  * No changes
 
 
-Changes in [0.9.10-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.9.10-rc.1) (2017-05-19)
+Changes in [0.9.10-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.9.10-rc.1) (2017-05-19)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.9...v0.9.10-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.9...v0.9.10-rc.1)
 
  * CSS for left_aligned Dropdowns, and adjustments for Country dd in Login
-   [\#3959](https://github.com/vector-im/riot-web/pull/3959)
+   [\#3959](https://github.com/element-hq/riot-web/pull/3959)
  * Add square flag pngs /w genflags.sh script
-   [\#3953](https://github.com/vector-im/riot-web/pull/3953)
+   [\#3953](https://github.com/element-hq/riot-web/pull/3953)
  * Add config for riot-bot on desktop app build
-   [\#3954](https://github.com/vector-im/riot-web/pull/3954)
+   [\#3954](https://github.com/element-hq/riot-web/pull/3954)
  * Desktop: 'copy link address'
-   [\#3952](https://github.com/vector-im/riot-web/pull/3952)
+   [\#3952](https://github.com/element-hq/riot-web/pull/3952)
  * Reduce rageshake log size to 1MB
-   [\#3943](https://github.com/vector-im/riot-web/pull/3943)
+   [\#3943](https://github.com/element-hq/riot-web/pull/3943)
  * CSS for putting country dd on same line as phone input
-   [\#3942](https://github.com/vector-im/riot-web/pull/3942)
+   [\#3942](https://github.com/element-hq/riot-web/pull/3942)
  * fix #3894
-   [\#3919](https://github.com/vector-im/riot-web/pull/3919)
+   [\#3919](https://github.com/element-hq/riot-web/pull/3919)
  * change vector->riot on the surface
-   [\#3894](https://github.com/vector-im/riot-web/pull/3894)
+   [\#3894](https://github.com/element-hq/riot-web/pull/3894)
  * move manifest.json outward so it is scoped properly
-   [\#3888](https://github.com/vector-im/riot-web/pull/3888)
+   [\#3888](https://github.com/element-hq/riot-web/pull/3888)
  * add to manifest
-   [\#3799](https://github.com/vector-im/riot-web/pull/3799)
+   [\#3799](https://github.com/element-hq/riot-web/pull/3799)
  * Automatically update component-index
-   [\#3886](https://github.com/vector-im/riot-web/pull/3886)
+   [\#3886](https://github.com/element-hq/riot-web/pull/3886)
  * move electron -> electron_app because npm smart
-   [\#3877](https://github.com/vector-im/riot-web/pull/3877)
+   [\#3877](https://github.com/element-hq/riot-web/pull/3877)
  * Fix bug report endpoint in config.sample.json.
-   [\#3863](https://github.com/vector-im/riot-web/pull/3863)
+   [\#3863](https://github.com/element-hq/riot-web/pull/3863)
  * Update 2 missed icons to the new icon
-   [\#3851](https://github.com/vector-im/riot-web/pull/3851)
+   [\#3851](https://github.com/element-hq/riot-web/pull/3851)
  * Make left panel better for new users (mk II)
-   [\#3804](https://github.com/vector-im/riot-web/pull/3804)
+   [\#3804](https://github.com/element-hq/riot-web/pull/3804)
  * match primary package.json
-   [\#3839](https://github.com/vector-im/riot-web/pull/3839)
+   [\#3839](https://github.com/element-hq/riot-web/pull/3839)
  * Re-add productName
-   [\#3829](https://github.com/vector-im/riot-web/pull/3829)
+   [\#3829](https://github.com/element-hq/riot-web/pull/3829)
  * Remove leading v in /version file, for SemVer and to match Electron ver
-   [\#3683](https://github.com/vector-im/riot-web/pull/3683)
+   [\#3683](https://github.com/element-hq/riot-web/pull/3683)
  * Fix scope of callback
-   [\#3790](https://github.com/vector-im/riot-web/pull/3790)
+   [\#3790](https://github.com/element-hq/riot-web/pull/3790)
  * Remember and Recall window layout/position state
-   [\#3622](https://github.com/vector-im/riot-web/pull/3622)
+   [\#3622](https://github.com/element-hq/riot-web/pull/3622)
  * Remove babelcheck
-   [\#3808](https://github.com/vector-im/riot-web/pull/3808)
+   [\#3808](https://github.com/element-hq/riot-web/pull/3808)
  * Include MXID and device id in rageshakes
-   [\#3809](https://github.com/vector-im/riot-web/pull/3809)
+   [\#3809](https://github.com/element-hq/riot-web/pull/3809)
  * import Modal
-   [\#3791](https://github.com/vector-im/riot-web/pull/3791)
+   [\#3791](https://github.com/element-hq/riot-web/pull/3791)
  * Pin filesize ver to fix break upstream
-   [\#3775](https://github.com/vector-im/riot-web/pull/3775)
+   [\#3775](https://github.com/element-hq/riot-web/pull/3775)
  * Improve Room Directory Look & Feel
-   [\#3751](https://github.com/vector-im/riot-web/pull/3751)
+   [\#3751](https://github.com/element-hq/riot-web/pull/3751)
  * Fix emote RRs alignment
-   [\#3742](https://github.com/vector-im/riot-web/pull/3742)
+   [\#3742](https://github.com/element-hq/riot-web/pull/3742)
  * Remove unused `placeholder` prop on RoomDropTarget
-   [\#3741](https://github.com/vector-im/riot-web/pull/3741)
+   [\#3741](https://github.com/element-hq/riot-web/pull/3741)
  * Modify CSS for matrix-org/matrix-react-sdk#833
-   [\#3732](https://github.com/vector-im/riot-web/pull/3732)
+   [\#3732](https://github.com/element-hq/riot-web/pull/3732)
  * Warn when exiting due to single-instance
-   [\#3727](https://github.com/vector-im/riot-web/pull/3727)
+   [\#3727](https://github.com/element-hq/riot-web/pull/3727)
  * Electron forgets it was maximized when you click on a notification
-   [\#3709](https://github.com/vector-im/riot-web/pull/3709)
+   [\#3709](https://github.com/element-hq/riot-web/pull/3709)
  * CSS to make h1 and h2 the same size as h1.
-   [\#3719](https://github.com/vector-im/riot-web/pull/3719)
+   [\#3719](https://github.com/element-hq/riot-web/pull/3719)
  * Prevent long room names/topics from pushing UI of the screen
-   [\#3721](https://github.com/vector-im/riot-web/pull/3721)
+   [\#3721](https://github.com/element-hq/riot-web/pull/3721)
  * Disable dropdown highlight on focus
-   [\#3717](https://github.com/vector-im/riot-web/pull/3717)
+   [\#3717](https://github.com/element-hq/riot-web/pull/3717)
  * Escape HTML Tags from Linux Notifications (electron)
-   [\#3564](https://github.com/vector-im/riot-web/pull/3564)
+   [\#3564](https://github.com/element-hq/riot-web/pull/3564)
  * styling for spoilerized access token view in Settings
-   [\#3651](https://github.com/vector-im/riot-web/pull/3651)
+   [\#3651](https://github.com/element-hq/riot-web/pull/3651)
  * Fix Webpack conf
-   [\#3690](https://github.com/vector-im/riot-web/pull/3690)
+   [\#3690](https://github.com/element-hq/riot-web/pull/3690)
  * Add config.json to .gitignore
-   [\#3599](https://github.com/vector-im/riot-web/pull/3599)
+   [\#3599](https://github.com/element-hq/riot-web/pull/3599)
  * add command line arg (--hidden) for electron app
-   [\#3641](https://github.com/vector-im/riot-web/pull/3641)
+   [\#3641](https://github.com/element-hq/riot-web/pull/3641)
  * fix ImageView Download functionality
-   [\#3640](https://github.com/vector-im/riot-web/pull/3640)
+   [\#3640](https://github.com/element-hq/riot-web/pull/3640)
  * Add cross-env into the mix
-   [\#3693](https://github.com/vector-im/riot-web/pull/3693)
+   [\#3693](https://github.com/element-hq/riot-web/pull/3693)
  * Remember acceptance for unsupported browsers.
-   [\#3694](https://github.com/vector-im/riot-web/pull/3694)
+   [\#3694](https://github.com/element-hq/riot-web/pull/3694)
  * Cosmetics to go with matrix-org/matrix-react-sdk#811
-   [\#3692](https://github.com/vector-im/riot-web/pull/3692)
+   [\#3692](https://github.com/element-hq/riot-web/pull/3692)
  * Cancel quicksearch on ESC
-   [\#3680](https://github.com/vector-im/riot-web/pull/3680)
+   [\#3680](https://github.com/element-hq/riot-web/pull/3680)
  * Optimise RoomList and implement quick-search functionality on it.
-   [\#3654](https://github.com/vector-im/riot-web/pull/3654)
+   [\#3654](https://github.com/element-hq/riot-web/pull/3654)
  * Progress updates for rageshake uploads
-   [\#3648](https://github.com/vector-im/riot-web/pull/3648)
+   [\#3648](https://github.com/element-hq/riot-web/pull/3648)
  * Factor out rageshake upload to a separate file
-   [\#3645](https://github.com/vector-im/riot-web/pull/3645)
+   [\#3645](https://github.com/element-hq/riot-web/pull/3645)
  * rageshake: fix race when collecting logs
-   [\#3644](https://github.com/vector-im/riot-web/pull/3644)
+   [\#3644](https://github.com/element-hq/riot-web/pull/3644)
  * Fix a flaky test
-   [\#3649](https://github.com/vector-im/riot-web/pull/3649)
+   [\#3649](https://github.com/element-hq/riot-web/pull/3649)
 
-Changes in [0.9.9](https://github.com/vector-im/riot-web/releases/tag/v0.9.9) (2017-04-25)
+Changes in [0.9.9](https://github.com/element-hq/riot-web/releases/tag/v0.9.9) (2017-04-25)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.9-rc.2...v0.9.9)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.9-rc.2...v0.9.9)
 
  * No changes
 
 
-Changes in [0.9.9-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.9.9-rc.2) (2017-04-24)
+Changes in [0.9.9-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.9.9-rc.2) (2017-04-24)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.9-rc.1...v0.9.9-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.9-rc.1...v0.9.9-rc.2)
 
  * Fix bug where links to Riot would fail to open.
 
 
-Changes in [0.9.9-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.9.9-rc.1) (2017-04-21)
+Changes in [0.9.9-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.9.9-rc.1) (2017-04-21)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.8...v0.9.9-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.8...v0.9.9-rc.1)
 
- * Update js-sdk and matrix-react-sdk to fix registration without a captcha (https://github.com/vector-im/riot-web/issues/3621)
+ * Update js-sdk and matrix-react-sdk to fix registration without a captcha (https://github.com/element-hq/riot-web/issues/3621)
 
 
-Changes in [0.9.8](https://github.com/vector-im/riot-web/releases/tag/v0.9.8) (2017-04-12)
+Changes in [0.9.8](https://github.com/element-hq/riot-web/releases/tag/v0.9.8) (2017-04-12)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.8-rc.3...v0.9.8)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.8-rc.3...v0.9.8)
 
  * No changes
 
-Changes in [0.9.8-rc.3](https://github.com/vector-im/riot-web/releases/tag/v0.9.8-rc.3) (2017-04-11)
+Changes in [0.9.8-rc.3](https://github.com/element-hq/riot-web/releases/tag/v0.9.8-rc.3) (2017-04-11)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.8-rc.2...v0.9.8-rc.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.8-rc.2...v0.9.8-rc.3)
 
  * Make the clear cache button work on desktop
-   [\#3598](https://github.com/vector-im/riot-web/pull/3598)
+   [\#3598](https://github.com/element-hq/riot-web/pull/3598)
 
-Changes in [0.9.8-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.9.8-rc.2) (2017-04-10)
+Changes in [0.9.8-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.9.8-rc.2) (2017-04-10)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.8-rc.1...v0.9.8-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.8-rc.1...v0.9.8-rc.2)
 
  * Redacted events bg: black lozenge -> torn paper
-   [\#3596](https://github.com/vector-im/riot-web/pull/3596)
+   [\#3596](https://github.com/element-hq/riot-web/pull/3596)
  * Add 'app' parameter to rageshake report
-   [\#3594](https://github.com/vector-im/riot-web/pull/3594)
+   [\#3594](https://github.com/element-hq/riot-web/pull/3594)
 
-Changes in [0.9.8-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.9.8-rc.1) (2017-04-07)
+Changes in [0.9.8-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.9.8-rc.1) (2017-04-07)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.7...v0.9.8-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.7...v0.9.8-rc.1)
 
  * Add support for indexeddb sync in webworker
-   [\#3578](https://github.com/vector-im/riot-web/pull/3578)
+   [\#3578](https://github.com/element-hq/riot-web/pull/3578)
  * Add CSS to make Emote sender cursor : pointer
-   [\#3574](https://github.com/vector-im/riot-web/pull/3574)
+   [\#3574](https://github.com/element-hq/riot-web/pull/3574)
  * Remove rageshake server
-   [\#3565](https://github.com/vector-im/riot-web/pull/3565)
+   [\#3565](https://github.com/element-hq/riot-web/pull/3565)
  * Adjust CSS for matrix-org/matrix-react-sdk#789
-   [\#3566](https://github.com/vector-im/riot-web/pull/3566)
+   [\#3566](https://github.com/element-hq/riot-web/pull/3566)
  * Fix tests to reflect recent changes
-   [\#3537](https://github.com/vector-im/riot-web/pull/3537)
+   [\#3537](https://github.com/element-hq/riot-web/pull/3537)
  * Do not assume getTs will return comparable integer
-   [\#3536](https://github.com/vector-im/riot-web/pull/3536)
+   [\#3536](https://github.com/element-hq/riot-web/pull/3536)
  * Rename ReactPerf to Perf
-   [\#3535](https://github.com/vector-im/riot-web/pull/3535)
+   [\#3535](https://github.com/element-hq/riot-web/pull/3535)
  * Don't show phone number as target for email notifs
-   [\#3530](https://github.com/vector-im/riot-web/pull/3530)
+   [\#3530](https://github.com/element-hq/riot-web/pull/3530)
  * Fix people section again
-   [\#3458](https://github.com/vector-im/riot-web/pull/3458)
+   [\#3458](https://github.com/element-hq/riot-web/pull/3458)
  * dark theme invert inconsistent across browsers
-   [\#3479](https://github.com/vector-im/riot-web/pull/3479)
+   [\#3479](https://github.com/element-hq/riot-web/pull/3479)
  * CSS for adding phone number in UserSettings
-   [\#3451](https://github.com/vector-im/riot-web/pull/3451)
+   [\#3451](https://github.com/element-hq/riot-web/pull/3451)
  * Support for phone number registration/signin, mk2
-   [\#3426](https://github.com/vector-im/riot-web/pull/3426)
+   [\#3426](https://github.com/element-hq/riot-web/pull/3426)
  * Confirm redactions with a dialog
-   [\#3470](https://github.com/vector-im/riot-web/pull/3470)
+   [\#3470](https://github.com/element-hq/riot-web/pull/3470)
  * Better CSS for redactions
-   [\#3453](https://github.com/vector-im/riot-web/pull/3453)
+   [\#3453](https://github.com/element-hq/riot-web/pull/3453)
  * Fix the people section
-   [\#3448](https://github.com/vector-im/riot-web/pull/3448)
+   [\#3448](https://github.com/element-hq/riot-web/pull/3448)
  * Merge the two RoomTile context menus into one
-   [\#3395](https://github.com/vector-im/riot-web/pull/3395)
+   [\#3395](https://github.com/element-hq/riot-web/pull/3395)
  * Refactor screen set after login
-   [\#3385](https://github.com/vector-im/riot-web/pull/3385)
+   [\#3385](https://github.com/element-hq/riot-web/pull/3385)
  * CSS for redacted EventTiles
-   [\#3379](https://github.com/vector-im/riot-web/pull/3379)
+   [\#3379](https://github.com/element-hq/riot-web/pull/3379)
  * Height:100% for welcome pages on Safari
-   [\#3340](https://github.com/vector-im/riot-web/pull/3340)
+   [\#3340](https://github.com/element-hq/riot-web/pull/3340)
  * `view_room` dispatch from `onClick` RoomTile
-   [\#3376](https://github.com/vector-im/riot-web/pull/3376)
+   [\#3376](https://github.com/element-hq/riot-web/pull/3376)
  * Hide statusAreaBox_line entirely when inCall
-   [\#3350](https://github.com/vector-im/riot-web/pull/3350)
+   [\#3350](https://github.com/element-hq/riot-web/pull/3350)
  * Set padding-bottom: 0px for .mx_Dialog spinner
-   [\#3351](https://github.com/vector-im/riot-web/pull/3351)
+   [\#3351](https://github.com/element-hq/riot-web/pull/3351)
  * Support InteractiveAuth based registration
-   [\#3333](https://github.com/vector-im/riot-web/pull/3333)
+   [\#3333](https://github.com/element-hq/riot-web/pull/3333)
  * Expose notification option for username/MXID
-   [\#3334](https://github.com/vector-im/riot-web/pull/3334)
+   [\#3334](https://github.com/element-hq/riot-web/pull/3334)
  * Float the toggle in the top right of MELS
-   [\#3190](https://github.com/vector-im/riot-web/pull/3190)
+   [\#3190](https://github.com/element-hq/riot-web/pull/3190)
  * More aggressive rageshake log culling
-   [\#3311](https://github.com/vector-im/riot-web/pull/3311)
+   [\#3311](https://github.com/element-hq/riot-web/pull/3311)
  * Don't overflow directory network options
-   [\#3282](https://github.com/vector-im/riot-web/pull/3282)
+   [\#3282](https://github.com/element-hq/riot-web/pull/3282)
  * CSS for ban / kick reason prompt
-   [\#3250](https://github.com/vector-im/riot-web/pull/3250)
+   [\#3250](https://github.com/element-hq/riot-web/pull/3250)
  * Allow forgetting rooms you're banned from
-   [\#3246](https://github.com/vector-im/riot-web/pull/3246)
+   [\#3246](https://github.com/element-hq/riot-web/pull/3246)
  * Fix icon paths in manifest
-   [\#3245](https://github.com/vector-im/riot-web/pull/3245)
+   [\#3245](https://github.com/element-hq/riot-web/pull/3245)
  * Fix broken tests caused by adding IndexedDB support
-   [\#3242](https://github.com/vector-im/riot-web/pull/3242)
+   [\#3242](https://github.com/element-hq/riot-web/pull/3242)
  * CSS for un-ban button in RoomSettings
-   [\#3227](https://github.com/vector-im/riot-web/pull/3227)
+   [\#3227](https://github.com/element-hq/riot-web/pull/3227)
  * Remove z-index property on avatar initials
-   [\#3239](https://github.com/vector-im/riot-web/pull/3239)
+   [\#3239](https://github.com/element-hq/riot-web/pull/3239)
  * Reposition certain icons in the status bar
-   [\#3233](https://github.com/vector-im/riot-web/pull/3233)
+   [\#3233](https://github.com/element-hq/riot-web/pull/3233)
  * CSS for kick/ban confirmation dialog
-   [\#3224](https://github.com/vector-im/riot-web/pull/3224)
+   [\#3224](https://github.com/element-hq/riot-web/pull/3224)
  * Style for split-out interactive auth
-   [\#3217](https://github.com/vector-im/riot-web/pull/3217)
+   [\#3217](https://github.com/element-hq/riot-web/pull/3217)
  * Use the teamToken threaded through from react sdk
-   [\#3196](https://github.com/vector-im/riot-web/pull/3196)
+   [\#3196](https://github.com/element-hq/riot-web/pull/3196)
  * rageshake: Add file server with basic auth
-   [\#3169](https://github.com/vector-im/riot-web/pull/3169)
+   [\#3169](https://github.com/element-hq/riot-web/pull/3169)
  * Fix bug with home icon not appearing when logged in as team member
-   [\#3162](https://github.com/vector-im/riot-web/pull/3162)
+   [\#3162](https://github.com/element-hq/riot-web/pull/3162)
  * Add ISSUE_TEMPLATE
-   [\#2836](https://github.com/vector-im/riot-web/pull/2836)
+   [\#2836](https://github.com/element-hq/riot-web/pull/2836)
  * Store bug reports in separate directories
-   [\#3150](https://github.com/vector-im/riot-web/pull/3150)
+   [\#3150](https://github.com/element-hq/riot-web/pull/3150)
  * Quick and dirty support for custom welcome pages.
-   [\#2575](https://github.com/vector-im/riot-web/pull/2575)
+   [\#2575](https://github.com/element-hq/riot-web/pull/2575)
  * RTS Welcome Pages
-   [\#3103](https://github.com/vector-im/riot-web/pull/3103)
+   [\#3103](https://github.com/element-hq/riot-web/pull/3103)
  * rageshake: Abide by Go standards
-   [\#3149](https://github.com/vector-im/riot-web/pull/3149)
+   [\#3149](https://github.com/element-hq/riot-web/pull/3149)
  * Bug report server script
-   [\#3072](https://github.com/vector-im/riot-web/pull/3072)
+   [\#3072](https://github.com/element-hq/riot-web/pull/3072)
  * Bump olm version
-   [\#3125](https://github.com/vector-im/riot-web/pull/3125)
+   [\#3125](https://github.com/element-hq/riot-web/pull/3125)
 
-Changes in [0.9.7](https://github.com/vector-im/riot-web/releases/tag/v0.9.7) (2017-02-04)
+Changes in [0.9.7](https://github.com/element-hq/riot-web/releases/tag/v0.9.7) (2017-02-04)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.7-rc.3...v0.9.7)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.7-rc.3...v0.9.7)
 
  * Update to matrix-js-sdk 0.7.5 (no changes from 0.7.5-rc.3)
  * Update to matrix-react-sdk 0.8.6 (no changes from 0.8.6-rc.3)
 
-Changes in [0.9.7-rc.3](https://github.com/vector-im/riot-web/releases/tag/v0.9.7-rc.3) (2017-02-03)
+Changes in [0.9.7-rc.3](https://github.com/element-hq/riot-web/releases/tag/v0.9.7-rc.3) (2017-02-03)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.7-rc.2...v0.9.7-rc.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.7-rc.2...v0.9.7-rc.3)
  * Update to latest Olm to fix key import/export and use of megolm sessions
    created on more recent versions
  * Update to latest matrix-react-sdk and matrix-js-sdk to fix e2e device
    handling
 
-Changes in [0.9.7-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.9.7-rc.2) (2017-02-03)
+Changes in [0.9.7-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.9.7-rc.2) (2017-02-03)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.7-rc.1...v0.9.7-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.7-rc.1...v0.9.7-rc.2)
 
  * Update matrix-js-sdk to get new device change
    notifications interface for more reliable e2e crypto
 
-Changes in [0.9.7-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.9.7-rc.1) (2017-02-03)
+Changes in [0.9.7-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.9.7-rc.1) (2017-02-03)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.6...v0.9.7-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.6...v0.9.7-rc.1)
 
  * Better user interface for screen readers and keyboard navigation
-   [\#2946](https://github.com/vector-im/riot-web/pull/2946)
+   [\#2946](https://github.com/element-hq/riot-web/pull/2946)
  * Allow mxc: URLs for icons in the NetworkDropdown
-   [\#3118](https://github.com/vector-im/riot-web/pull/3118)
+   [\#3118](https://github.com/element-hq/riot-web/pull/3118)
  * make TopRightMenu more intuitive
-   [\#3117](https://github.com/vector-im/riot-web/pull/3117)
+   [\#3117](https://github.com/element-hq/riot-web/pull/3117)
  * Handle icons with width > height
-   [\#3110](https://github.com/vector-im/riot-web/pull/3110)
+   [\#3110](https://github.com/element-hq/riot-web/pull/3110)
  * Fix jenkins build
-   [\#3105](https://github.com/vector-im/riot-web/pull/3105)
+   [\#3105](https://github.com/element-hq/riot-web/pull/3105)
  * Add CSS for a support box in login
-   [\#3081](https://github.com/vector-im/riot-web/pull/3081)
+   [\#3081](https://github.com/element-hq/riot-web/pull/3081)
  * Allow a custom login logo to be displayed on login
-   [\#3082](https://github.com/vector-im/riot-web/pull/3082)
+   [\#3082](https://github.com/element-hq/riot-web/pull/3082)
  * Fix the width of input fields within login/reg box
-   [\#3080](https://github.com/vector-im/riot-web/pull/3080)
+   [\#3080](https://github.com/element-hq/riot-web/pull/3080)
  * Set BaseAvatar_image bg colour = #fff
-   [\#3057](https://github.com/vector-im/riot-web/pull/3057)
+   [\#3057](https://github.com/element-hq/riot-web/pull/3057)
  * only recalculate favicon if it changes
-   [\#3067](https://github.com/vector-im/riot-web/pull/3067)
+   [\#3067](https://github.com/element-hq/riot-web/pull/3067)
  * CSS tweak for email address lookup
-   [\#3064](https://github.com/vector-im/riot-web/pull/3064)
+   [\#3064](https://github.com/element-hq/riot-web/pull/3064)
  * Glue the dialog to rageshake: honour sendLogs flag.
-   [\#3061](https://github.com/vector-im/riot-web/pull/3061)
+   [\#3061](https://github.com/element-hq/riot-web/pull/3061)
  * Don't use hash-named directory for dev server
-   [\#3049](https://github.com/vector-im/riot-web/pull/3049)
+   [\#3049](https://github.com/element-hq/riot-web/pull/3049)
  * Implement bug reporting logic
-   [\#3000](https://github.com/vector-im/riot-web/pull/3000)
+   [\#3000](https://github.com/element-hq/riot-web/pull/3000)
  * Add css for bug report dialog
-   [\#3045](https://github.com/vector-im/riot-web/pull/3045)
+   [\#3045](https://github.com/element-hq/riot-web/pull/3045)
  * Increase the max-height of the expanded status bar
-   [\#3043](https://github.com/vector-im/riot-web/pull/3043)
+   [\#3043](https://github.com/element-hq/riot-web/pull/3043)
  * Hopefully, fix intermittent test failure
-   [\#3040](https://github.com/vector-im/riot-web/pull/3040)
+   [\#3040](https://github.com/element-hq/riot-web/pull/3040)
  * CSS for 'searching known users'
-   [\#2971](https://github.com/vector-im/riot-web/pull/2971)
+   [\#2971](https://github.com/element-hq/riot-web/pull/2971)
  * Animate status bar max-height and margin-top
-   [\#2981](https://github.com/vector-im/riot-web/pull/2981)
+   [\#2981](https://github.com/element-hq/riot-web/pull/2981)
  * Add eslint config
-   [\#3032](https://github.com/vector-im/riot-web/pull/3032)
+   [\#3032](https://github.com/element-hq/riot-web/pull/3032)
  * Re-position typing avatars relative to "is typing"
-   [\#3030](https://github.com/vector-im/riot-web/pull/3030)
+   [\#3030](https://github.com/element-hq/riot-web/pull/3030)
  * CSS for avatars that appear when users are typing
-   [\#2998](https://github.com/vector-im/riot-web/pull/2998)
+   [\#2998](https://github.com/element-hq/riot-web/pull/2998)
  * Add StartupWMClass
-   [\#3001](https://github.com/vector-im/riot-web/pull/3001)
+   [\#3001](https://github.com/element-hq/riot-web/pull/3001)
  * Fix link to image for event options menu
-   [\#3002](https://github.com/vector-im/riot-web/pull/3002)
+   [\#3002](https://github.com/element-hq/riot-web/pull/3002)
  * Make riot desktop single instance
-   [\#2999](https://github.com/vector-im/riot-web/pull/2999)
+   [\#2999](https://github.com/element-hq/riot-web/pull/2999)
  * Add electron tray icon
-   [\#2997](https://github.com/vector-im/riot-web/pull/2997)
+   [\#2997](https://github.com/element-hq/riot-web/pull/2997)
  * Fixes to electron desktop notifs
-   [\#2994](https://github.com/vector-im/riot-web/pull/2994)
+   [\#2994](https://github.com/element-hq/riot-web/pull/2994)
  * Auto-hide the electron menu bar
-   [\#2975](https://github.com/vector-im/riot-web/pull/2975)
+   [\#2975](https://github.com/element-hq/riot-web/pull/2975)
  * A couple of tweaks to the karma config
-   [\#2987](https://github.com/vector-im/riot-web/pull/2987)
+   [\#2987](https://github.com/element-hq/riot-web/pull/2987)
  * Deploy script
-   [\#2974](https://github.com/vector-im/riot-web/pull/2974)
+   [\#2974](https://github.com/element-hq/riot-web/pull/2974)
  * Use the postcss-webpack-loader
-   [\#2990](https://github.com/vector-im/riot-web/pull/2990)
+   [\#2990](https://github.com/element-hq/riot-web/pull/2990)
  * Switch CSS to using postcss, and implement a dark theme.
-   [\#2973](https://github.com/vector-im/riot-web/pull/2973)
+   [\#2973](https://github.com/element-hq/riot-web/pull/2973)
  * Update redeploy script to keep old bundles
-   [\#2969](https://github.com/vector-im/riot-web/pull/2969)
+   [\#2969](https://github.com/element-hq/riot-web/pull/2969)
  * Include current version in update check explicitly
-   [\#2967](https://github.com/vector-im/riot-web/pull/2967)
+   [\#2967](https://github.com/element-hq/riot-web/pull/2967)
  * Add another layer of directory to webpack chunks
-   [\#2966](https://github.com/vector-im/riot-web/pull/2966)
+   [\#2966](https://github.com/element-hq/riot-web/pull/2966)
  * Fix links to fonts and images from CSS
-   [\#2965](https://github.com/vector-im/riot-web/pull/2965)
+   [\#2965](https://github.com/element-hq/riot-web/pull/2965)
  * Put parent build hash in webpack output filenames
-   [\#2961](https://github.com/vector-im/riot-web/pull/2961)
+   [\#2961](https://github.com/element-hq/riot-web/pull/2961)
  * update README to point to new names/locations
-   [\#2846](https://github.com/vector-im/riot-web/pull/2846)
+   [\#2846](https://github.com/element-hq/riot-web/pull/2846)
 
-Changes in [0.9.6](https://github.com/vector-im/riot-web/releases/tag/v0.9.6) (2017-01-16)
+Changes in [0.9.6](https://github.com/element-hq/riot-web/releases/tag/v0.9.6) (2017-01-16)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.6-rc.1...v0.9.6)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.6-rc.1...v0.9.6)
 
  * Update to matrix-js-sdk 0.9.6 for video calling fix
 
-Changes in [0.9.6-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.9.6-rc.1) (2017-01-13)
+Changes in [0.9.6-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.9.6-rc.1) (2017-01-13)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.5...v0.9.6-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.5...v0.9.6-rc.1)
 
  * Build the js-sdk in the CI script
-   [\#2920](https://github.com/vector-im/riot-web/pull/2920)
+   [\#2920](https://github.com/element-hq/riot-web/pull/2920)
  * Hopefully fix Windows shortcuts
-   [\#2917](https://github.com/vector-im/riot-web/pull/2917)
+   [\#2917](https://github.com/element-hq/riot-web/pull/2917)
  * Update README now the js-sdk has a transpile step
-   [\#2921](https://github.com/vector-im/riot-web/pull/2921)
+   [\#2921](https://github.com/element-hq/riot-web/pull/2921)
  * Use the role for 'toggle dev tools'
-   [\#2915](https://github.com/vector-im/riot-web/pull/2915)
+   [\#2915](https://github.com/element-hq/riot-web/pull/2915)
  * Enable screen sharing easter-egg in desktop app
-   [\#2909](https://github.com/vector-im/riot-web/pull/2909)
+   [\#2909](https://github.com/element-hq/riot-web/pull/2909)
  * make electron send email validation URLs with a nextlink of riot.im
-   [\#2808](https://github.com/vector-im/riot-web/pull/2808)
+   [\#2808](https://github.com/element-hq/riot-web/pull/2808)
  * add Debian Stretch install steps to readme
-   [\#2809](https://github.com/vector-im/riot-web/pull/2809)
+   [\#2809](https://github.com/element-hq/riot-web/pull/2809)
  * Update desktop build instructions fixes #2792
-   [\#2793](https://github.com/vector-im/riot-web/pull/2793)
+   [\#2793](https://github.com/element-hq/riot-web/pull/2793)
  * CSS for the delete threepid button
-   [\#2784](https://github.com/vector-im/riot-web/pull/2784)
+   [\#2784](https://github.com/element-hq/riot-web/pull/2784)
 
-Changes in [0.9.5](https://github.com/vector-im/riot-web/releases/tag/v0.9.5) (2016-12-24)
+Changes in [0.9.5](https://github.com/element-hq/riot-web/releases/tag/v0.9.5) (2016-12-24)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.4...v0.9.5)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.4...v0.9.5)
 
  * make electron send email validation URLs with a nextlink of riot.im rather than file:///
  * add gnu-tar to debian electron build deps
  * fix win32 shortcut in start menu
 
-Changes in [0.9.4](https://github.com/vector-im/riot-web/releases/tag/v0.9.4) (2016-12-22)
+Changes in [0.9.4](https://github.com/element-hq/riot-web/releases/tag/v0.9.4) (2016-12-22)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.3...v0.9.4)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.3...v0.9.4)
 
  * Update to libolm 2.1.0. This should help resolve a problem with browser
-   sessions being logged out ([\#2726](https://github.com/vector-im/riot-web/issues/2726)).
+   sessions being logged out ([\#2726](https://github.com/element-hq/riot-web/issues/2726)).
 
-Changes in [0.9.3](https://github.com/vector-im/riot-web/releases/tag/v0.9.3) (2016-12-22)
+Changes in [0.9.3](https://github.com/element-hq/riot-web/releases/tag/v0.9.3) (2016-12-22)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.2...v0.9.3)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.2...v0.9.3)
 
  * (from matrix-react-sdk) Fix regression where the date separator would be displayed
    at the wrong time of day.
  * README.md: fix GFMD for nativefier
-   [\#2755](https://github.com/vector-im/riot-web/pull/2755)
+   [\#2755](https://github.com/element-hq/riot-web/pull/2755)
 
-Changes in [0.9.2](https://github.com/vector-im/riot-web/releases/tag/v0.9.2) (2016-12-16)
+Changes in [0.9.2](https://github.com/element-hq/riot-web/releases/tag/v0.9.2) (2016-12-16)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.1...v0.9.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.1...v0.9.2)
 
  * Remove the client side filtering from the room dir
-   [\#2750](https://github.com/vector-im/riot-web/pull/2750)
+   [\#2750](https://github.com/element-hq/riot-web/pull/2750)
  * Configure olm memory size
-   [\#2745](https://github.com/vector-im/riot-web/pull/2745)
+   [\#2745](https://github.com/element-hq/riot-web/pull/2745)
  * Support room dir 3rd party network filtering
-   [\#2747](https://github.com/vector-im/riot-web/pull/2747)
+   [\#2747](https://github.com/element-hq/riot-web/pull/2747)
 
-Changes in [0.9.1](https://github.com/vector-im/riot-web/releases/tag/v0.9.1) (2016-12-09)
+Changes in [0.9.1](https://github.com/element-hq/riot-web/releases/tag/v0.9.1) (2016-12-09)
 ==========================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.1-rc.2...v0.9.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.1-rc.2...v0.9.1)
 
  * Update README to say how to build the desktop app
-   [\#2732](https://github.com/vector-im/riot-web/pull/2732)
+   [\#2732](https://github.com/element-hq/riot-web/pull/2732)
  * Add signing ID in release_config.yaml
-   [\#2731](https://github.com/vector-im/riot-web/pull/2731)
+   [\#2731](https://github.com/element-hq/riot-web/pull/2731)
  * Makeover!
-   [\#2722](https://github.com/vector-im/riot-web/pull/2722)
+   [\#2722](https://github.com/element-hq/riot-web/pull/2722)
  * Fix broken tests
-   [\#2730](https://github.com/vector-im/riot-web/pull/2730)
+   [\#2730](https://github.com/element-hq/riot-web/pull/2730)
  * Make the 'loading' tests work in isolation
-   [\#2727](https://github.com/vector-im/riot-web/pull/2727)
+   [\#2727](https://github.com/element-hq/riot-web/pull/2727)
  * Use a PNG for the icon on non-Windows
-   [\#2708](https://github.com/vector-im/riot-web/pull/2708)
+   [\#2708](https://github.com/element-hq/riot-web/pull/2708)
  * Add missing brackets to call to toUpperCase
-   [\#2703](https://github.com/vector-im/riot-web/pull/2703)
+   [\#2703](https://github.com/element-hq/riot-web/pull/2703)
 
-Changes in [0.9.1-rc.2](https://github.com/vector-im/riot-web/releases/tag/v0.9.1-rc.2) (2016-12-06)
+Changes in [0.9.1-rc.2](https://github.com/element-hq/riot-web/releases/tag/v0.9.1-rc.2) (2016-12-06)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.1-rc.1...v0.9.1-rc.2)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.1-rc.1...v0.9.1-rc.2)
 
  * Fix clicking on notifications
-   [\#2700](https://github.com/vector-im/riot-web/pull/2700)
+   [\#2700](https://github.com/element-hq/riot-web/pull/2700)
  * Desktop app: Only show window when ready
-   [\#2697](https://github.com/vector-im/riot-web/pull/2697)
+   [\#2697](https://github.com/element-hq/riot-web/pull/2697)
 
-Changes in [0.9.1-rc.1](https://github.com/vector-im/riot-web/releases/tag/v0.9.1-rc.1) (2016-12-05)
+Changes in [0.9.1-rc.1](https://github.com/element-hq/riot-web/releases/tag/v0.9.1-rc.1) (2016-12-05)
 ====================================================================================================
-[Full Changelog](https://github.com/vector-im/riot-web/compare/v0.9.0...v0.9.1-rc.1)
+[Full Changelog](https://github.com/element-hq/riot-web/compare/v0.9.0...v0.9.1-rc.1)
 
  * Final bits to prepare electron distribtion:
-   [\#2653](https://github.com/vector-im/riot-web/pull/2653)
+   [\#2653](https://github.com/element-hq/riot-web/pull/2653)
  * Update name & repo to reflect renamed repository
-   [\#2692](https://github.com/vector-im/riot-web/pull/2692)
+   [\#2692](https://github.com/element-hq/riot-web/pull/2692)
  * Document cross_origin_renderer_url
-   [\#2680](https://github.com/vector-im/riot-web/pull/2680)
+   [\#2680](https://github.com/element-hq/riot-web/pull/2680)
  * Add css for the iframes for e2e attachments
-   [\#2659](https://github.com/vector-im/riot-web/pull/2659)
+   [\#2659](https://github.com/element-hq/riot-web/pull/2659)
  * Fix config location in some more places
-   [\#2670](https://github.com/vector-im/riot-web/pull/2670)
+   [\#2670](https://github.com/element-hq/riot-web/pull/2670)
  * CSS updates for s/block/blacklist for e2e
-   [\#2662](https://github.com/vector-im/riot-web/pull/2662)
+   [\#2662](https://github.com/element-hq/riot-web/pull/2662)
  * Update to electron 1.4.8
-   [\#2660](https://github.com/vector-im/riot-web/pull/2660)
+   [\#2660](https://github.com/element-hq/riot-web/pull/2660)
  * Add electron config
-   [\#2644](https://github.com/vector-im/riot-web/pull/2644)
+   [\#2644](https://github.com/element-hq/riot-web/pull/2644)
  * Move getDefaultDeviceName into the Platforms
-   [\#2643](https://github.com/vector-im/riot-web/pull/2643)
+   [\#2643](https://github.com/element-hq/riot-web/pull/2643)
  * Add Freenode & Mozilla domains
-   [\#2641](https://github.com/vector-im/riot-web/pull/2641)
+   [\#2641](https://github.com/element-hq/riot-web/pull/2641)
  * Include config.sample.json in dist tarball
-   [\#2614](https://github.com/vector-im/riot-web/pull/2614)
+   [\#2614](https://github.com/element-hq/riot-web/pull/2614)
 
-Changes in [0.9.0](https://github.com/vector-im/vector-web/releases/tag/v0.9.0) (2016-11-19)
+Changes in [0.9.0](https://github.com/element-hq/vector-web/releases/tag/v0.9.0) (2016-11-19)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.8.4...v0.9.0)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.8.4...v0.9.0)
 
  * Add a cachebuster to /version
-   [\#2596](https://github.com/vector-im/vector-web/pull/2596)
+   [\#2596](https://github.com/element-hq/vector-web/pull/2596)
  * Add a 'View decrypted source' button
-   [\#2587](https://github.com/vector-im/vector-web/pull/2587)
+   [\#2587](https://github.com/element-hq/vector-web/pull/2587)
  * Fix changelog dialog to  read new version format
-   [\#2577](https://github.com/vector-im/vector-web/pull/2577)
+   [\#2577](https://github.com/element-hq/vector-web/pull/2577)
  * Build all of the vector dir in the build process
-   [\#2558](https://github.com/vector-im/vector-web/pull/2558)
+   [\#2558](https://github.com/element-hq/vector-web/pull/2558)
  * Support for get_app_version
-   [\#2553](https://github.com/vector-im/vector-web/pull/2553)
+   [\#2553](https://github.com/element-hq/vector-web/pull/2553)
  * Add CSS for mlist truncation
-   [\#2565](https://github.com/vector-im/vector-web/pull/2565)
+   [\#2565](https://github.com/element-hq/vector-web/pull/2565)
  * Add menu option for `external_url` if present
-   [\#2560](https://github.com/vector-im/vector-web/pull/2560)
+   [\#2560](https://github.com/element-hq/vector-web/pull/2560)
  * Make auto-update configureable
-   [\#2555](https://github.com/vector-im/vector-web/pull/2555)
+   [\#2555](https://github.com/element-hq/vector-web/pull/2555)
  * Missed files electron windows fixes
-   [\#2556](https://github.com/vector-im/vector-web/pull/2556)
+   [\#2556](https://github.com/element-hq/vector-web/pull/2556)
  * Add some CSS for  scalar error popup
-   [\#2554](https://github.com/vector-im/vector-web/pull/2554)
+   [\#2554](https://github.com/element-hq/vector-web/pull/2554)
  * Catch unhandled errors in the electron process
-   [\#2552](https://github.com/vector-im/vector-web/pull/2552)
+   [\#2552](https://github.com/element-hq/vector-web/pull/2552)
  * Slight grab-bag of fixes for electron on Windows
-   [\#2551](https://github.com/vector-im/vector-web/pull/2551)
+   [\#2551](https://github.com/element-hq/vector-web/pull/2551)
  * Electron app (take 3)
-   [\#2535](https://github.com/vector-im/vector-web/pull/2535)
+   [\#2535](https://github.com/element-hq/vector-web/pull/2535)
  * Use webpack-dev-server instead of http-server
-   [\#2542](https://github.com/vector-im/vector-web/pull/2542)
+   [\#2542](https://github.com/element-hq/vector-web/pull/2542)
  * Better support no-config when loading from file
-   [\#2541](https://github.com/vector-im/vector-web/pull/2541)
+   [\#2541](https://github.com/element-hq/vector-web/pull/2541)
  * Fix loading with no config from HTTP
-   [\#2540](https://github.com/vector-im/vector-web/pull/2540)
+   [\#2540](https://github.com/element-hq/vector-web/pull/2540)
  * Move 'new version' support into Platform
-   [\#2532](https://github.com/vector-im/vector-web/pull/2532)
+   [\#2532](https://github.com/element-hq/vector-web/pull/2532)
  * Add Notification support to the Web Platform
-   [\#2533](https://github.com/vector-im/vector-web/pull/2533)
+   [\#2533](https://github.com/element-hq/vector-web/pull/2533)
  * Use the defaults if given a blank config file
-   [\#2534](https://github.com/vector-im/vector-web/pull/2534)
+   [\#2534](https://github.com/element-hq/vector-web/pull/2534)
  * Implement Platforms
-   [\#2531](https://github.com/vector-im/vector-web/pull/2531)
+   [\#2531](https://github.com/element-hq/vector-web/pull/2531)
 
-Changes in [0.8.4](https://github.com/vector-im/vector-web/releases/tag/v0.8.4) (2016-11-04)
+Changes in [0.8.4](https://github.com/element-hq/vector-web/releases/tag/v0.8.4) (2016-11-04)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.8.4-rc.2...v0.8.4)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.8.4-rc.2...v0.8.4)
 
  * No changes
 
-Changes in [0.8.4-rc.2](https://github.com/vector-im/vector-web/releases/tag/v0.8.4-rc.2) (2016-11-02)
+Changes in [0.8.4-rc.2](https://github.com/element-hq/vector-web/releases/tag/v0.8.4-rc.2) (2016-11-02)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.8.4-rc.1...v0.8.4-rc.2)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.8.4-rc.1...v0.8.4-rc.2)
 
  * Fix the version in the generated distribution package
 
-Changes in [0.8.4-rc.1](https://github.com/vector-im/vector-web/releases/tag/v0.8.4-rc.1) (2016-11-02)
+Changes in [0.8.4-rc.1](https://github.com/element-hq/vector-web/releases/tag/v0.8.4-rc.1) (2016-11-02)
 ======================================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.8.3...v0.8.4-rc.1)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.8.3...v0.8.4-rc.1)
 
 Breaking Changes
 ----------------
@@ -8448,164 +8448,164 @@ Breaking Changes
 Other Changes
 -------------
  * Rename the package script/output dir to 'dist'
-   [\#2528](https://github.com/vector-im/vector-web/pull/2528)
+   [\#2528](https://github.com/element-hq/vector-web/pull/2528)
  * Avoid errors if olm is missing
-   [\#2518](https://github.com/vector-im/vector-web/pull/2518)
+   [\#2518](https://github.com/element-hq/vector-web/pull/2518)
  * Put a cachebuster in the names of CSS and JS files
-   [\#2515](https://github.com/vector-im/vector-web/pull/2515)
+   [\#2515](https://github.com/element-hq/vector-web/pull/2515)
  * Bump to olm 2.0.0
-   [\#2517](https://github.com/vector-im/vector-web/pull/2517)
+   [\#2517](https://github.com/element-hq/vector-web/pull/2517)
  * Don't include the world in the published packages
-   [\#2516](https://github.com/vector-im/vector-web/pull/2516)
+   [\#2516](https://github.com/element-hq/vector-web/pull/2516)
  * Use webpack to copy olm.js
-   [\#2514](https://github.com/vector-im/vector-web/pull/2514)
+   [\#2514](https://github.com/element-hq/vector-web/pull/2514)
  * Don't include two copies of the CSS in the tarball
-   [\#2513](https://github.com/vector-im/vector-web/pull/2513)
+   [\#2513](https://github.com/element-hq/vector-web/pull/2513)
  * Correct text alignment on room directory search
-   [\#2512](https://github.com/vector-im/vector-web/pull/2512)
+   [\#2512](https://github.com/element-hq/vector-web/pull/2512)
  * Correct spelling of 'rel'
-   [\#2510](https://github.com/vector-im/vector-web/pull/2510)
+   [\#2510](https://github.com/element-hq/vector-web/pull/2510)
  * readme tweaks
-   [\#2507](https://github.com/vector-im/vector-web/pull/2507)
+   [\#2507](https://github.com/element-hq/vector-web/pull/2507)
  * s/vector/riot/ in the readme
-   [\#2491](https://github.com/vector-im/vector-web/pull/2491)
+   [\#2491](https://github.com/element-hq/vector-web/pull/2491)
  * Switch to babel 6, again
-   [\#2480](https://github.com/vector-im/vector-web/pull/2480)
+   [\#2480](https://github.com/element-hq/vector-web/pull/2480)
  * Revert "Switch to babel 6"
-   [\#2472](https://github.com/vector-im/vector-web/pull/2472)
+   [\#2472](https://github.com/element-hq/vector-web/pull/2472)
  * Switch to babel 6
-   [\#2461](https://github.com/vector-im/vector-web/pull/2461)
+   [\#2461](https://github.com/element-hq/vector-web/pull/2461)
 
-Changes in [0.8.3](https://github.com/vector-im/vector-web/releases/tag/v0.8.3) (2016-10-12)
+Changes in [0.8.3](https://github.com/element-hq/vector-web/releases/tag/v0.8.3) (2016-10-12)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.8.2...v0.8.3)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.8.2...v0.8.3)
 
  * Centre images in dialog buttons
-   [\#2453](https://github.com/vector-im/vector-web/pull/2453)
+   [\#2453](https://github.com/element-hq/vector-web/pull/2453)
  * Only show quote option if RTE is enabled
-   [\#2448](https://github.com/vector-im/vector-web/pull/2448)
+   [\#2448](https://github.com/element-hq/vector-web/pull/2448)
  * Fix join button for 'matrix' networks
-   [\#2443](https://github.com/vector-im/vector-web/pull/2443)
+   [\#2443](https://github.com/element-hq/vector-web/pull/2443)
  * Don't stop paginating if no rooms match
-   [\#2422](https://github.com/vector-im/vector-web/pull/2422)
+   [\#2422](https://github.com/element-hq/vector-web/pull/2422)
 
-Changes in [0.8.2](https://github.com/vector-im/vector-web/releases/tag/v0.8.2) (2016-10-05)
+Changes in [0.8.2](https://github.com/element-hq/vector-web/releases/tag/v0.8.2) (2016-10-05)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.8.1...v0.8.2)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.8.1...v0.8.2)
 
  * Add native joining of 3p networks to room dir
-   [\#2379](https://github.com/vector-im/vector-web/pull/2379)
+   [\#2379](https://github.com/element-hq/vector-web/pull/2379)
  * Update to linkify 2.1.3
-   [\#2406](https://github.com/vector-im/vector-web/pull/2406)
+   [\#2406](https://github.com/element-hq/vector-web/pull/2406)
  * Use 'Sign In' / 'Sign Out' universally
-   [\#2383](https://github.com/vector-im/vector-web/pull/2383)
+   [\#2383](https://github.com/element-hq/vector-web/pull/2383)
  * Prevent network dropdown resizing slightly
-   [\#2382](https://github.com/vector-im/vector-web/pull/2382)
+   [\#2382](https://github.com/element-hq/vector-web/pull/2382)
  * Room directory: indicate when there are no results
-   [\#2380](https://github.com/vector-im/vector-web/pull/2380)
+   [\#2380](https://github.com/element-hq/vector-web/pull/2380)
  * Room dir: New filtering & 3rd party networks
-   [\#2362](https://github.com/vector-im/vector-web/pull/2362)
+   [\#2362](https://github.com/element-hq/vector-web/pull/2362)
  * Update linkify version
-   [\#2359](https://github.com/vector-im/vector-web/pull/2359)
+   [\#2359](https://github.com/element-hq/vector-web/pull/2359)
  * Directory search join button
-   [\#2339](https://github.com/vector-im/vector-web/pull/2339)
+   [\#2339](https://github.com/element-hq/vector-web/pull/2339)
 
-Changes in [0.8.1](https://github.com/vector-im/vector-web/releases/tag/v0.8.1) (2016-09-21)
+Changes in [0.8.1](https://github.com/element-hq/vector-web/releases/tag/v0.8.1) (2016-09-21)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.8.0...v0.8.1)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.8.0...v0.8.1)
 
 
-Changes in [0.8.0](https://github.com/vector-im/vector-web/releases/tag/v0.8.0) (2016-09-21)
+Changes in [0.8.0](https://github.com/element-hq/vector-web/releases/tag/v0.8.0) (2016-09-21)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.7.5-r3...v0.8.0)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.7.5-r3...v0.8.0)
 
  * Dbkr/rebrand
-   [\#2285](https://github.com/vector-im/vector-web/pull/2285)
+   [\#2285](https://github.com/element-hq/vector-web/pull/2285)
  * Listen for close_scalar and close the dialog box when received
-   [\#2282](https://github.com/vector-im/vector-web/pull/2282)
+   [\#2282](https://github.com/element-hq/vector-web/pull/2282)
  * Revert "improve lipstick and support scalar logout"
-   [\#2281](https://github.com/vector-im/vector-web/pull/2281)
+   [\#2281](https://github.com/element-hq/vector-web/pull/2281)
  * improve lipstick and support scalar logout
-   [\#2280](https://github.com/vector-im/vector-web/pull/2280)
+   [\#2280](https://github.com/element-hq/vector-web/pull/2280)
  * Fix changelog links
-   [\#2071](https://github.com/vector-im/vector-web/pull/2071)
+   [\#2071](https://github.com/element-hq/vector-web/pull/2071)
  * Paginate Room Directory
-   [\#2241](https://github.com/vector-im/vector-web/pull/2241)
+   [\#2241](https://github.com/element-hq/vector-web/pull/2241)
  * Make redeploy script symlink config
-   [\#2240](https://github.com/vector-im/vector-web/pull/2240)
+   [\#2240](https://github.com/element-hq/vector-web/pull/2240)
  * Update the version of olm to 1.3.0
-   [\#2210](https://github.com/vector-im/vector-web/pull/2210)
+   [\#2210](https://github.com/element-hq/vector-web/pull/2210)
  * Directory network selector
-   [\#2219](https://github.com/vector-im/vector-web/pull/2219)
+   [\#2219](https://github.com/element-hq/vector-web/pull/2219)
  * Wmwragg/two state sublist headers
-   [\#2235](https://github.com/vector-im/vector-web/pull/2235)
+   [\#2235](https://github.com/element-hq/vector-web/pull/2235)
  * Wmwragg/correct incoming call positioning
-   [\#2222](https://github.com/vector-im/vector-web/pull/2222)
+   [\#2222](https://github.com/element-hq/vector-web/pull/2222)
  * Wmwragg/remove old filter
-   [\#2211](https://github.com/vector-im/vector-web/pull/2211)
+   [\#2211](https://github.com/element-hq/vector-web/pull/2211)
  * Wmwragg/multi invite bugfix
-   [\#2198](https://github.com/vector-im/vector-web/pull/2198)
+   [\#2198](https://github.com/element-hq/vector-web/pull/2198)
  * Wmwragg/chat multi invite
-   [\#2181](https://github.com/vector-im/vector-web/pull/2181)
+   [\#2181](https://github.com/element-hq/vector-web/pull/2181)
  * shuffle bottomleftmenu around a bit
-   [\#2182](https://github.com/vector-im/vector-web/pull/2182)
+   [\#2182](https://github.com/element-hq/vector-web/pull/2182)
  * Improve autocomplete behaviour (styling)
-   [\#2175](https://github.com/vector-im/vector-web/pull/2175)
+   [\#2175](https://github.com/element-hq/vector-web/pull/2175)
  * First wave of E2E visuals
-   [\#2163](https://github.com/vector-im/vector-web/pull/2163)
+   [\#2163](https://github.com/element-hq/vector-web/pull/2163)
  * FilePanel and NotificationPanel support
-   [\#2113](https://github.com/vector-im/vector-web/pull/2113)
+   [\#2113](https://github.com/element-hq/vector-web/pull/2113)
  * Cursor: pointer on member info create room button
-   [\#2151](https://github.com/vector-im/vector-web/pull/2151)
+   [\#2151](https://github.com/element-hq/vector-web/pull/2151)
  * Support for adding DM rooms to the MemberInfo Panel
-   [\#2147](https://github.com/vector-im/vector-web/pull/2147)
+   [\#2147](https://github.com/element-hq/vector-web/pull/2147)
  * Wmwragg/one to one indicators
-   [\#2139](https://github.com/vector-im/vector-web/pull/2139)
+   [\#2139](https://github.com/element-hq/vector-web/pull/2139)
  * Added back the Directory listing button, with new tootlip
-   [\#2136](https://github.com/vector-im/vector-web/pull/2136)
+   [\#2136](https://github.com/element-hq/vector-web/pull/2136)
  * wmwragg/chat invite dialog fix
-   [\#2134](https://github.com/vector-im/vector-web/pull/2134)
+   [\#2134](https://github.com/element-hq/vector-web/pull/2134)
  * Wmwragg/one to one chat
-   [\#2110](https://github.com/vector-im/vector-web/pull/2110)
+   [\#2110](https://github.com/element-hq/vector-web/pull/2110)
  * Support toggling DM status of rooms
-   [\#2111](https://github.com/vector-im/vector-web/pull/2111)
+   [\#2111](https://github.com/element-hq/vector-web/pull/2111)
  * Formatting toolbar for RTE message composer.
-   [\#2082](https://github.com/vector-im/vector-web/pull/2082)
+   [\#2082](https://github.com/element-hq/vector-web/pull/2082)
  * jenkins.sh: install olm from jenkins artifacts
-   [\#2092](https://github.com/vector-im/vector-web/pull/2092)
+   [\#2092](https://github.com/element-hq/vector-web/pull/2092)
  * e2e device CSS
-   [\#2085](https://github.com/vector-im/vector-web/pull/2085)
+   [\#2085](https://github.com/element-hq/vector-web/pull/2085)
  * Bump to olm 1.1.0
-   [\#2069](https://github.com/vector-im/vector-web/pull/2069)
+   [\#2069](https://github.com/element-hq/vector-web/pull/2069)
  * Improve readability of the changelog dialog
-   [\#2056](https://github.com/vector-im/vector-web/pull/2056)
+   [\#2056](https://github.com/element-hq/vector-web/pull/2056)
  * Turn react consistency checks back on in develop builds
-   [\#2009](https://github.com/vector-im/vector-web/pull/2009)
+   [\#2009](https://github.com/element-hq/vector-web/pull/2009)
  * Wmwragg/direct chat sublist
-   [\#2028](https://github.com/vector-im/vector-web/pull/2028)
+   [\#2028](https://github.com/element-hq/vector-web/pull/2028)
 
-Changes in [0.7.5-r3](https://github.com/vector-im/vector-web/releases/tag/v0.7.5-r3) (2016-09-02)
+Changes in [0.7.5-r3](https://github.com/element-hq/vector-web/releases/tag/v0.7.5-r3) (2016-09-02)
 ==================================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.7.5-r2...v0.7.5-r3)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.7.5-r2...v0.7.5-r3)
 
  * Bump to matrix-react-sdk 0.6.5-r3 in order to fix bug #2020 (tightloop when flooded with join events)
 
 
-Changes in [0.7.5-r2](https://github.com/vector-im/vector-web/releases/tag/v0.7.5-r2) (2016-09-01)
+Changes in [0.7.5-r2](https://github.com/element-hq/vector-web/releases/tag/v0.7.5-r2) (2016-09-01)
 ==================================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.7.5-r1...v0.7.5-r2)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.7.5-r1...v0.7.5-r2)
 
  * Bump to matrix-react-sdk 0.6.5-r1 in order to fix guest access
 
-Changes in [0.7.5-r1](https://github.com/vector-im/vector-web/releases/tag/v0.7.5-r1) (2016-08-28)
+Changes in [0.7.5-r1](https://github.com/element-hq/vector-web/releases/tag/v0.7.5-r1) (2016-08-28)
 ==================================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.7.5...v0.7.5-r1)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.7.5...v0.7.5-r1)
 
  * Correctly pin deps :(
 
-Changes in [0.7.5](https://github.com/vector-im/vector-web/releases/tag/v0.7.5) (2016-08-28)
+Changes in [0.7.5](https://github.com/element-hq/vector-web/releases/tag/v0.7.5) (2016-08-28)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.7.4-r1...v0.7.5)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.7.4-r1...v0.7.5)
 
  * re-add leave button in RoomSettings
  * add /user URLs
@@ -8616,258 +8616,258 @@ Changes in [0.7.5](https://github.com/vector-im/vector-web/releases/tag/v0.7.5) 
  * warn people to put their Matrix HS on a separate domain to Vector
  * fix zalgos again
  * Add .travis.yml
-   [\#2007](https://github.com/vector-im/vector-web/pull/2007)
+   [\#2007](https://github.com/element-hq/vector-web/pull/2007)
  * add fancy changelog dialog
-   [\#1972](https://github.com/vector-im/vector-web/pull/1972)
+   [\#1972](https://github.com/element-hq/vector-web/pull/1972)
  * Update autocomplete design
-   [\#1978](https://github.com/vector-im/vector-web/pull/1978)
+   [\#1978](https://github.com/element-hq/vector-web/pull/1978)
  * Update encryption info in README
-   [\#2001](https://github.com/vector-im/vector-web/pull/2001)
+   [\#2001](https://github.com/element-hq/vector-web/pull/2001)
  * Added event/info message avatars back in
-   [\#2000](https://github.com/vector-im/vector-web/pull/2000)
+   [\#2000](https://github.com/element-hq/vector-web/pull/2000)
  * Wmwragg/chat message presentation
-   [\#1987](https://github.com/vector-im/vector-web/pull/1987)
+   [\#1987](https://github.com/element-hq/vector-web/pull/1987)
  * Make the notification slider work
-   [\#1982](https://github.com/vector-im/vector-web/pull/1982)
+   [\#1982](https://github.com/element-hq/vector-web/pull/1982)
  * Use cpx to copy olm.js, and add watcher
-   [\#1966](https://github.com/vector-im/vector-web/pull/1966)
+   [\#1966](https://github.com/element-hq/vector-web/pull/1966)
  * Make up a device display name
-   [\#1959](https://github.com/vector-im/vector-web/pull/1959)
+   [\#1959](https://github.com/element-hq/vector-web/pull/1959)
 
-Changes in [0.7.4-r1](https://github.com/vector-im/vector-web/releases/tag/v0.7.4-r1) (2016-08-12)
+Changes in [0.7.4-r1](https://github.com/element-hq/vector-web/releases/tag/v0.7.4-r1) (2016-08-12)
 ==================================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.7.4...v0.7.4-r1)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.7.4...v0.7.4-r1)
  * Update to matrix-react-sdk 0.6.4-r1 to fix inviting multiple people
 
 
-Changes in [0.7.4](https://github.com/vector-im/vector-web/releases/tag/v0.7.4) (2016-08-11)
+Changes in [0.7.4](https://github.com/element-hq/vector-web/releases/tag/v0.7.4) (2016-08-11)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.7.3...v0.7.4)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.7.3...v0.7.4)
 
  * Don't show border on composer when not in RTE mode
-   [\#1954](https://github.com/vector-im/vector-web/pull/1954)
+   [\#1954](https://github.com/element-hq/vector-web/pull/1954)
  * Wmwragg/room tag menu
-   [\#1941](https://github.com/vector-im/vector-web/pull/1941)
+   [\#1941](https://github.com/element-hq/vector-web/pull/1941)
  * Don't redirect to mobile app if verifying 3pid
-   [\#1951](https://github.com/vector-im/vector-web/pull/1951)
+   [\#1951](https://github.com/element-hq/vector-web/pull/1951)
  * Make sure that we clear localstorage before *all* tests
-   [\#1950](https://github.com/vector-im/vector-web/pull/1950)
+   [\#1950](https://github.com/element-hq/vector-web/pull/1950)
  * Basic CSS for multi-invite dialog
-   [\#1942](https://github.com/vector-im/vector-web/pull/1942)
+   [\#1942](https://github.com/element-hq/vector-web/pull/1942)
  * More tests for the loading process:
-   [\#1947](https://github.com/vector-im/vector-web/pull/1947)
+   [\#1947](https://github.com/element-hq/vector-web/pull/1947)
  * Support for refactored login token handling
-   [\#1946](https://github.com/vector-im/vector-web/pull/1946)
+   [\#1946](https://github.com/element-hq/vector-web/pull/1946)
  * Various fixes and improvements to emojification.
-   [\#1935](https://github.com/vector-im/vector-web/pull/1935)
+   [\#1935](https://github.com/element-hq/vector-web/pull/1935)
  * More app-loading tests
-   [\#1938](https://github.com/vector-im/vector-web/pull/1938)
+   [\#1938](https://github.com/element-hq/vector-web/pull/1938)
  * Some tests of the application load process
-   [\#1936](https://github.com/vector-im/vector-web/pull/1936)
+   [\#1936](https://github.com/element-hq/vector-web/pull/1936)
  * Add 'enable labs' setting to sample config
-   [\#1930](https://github.com/vector-im/vector-web/pull/1930)
+   [\#1930](https://github.com/element-hq/vector-web/pull/1930)
  * Matthew/scalar
-   [\#1928](https://github.com/vector-im/vector-web/pull/1928)
+   [\#1928](https://github.com/element-hq/vector-web/pull/1928)
  * Fix unit tests
-   [\#1929](https://github.com/vector-im/vector-web/pull/1929)
+   [\#1929](https://github.com/element-hq/vector-web/pull/1929)
  * Wmwragg/mute mention state fix
-   [\#1926](https://github.com/vector-im/vector-web/pull/1926)
+   [\#1926](https://github.com/element-hq/vector-web/pull/1926)
  * CSS for deactivate account dialog
-   [\#1919](https://github.com/vector-im/vector-web/pull/1919)
+   [\#1919](https://github.com/element-hq/vector-web/pull/1919)
  * Wmwragg/mention state menu
-   [\#1900](https://github.com/vector-im/vector-web/pull/1900)
+   [\#1900](https://github.com/element-hq/vector-web/pull/1900)
  * Fix UnknownBody styling for #1901
-   [\#1913](https://github.com/vector-im/vector-web/pull/1913)
+   [\#1913](https://github.com/element-hq/vector-web/pull/1913)
  * Exclude olm from the webpack
-   [\#1914](https://github.com/vector-im/vector-web/pull/1914)
+   [\#1914](https://github.com/element-hq/vector-web/pull/1914)
  * Wmwragg/button updates
-   [\#1912](https://github.com/vector-im/vector-web/pull/1912)
+   [\#1912](https://github.com/element-hq/vector-web/pull/1912)
  * Wmwragg/button updates
-   [\#1828](https://github.com/vector-im/vector-web/pull/1828)
+   [\#1828](https://github.com/element-hq/vector-web/pull/1828)
  * CSS for device management UI
-   [\#1909](https://github.com/vector-im/vector-web/pull/1909)
+   [\#1909](https://github.com/element-hq/vector-web/pull/1909)
  * Fix a warning from RoomSubList
-   [\#1908](https://github.com/vector-im/vector-web/pull/1908)
+   [\#1908](https://github.com/element-hq/vector-web/pull/1908)
  * Fix notifications warning layout
-   [\#1907](https://github.com/vector-im/vector-web/pull/1907)
+   [\#1907](https://github.com/element-hq/vector-web/pull/1907)
  * Remove relayoutOnUpdate prop on gemini-scrollbar
-   [\#1883](https://github.com/vector-im/vector-web/pull/1883)
+   [\#1883](https://github.com/element-hq/vector-web/pull/1883)
  * Bump dependency versions
-   [\#1842](https://github.com/vector-im/vector-web/pull/1842)
+   [\#1842](https://github.com/element-hq/vector-web/pull/1842)
  * Wmwragg/mention state indicator round 2
-   [\#1835](https://github.com/vector-im/vector-web/pull/1835)
+   [\#1835](https://github.com/element-hq/vector-web/pull/1835)
  * Wmwragg/spinner fix
-   [\#1822](https://github.com/vector-im/vector-web/pull/1822)
+   [\#1822](https://github.com/element-hq/vector-web/pull/1822)
  * Wmwragg/mention state indicator
-   [\#1823](https://github.com/vector-im/vector-web/pull/1823)
+   [\#1823](https://github.com/element-hq/vector-web/pull/1823)
  * Revert "Presentation for inline link"
-   [\#1809](https://github.com/vector-im/vector-web/pull/1809)
+   [\#1809](https://github.com/element-hq/vector-web/pull/1809)
  * Wmwragg/modal restyle
-   [\#1806](https://github.com/vector-im/vector-web/pull/1806)
+   [\#1806](https://github.com/element-hq/vector-web/pull/1806)
  * Presentation for inline link
-   [\#1799](https://github.com/vector-im/vector-web/pull/1799)
+   [\#1799](https://github.com/element-hq/vector-web/pull/1799)
  * CSS for offline user colours
-   [\#1798](https://github.com/vector-im/vector-web/pull/1798)
+   [\#1798](https://github.com/element-hq/vector-web/pull/1798)
  * Wmwragg/typography updates
-   [\#1776](https://github.com/vector-im/vector-web/pull/1776)
+   [\#1776](https://github.com/element-hq/vector-web/pull/1776)
  * webpack: always use the olm from vector-web
-   [\#1766](https://github.com/vector-im/vector-web/pull/1766)
+   [\#1766](https://github.com/element-hq/vector-web/pull/1766)
  * feat: large emoji support
-   [\#1718](https://github.com/vector-im/vector-web/pull/1718)
+   [\#1718](https://github.com/element-hq/vector-web/pull/1718)
  * Autocomplete
-   [\#1717](https://github.com/vector-im/vector-web/pull/1717)
+   [\#1717](https://github.com/element-hq/vector-web/pull/1717)
  * #1664 Set a maximum height for codeblocks
-   [\#1670](https://github.com/vector-im/vector-web/pull/1670)
+   [\#1670](https://github.com/element-hq/vector-web/pull/1670)
  * CSS for device blocking
-   [\#1688](https://github.com/vector-im/vector-web/pull/1688)
+   [\#1688](https://github.com/element-hq/vector-web/pull/1688)
  * Fix joining rooms by typing the alias
-   [\#1685](https://github.com/vector-im/vector-web/pull/1685)
+   [\#1685](https://github.com/element-hq/vector-web/pull/1685)
  * Add ability to delete an alias from room directory
-   [\#1680](https://github.com/vector-im/vector-web/pull/1680)
+   [\#1680](https://github.com/element-hq/vector-web/pull/1680)
  * package.json: add olm as optionalDependency
-   [\#1678](https://github.com/vector-im/vector-web/pull/1678)
+   [\#1678](https://github.com/element-hq/vector-web/pull/1678)
  * Another go at enabling olm on vector.im/develop
-   [\#1675](https://github.com/vector-im/vector-web/pull/1675)
+   [\#1675](https://github.com/element-hq/vector-web/pull/1675)
  * CSS for unverify button
-   [\#1661](https://github.com/vector-im/vector-web/pull/1661)
+   [\#1661](https://github.com/element-hq/vector-web/pull/1661)
  * CSS fix for rooms with crypto enabled
-   [\#1660](https://github.com/vector-im/vector-web/pull/1660)
+   [\#1660](https://github.com/element-hq/vector-web/pull/1660)
  * Karma: fix warning by ignoring olm
-   [\#1652](https://github.com/vector-im/vector-web/pull/1652)
+   [\#1652](https://github.com/element-hq/vector-web/pull/1652)
  * Update for react-sdk dbkr/fix_peeking branch
-   [\#1639](https://github.com/vector-im/vector-web/pull/1639)
+   [\#1639](https://github.com/element-hq/vector-web/pull/1639)
  * Update README.md
-   [\#1641](https://github.com/vector-im/vector-web/pull/1641)
+   [\#1641](https://github.com/element-hq/vector-web/pull/1641)
  * Fix karma tests
-   [\#1643](https://github.com/vector-im/vector-web/pull/1643)
+   [\#1643](https://github.com/element-hq/vector-web/pull/1643)
  * Rich Text Editor
-   [\#1553](https://github.com/vector-im/vector-web/pull/1553)
+   [\#1553](https://github.com/element-hq/vector-web/pull/1553)
  * Fix RoomDirectory to join by alias whenever possible.
-   [\#1615](https://github.com/vector-im/vector-web/pull/1615)
+   [\#1615](https://github.com/element-hq/vector-web/pull/1615)
  * Make the config optional
-   [\#1612](https://github.com/vector-im/vector-web/pull/1612)
+   [\#1612](https://github.com/element-hq/vector-web/pull/1612)
  * CSS support for device verification
-   [\#1610](https://github.com/vector-im/vector-web/pull/1610)
+   [\#1610](https://github.com/element-hq/vector-web/pull/1610)
  * Don't use SdkConfig
-   [\#1609](https://github.com/vector-im/vector-web/pull/1609)
+   [\#1609](https://github.com/element-hq/vector-web/pull/1609)
  * serve config.json statically instead of bundling it
-   [\#1516](https://github.com/vector-im/vector-web/pull/1516)
+   [\#1516](https://github.com/element-hq/vector-web/pull/1516)
 
-Changes in [0.7.3](https://github.com/vector-im/vector-web/releases/tag/v0.7.3) (2016-06-03)
+Changes in [0.7.3](https://github.com/element-hq/vector-web/releases/tag/v0.7.3) (2016-06-03)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.7.2...v0.7.3)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.7.2...v0.7.3)
 
 * Update to react-sdk 0.6.3
 
-Changes in [0.7.2](https://github.com/vector-im/vector-web/releases/tag/v0.7.2) (2016-06-02)
+Changes in [0.7.2](https://github.com/element-hq/vector-web/releases/tag/v0.7.2) (2016-06-02)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.7.1...v0.7.2)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.7.1...v0.7.2)
 
  * Correctly bump the dep on new matrix-js-sdk and matrix-react-sdk
 
-Changes in [0.7.1](https://github.com/vector-im/vector-web/releases/tag/v0.7.1) (2016-06-02)
+Changes in [0.7.1](https://github.com/element-hq/vector-web/releases/tag/v0.7.1) (2016-06-02)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.7.0...v0.7.1)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.7.0...v0.7.1)
 
  * Fix accidentally committed local changes to the default config.json (doh!)
 
-Changes in [0.7.0](https://github.com/vector-im/vector-web/releases/tag/v0.7.0) (2016-06-02)
+Changes in [0.7.0](https://github.com/element-hq/vector-web/releases/tag/v0.7.0) (2016-06-02)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.6.1...v0.7.0)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.6.1...v0.7.0)
 
  * Update to matrix-react-sdk 0.6.0 - see
    [changelog](https://github.com/matrix-org/matrix-react-sdk/blob/v0.6.0/CHANGELOG.md)
  * Style selection color.
-   [\#1557](https://github.com/vector-im/vector-web/pull/1557)
+   [\#1557](https://github.com/element-hq/vector-web/pull/1557)
  * Fix NPE when loading the Settings page which infini-spinnered
-   [\#1518](https://github.com/vector-im/vector-web/pull/1518)
+   [\#1518](https://github.com/element-hq/vector-web/pull/1518)
  * Add option to enable email notifications
-   [\#1469](https://github.com/vector-im/vector-web/pull/1469)
+   [\#1469](https://github.com/element-hq/vector-web/pull/1469)
 
-Changes in [0.6.1](https://github.com/vector-im/vector-web/releases/tag/v0.6.1) (2016-04-22)
+Changes in [0.6.1](https://github.com/element-hq/vector-web/releases/tag/v0.6.1) (2016-04-22)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.6.0...v0.6.1)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.6.0...v0.6.1)
 
  * Update to matrix-react-sdk 0.5.2 - see
    [changelog](https://github.com/matrix-org/matrix-react-sdk/blob/v0.5.2/CHANGELOG.md)
  * Don't relayout scrollpanels every time something changes
-   [\#1438](https://github.com/vector-im/vector-web/pull/1438)
+   [\#1438](https://github.com/element-hq/vector-web/pull/1438)
  * Include react-addons-perf for non-production builds
-   [\#1431](https://github.com/vector-im/vector-web/pull/1431)
+   [\#1431](https://github.com/element-hq/vector-web/pull/1431)
 
-Changes in [0.6.0](https://github.com/vector-im/vector-web/releases/tag/v0.6.0) (2016-04-19)
+Changes in [0.6.0](https://github.com/element-hq/vector-web/releases/tag/v0.6.0) (2016-04-19)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.5.0...v0.6.0)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.5.0...v0.6.0)
 
  * Matthew/design tweaks
-   [\#1402](https://github.com/vector-im/vector-web/pull/1402)
+   [\#1402](https://github.com/element-hq/vector-web/pull/1402)
  * Improve handling of notification rules we can't parse
-   [\#1399](https://github.com/vector-im/vector-web/pull/1399)
+   [\#1399](https://github.com/element-hq/vector-web/pull/1399)
  * Do less mangling of jenkins builds
-   [\#1391](https://github.com/vector-im/vector-web/pull/1391)
+   [\#1391](https://github.com/element-hq/vector-web/pull/1391)
  * Start Notifications component refactor
-   [\#1386](https://github.com/vector-im/vector-web/pull/1386)
+   [\#1386](https://github.com/element-hq/vector-web/pull/1386)
  * make the UI fadable to help with decluttering
-   [\#1376](https://github.com/vector-im/vector-web/pull/1376)
+   [\#1376](https://github.com/element-hq/vector-web/pull/1376)
  * Get and display a user's pushers in settings
-   [\#1374](https://github.com/vector-im/vector-web/pull/1374)
+   [\#1374](https://github.com/element-hq/vector-web/pull/1374)
  * URL previewing support
-   [\#1343](https://github.com/vector-im/vector-web/pull/1343)
+   [\#1343](https://github.com/element-hq/vector-web/pull/1343)
  * 😄 Emoji autocomplete and unicode emoji to image conversion using emojione.
-   [\#1332](https://github.com/vector-im/vector-web/pull/1332)
+   [\#1332](https://github.com/element-hq/vector-web/pull/1332)
  * Show full-size avatar on MemberInfo avatar click
-   [\#1340](https://github.com/vector-im/vector-web/pull/1340)
+   [\#1340](https://github.com/element-hq/vector-web/pull/1340)
  * Numerous other changes via [matrix-react-sdk 0.5.1](https://github.com/matrix-org/matrix-react-sdk/blob/v0.5.1/CHANGELOG.md)
 
-Changes in [0.5.0](https://github.com/vector-im/vector-web/releases/tag/v0.5.0) (2016-03-30)
+Changes in [0.5.0](https://github.com/element-hq/vector-web/releases/tag/v0.5.0) (2016-03-30)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.4.1...v0.5.0)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.4.1...v0.5.0)
 
  * Prettier, animated placeholder :D
-   [\#1292](https://github.com/vector-im/vector-web/pull/1292)
+   [\#1292](https://github.com/element-hq/vector-web/pull/1292)
    (Disabled for now due to high CPU usage)
  * RoomDirectory: use SimpleRoomHeader instead of RoomHeader
-   [\#1307](https://github.com/vector-im/vector-web/pull/1307)
+   [\#1307](https://github.com/element-hq/vector-web/pull/1307)
  * Tell webpack not to parse the highlight.js languages
-   [\#1277](https://github.com/vector-im/vector-web/pull/1277)
+   [\#1277](https://github.com/element-hq/vector-web/pull/1277)
  * CSS for https://github.com/matrix-org/matrix-react-sdk/pull/247
-   [\#1249](https://github.com/vector-im/vector-web/pull/1249)
+   [\#1249](https://github.com/element-hq/vector-web/pull/1249)
  * URI-decode the hash-fragment
-   [\#1254](https://github.com/vector-im/vector-web/pull/1254)
+   [\#1254](https://github.com/element-hq/vector-web/pull/1254)
 
-Changes in [0.4.1](https://github.com/vector-im/vector-web/releases/tag/v0.4.1) (2016-03-23)
+Changes in [0.4.1](https://github.com/element-hq/vector-web/releases/tag/v0.4.1) (2016-03-23)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.4.0...v0.4.1)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.4.0...v0.4.1)
  * Update to matrix-react-sdk 0.3.1; see
    https://github.com/matrix-org/matrix-react-sdk/blob/v0.3.1/CHANGELOG.md
    (Disables debug logging)
 
-Changes in [0.4.0](https://github.com/vector-im/vector-web/releases/tag/v0.4.0) (2016-03-23)
+Changes in [0.4.0](https://github.com/element-hq/vector-web/releases/tag/v0.4.0) (2016-03-23)
 ============================================================================================
-[Full Changelog](https://github.com/vector-im/vector-web/compare/v0.3.0...v0.4.0)
+[Full Changelog](https://github.com/element-hq/vector-web/compare/v0.3.0...v0.4.0)
 
  * Update to matrix-react-sdk 0.3.0; see
    https://github.com/matrix-org/matrix-react-sdk/blob/master/CHANGELOG.md
 
 Other changes
  * permalink button
-   [\#1232](https://github.com/vector-im/vector-web/pull/1232)
+   [\#1232](https://github.com/element-hq/vector-web/pull/1232)
  * make senderprofiles clickable
-   [\#1191](https://github.com/vector-im/vector-web/pull/1191)
+   [\#1191](https://github.com/element-hq/vector-web/pull/1191)
  * fix notif spam when logging in from a guest session by correctly logging out
    first.
-   [\#1180](https://github.com/vector-im/vector-web/pull/1180)
+   [\#1180](https://github.com/element-hq/vector-web/pull/1180)
  * use new start_login_from_guest dispatch for cancellable logins from guest
    accounts
-   [\#1165](https://github.com/vector-im/vector-web/pull/1165)
+   [\#1165](https://github.com/element-hq/vector-web/pull/1165)
  * Use then() chaining rather than manual callbacks
-   [\#1171](https://github.com/vector-im/vector-web/pull/1171)
+   [\#1171](https://github.com/element-hq/vector-web/pull/1171)
  * Remove trailing whitespace
-   [\#1163](https://github.com/vector-im/vector-web/pull/1163)
+   [\#1163](https://github.com/element-hq/vector-web/pull/1163)
  * Update the actions of default rules instead of overriding.
-   [\#1037](https://github.com/vector-im/vector-web/pull/1037)
+   [\#1037](https://github.com/element-hq/vector-web/pull/1037)
  * Update README to include `npm install` in react-sdk
-   [\#1137](https://github.com/vector-im/vector-web/pull/1137)
+   [\#1137](https://github.com/element-hq/vector-web/pull/1137)
 
 Changes in vector v0.3.0 (2016-03-11)
 ======================================

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,7 +284,7 @@ be required.
 
 # Review expectations
 
-See https://github.com/vector-im/element-meta/wiki/Review-process
+See https://github.com/element-hq/element-meta/wiki/Review-process
 
 # Merge Strategy
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Chat](https://img.shields.io/matrix/element-web:matrix.org?logo=matrix)](https://matrix.to/#/#element-web:matrix.org)
-![Tests](https://github.com/vector-im/element-web/actions/workflows/tests.yaml/badge.svg)
-![Static Analysis](https://github.com/vector-im/element-web/actions/workflows/static_analysis.yaml/badge.svg)
+![Tests](https://github.com/element-hq/element-web/actions/workflows/tests.yaml/badge.svg)
+![Static Analysis](https://github.com/element-hq/element-web/actions/workflows/static_analysis.yaml/badge.svg)
 [![Localazy](https://img.shields.io/endpoint?url=https%3A%2F%2Fconnect.localazy.com%2Fstatus%2Felement-web%2Fdata%3Fcontent%3Dall%26title%3Dlocalazy%26logo%3Dtrue)](https://localazy.com/p/element-web)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=element-web&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=element-web)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=element-web&metric=coverage)](https://sonarcloud.io/summary/new_code?id=element-web)
@@ -32,8 +32,8 @@ Element has several tiers of support for different environments:
     -   Everything else
 
 For accessing Element on an Android or iOS device, we currently recommend the
-native apps [element-android](https://github.com/vector-im/element-android)
-and [element-ios](https://github.com/vector-im/element-ios).
+native apps [element-android](https://github.com/element-hq/element-android)
+and [element-ios](https://github.com/element-hq/element-ios).
 
 # Getting Started
 
@@ -57,7 +57,7 @@ access to Element (or other apps) due to sharing the same domain.
 
 We have put some coarse mitigations into place to try to protect against this
 situation, but it's still not good practice to do it in the first place. See
-<https://github.com/vector-im/element-web/issues/1977> for more details.
+<https://github.com/element-hq/element-web/issues/1977> for more details.
 
 ## Configuration best practices
 
@@ -111,7 +111,7 @@ guide](https://classic.yarnpkg.com/en/docs/install) if you do not have it alread
 
 1. Install or update `node.js` so that your `node` is at least the current recommended LTS.
 1. Install `yarn` if not present already.
-1. Clone the repo: `git clone https://github.com/vector-im/element-web.git`.
+1. Clone the repo: `git clone https://github.com/element-hq/element-web.git`.
 1. Switch to the element-web directory: `cd element-web`.
 1. Install the prerequisites: `yarn install`.
     - If you're using the `develop` branch, then it is recommended to set up a
@@ -137,7 +137,7 @@ Element can also be run as a desktop app, wrapped in Electron. You can download 
 pre-built version from <https://element.io/get-started> or, if you prefer,
 build it yourself.
 
-To build it yourself, follow the instructions at <https://github.com/vector-im/element-desktop>.
+To build it yourself, follow the instructions at <https://github.com/element-hq/element-desktop>.
 
 Many thanks to @aviraldg for the initial work on the Electron integration.
 
@@ -151,7 +151,7 @@ See the [configuration docs](docs/config.md) for more details.
 # Labs Features
 
 Some features of Element may be enabled by flags in the `Labs` section of the settings.
-Some of these features are described in [labs.md](https://github.com/vector-im/element-web/blob/develop/docs/labs.md).
+Some of these features are described in [labs.md](https://github.com/element-hq/element-web/blob/develop/docs/labs.md).
 
 # Caching requirements
 
@@ -231,7 +231,7 @@ popd
 Clone the repo and switch to the `element-web` directory:
 
 ```bash
-git clone https://github.com/vector-im/element-web.git
+git clone https://github.com/element-hq/element-web.git
 cd element-web
 ```
 
@@ -267,8 +267,8 @@ for changes. If the inotify limits are too low your build will fail silently or 
 `Error: EMFILE: too many open files`. To avoid these issues, we recommend a watch limit
 of at least `128M` and instance limit around `512`.
 
-You may be interested in issues [#15750](https://github.com/vector-im/element-web/issues/15750) and
-[#15774](https://github.com/vector-im/element-web/issues/15774) for further details.
+You may be interested in issues [#15750](https://github.com/element-hq/element-web/issues/15750) and
+[#15774](https://github.com/element-hq/element-web/issues/15774) for further details.
 
 To set a new inotify watch and instance limit, execute:
 
@@ -316,6 +316,6 @@ For a developer guide, see the [translating dev doc](docs/translating-dev.md).
 
 # Triaging issues
 
-Issues are triaged by community members and the Web App Team, following the [triage process](https://github.com/vector-im/element-meta/wiki/Triage-process).
+Issues are triaged by community members and the Web App Team, following the [triage process](https://github.com/element-hq/element-meta/wiki/Triage-process).
 
-We use [issue labels](https://github.com/vector-im/element-meta/wiki/Issue-labelling) to sort all incoming issues.
+We use [issue labels](https://github.com/element-hq/element-meta/wiki/Issue-labelling) to sort all incoming issues.

--- a/docs/betas.md
+++ b/docs/betas.md
@@ -4,7 +4,7 @@ Beta features are features that are not ready for production yet but the team
 wants more people to try the features and give feedback on them.
 
 Before a feature gets into its beta phase, it is often a labs feature (see
-[Labs](https://github.com/vector-im/element-web/blob/develop/docs/labs.md)).
+[Labs](https://github.com/element-hq/element-web/blob/develop/docs/labs.md)).
 
 **Be warned! Beta features may not be completely finalised or stable!**
 

--- a/docs/choosing-an-issue.md
+++ b/docs/choosing-an-issue.md
@@ -18,12 +18,12 @@ If you're looking for inspiration on where to start, keep reading!
 ## Finding a good first issue
 
 All the issues for Element Web live in the
-[element-web](https://github.com/vector-im/element-web) repository, including
+[element-web](https://github.com/element-hq/element-web) repository, including
 issues that actually need fixing in `matrix-react-sdk` or one of the related
 repos.
 
 The first place to look is for
-[issues tagged with "good first issue"](https://github.com/vector-im/element-web/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
+[issues tagged with "good first issue"](https://github.com/element-hq/element-web/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
 
 Look through that list and find something that catches your interest. If there
 is nothing, there, try gently asking in
@@ -38,8 +38,8 @@ issue a **GOOD** choice:
 -   You think you can understand what's needed.
 -   It already has approval from Element Web's designers (look for comments from
     members of the
-    [Product](https://github.com/orgs/vector-im/teams/product/members) or
-    [Design](https://github.com/orgs/vector-im/teams/design/members) teams).
+    [Product](https://github.com/orgs/element-hq/teams/product/members) or
+    [Design](https://github.com/orgs/element-hq/teams/design/members) teams).
 
 Here are some things that might make it a **BAD** choice:
 
@@ -57,7 +57,7 @@ way the product works, or how it looks in a specific area.
 Once you've fixed a few small things, you can consider taking on something a
 little larger. This should mostly be driven by what you find interesting, but
 you may also find the
-[Help Wanted](https://github.com/vector-im/element-web/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Help+Wanted%22)
+[Help Wanted](https://github.com/element-hq/element-web/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Help+Wanted%22)
 label useful.
 
 Note that the same comment applies as in the previous section: if you want to

--- a/docs/config.md
+++ b/docs/config.md
@@ -480,7 +480,7 @@ decentralised.
 
 ## Desktop app configuration
 
-See https://github.com/vector-im/element-desktop#user-specified-configjson
+See https://github.com/element-hq/element-desktop#user-specified-configjson
 
 ## UI Features
 

--- a/docs/customisations.md
+++ b/docs/customisations.md
@@ -2,7 +2,7 @@
 
 ### 🦖 DEPRECATED
 
-Customisations have been deprecated in favour of the [Module API](https://github.com/vector-im/element-web/blob/develop/docs/modules.md).
+Customisations have been deprecated in favour of the [Module API](https://github.com/element-hq/element-web/blob/develop/docs/modules.md).
 If you have use cases from customisations which are not yet available via the Module API please open an issue.
 Customisations will be removed from the codebase in a future release.
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -53,7 +53,7 @@ When starting work on a feature, we should create a matching feature flag:
 SettingsStore.getValue("feature_cats");
 ```
 
-3. Document the feature in the [labs documentation](https://github.com/vector-im/element-web/blob/develop/docs/labs.md)
+3. Document the feature in the [labs documentation](https://github.com/element-hq/element-web/blob/develop/docs/labs.md)
 
 With these steps completed, the feature is disabled by default, but can be
 enabled on develop and nightly by interested users for testing.
@@ -64,9 +64,9 @@ The following lists a few common options.
 ## Enabling by default on develop and nightly
 
 Set the feature to `true` in the
-[develop](https://github.com/vector-im/element-web/blob/develop/element.io/develop/config.json)
+[develop](https://github.com/element-hq/element-web/blob/develop/element.io/develop/config.json)
 and
-[nightly](https://github.com/vector-im/element-desktop/blob/develop/element.io/nightly/config.json)
+[nightly](https://github.com/element-hq/element-desktop/blob/develop/element.io/nightly/config.json)
 configs:
 
 ```json
@@ -78,9 +78,9 @@ configs:
 ## Enabling by default on staging, app, and release
 
 Set the feature to `true` in the
-[staging / app](https://github.com/vector-im/element-web/blob/develop/element.io/app/config.json)
+[staging / app](https://github.com/element-hq/element-web/blob/develop/element.io/app/config.json)
 and
-[release](https://github.com/vector-im/element-desktop/blob/develop/element.io/release/config.json)
+[release](https://github.com/element-hq/element-desktop/blob/develop/element.io/release/config.json)
 configs.
 
 **Note:** The above will only enable the feature for https://app.element.io and official Element
@@ -95,19 +95,19 @@ If the feature is meant to be turned off/on by the user:
 
 1. Remove `isFeature` from the [setting](https://github.com/matrix-org/matrix-react-sdk/blob/develop/src/settings/Settings.ts)
 2. Change the `default` to `true` (if desired).
-3. Remove the feature from the [labs documentation](https://github.com/vector-im/element-web/blob/develop/docs/labs.md)
+3. Remove the feature from the [labs documentation](https://github.com/element-hq/element-web/blob/develop/docs/labs.md)
 4. Celebrate! 🥳
 
 If the feature is meant to be forced on (non-configurable):
 
 1. Remove the [setting](https://github.com/matrix-org/matrix-react-sdk/blob/develop/src/settings/Settings.ts)
 2. Remove all `getValue` lines that test for the feature.
-3. Remove the feature from the [labs documentation](https://github.com/vector-im/element-web/blob/develop/docs/labs.md)
+3. Remove the feature from the [labs documentation](https://github.com/element-hq/element-web/blob/develop/docs/labs.md)
 4. If applicable, remove the feature state from
-   [develop](https://github.com/vector-im/element-web/blob/develop/element.io/develop/config.json),
-   [nightly](https://github.com/vector-im/element-desktop/blob/develop/element.io/nightly/config.json),
-   [staging / app](https://github.com/vector-im/element-web/blob/develop/element.io/app/config.json),
+   [develop](https://github.com/element-hq/element-web/blob/develop/element.io/develop/config.json),
+   [nightly](https://github.com/element-hq/element-desktop/blob/develop/element.io/nightly/config.json),
+   [staging / app](https://github.com/element-hq/element-web/blob/develop/element.io/app/config.json),
    and
-   [release](https://github.com/vector-im/element-desktop/blob/develop/element.io/release/config.json)
+   [release](https://github.com/element-hq/element-desktop/blob/develop/element.io/release/config.json)
    configs
 5. Celebrate! 🥳

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,7 +8,7 @@ There are some exceptions like when using localhost, which is considered a [secu
 
 ## Release tarball
 
-1. Download the latest version from <https://github.com/vector-im/element-web/releases>
+1. Download the latest version from <https://github.com/element-hq/element-web/releases>
 1. Untar the tarball on your web server
 1. Move (or symlink) the `element-x.x.x` directory to an appropriate name
 1. Configure the correct caching headers in your webserver (see below)
@@ -55,7 +55,7 @@ docker run -p 80:80 -v /etc/element-web/config.json:/app/config.json vectorim/el
 To build the image yourself:
 
 ```bash
-git clone https://github.com/vector-im/element-web.git element-web
+git clone https://github.com/element-hq/element-web.git element-web
 cd element-web
 git checkout master
 docker build .

--- a/docs/jitsi.md
+++ b/docs/jitsi.md
@@ -64,7 +64,7 @@ Element Android (1.0.5+) supports custom Jitsi domains, similar to Element Web a
 calls work directly between clients or via TURN servers configured on the respective
 homeservers.
 
-For rooms with more than 2 joined members, when creating a Jitsi conference via call/video buttons of the toolbar (not via integration manager), Element Android will create a widget using the [wrapper](https://github.com/vector-im/element-web/blob/develop/docs/jitsi-dev.md) hosted on `app.element.io`.
+For rooms with more than 2 joined members, when creating a Jitsi conference via call/video buttons of the toolbar (not via integration manager), Element Android will create a widget using the [wrapper](https://github.com/element-hq/element-web/blob/develop/docs/jitsi-dev.md) hosted on `app.element.io`.
 The domain used is the one specified by the `/.well-known/matrix/client` endpoint, and if not present it uses the fallback defined in `config.json` (meet.element.io)
 
 For active Jitsi widgets in the room, a native Jitsi widget UI is created and points to the instance specified in the `domain` key of the widget content data.

--- a/docs/labs.md
+++ b/docs/labs.md
@@ -5,7 +5,7 @@ to `Settings->Labs`. This list is non-exhaustive and subject to change, chat in
 [#element-web:matrix.org](https://matrix.to/#/#element-web:matrix.org) for more information.
 
 If a labs features gets more stable, it _may_ be promoted to a beta feature
-(see [Betas](https://github.com/vector-im/element-web/blob/develop/docs/betas.md)).
+(see [Betas](https://github.com/element-hq/element-web/blob/develop/docs/betas.md)).
 
 **Be warned! Labs features are not finalised, they may be fragile, they may change, they may be
 dropped. Ask in the room if you are unclear about any details here.**

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -30,7 +30,7 @@ Once your change to the module API is accepted, the `@matrix-org/react-sdk-modul
 `matrix-react-sdk` and `element-web` layers (usually by us, the maintainers) to ensure your module can operate.
 
 If you're not adding anything to the module API, or your change was accepted per above, then start off with a clone of
-our [ILAG module](https://github.com/vector-im/element-web-ilag-module) which will give you a general idea for what the
+our [ILAG module](https://github.com/element-hq/element-web-ilag-module) which will give you a general idea for what the
 structure of a module is and how it works.
 
 The following requirements are key for any module:

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -6,14 +6,14 @@ at runtime.
 
 ## Installing modules
 
-If you already have a module you want to install, such as our [ILAG Module](https://github.com/vector-im/element-web-ilag-module),
+If you already have a module you want to install, such as our [ILAG Module](https://github.com/element-hq/element-web-ilag-module),
 then copy `build_config.sample.yaml` to `build_config.yaml` in the same directory. In your new `build_config.yaml` simply
 add the reference to the module as described by the sample file, using the same syntax you would for `yarn add`:
 
 ```yaml
 modules:
     # Our module happens to be published on NPM, so we use that syntax to reference it.
-    - "@vector-im/element-web-ilag-module@latest"
+    - "@element-hq/element-web-ilag-module@latest"
 ```
 
 Then build the app as you normally would: `yarn build` or `yarn dist` (if compatible on your platform). If you are building

--- a/docs/native-node-modules.md
+++ b/docs/native-node-modules.md
@@ -1,3 +1,3 @@
 # Native Node Modules
 
-This documentation moved to the [`element-desktop`](https://github.com/vector-im/element-desktop/blob/develop/docs/native-node-modules.md) repository.
+This documentation moved to the [`element-desktop`](https://github.com/element-hq/element-desktop/blob/develop/docs/native-node-modules.md) repository.

--- a/docs/release.md
+++ b/docs/release.md
@@ -82,8 +82,8 @@ This label will automagically convert to `X-Release-Blocker` at the conclusion o
 
 This release process revolves around our four main repositories:
 
--   [Element Desktop](https://github.com/vector-im/element-desktop/)
--   [Element Web](https://github.com/vector-im/element-web/)
+-   [Element Desktop](https://github.com/element-hq/element-desktop/)
+-   [Element Web](https://github.com/element-hq/element-web/)
 -   [Matrix React SDK](https://github.com/matrix-org/matrix-react-sdk/)
 -   [Matrix JS SDK](https://github.com/matrix-org/matrix-js-sdk/)
 
@@ -97,7 +97,7 @@ We own other repositories, but they have more ad-hoc releases and are not part o
 <details><summary><h1>Prerequisites</h1></summary><blockquote>
 
 -   You must be part of the 2 Releasers GitHub groups:
-    -   <https://github.com/orgs/vector-im/teams/element-web-releasers>
+    -   <https://github.com/orgs/element-hq/teams/element-web-releasers>
     -   <https://github.com/orgs/matrix-org/teams/element-web-releasers>
 -   You will need access to the **VPN** ([docs](https://gitlab.matrix.org/new-vector/internal/-/wikis/SRE/Tailscale)) to be able to follow the instructions under Deploy below.
 -   You will need the ability to **SSH** in to the production machines to be able to follow the instructions under Deploy below. Ensure that your SSH key has a non-empty passphrase, and you registered your SSH key with Ops. Log a ticket at https://github.com/matrix-org/matrix-ansible-private and ask for:
@@ -168,7 +168,7 @@ The goal of this stage is to get the code you want to ship onto the `staging` br
 There are multiple ways to accomplish this depending on the type of release you need to perform.
 
 For the first RC in a given release cycle the easiest way to prepare branches is using the
-[Cut branches automation](https://github.com/vector-im/element-web/actions/workflows/release_prepare.yml) -
+[Cut branches automation](https://github.com/element-hq/element-web/actions/workflows/release_prepare.yml) -
 this will take `develop` and merge it into the `staging` on the chosen repositories.
 
 For subsequent RCs, if you need to include a change you may PR it directly to the `staging` branch or rely on the
@@ -204,13 +204,13 @@ The next stop is matrix-react-sdk; kick off a release using [the automation](htt
 
 ### Element Web
 
-The next stop is element-web; kick off a release using [the automation](https://github.com/vector-im/element-web/actions/workflows/release.yml) - making sure to select the right type of release. For anything other than an RC: choose final. In the SDK version fields enter the versions you wish to use, for typical releases including all the layers this would be the versions released in the stages above.
+The next stop is element-web; kick off a release using [the automation](https://github.com/element-hq/element-web/actions/workflows/release.yml) - making sure to select the right type of release. For anything other than an RC: choose final. In the SDK version fields enter the versions you wish to use, for typical releases including all the layers this would be the versions released in the stages above.
 
 -   [ ] Element Web has been released
 
 ### Element Desktop
 
-The next stop is element-desktop; kick off a release using [the automation](https://github.com/vector-im/element-desktop/actions/workflows/release.yml) - making sure to select the right type of release. For anything other than an RC: choose final. In the JS SDK version field enter the version of the JS SDK you wish to use, for typical releases including all the layers this would be the version released in the stage above.
+The next stop is element-desktop; kick off a release using [the automation](https://github.com/element-hq/element-desktop/actions/workflows/release.yml) - making sure to select the right type of release. For anything other than an RC: choose final. In the JS SDK version field enter the version of the JS SDK you wish to use, for typical releases including all the layers this would be the version released in the stage above.
 
 -   [ ] Element Desktop has been released
 
@@ -235,7 +235,7 @@ For final releases additionally do these steps:
 
 We have some manual housekeeping to do in order to prepare for the next release.
 
--   [ ] Update topics using [the automation](https://github.com/vector-im/element-web/actions/workflows/update-topics.yaml). It will autodetect the current latest version. Don't forget the date you supply should be e.g. September 5th (including the "th") for the script to work.
+-   [ ] Update topics using [the automation](https://github.com/element-hq/element-web/actions/workflows/update-topics.yaml). It will autodetect the current latest version. Don't forget the date you supply should be e.g. September 5th (including the "th") for the script to work.
 -   [ ] Announce the release in [#element-web-announcements:matrix.org](https://matrix.to/#/#element-web-announcements:matrix.org)
 
 <details><summary>(show)</summary>
@@ -246,7 +246,7 @@ With wording like:
 >
 > This version adds ... and fixes bugs ...
 >
-> Check it out at app.element.io, in Element Desktop, or from Docker Hub. Changelog and more details at https://github.com/vector-im/element-web/releases/tag/v1.11.24
+> Check it out at app.element.io, in Element Desktop, or from Docker Hub. Changelog and more details at https://github.com/element-hq/element-web/releases/tag/v1.11.24
 
 </details>
 
@@ -256,13 +256,13 @@ For the first RC of a given release cycle do these steps:
 
 -   [ ] Go to the [matrix-react-sdk Renovate dashboard](https://github.com/matrix-org/matrix-react-sdk/issues/9667) and click the checkbox to create/update its PRs.
 
--   [ ] Go to the [element-web Renovate dashboard](https://github.com/vector-im/element-web/issues/22941) and click the checkbox to create/update its PRs.
+-   [ ] Go to the [element-web Renovate dashboard](https://github.com/element-hq/element-web/issues/22941) and click the checkbox to create/update its PRs.
 
--   [ ] Go to the [element-desktop Renovate dashboard](https://github.com/vector-im/element-desktop/issues/465) and click the checkbox to create/update its PRs.
+-   [ ] Go to the [element-desktop Renovate dashboard](https://github.com/element-hq/element-desktop/issues/465) and click the checkbox to create/update its PRs.
 
 -   [ ] Later, check back and merge the PRs that succeeded to build. The ones that failed will get picked up by the [maintainer](https://docs.google.com/document/d/1V5VINWXATMpz9UBw4IKmVVB8aw3CxM0Jt7igtHnDfSk/edit#).
 
 For final releases additionally do these steps:
 
--   [ ] Archive done column on the [team board](https://github.com/orgs/vector-im/projects/67/views/34) _Note: this should be automated_
+-   [ ] Archive done column on the [team board](https://github.com/orgs/element-hq/projects/67/views/34) _Note: this should be automated_
 -   [ ] Add entry to the [milestones diary](https://docs.google.com/document/d/1cpRFJdfNCo2Ps6jqzQmatzbYEToSrQpyBug0aP_iwZE/edit#heading=h.6y55fw4t283z). The document says only to add significant releases, but we add all of them just in case.

--- a/docs/translating-dev.md
+++ b/docs/translating-dev.md
@@ -36,7 +36,7 @@ function getColorName(hex) {
 
 ## Key naming rules
 
-These rules are based on https://github.com/vector-im/element-x-android/blob/develop/tools/localazy/README.md
+These rules are based on https://github.com/element-hq/element-x-android/blob/develop/tools/localazy/README.md
 At this time we are not trying to have a translation key per UI element as some methodologies use,
 whilst that would offer the greatest flexibility, it would also make reuse between projects nigh impossible.
 We are aiming for a set of common strings to be shared then some more localised translations per context they may appear in.


### PR DESCRIPTION
Hi there. I can see that `vector-im` is now `element-hq` (congratulations!), so I took the liberty of making a fork where all instances of the old name in markdown files have been changed to use the updated name.

This is my first PR in several years, so I apologize if I've done something incorrectly. I don't know a lot about TypeScript, so this seemed like a convenient way to support the project.

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->