### PR TITLE
Replace `MatrixClient.isRoomEncrypted` by `MatrixClient.CryptoApi.isEncryptionEnabledInRoom` in `ContentMessages.ts`

### DIFF
--- a/src/ContentMessages.ts
+++ b/src/ContentMessages.ts
@@ -337,7 +337,7 @@ export async function uploadFile(
     const abortController = controller ?? new AbortController();
 
     // If the room is encrypted then encrypt the file before uploading it.
-    if (matrixClient.isRoomEncrypted(roomId)) {
+    if (await matrixClient.getCrypto()?.isEncryptionEnabledInRoom(roomId)) {
         // First read the file into memory.
         const data = await readFileAsArrayBuffer(file);
         if (abortController.signal.aborted) throw new UploadCanceledError();

--- a/test/test-utils/test-utils.ts
+++ b/test/test-utils/test-utils.ts
@@ -125,7 +125,7 @@ export function createTestClient(): MatrixClient {
             getUserVerificationStatus: jest.fn(),
             getDeviceVerificationStatus: jest.fn(),
             resetKeyBackup: jest.fn(),
-            isEncryptionEnabledInRoom: jest.fn(),
+            isEncryptionEnabledInRoom: jest.fn().mockResolvedValue(false),
             getVerificationRequestsToDeviceInProgress: jest.fn().mockReturnValue([]),
             setDeviceIsolationMode: jest.fn(),
             prepareToEncrypt: jest.fn(),
@@ -273,6 +273,7 @@ export function createTestClient(): MatrixClient {
         isFallbackICEServerAllowed: jest.fn().mockReturnValue(false),
         getAuthIssuer: jest.fn(),
         getOrCreateFilter: jest.fn(),
+        sendStickerMessage: jest.fn(),
     } as unknown as MatrixClient;
 
     client.reEmitter = new ReEmitter(client);


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)

Task https://github.com/element-hq/element-web/issues/26922
Replace `MatrixClient.isRoomEncrypted` by `MatrixClient.CryptoApi.isEncryptionEnabledInRoom` in `ContentMessages.ts`