### PR TITLE
Update new ShareDialog

### DIFF
--- a/res/css/views/dialogs/_ShareDialog.pcss
+++ b/res/css/views/dialogs/_ShareDialog.pcss
@@ -13,7 +13,7 @@ Please see LICENSE files in the repository root for full details.
 
 .mx_ShareDialog .mx_ShareDialog_content {
     margin: 10px 0;
-
+    text-align: center;
     .mx_CopyableText {
         width: unset; /* full width */
 
@@ -27,27 +27,51 @@ Please see LICENSE files in the repository root for full details.
     }
 }
 
-.mx_ShareDialog_split {
+.mx_ShareDialog_url {
+    text-align: center;
+    color: var(--cpd-color-text-secondary);
+    overflow-wrap: break-word;
+    max-width: 400px;
+}
+.mx_ShareDialog_checkbox {
+    display: inline-block;
+    margin: var(--cpd-space-4x) 0;
+}
+.mx_ShareDialog_button {
+    width: 100%;
+}
+
+.mx_ShareDialog_qrCode {
+    display: flex;
+    justify-content: center;
+}
+
+.mx_ShareDialog_qrCode img {
+    margin: 0 var(--cpd-space-8x);
+    image-rendering: pixelated;
+}
+
+.mx_LegacyShareDialog_split {
     display: flex;
     flex-wrap: wrap;
 }
 
-.mx_ShareDialog_qrcode_container {
+.mx_LegacyShareDialog_qrcode_container {
     float: left;
     height: 256px;
     width: 256px;
     margin-right: 64px;
 }
 
-.mx_ShareDialog_qrcode_container + .mx_ShareDialog_social_container {
+.mx_LegacyShareDialog_qrcode_container + .mx_LegacyShareDialog_social_container {
     width: 299px;
 }
 
-.mx_ShareDialog_social_container {
+.mx_LegacyShareDialog_social_container {
     display: inline-block;
 }
 
-.mx_ShareDialog_social_icon {
+.mx_LegacyShareDialog_social_icon {
     display: inline-grid;
     margin-right: 10px;
     margin-bottom: 10px;

--- a/src/components/views/rooms/RoomHeader/CallGuestLinkButton.tsx
+++ b/src/components/views/rooms/RoomHeader/CallGuestLinkButton.tsx
@@ -12,7 +12,7 @@ import { logger } from "matrix-js-sdk/src/logger";
 import { EventType, JoinRule, Room } from "matrix-js-sdk/src/matrix";
 
 import Modal from "../../../../Modal";
-import ShareDialog from "../../dialogs/ShareDialog";
+import { ShareDialog } from "../../dialogs/ShareDialog";
 import { _t } from "../../../../languageHandler";
 import SettingsStore from "../../../../settings/SettingsStore";
 import { calculateRoomVia } from "../../../../utils/permalinks/Permalinks";

--- a/test/unit-tests/components/views/dialogs/ShareDialog-test.tsx
+++ b/test/unit-tests/components/views/dialogs/ShareDialog-test.tsx
@@ -75,7 +75,7 @@ describe("ShareDialog", () => {
             return originalGetValue(feature);
         });
         const { container } = render(<ShareDialog target={room} onFinished={jest.fn()} />, getWrapper());
-        const qrCodesVisible = container.getElementsByClassName("mx_ShareDialog_qrcode_container").length > 0;
+        const qrCodesVisible = container.getElementsByClassName("mx_LegacyShareDialog_qrcode_container").length > 0;
         expect(qrCodesVisible).toBe(true);
     });
 
@@ -86,7 +86,7 @@ describe("ShareDialog", () => {
             return originalGetValue(feature);
         });
         const { container } = render(<ShareDialog target={room} onFinished={jest.fn()} />, getWrapper());
-        const qrCodesVisible = container.getElementsByClassName("mx_ShareDialog_social_container").length > 0;
+        const qrCodesVisible = container.getElementsByClassName("mx_LegacyShareDialog_social_container").length > 0;
         expect(qrCodesVisible).toBe(true);
     });
     it("renders custom title and subtitle", () => {


### PR DESCRIPTION
This still makes the old share dialog the default export but alsoe exposes the new dialog style.
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
