### PR TITLE
Update the issue triage labeller for the new triage project

### DIFF
--- a/.github/workflows/triage-labelled.yml
+++ b/.github/workflows/triage-labelled.yml
@@ -60,8 +60,8 @@ jobs:
             - uses: konradpabjan/move-labeled-or-milestoned-issue@190352295fe309fcb113b49193bc81d9aaa9cb01
               with:
                   action-token: "${{ secrets.ELEMENT_BOT_TOKEN }}"
-                  project-url: "https://github.com/element-hq/element-web/projects/27"
-                  column-name: "Need info"
+                  project-url: "https://github.com/element-hq/element-web/projects/120"
+                  column-name: "Needs info"
                   label-name: "X-Needs-Info"
 
     add_priority_design_issues_to_project:


### PR DESCRIPTION
It was failing because the old project has been deleted, so update it to the new one.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md)).
