### PR TITLE
docs: clarify support policy on unsupported environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Element has several tiers of support for different environments:
     -   Element as an installed PWA via current stable version of Chrome
     -   Mobile web for current stable version of Chrome, Firefox, and Safari on Android, iOS, and iPadOS
 -   Not supported
-    -   Definition: Issues only affecting unsupported environments are **closed**
+    -   Definition: Issues asking for support of unsupported environments are **closed**
     -   Everything else
 
 For accessing Element on an Android or iOS device, we currently recommend the


### PR DESCRIPTION
This is a clarification of the support policy on unsupported environments, intending to allow suggestions that would improve the currently user-hostile UX relating to unsupported environments, while still making clear that unsupported environments are in fact unsupported.

Motivated by the rather trigger-happy closure of https://github.com/element-hq/element-desktop/issues/1535