### PR TITLE
Don't add `labs` label for `A-Message-Pinning`

### DIFF
--- a/.github/workflows/triage-labelled.yml
+++ b/.github/workflows/triage-labelled.yml
@@ -14,7 +14,6 @@ jobs:
         runs-on: ubuntu-latest
         if: >
             contains(github.event.issue.labels.*.name, 'A-Maths') ||
-            contains(github.event.issue.labels.*.name, 'A-Message-Pinning') ||
             contains(github.event.issue.labels.*.name, 'A-Location-Sharing') ||
             contains(github.event.issue.labels.*.name, 'Z-IA') ||
             contains(github.event.issue.labels.*.name, 'A-Jump-To-Date ') ||


### PR DESCRIPTION
Since message pinning is no longer in labs