### PR TITLE
Force legacy crypto for loading tests

### DIFF
--- a/test/app-tests/loading-test.tsx
+++ b/test/app-tests/loading-test.tsx
@@ -130,7 +130,7 @@ describe("loading:", function () {
                 home_url: "data:text/html;charset=utf-8;base64,PGh0bWw+PC9odG1sPg==",
             },
             features: {
-                "feature_rust_crypto": false,
+                feature_rust_crypto: false,
             },
             ...(opts.config ?? {}),
         } as IConfigOptions;

--- a/test/app-tests/loading-test.tsx
+++ b/test/app-tests/loading-test.tsx
@@ -129,6 +129,9 @@ describe("loading:", function () {
             embedded_pages: {
                 home_url: "data:text/html;charset=utf-8;base64,PGh0bWw+PC9odG1sPg==",
             },
+            features: {
+                "feature_rust_crypto": false,
+            },
             ...(opts.config ?? {}),
         } as IConfigOptions;
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

The `loading-test.tsx` only runs correctly on legacy crypto. They are running a mix of localStorage and indexeddb storage (partial mock of indexeddb through the all stack), and also they are running without crypto (by not loading libolm). The rust sdk doesn't work this way, it's using indexeddb to store things and cannot be disabled by not loading a lib.


## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This change is marked as an *internal change* (Task), so will not be included in the changelog.<!-- CHANGELOG_PREVIEW_END -->