### PR TITLE
Fix develop build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -714,8 +714,8 @@ module.exports = (env, argv) => {
                     sourcemaps: {
                         paths: "./webapp/bundles/**",
                     },
-                    errorHandler: (err, invokeErr, compilation) => {
-                        compilation.warnings.push("Sentry CLI Plugin: " + err.message);
+                    errorHandler: (err) => {
+                        console.warn("Sentry CLI Plugin: " + err.message);
                         console.log(`::warning title=Sentry error::${err.message}`);
                     },
                 }),


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md)).

Use `console.warn` instead of an undefined `compilation` object.

Fix develop build https://github.com/element-hq/element-web/actions/runs/10249545922/job/28353165571
According to https://www.npmjs.com/package/@sentry/webpack-plugin#errorhandler only the error object is a parameter of the callback
