### PR TITLE
Fix jumpy timeline when the pinned message banner is displayed

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -2372,7 +2372,11 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         );
 
         const pinnedMessageBanner = (
-            <PinnedMessageBanner room={this.state.room} permalinkCreator={this.permalinkCreator} />
+            <PinnedMessageBanner
+                room={this.state.room}
+                permalinkCreator={this.permalinkCreator}
+                resizeNotifier={this.props.resizeNotifier}
+            />
         );
 
         let messageComposer;

--- a/test/unit-tests/components/views/rooms/PinnedMessageBanner-test.tsx
+++ b/test/unit-tests/components/views/rooms/PinnedMessageBanner-test.tsx
@@ -20,6 +20,7 @@ import RightPanelStore from "../../../../../src/stores/right-panel/RightPanelSto
 import { RightPanelPhases } from "../../../../../src/stores/right-panel/RightPanelStorePhases";
 import { UPDATE_EVENT } from "../../../../../src/stores/AsyncStore";
 import { Action } from "../../../../../src/dispatcher/actions";
+import ResizeNotifier from "../../../../../src/utils/ResizeNotifier.ts";
 
 describe("<PinnedMessageBanner />", () => {
     const userId = "@alice:server.org";
@@ -28,10 +29,12 @@ describe("<PinnedMessageBanner />", () => {
     let mockClient: MatrixClient;
     let room: Room;
     let permalinkCreator: RoomPermalinkCreator;
+    let resizeNotifier: ResizeNotifier;
     beforeEach(() => {
         mockClient = stubClient();
         room = new Room(roomId, mockClient, userId);
         permalinkCreator = new RoomPermalinkCreator(room);
+        resizeNotifier = new ResizeNotifier();
         jest.spyOn(dis, "dispatch").mockReturnValue(undefined);
     });
 
@@ -77,7 +80,7 @@ describe("<PinnedMessageBanner />", () => {
      */
     function renderBanner() {
         return render(
-            <PinnedMessageBanner permalinkCreator={permalinkCreator} room={room} />,
+            <PinnedMessageBanner permalinkCreator={permalinkCreator} room={room} resizeNotifier={resizeNotifier} />,
             withClientContextRenderOptions(mockClient),
         );
     }
@@ -145,7 +148,9 @@ describe("<PinnedMessageBanner />", () => {
             event3.getId()!,
         ]);
         jest.spyOn(pinnedEventHooks, "useSortedFetchedPinnedEvents").mockReturnValue([event1, event2, event3]);
-        rerender(<PinnedMessageBanner permalinkCreator={permalinkCreator} room={room} />);
+        rerender(
+            <PinnedMessageBanner permalinkCreator={permalinkCreator} room={room} resizeNotifier={resizeNotifier} />,
+        );
         await expect(screen.findByText("Third pinned message")).resolves.toBeVisible();
         expect(asFragment()).toMatchSnapshot();
     });
@@ -206,6 +211,42 @@ describe("<PinnedMessageBanner />", () => {
         expect(asFragment()).toMatchSnapshot();
     });
 
+    describe("Notify the timeline to resize", () => {
+        beforeEach(() => {
+            jest.spyOn(resizeNotifier, "notifyTimelineHeightChanged");
+            jest.spyOn(pinnedEventHooks, "usePinnedEvents").mockReturnValue([event1.getId()!, event2.getId()!]);
+            jest.spyOn(pinnedEventHooks, "useSortedFetchedPinnedEvents").mockReturnValue([event1, event2]);
+        });
+
+        it("should notify the timeline to resize when we display the banner", async () => {
+            renderBanner();
+            await expect(screen.findByText("Second pinned message")).resolves.toBeVisible();
+            // The banner is displayed, so we need to resize the timeline
+            expect(resizeNotifier.notifyTimelineHeightChanged).toHaveBeenCalledTimes(1);
+
+            await userEvent.click(screen.getByRole("button", { name: "View the pinned message in the timeline." }));
+            await expect(screen.findByText("First pinned message")).resolves.toBeVisible();
+            // The banner is already displayed, so we don't need to resize the timeline
+            expect(resizeNotifier.notifyTimelineHeightChanged).toHaveBeenCalledTimes(1);
+        });
+
+        it("should notify the timeline to resize when we hide the banner", async () => {
+            const { rerender } = renderBanner();
+            await expect(screen.findByText("Second pinned message")).resolves.toBeVisible();
+            // The banner is displayed, so we need to resize the timeline
+            expect(resizeNotifier.notifyTimelineHeightChanged).toHaveBeenCalledTimes(1);
+
+            // The banner has no event to display and is hidden
+            jest.spyOn(pinnedEventHooks, "usePinnedEvents").mockReturnValue([]);
+            jest.spyOn(pinnedEventHooks, "useSortedFetchedPinnedEvents").mockReturnValue([]);
+            rerender(
+                <PinnedMessageBanner permalinkCreator={permalinkCreator} room={room} resizeNotifier={resizeNotifier} />,
+            );
+            // The timeline should be resized
+            expect(resizeNotifier.notifyTimelineHeightChanged).toHaveBeenCalledTimes(2);
+        });
+    });
+
     describe("Right button", () => {
         beforeEach(() => {
             jest.spyOn(pinnedEventHooks, "usePinnedEvents").mockReturnValue([event1.getId()!, event2.getId()!]);
@@ -217,6 +258,8 @@ describe("<PinnedMessageBanner />", () => {
             jest.spyOn(RightPanelStore.instance, "isOpenForRoom").mockReturnValue(false);
 
             renderBanner();
+            await expect(screen.findByText("Second pinned message")).resolves.toBeVisible();
+
             expect(screen.getByRole("button", { name: "View all" })).toBeVisible();
         });
 
@@ -228,6 +271,8 @@ describe("<PinnedMessageBanner />", () => {
             });
 
             renderBanner();
+            await expect(screen.findByText("Second pinned message")).resolves.toBeVisible();
+
             expect(screen.getByRole("button", { name: "View all" })).toBeVisible();
         });
 
@@ -239,6 +284,8 @@ describe("<PinnedMessageBanner />", () => {
             });
 
             renderBanner();
+            await expect(screen.findByText("Second pinned message")).resolves.toBeVisible();
+
             expect(screen.getByRole("button", { name: "Close list" })).toBeVisible();
         });
 
@@ -263,6 +310,7 @@ describe("<PinnedMessageBanner />", () => {
             });
 
             renderBanner();
+            await expect(screen.findByText("Second pinned message")).resolves.toBeVisible();
             expect(screen.getByRole("button", { name: "Close list" })).toBeVisible();
 
             jest.spyOn(RightPanelStore.instance, "isOpenForRoom").mockReturnValue(false);


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)

Closes https://github.com/element-hq/element-web/issues/28390

We notify the timeline to resize when we display or hide the pinned message banner.
I also fixed multiple warnings of unhandled react state updates in the test.
