### PR TITLE
Start sending stable `m.marked_unread` events

### DIFF
--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -151,10 +151,7 @@ export async function setMarkedUnreadState(room: Room, client: MatrixClient, unr
     const currentState = getMarkedUnreadState(room);
 
     if (Boolean(currentState) !== unread) {
-        // Assuming MSC2867 passes FCP with no changes, we should update to start writing
-        // the flag to the stable prefix (or both) and then ultimately use only the
-        // stable prefix.
-        await client.setRoomAccountData(room.roomId, MARKED_UNREAD_TYPE_UNSTABLE, { unread });
+        await client.setRoomAccountData(room.roomId, MARKED_UNREAD_TYPE_STABLE, { unread });
     }
 }
 

--- a/test/unit-tests/components/views/context_menus/RoomGeneralContextMenu-test.tsx
+++ b/test/unit-tests/components/views/context_menus/RoomGeneralContextMenu-test.tsx
@@ -150,7 +150,7 @@ describe("RoomGeneralContextMenu", () => {
 
         await sleep(0);
 
-        expect(mockClient.setRoomAccountData).toHaveBeenCalledWith(ROOM_ID, "com.famedly.marked_unread", {
+        expect(mockClient.setRoomAccountData).toHaveBeenCalledWith(ROOM_ID, "m.marked_unread", {
             unread: true,
         });
         expect(onFinished).toHaveBeenCalled();

--- a/test/unit-tests/stores/RoomViewStore-test.ts
+++ b/test/unit-tests/stores/RoomViewStore-test.ts
@@ -338,7 +338,7 @@ describe("RoomViewStore", function () {
         });
         dis.dispatch({ action: Action.ViewRoom, room_id: roomId });
         await untilDispatch(Action.ActiveRoomChanged, dis);
-        expect(mockClient.setRoomAccountData).toHaveBeenCalledWith(roomId, "com.famedly.marked_unread", {
+        expect(mockClient.setRoomAccountData).toHaveBeenCalledWith(roomId, "m.marked_unread", {
             unread: false,
         });
     });

--- a/test/unit-tests/stores/notifications/RoomNotificationState-test.ts
+++ b/test/unit-tests/stores/notifications/RoomNotificationState-test.ts
@@ -91,7 +91,7 @@ describe("RoomNotificationState", () => {
         const listener = jest.fn();
         roomNotifState.addListener(NotificationStateEvents.Update, listener);
         const accountDataEvent = {
-            getType: () => "com.famedly.marked_unread",
+            getType: () => "m.marked_unread",
             getContent: () => {
                 return { unread: true };
             },

--- a/test/unit-tests/utils/notifications-test.ts
+++ b/test/unit-tests/utils/notifications-test.ts
@@ -270,7 +270,7 @@ describe("notifications", () => {
         // set true, no existing event
         it("sets unread flag if event doesn't exist", async () => {
             await setMarkedUnreadState(room, client, true);
-            expect(client.setRoomAccountData).toHaveBeenCalledWith(ROOM_ID, "com.famedly.marked_unread", {
+            expect(client.setRoomAccountData).toHaveBeenCalledWith(ROOM_ID, "m.marked_unread", {
                 unread: true,
             });
         });
@@ -287,7 +287,7 @@ describe("notifications", () => {
                 .fn()
                 .mockReturnValue({ getContent: jest.fn().mockReturnValue({ unread: false }) });
             await setMarkedUnreadState(room, client, true);
-            expect(client.setRoomAccountData).toHaveBeenCalledWith(ROOM_ID, "com.famedly.marked_unread", {
+            expect(client.setRoomAccountData).toHaveBeenCalledWith(ROOM_ID, "m.marked_unread", {
                 unread: true,
             });
         });
@@ -316,7 +316,7 @@ describe("notifications", () => {
                 .fn()
                 .mockReturnValue({ getContent: jest.fn().mockReturnValue({ unread: true }) });
             await setMarkedUnreadState(room, client, false);
-            expect(client.setRoomAccountData).toHaveBeenCalledWith(ROOM_ID, "com.famedly.marked_unread", {
+            expect(client.setRoomAccountData).toHaveBeenCalledWith(ROOM_ID, "m.marked_unread", {
                 unread: false,
             });
         });


### PR DESCRIPTION
Both events are already being read in `getMarkedUnreadState` above. If the stable event exists, the unstable one is ignored entirely, so it should be sufficient to only write to the stable event going forward.