### PR TITLE
Roll out Rust crypto to 30% of existing users on `app.element.io`

### DIFF
--- a/element.io/app/config.json
+++ b/element.io/app/config.json
@@ -45,6 +45,6 @@
     "privacy_policy_url": "https://element.io/cookie-policy",
     "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx",
     "setting_defaults": {
-        "RustCrypto.staged_rollout_percent": 10
+        "RustCrypto.staged_rollout_percent": 30
     }
 }


### PR DESCRIPTION
We've not heard any concerns recently, and the [last blocker](https://github.com/element-hq/element-web/issues/27324) was released on 23 April. Let's migrate 30% of existing `app.element.io` users.

This change will be deployed manually once the PR is merged.

Part of https://github.com/element-hq/element-web/issues/27284.