### PR TITLE
Fix matrix-widget-api version in package.json

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8365,7 +8365,7 @@ matrix-events-sdk@0.0.1:
     jwt-decode "^4.0.0"
     loglevel "^1.7.1"
     matrix-events-sdk "0.0.1"
-    matrix-widget-api "^1.8.2"
+    matrix-widget-api "^1.10.0"
     oidc-client-ts "^3.0.1"
     p-retry "4"
     sdp-transform "^2.14.1"


### PR DESCRIPTION
matrix-js-sdk#develop now depends on matrix-widget-api^v1.10.0, so update the lockfile to match that. A yarn install would update the lockfile otherwise.

The correct version was reverted by element-hq/element-web#28430.

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
