### PR TITLE
Add SSO redirect option for login page

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -250,12 +250,14 @@ When Element is deployed alongside a homeserver with SSO-only login, some option
    user can be sent to in order to log them out of that system too, making logout symmetric between Element and the SSO system.
 2. `sso_redirect_options`: Options to define how to handle unauthenticated users. If the object contains `"immediate": true`, then
    all unauthenticated users will be automatically redirected to the SSO system to start their login. If instead you'd only like to
-   have users which land on the welcome page to be redirected, use `"on_welcome_page": true`. As an example:
+   have users which land on the welcome page to be redirected, use `"on_welcome_page": true`. Additionally, there is an option to
+   redirect anyone landing on the login page, by using `"on_login_page": true`. As an example:
     ```json
     {
         "sso_redirect_options": {
             "immediate": false,
-            "on_welcome_page": true
+            "on_welcome_page": true,
+            "on_login_page": true
         }
     }
     ```

--- a/src/vector/app.tsx
+++ b/src/vector/app.tsx
@@ -89,7 +89,12 @@ export async function loadApp(fragParams: {}, matrixChatRef: React.Ref<MatrixCha
     // XXX: This path matching is a bit brittle, but better to do it early instead of in the app code.
     const isWelcomeOrLanding =
         window.location.hash === "#/welcome" || window.location.hash === "#" || window.location.hash === "";
+    const isLoginPage = window.location.hash === "#/login";
+
     if (!autoRedirect && ssoRedirects.on_welcome_page && isWelcomeOrLanding) {
+        autoRedirect = true;
+    }
+    if (!autoRedirect && ssoRedirects.on_login_page && isLoginPage) {
         autoRedirect = true;
     }
     if (!hasPossibleToken && !isReturningFromSso && autoRedirect) {


### PR DESCRIPTION
This adds the option to redirect to SSO from the login page. This may help when SSO should be the only login option, while still allowing guests to view public rooms.

Coincides with the following change: https://github.com/matrix-org/matrix-react-sdk/pull/12622

Signed-off-by: Bart van der Braak <bartvdbraak@gmail.com>