### PR TITLE
Temporarily add a default branch to handle unknown shield codes

### DIFF
--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -757,6 +757,9 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                 case EventShieldReason.MISMATCHED_SENDER_KEY:
                     shieldReasonMessage = _t("encryption|event_shield_reason_mismatched_sender_key");
                     break;
+
+                default:
+                    shieldReasonMessage = _t("error|unknown");
             }
 
             if (this.state.shieldColour === EventShieldColour.GREY) {


### PR DESCRIPTION
Temporary measure in order to get https://github.com/matrix-org/matrix-js-sdk/pull/4529 and https://github.com/element-hq/element-web/pull/28476 merged without upsetting the CI.

In short, 4529 adds new shield codes, and 28476 handles those shield codes.  If 4529 gets merged first, then TypeScript will complain in this repo because not all the shield codes are handled, and so `shieldReasonMessage` may be unset.  So the plan is to merge this PR first, so that it handles all unknown shield codes, then merge 4529, and then merge 28476 (after resolving the conflict that it will have with this PR, by replacing the changes that this PR makes).

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
