### PR TITLE
Remove deprecated  `MatrixClient.keyBackupKeyFromPassword` call.

### DIFF
--- a/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
+++ b/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
@@ -404,13 +404,10 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
     };
 
     private restoreBackup = async (): Promise<void> => {
-        const keyCallback = (k: Uint8Array): void => {};
-
         const { finished } = Modal.createDialog(
             RestoreKeyBackupDialog,
             {
                 showSummary: false,
-                keyCallback,
             },
             undefined,
             /* priority = */ false,

--- a/src/components/views/dialogs/security/RestoreKeyBackupDialog.tsx
+++ b/src/components/views/dialogs/security/RestoreKeyBackupDialog.tsx
@@ -37,9 +37,6 @@ interface IProps {
     // if false, will close the dialog as soon as the restore completes successfully
     // default: true
     showSummary?: boolean;
-    // If specified, gather the key from the user but then call the function with the backup
-    // key rather than actually (necessarily) restoring the backup.
-    keyCallback?: (key: Uint8Array) => void;
     onFinished(done?: boolean): void;
 }
 
@@ -156,13 +153,6 @@ export default class RestoreKeyBackupDialog extends React.PureComponent<IProps, 
                 this.state.backupInfo,
                 { progressCallback: this.progressCallback },
             );
-            if (this.props.keyCallback) {
-                const key = await MatrixClientPeg.safeGet().keyBackupKeyFromPassword(
-                    this.state.passPhrase,
-                    this.state.backupInfo,
-                );
-                this.props.keyCallback(key);
-            }
 
             if (!this.props.showSummary) {
                 this.props.onFinished(true);
@@ -197,10 +187,6 @@ export default class RestoreKeyBackupDialog extends React.PureComponent<IProps, 
                 this.state.backupInfo,
                 { progressCallback: this.progressCallback },
             );
-            if (this.props.keyCallback) {
-                const key = decodeRecoveryKey(this.state.recoveryKey);
-                this.props.keyCallback(key);
-            }
             if (!this.props.showSummary) {
                 this.props.onFinished(true);
                 return;

--- a/test/unit-tests/components/views/dialogs/security/CreateSecretStorageDialog-test.tsx
+++ b/test/unit-tests/components/views/dialogs/security/CreateSecretStorageDialog-test.tsx
@@ -122,7 +122,6 @@ describe("CreateSecretStorageDialog", () => {
             expect(modalSpy).toHaveBeenCalledWith(
                 RestoreKeyBackupDialog,
                 {
-                    keyCallback: expect.any(Function),
                     showSummary: false,
                 },
                 undefined,
@@ -200,7 +199,6 @@ describe("CreateSecretStorageDialog", () => {
             expect(modalSpy).toHaveBeenCalledWith(
                 RestoreKeyBackupDialog,
                 {
-                    keyCallback: expect.any(Function),
                     showSummary: false,
                 },
                 undefined,


### PR DESCRIPTION


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)

Task https://github.com/element-hq/element-web/issues/26922

- The `keyBackupKeyFromPassword` call is bound to the `keyCallback` props which is not used in `CreateSecretStorageDialog`
- Remove code bound to `keyCallback` props