### PR TITLE
Saner Releases - ensure we set up staging branches in bottom-up order

### DIFF
--- a/.github/workflows/release_prepare.yml
+++ b/.github/workflows/release_prepare.yml
@@ -25,6 +25,9 @@ on:
 jobs:
     prepare:
         runs-on: ubuntu-latest
+        env:
+            # The order is specified bottom-up to avoid any races for allchange
+            REPOS: matrix-js-sdk matrix-react-sdk element-web element-desktop
         steps:
             - name: Checkout Element Desktop
               uses: actions/checkout@v4
@@ -67,15 +70,11 @@ jobs:
                   fetch-tags: true
                   token: ${{ secrets.ELEMENT_BOT_TOKEN }}
 
-            - name: Resolve repos
-              run: |
-                  echo "REPOS=$(ls . | tr '\n' ' ')" >> $GITHUB_ENV
-
             - name: Merge develop
               run: |
                   git config --global user.email "releases@riot.im"
                   git config --global user.name "RiotRobot"
-                  for REPO in $REPOS; do git -C "$REPO" merge origin/develop; done
+                  for REPO in $REPOS; do [ -d "$REPO" ] && git -C "$REPO" merge origin/develop; done
 
             - name: Push staging
-              run: for REPO in $REPOS; do git -C "$REPO" push origin staging; done
+              run: for REPO in $REPOS; do [ -d "$REPO" ] && git -C "$REPO" push origin staging; done


### PR DESCRIPTION
To avoid potential for races as upstream changelogs are ingested

<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->