### PR TITLE
Remove `MatrixClient.getDehydratedDevice` call

### DIFF
--- a/src/stores/SetupEncryptionStore.ts
+++ b/src/stores/SetupEncryptionStore.ts
@@ -101,18 +101,14 @@ export class SetupEncryptionStore extends EventEmitter {
             this.keyInfo = keys[this.keyId];
         }
 
-        // do we have any other verified devices which are E2EE which we can verify against?
-        const dehydratedDevice = await cli.getDehydratedDevice();
         const ownUserId = cli.getUserId()!;
         const crypto = cli.getCrypto()!;
+        // do we have any other verified devices which are E2EE which we can verify against?
         const userDevices: Iterable<Device> =
             (await crypto.getUserDeviceInfo([ownUserId])).get(ownUserId)?.values() ?? [];
         this.hasDevicesToVerifyAgainst = await asyncSome(userDevices, async (device) => {
-            // Ignore dehydrated devices.  `dehydratedDevice` is set by the
-            // implementation of MSC2697, whereas MSC3814 proposes that devices
-            // should set a `dehydrated` flag in the device key.  We ignore
-            // both types of dehydrated devices.
-            if (dehydratedDevice && device.deviceId == dehydratedDevice?.device_id) return false;
+            // Ignore dehydrated devices. MSC3814 proposes that devices
+            // should set a `dehydrated` flag in the device key.
             if (device.dehydrated) return false;
 
             // ignore devices without an identity key

--- a/test/unit-tests/stores/SetupEncryptionStore-test.ts
+++ b/test/unit-tests/stores/SetupEncryptionStore-test.ts
@@ -10,7 +10,6 @@ import { mocked, Mocked } from "jest-mock";
 import { IBootstrapCrossSigningOpts } from "matrix-js-sdk/src/crypto";
 import { MatrixClient, Device } from "matrix-js-sdk/src/matrix";
 import { SecretStorageKeyDescriptionAesV1, ServerSideSecretStorage } from "matrix-js-sdk/src/secret-storage";
-import { IDehydratedDevice } from "matrix-js-sdk/src/crypto/dehydration";
 import { CryptoApi, DeviceVerificationStatus } from "matrix-js-sdk/src/crypto-api";
 
 import { SdkContextClass } from "../../../src/contexts/SDKContext";
@@ -95,28 +94,6 @@ describe("SetupEncryptionStore", () => {
             await emitPromise(setupEncryptionStore, "update");
 
             expect(setupEncryptionStore.hasDevicesToVerifyAgainst).toBe(true);
-        });
-
-        it("should ignore the MSC2697 dehydrated device", async () => {
-            mockSecretStorage.isStored.mockResolvedValue({ sskeyid: {} as SecretStorageKeyDescriptionAesV1 });
-
-            client.getDehydratedDevice.mockResolvedValue({ device_id: "dehydrated" } as IDehydratedDevice);
-
-            const fakeDevice = new Device({
-                deviceId: "dehydrated",
-                userId: "",
-                algorithms: [],
-                keys: new Map([["curve25519:dehydrated", "identityKey"]]),
-            });
-            mockCrypto.getUserDeviceInfo.mockResolvedValue(
-                new Map([[client.getSafeUserId(), new Map([[fakeDevice.deviceId, fakeDevice]])]]),
-            );
-
-            setupEncryptionStore.start();
-            await emitPromise(setupEncryptionStore, "update");
-
-            expect(setupEncryptionStore.hasDevicesToVerifyAgainst).toBe(false);
-            expect(mockCrypto.getDeviceVerificationStatus).not.toHaveBeenCalled();
         });
 
         it("should ignore the MSC3812 dehydrated device", async () => {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)

Task https://github.com/element-hq/element-web/issues/26922
`MatrixClient.getDehydratedDevice` is deprecated.
[`RustCrypto.getUserDeviceInfo`](https://github.com/matrix-org/matrix-js-sdk/blob/develop/src/rust-crypto/rust-crypto.ts#L483) can still return the dehydrated devices of MSC 2697 however it was an experimental feature behind a labs flag. We can ignore and don't worry about them.