### PR TITLE
Fix CI docs generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
                   mdbook-version: "0.4.10"
 
             - name: Install mdbook extensions
-              run: cargo install mdbook-combiner mdbook-mermaid
+              run: cargo install mdbook-combiner@0.1.15 mdbook-mermaid
 
             - name: Prepare docs
               run: |


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md)).

Fix https://github.com/element-hq/element-web/actions/runs/9368190448/job/25789587578
Result with the fix https://github.com/element-hq/element-web/actions/runs/9402024104/job/25895123158?pr=27530

The [`0.1.16` of mdbook-combiner](https://github.com/jscarrott/mdbook-combiner/releases/tag/v0.1.16) is messing with the generated path of the `SUMMARY.MD`.
With the `0.1.15`, the path are correctly created in the generated `SUMMARY.MD` but the `0.1.16` seems to skip this step.
