### PR TITLE
Fix multiple pinned messages flaky tests

### DIFF
--- a/playwright/e2e/pinned-messages/index.ts
+++ b/playwright/e2e/pinned-messages/index.ts
@@ -129,6 +129,7 @@ export class Helpers {
         const timelineMessage = this.page.locator(".mx_MTextBody", { hasText: message });
         await timelineMessage.click({ button: "right" });
         await this.page.getByRole("menuitem", { name: "Pin", exact: true }).click();
+        await this.assertMessageInBanner(message);
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)

Wait for the new pinned message to be displayed in the banner to pin the next one.
Currently, we send a state event with the new pinned message lists. Until we get updated with this new list from the sync, the current pinned message list  doesn't include the new pin message.
