### PR TITLE
Add debugging for service worker version check

### DIFF
--- a/src/serviceworker/index.ts
+++ b/src/serviceworker/index.ts
@@ -108,7 +108,9 @@ async function tryUpdateServerSupportMap(clientApiUrl: string, accessToken?: str
         supportsAuthedMedia: Boolean(versions?.versions?.includes("v1.11")),
         cacheExpiryTimeMs: new Date().getTime() + 2 * 60 * 60 * 1000, // 2 hours from now
     };
-    console.log(`[ServiceWorker] serverSupportMap update for '${clientApiUrl}': ${JSON.stringify(serverSupportMap[clientApiUrl])}`);
+    console.log(
+        `[ServiceWorker] serverSupportMap update for '${clientApiUrl}': ${JSON.stringify(serverSupportMap[clientApiUrl])}`,
+    );
 }
 
 // Ideally we'd use the `Client` interface for `client`, but since it's not available (see 'fetch' listener), we use

--- a/src/serviceworker/index.ts
+++ b/src/serviceworker/index.ts
@@ -102,11 +102,13 @@ async function tryUpdateServerSupportMap(clientApiUrl: string, accessToken?: str
 
     const config = fetchConfigForToken(accessToken);
     const versions = await (await fetch(`${clientApiUrl}/_matrix/client/versions`, config)).json();
+    console.log(`[ServiceWorker] /versions response for '${clientApiUrl}': ${JSON.stringify(versions)}`);
 
     serverSupportMap[clientApiUrl] = {
         supportsAuthedMedia: Boolean(versions?.versions?.includes("v1.11")),
         cacheExpiryTimeMs: new Date().getTime() + 2 * 60 * 60 * 1000, // 2 hours from now
     };
+    console.log(`[ServiceWorker] serverSupportMap update for '${clientApiUrl}': ${JSON.stringify(serverSupportMap[clientApiUrl])}`);
 }
 
 // Ideally we'd use the `Client` interface for `client`, but since it's not available (see 'fetch' listener), we use


### PR DESCRIPTION
Some users are reporting that the service worker isn't doing its job - the most probable reason appears to be a failed versions check, but it's unclear why that would fail. This adds some debugging to help figure out what might be going on.