### PR TITLE
Fix format bar position

### DIFF
--- a/src/components/views/rooms/MessageComposerFormatBar.tsx
+++ b/src/components/views/rooms/MessageComposerFormatBar.tsx
@@ -33,6 +33,12 @@ interface IState {
 
 export default class MessageComposerFormatBar extends React.PureComponent<IProps, IState> {
     private readonly formatBarRef = createRef<HTMLDivElement>();
+    /**
+     * The height of the format bar in pixels.
+     * Height 32px + 2px border
+     * @private
+     */
+    private readonly BAR_HEIGHT = 34;
 
     public constructor(props: IProps) {
         super(props);
@@ -96,7 +102,7 @@ export default class MessageComposerFormatBar extends React.PureComponent<IProps
         this.setState({ visible: true });
         const parentRect = this.formatBarRef.current.parentElement.getBoundingClientRect();
         this.formatBarRef.current.style.left = `${selectionRect.left - parentRect.left}px`;
-        const halfBarHeight = this.formatBarRef.current.clientHeight / 2; // used to center the bar
+        const halfBarHeight = this.BAR_HEIGHT / 2; // used to center the bar
         const offset = halfBarHeight + 2; // makes sure the bar won't cover selected text
         const offsetLimit = halfBarHeight + offset;
         const position = Math.max(selectionRect.top - parentRect.top - offsetLimit, -offsetLimit);


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)

Closes https://github.com/element-hq/element-web/issues/28532
- When we want to display the format bar, the component doesn't have yet its height. Since the height is hardcoded in CSS, we can use also an hardcoded value for the computation.
- Added 1 px more than the initial computation which didn't include the border size, it allows the selection to not overflow over the formatting bar.
