### PR TITLE
Add workaround for webpack builds on platforms unsupported by Sentry

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -707,7 +707,7 @@ module.exports = (env, argv) => {
             }),
 
             // Upload to sentry if sentry env is present
-            // This plugin fails to import on some platforms like ppc64le & s390x even if the plugin isn't called,
+            // This plugin throws an error on import on some platforms like ppc64le & s390x even if the plugin isn't called,
             // so we require it conditionally.
             process.env.SENTRY_DSN &&
                 require("@sentry/webpack-plugin").sentryWebpackPlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,6 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 const HtmlWebpackInjectPreload = require("@principalstudio/html-webpack-inject-preload");
-const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");
 const crypto = require("crypto");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 
@@ -707,9 +706,11 @@ module.exports = (env, argv) => {
                 files: [{ match: /.*Inter.*\.woff2$/ }],
             }),
 
-            // upload to sentry if sentry env is present
+            // Upload to sentry if sentry env is present
+            // This plugin fails to import on some platforms like ppc64le & s390x even if the plugin isn't called,
+            // so we require it conditionally.
             process.env.SENTRY_DSN &&
-                sentryWebpackPlugin({
+                require("@sentry/webpack-plugin").sentryWebpackPlugin({
                     release: process.env.VERSION,
                     sourcemaps: {
                         paths: "./webapp/bundles/**",


### PR DESCRIPTION
```
$ webpack --progress --mode production
[webpack-cli] Failed to load '/builds/selfisekai/aports/community/element-web/src/element-web-1.11.55/webpack.config.js' config
[webpack-cli] Error: Unsupported operating system or architecture! Sentry CLI does not work on this architecture.
Sentry CLI supports:
- Darwin (macOS)
- Linux and FreeBSD on x64, x86, ia32, arm64, and arm architectures
- Windows x64, x86, and ia32 architectures
```

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->