### PR TITLE
Fix MSC2530 caption not showing with bubbles mode

### DIFF
--- a/res/css/views/rooms/_EventBubbleTile.pcss
+++ b/res/css/views/rooms/_EventBubbleTile.pcss
@@ -48,6 +48,7 @@ Please see LICENSE files in the repository root for full details.
 
     .mx_EventTile_content {
         margin-right: 0;
+        height: max-content;
     }
 
     .mx_EventTile_avatar {
@@ -524,6 +525,10 @@ Please see LICENSE files in the repository root for full details.
 
     .mx_MTextBody {
         max-width: 100%;
+    }
+
+    .mx_EventTile_caption {
+        padding: 0.5em 0em 1.5em 0em;
     }
 
     .mx_LegacyCallEvent_wrapper,


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
