### PR TITLE
Use stable endpoints for MSC3916

### DIFF
--- a/src/serviceworker/index.ts
+++ b/src/serviceworker/index.ts
@@ -20,7 +20,7 @@ import { buildAndEncodePickleKey } from "matrix-react-sdk/src/utils/tokens/pickl
 
 const serverSupportMap: {
     [serverUrl: string]: {
-        supportsMSC3916: boolean;
+        supportsAuthedMedia: boolean;
         cacheExpiryTimeMs: number;
     };
 } = {};
@@ -79,10 +79,8 @@ self.addEventListener("fetch", (event: FetchEvent) => {
                 await tryUpdateServerSupportMap(csApi, accessToken);
 
                 // If we have server support (and a means of authentication), rewrite the URL to use MSC3916 endpoints.
-                if (serverSupportMap[csApi].supportsMSC3916 && accessToken) {
-                    // Currently unstable only.
-                    // TODO: Support stable endpoints when available.
-                    url = url.replace(/\/media\/v3\/(.*)\//, "/client/unstable/org.matrix.msc3916/media/$1/");
+                if (serverSupportMap[csApi].supportsAuthedMedia && accessToken) {
+                    url = url.replace(/\/media\/v3\/(.*)\//, "/client/v1/media/$1/");
                 } // else by default we make no changes
             } catch (err) {
                 console.error("SW: Error in request rewrite.", err);
@@ -106,7 +104,7 @@ async function tryUpdateServerSupportMap(clientApiUrl: string, accessToken?: str
     const versions = await (await fetch(`${clientApiUrl}/_matrix/client/versions`, config)).json();
 
     serverSupportMap[clientApiUrl] = {
-        supportsMSC3916: Boolean(versions?.unstable_features?.["org.matrix.msc3916"]),
+        supportsAuthedMedia: Boolean(versions?.versions?.includes("v1.11")),
         cacheExpiryTimeMs: new Date().getTime() + 2 * 60 * 60 * 1000, // 2 hours from now
     };
 }


### PR DESCRIPTION
The MSC has completed FCP, so stable endpoints can be used.

Seeing as limited servers have shipped with the unstable endpoints, we're not generally concerned with backwards compatibility to `unstable` here - none of the freezing for the unauthenticated endpoints has happened yet.

For the "Matrix 1.11" bits, I am extremely confident that 1.11 will ship with MSC3916 - it's a release blocker. See https://github.com/matrix-org/matrix-spec/issues/1857 for release coordination.

**Requires https://github.com/matrix-org/matrix-react-sdk/pull/12602** (for tests)