### PR TITLE
Update variants/openDesk/build_config.yaml

### DIFF
--- a/variants/openDesk/build_config.yaml
+++ b/variants/openDesk/build_config.yaml
@@ -7,5 +7,6 @@
 # The values of this are provided to `yarn add` for inclusion.
 modules:
     - "@nordeck/element-web-guest-module@1.0.0"
-    - "@nordeck/element-web-opendesk-module@0.3.0"
+    - "@nordeck/element-web-opendesk-module@0.4.0"
     - "@nordeck/element-web-widget-lifecycle-module@1.0.1"
+    - "@nordeck/element-web-widget-toggles-module@0.1.0"


### PR DESCRIPTION
@nordeck/element-web-opendesk-module@0.4.0:
- Remove widget toggles
- Breaking Change: The module does not support the widget toggles anymore. The widget toggles are an own module now. See https://www.npmjs.com/package/@nordeck/element-web-widget-toggles-module.

@nordeck/element-web-widget-toggles-module@0.1.0:
- Initial version

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md))