### PR TITLE
Enable element call by default on sample config

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -48,7 +48,7 @@
         "feature_element_call_video_rooms": true
     },
     "element_call": {
-        "url": "https://call.element.io",
+        "url": "https://call.element.io"
     },
     "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx"
 }

--- a/config.sample.json
+++ b/config.sample.json
@@ -42,10 +42,13 @@
     "jitsi": {
         "preferred_domain": "meet.element.io"
     },
+    "features": {
+        "feature_video_rooms": true,
+        "feature_group_calls": true,
+        "feature_element_call_video_rooms": true
+    },
     "element_call": {
         "url": "https://call.element.io",
-        "participant_limit": 8,
-        "brand": "Element Call"
     },
     "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx"
 }


### PR DESCRIPTION
Following the same logic from https://github.com/element-hq/element-web/pull/28314, this patch enables Element Call by default for other configs.

Downstream distributions that use the sample config should start using Element Call also!

Example: https://discourse.nixos.org/t/element-call-not-enabled-in-element-desktop/56077/3?u=yajo

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
