### PR TITLE
Fix missing deviceId mock in test

### DIFF
--- a/test/app-tests/loading-test.tsx
+++ b/test/app-tests/loading-test.tsx
@@ -304,6 +304,7 @@ describe("loading:", function () {
             localStorage.setItem("mx_is_url", "http://localhost");
             localStorage.setItem("mx_access_token", "access_token");
             localStorage.setItem("mx_user_id", "@me:localhost");
+            localStorage.setItem("mx_device_id", "QWERTYUIOP");
             localStorage.setItem("mx_last_room_id", "!last_room:id");
 
             // Create a crypto store as well to satisfy storage consistency checks
@@ -403,6 +404,7 @@ describe("loading:", function () {
                         })
                         .respond(200, {
                             user_id: "@guest:localhost",
+                            device_id: "QWERTYUIOP",
                             access_token: "secret_token",
                         });
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Fix some test that are failing in rust_crypto due to missing `device_id` mock.

Legacy was not reaching that point because crypto initialisation was failing anyhow because libolm not loaded (`globalThis.Olm` undefined), and the error[ is swallowed in legacy ](https://github.com/matrix-org/matrix-react-sdk/blob/01f0c668b76cee5f2d6e74e7edca41d73a76fc58/src/MatrixClientPeg.ts#L360)
## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->