### PR TITLE
Docs: Align `widget_build_url_ignore_dm` with call behaviour switch between 1:1 and Widget

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -375,7 +375,7 @@ The VoIP and Jitsi options are:
     ```
     The `widget` is the `content` of a normal widget state event. The `layout` is the layout specifier for the widget being created,
     as defined by the `io.element.widgets.layout` state event. By default this applies to all rooms, but the behaviour can be skipped for
-    2-person rooms where 1:1 voip will be used by setting the option `widget_build_url_ignore_dm` to `true`.
+    2-person rooms, causing Element to fall back to 1:1 VoIP, by setting the option `widget_build_url_ignore_dm` to `true`.
 5. `audio_stream_url`: Optional URL to pass to Jitsi to enable live streaming. This option is considered experimental and may be removed
    at any time without notice.
 6. `element_call`: Optional configuration for native group calls using Element Call, with the following subkeys:

--- a/docs/config.md
+++ b/docs/config.md
@@ -374,8 +374,8 @@ The VoIP and Jitsi options are:
     }
     ```
     The `widget` is the `content` of a normal widget state event. The `layout` is the layout specifier for the widget being created,
-    as defined by the `io.element.widgets.layout` state event. By default this applies to all rooms, but the behaviour can be skipped for DMs
-    by setting the option `widget_build_url_ignore_dm` to `true`.
+    as defined by the `io.element.widgets.layout` state event. By default this applies to all rooms, but the behaviour can be skipped for
+    2-person rooms where 1:1 voip will be used by setting the option `widget_build_url_ignore_dm` to `true`.
 5. `audio_stream_url`: Optional URL to pass to Jitsi to enable live streaming. This option is considered experimental and may be removed
    at any time without notice.
 6. `element_call`: Optional configuration for native group calls using Element Call, with the following subkeys:


### PR DESCRIPTION
For https://github.com/matrix-org/matrix-react-sdk/pull/12760