### PR TITLE
Enable the TAC in develop

### DIFF
--- a/element.io/develop/config.json
+++ b/element.io/develop/config.json
@@ -48,6 +48,7 @@
     },
     "privacy_policy_url": "https://element.io/cookie-policy",
     "features": {
+        "threadsActivityCentre": true,
         "feature_video_rooms": true,
         "feature_new_room_decoration_ui": true,
         "feature_element_call_video_rooms": true


### PR DESCRIPTION
While we work through fixing all the tests on https://github.com/matrix-org/matrix-react-sdk/pull/12439 enable the TAC on nightly so we can get wider testing.

Matching https://github.com/element-hq/element-desktop/pull/1635 for nightly

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md)).
