### PR TITLE
Fix: 1:1 call - screen sharing no longer works after pressing the cancel button in Element-Desktop

### DIFF
--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -170,7 +170,12 @@ export default class ElectronPlatform extends VectorBasePlatform {
         window.electron.on("openDesktopCapturerSourcePicker", () => {
             const { finished } = Modal.createDialog(DesktopCapturerSourcePicker);
             finished.then(([source]) => {
-                if (!source) return;
+                if (!source) 
+                    source = {
+                    id: "",
+                    name: "",
+                    thumbnailURL: ""
+                };
                 this.ipc.call("callDisplayMediaCallback", source);
             });
         });

--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -170,13 +170,7 @@ export default class ElectronPlatform extends VectorBasePlatform {
         window.electron.on("openDesktopCapturerSourcePicker", () => {
             const { finished } = Modal.createDialog(DesktopCapturerSourcePicker);
             finished.then(([source]) => {
-                if (!source) 
-                    source = {
-                    id: "",
-                    name: "",
-                    thumbnailURL: ""
-                };
-                this.ipc.call("callDisplayMediaCallback", source);
+                this.ipc.call("callDisplayMediaCallback", source ?? { id: "", name: "", thumbnailURL: "" });
             });
         });
 

--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -170,6 +170,7 @@ export default class ElectronPlatform extends VectorBasePlatform {
         window.electron.on("openDesktopCapturerSourcePicker", () => {
             const { finished } = Modal.createDialog(DesktopCapturerSourcePicker);
             finished.then(([source]) => {
+                // getDisplayMedia promise does not return if no dummy is passed here as source
                 this.ipc.call("callDisplayMediaCallback", source ?? { id: "", name: "", thumbnailURL: "" });
             });
         });


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-desktop/issues/1367


Signed-off-by: Stephan Raab <info@gumara.de>

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md)).
