### PR TITLE
Fix stale action not closing issues as expected

### DIFF
--- a/.github/workflows/triage-stale-flaky-tests.yml
+++ b/.github/workflows/triage-stale-flaky-tests.yml
@@ -6,6 +6,7 @@ jobs:
     close:
         runs-on: ubuntu-latest
         permissions:
+            actions: write
             issues: write
         steps:
             - uses: actions/stale@v9


### PR DESCRIPTION
Stale action uses [cache](https://github.com/actions/stale?tab=readme-ov-file#statefulness) to keep track of issues it has already processed. This cache is supposed to be deleted at the end of the run but it never happens due to a lack of permission. See https://github.com/element-hq/element-web/actions/runs/10588795861/job/29341882041#step:2:7046

The end result of this is that some issues are [just never considered for closing once they're in the cache](https://github.com/element-hq/element-web/actions/runs/10588795861/job/29341882041#step:2:80). 

Relevant:
https://github.com/actions/stale/issues/1131#issuecomment-1959835001