### PR TITLE
Update `element.io develop` configuration to migrate all existing users to the new rust crypto stack

### DIFF
--- a/docs/labs.md
+++ b/docs/labs.md
@@ -116,6 +116,23 @@ Configures Element to use a new cryptography implementation based on the [matrix
 
 This setting is (currently) _sticky_ to a user's session: it only takes effect when the user logs in to a new session. Likewise, even after disabling the setting in `config.json`, the Rust implementation will remain in use until users log out.
 
+This configuration value is now set to `true` by default. This means that without any additional configuration
+every new login will use the new cryptography implementation.
+
+For administrators looking to transition existing users to the new stack, the `RustCrypto.staged_rollout_percent` configuration is available.
+This configuration allows for a phased migration of users, represented as an integer percentage (0 to 100). By default, this value is set to `0`,
+which means no existing users will be migrated to the new stack. If you wish to migrate all users, you can adjust this value to `100`.
+
+This configuration should be placed under the `setting_defaults` section as shown:
+
+```
+    "setting_defaults": {
+        "RustCrypto.staged_rollout_percent": 20
+    },
+```
+
+By adjusting the `RustCrypto.staged_rollout_percent` value, you can control the migration process according to your deployment strategy.
+
 ## New room header & details (`feature_new_room_decoration_ui`) [In Development]
 
 Refactors visually the room header and room sidebar

--- a/element.io/develop/config.json
+++ b/element.io/develop/config.json
@@ -49,9 +49,11 @@
     "privacy_policy_url": "https://element.io/cookie-policy",
     "features": {
         "feature_video_rooms": true,
-        "feature_rust_crypto": true,
         "feature_new_room_decoration_ui": true,
         "feature_element_call_video_rooms": true
+    },
+    "setting_defaults": {
+        "RustCrypto.staged_rollout_percent": 100
     },
     "element_call": {
         "url": "https://call.element.dev"


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Depends on:
https://github.com/matrix-org/matrix-react-sdk/pull/12184

The feature flag `feature_rust_crypto` is not `true` by default.

The `config.json` for develop has been updated in order to migrate all existing users to rust (`RustCrypto.staged_rollout_percent: 100` ).

`app.element.io` is only using the default. Meaning that new logins will now use the rust crypo stack.
Existing users will stay on legacy because the `RustCrypto.staged_rollout_percent` setting default is 0.

The plan is to incrementally update the `staged_rollout_percent` on app.element.io in future releases.

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->