### PR TITLE
Roll out Rust crypto to 60% of existing users on app.element.io

### DIFF
--- a/element.io/app/config.json
+++ b/element.io/app/config.json
@@ -45,6 +45,6 @@
     "privacy_policy_url": "https://element.io/cookie-policy",
     "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx",
     "setting_defaults": {
-        "RustCrypto.staged_rollout_percent": 30
+        "RustCrypto.staged_rollout_percent": 60
     }
 }


### PR DESCRIPTION
It's time to roll out rust crypto a bit further.

Followup to https://github.com/element-hq/element-web/pull/27416. Part of https://github.com/element-hq/element-web/issues/27490.

This change will be deployed manually once the PR is merged.