### PR TITLE
Add a Modernizr check for v mode regexes

### DIFF
--- a/src/vector/index.ts
+++ b/src/vector/index.ts
@@ -56,8 +56,8 @@ function checkBrowserFeatures(): boolean {
         return false;
     }
 
-    // Custom checks atop Modernizr because it doesn't have ES2018/ES2019 checks
-    // in it for some features we depend on.
+    // Custom checks atop Modernizr because it doesn't have checks in it for
+    // some features we depend on.
     // Modernizr requires rules to be lowercase with no punctuation.
     // ES2018: http://262.ecma-international.org/9.0/#sec-promise.prototype.finally
     window.Modernizr.addTest("promiseprototypefinally", () => typeof window.Promise?.prototype?.finally === "function");
@@ -70,6 +70,11 @@ function checkBrowserFeatures(): boolean {
     );
     // ES2019: http://262.ecma-international.org/10.0/#sec-object.fromentries
     window.Modernizr.addTest("objectfromentries", () => typeof window.Object?.fromEntries === "function");
+    // ES2024: https://tc39.es/ecma262/2024/#sec-get-regexp.prototype.unicodesets
+    window.Modernizr.addTest(
+        "regexpunicodesets",
+        () => window.RegExp?.prototype && "unicodeSets" in window.RegExp.prototype,
+    );
 
     const featureList = Object.keys(window.Modernizr) as Array<keyof ModernizrStatic>;
 


### PR DESCRIPTION
I plan to use [v mode regexes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets#browser_compatibility) to [test for emoji sequences](https://github.com/matrix-org/matrix-react-sdk/pull/12582), and @t3chguy has advised me that we need to ensure that the "incompatible browser" screen shows if they are not supported.