### PR TITLE
Prefer native apps over PWA

### DIFF
--- a/res/manifest.json
+++ b/res/manifest.json
@@ -71,6 +71,7 @@
             "type": "image/png"
         }
     ],
+    "prefer_related_applications": true,
     "related_applications": [
         {
             "platform": "play",


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->
This PR enables the [native app install prompt](https://developer.chrome.com/blog/app-install-banners-native) for the PWA by setting the [`prefer_related_applications`](https://developer.mozilla.org/en-US/docs/Web/Manifest/prefer_related_applications) property to true in the manifest.  This property tells the browser to suggest the installation of the native app (if supported) listed in [`related_applications`](https://github.com/element-hq/element-web/blob/develop/res/manifest.json#L74), instead of the PWA.

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md)).
