### PR TITLE
Enable "should find unknown people"

### DIFF
--- a/playwright/e2e/spotlight/spotlight.spec.ts
+++ b/playwright/e2e/spotlight/spotlight.spec.ts
@@ -216,7 +216,7 @@ test.describe("Spotlight", () => {
      *
      * https://github.com/matrix-org/synapse/issues/16472
      */
-    test.skip("should find unknown people", async ({ page, app }) => {
+    test("should find unknown people", async ({ page, app }) => {
         const spotlight = await app.openSpotlight();
         await page.waitForTimeout(500); // wait for the dialog to settle
         await spotlight.filter(Filter.People);


### PR DESCRIPTION
Un-skips flake -> https://github.com/element-hq/element-web/issues/26138

I could not make it flake locally, even if I removed the added timeout.

Maybe we should re-enabled in case it was related to cypress or something that's been fixed in synapse?

We can leave the flake and synapse issue open till we have confirmed it's not flaking.