### PR TITLE
Stop adding Element-R issues to the Crypto team board

### DIFF
--- a/.github/workflows/triage-labelled.yml
+++ b/.github/workflows/triage-labelled.yml
@@ -175,26 +175,3 @@ jobs:
               with:
                   project-url: https://github.com/orgs/element-hq/projects/101
                   github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
-
-    element_r:
-        name: Add Element R issues to Crypto Team board
-        runs-on: ubuntu-latest
-        if: >
-            contains(github.event.issue.labels.*.name, 'A-Element-R')
-        steps:
-            - id: add_to_project
-              uses: actions/add-to-project@v1.0.2
-              with:
-                  project-url: ${{ env.PROJECT_URL }}
-                  github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
-
-            - id: set_fields
-              uses: titoportas/update-project-fields@421a54430b3cdc9eefd8f14f9ce0142ab7678751 # v0.1.0
-              with:
-                  project-url: ${{ env.PROJECT_URL }}
-                  github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
-                  item-id: ${{ steps.add_to_project.outputs.itemId }} # Use the item-id output of the previous step
-                  field-keys: Workstream,module
-                  field-values: Element-R,web
-        env:
-            PROJECT_URL: https://github.com/orgs/element-hq/projects/76


### PR DESCRIPTION
Now that Element-R is universal, issues affecting Element-R are just "issues". As such, it's no longer appropriate to add these to the Crypto team board.