### PR TITLE
Add a modernizr check for WebAssembly support

### DIFF
--- a/src/vector/index.ts
+++ b/src/vector/index.ts
@@ -79,6 +79,10 @@ function checkBrowserFeatures(): boolean {
     // and older Firefox has the former but not the latter, so we add our own.
     window.Modernizr.addTest("intlsegmenter", () => typeof window.Intl?.Segmenter === "function");
 
+    // Basic test for WebAssembly support. We could also try instantiating a simple module,
+    // although this would start to make (more) assumptions about how rust-crypto loads its wasm.
+    window.Modernizr.addTest("wasm", () => typeof WebAssembly === "object" && typeof WebAssembly.Module === "function");
+
     const featureList = Object.keys(window.Modernizr) as Array<keyof ModernizrStatic>;
 
     let featureComplete = true;
@@ -240,6 +244,10 @@ async function start(): Promise<void> {
 }
 
 start().catch((err) => {
+    // If we get here, things have gone terribly wrong and we cannot load the app javascript at all.
+    // Show a different, very simple iframed-static error page. Or actually, one of two different ones
+    // depending on whether the browser is supported (ie. we think we should be able to load but
+    // failed) or unsupported (where we tried anyway and, lo and behold, we failed).
     logger.error(err);
     // show the static error in an iframe to not lose any context / console data
     // with some basic styling to make the iframe full page


### PR DESCRIPTION
We don't work at all without this now and currently fail in terrible ways. This will cause us to display the 'unsupported browser' screen if we don't have wasm.

Also comment the three different types of error page.

Playwright test coming for this in react-sdk.

Fixes https://github.com/element-hq/element-web/issues/27735

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md)).
