### PR TITLE
remove Libera.Chat bridge from room_directory

### DIFF
--- a/element.io/app/config.json
+++ b/element.io/app/config.json
@@ -22,7 +22,7 @@
     "uisi_autorageshake_app": "element-auto-uisi",
     "show_labs_settings": false,
     "room_directory": {
-        "servers": ["matrix.org", "gitter.im", "libera.chat"]
+        "servers": ["matrix.org", "gitter.im"]
     },
     "enable_presence_by_hs_url": {
         "https://matrix.org": false,

--- a/element.io/develop/config.json
+++ b/element.io/develop/config.json
@@ -22,7 +22,7 @@
     "uisi_autorageshake_app": "element-auto-uisi",
     "show_labs_settings": true,
     "room_directory": {
-        "servers": ["matrix.org", "gitter.im", "libera.chat"]
+        "servers": ["matrix.org", "gitter.im"]
     },
     "enable_presence_by_hs_url": {
         "https://matrix.org": false,


### PR DESCRIPTION
As of 2023-08-05, the official Libera.Chat bridge was taken down.
