### PR TITLE
Rename CreateCrossSigningDialog to InitialCryptoSetupDialog

### DIFF
--- a/src/components/structures/auth/E2eSetup.tsx
+++ b/src/components/structures/auth/E2eSetup.tsx
@@ -11,7 +11,7 @@ import { MatrixClient } from "matrix-js-sdk/src/matrix";
 
 import AuthPage from "../../views/auth/AuthPage";
 import CompleteSecurityBody from "../../views/auth/CompleteSecurityBody";
-import InitialCryptoSetup from "../../views/dialogs/security/InitialCryptoSetup";
+import InitialCryptoSetupDialog from "../../views/dialogs/security/InitialCryptoSetup";
 
 interface IProps {
     matrixClient: MatrixClient;
@@ -25,7 +25,7 @@ export default class E2eSetup extends React.Component<IProps> {
         return (
             <AuthPage>
                 <CompleteSecurityBody>
-                    <InitialCryptoSetup
+                    <InitialCryptoSetupDialog
                         matrixClient={this.props.matrixClient}
                         onFinished={this.props.onFinished}
                         accountPassword={this.props.accountPassword}

--- a/src/components/structures/auth/E2eSetup.tsx
+++ b/src/components/structures/auth/E2eSetup.tsx
@@ -11,7 +11,7 @@ import { MatrixClient } from "matrix-js-sdk/src/matrix";
 
 import AuthPage from "../../views/auth/AuthPage";
 import CompleteSecurityBody from "../../views/auth/CompleteSecurityBody";
-import CreateCrossSigningDialog from "../../views/dialogs/security/CreateCrossSigningDialog";
+import InitialCryptoSetup from "../../views/dialogs/security/InitialCryptoSetup";
 
 interface IProps {
     matrixClient: MatrixClient;
@@ -25,7 +25,7 @@ export default class E2eSetup extends React.Component<IProps> {
         return (
             <AuthPage>
                 <CompleteSecurityBody>
-                    <CreateCrossSigningDialog
+                    <InitialCryptoSetup
                         matrixClient={this.props.matrixClient}
                         onFinished={this.props.onFinished}
                         accountPassword={this.props.accountPassword}

--- a/src/components/structures/auth/E2eSetup.tsx
+++ b/src/components/structures/auth/E2eSetup.tsx
@@ -11,7 +11,7 @@ import { MatrixClient } from "matrix-js-sdk/src/matrix";
 
 import AuthPage from "../../views/auth/AuthPage";
 import CompleteSecurityBody from "../../views/auth/CompleteSecurityBody";
-import InitialCryptoSetupDialog from "../../views/dialogs/security/InitialCryptoSetup";
+import InitialCryptoSetupDialog from "../../views/dialogs/security/InitialCryptoSetupDialog";
 
 interface IProps {
     matrixClient: MatrixClient;

--- a/src/components/structures/auth/E2eSetup.tsx
+++ b/src/components/structures/auth/E2eSetup.tsx
@@ -11,7 +11,7 @@ import { MatrixClient } from "matrix-js-sdk/src/matrix";
 
 import AuthPage from "../../views/auth/AuthPage";
 import CompleteSecurityBody from "../../views/auth/CompleteSecurityBody";
-import InitialCryptoSetupDialog from "../../views/dialogs/security/InitialCryptoSetupDialog";
+import { InitialCryptoSetupDialog } from "../../views/dialogs/security/InitialCryptoSetupDialog";
 
 interface IProps {
     matrixClient: MatrixClient;

--- a/src/components/views/dialogs/security/InitialCryptoSetupDialog.tsx
+++ b/src/components/views/dialogs/security/InitialCryptoSetupDialog.tsx
@@ -29,7 +29,7 @@ interface Props {
  * up message key backup. In most cases, only a spinner is shown, but for more
  * complex auth like SSO, the user may need to complete some steps to proceed.
  */
-const InitialCryptoSetup: React.FC<Props> = ({ matrixClient, accountPassword, tokenLogin, onFinished }) => {
+const InitialCryptoSetupDialog: React.FC<Props> = ({ matrixClient, accountPassword, tokenLogin, onFinished }) => {
     const [error, setError] = useState(false);
 
     const doSetup = useCallback(async () => {
@@ -102,4 +102,4 @@ const InitialCryptoSetup: React.FC<Props> = ({ matrixClient, accountPassword, to
     );
 };
 
-export default InitialCryptoSetup;
+export default InitialCryptoSetupDialog;

--- a/src/components/views/dialogs/security/InitialCryptoSetupDialog.tsx
+++ b/src/components/views/dialogs/security/InitialCryptoSetupDialog.tsx
@@ -25,8 +25,8 @@ interface Props {
 }
 
 /*
- * Walks the user through the process of creating a cross-signing keys and setting
- * up message key backup. In most cases, only a spinner is shown, but for more
+ * Walks the user through the process of creating a cross-signing keys.
+ * In most cases, only a spinner is shown, but for more
  * complex auth like SSO, the user may need to complete some steps to proceed.
  */
 const InitialCryptoSetupDialog: React.FC<Props> = ({ matrixClient, accountPassword, tokenLogin, onFinished }) => {

--- a/src/components/views/dialogs/security/InitialCryptoSetupDialog.tsx
+++ b/src/components/views/dialogs/security/InitialCryptoSetupDialog.tsx
@@ -41,11 +41,6 @@ const InitialCryptoSetupDialog: React.FC<Props> = ({ matrixClient, accountPasswo
         try {
             await createCrossSigning(matrixClient, tokenLogin, accountPassword);
 
-            const backupInfo = await matrixClient.getKeyBackupVersion();
-            if (backupInfo === null) {
-                await cryptoApi.resetKeyBackup();
-            }
-
             onFinished(true);
         } catch (e) {
             if (tokenLogin) {

--- a/src/components/views/dialogs/security/InitialCryptoSetupDialog.tsx
+++ b/src/components/views/dialogs/security/InitialCryptoSetupDialog.tsx
@@ -29,7 +29,12 @@ interface Props {
  * In most cases, only a spinner is shown, but for more
  * complex auth like SSO, the user may need to complete some steps to proceed.
  */
-const InitialCryptoSetupDialog: React.FC<Props> = ({ matrixClient, accountPassword, tokenLogin, onFinished }) => {
+export const InitialCryptoSetupDialog: React.FC<Props> = ({
+    matrixClient,
+    accountPassword,
+    tokenLogin,
+    onFinished,
+}) => {
     const [error, setError] = useState(false);
 
     const doSetup = useCallback(async () => {
@@ -96,5 +101,3 @@ const InitialCryptoSetupDialog: React.FC<Props> = ({ matrixClient, accountPasswo
         </BaseDialog>
     );
 };
-
-export default InitialCryptoSetupDialog;

--- a/test/components/views/dialogs/security/InitialCryptoSetupDialog-test.tsx
+++ b/test/components/views/dialogs/security/InitialCryptoSetupDialog-test.tsx
@@ -12,7 +12,7 @@ import { mocked } from "jest-mock";
 import { MatrixClient } from "matrix-js-sdk/src/matrix";
 
 import { createCrossSigning } from "../../../../../src/CreateCrossSigning";
-import InitialCryptoSetupDialog from "../../../../../src/components/views/dialogs/security/InitialCryptoSetupDialog";
+import { InitialCryptoSetupDialog } from "../../../../../src/components/views/dialogs/security/InitialCryptoSetupDialog";
 import { createTestClient } from "../../../../test-utils";
 
 jest.mock("../../../../../src/CreateCrossSigning", () => ({

--- a/test/components/views/dialogs/security/InitialCryptoSetupDialog-test.tsx
+++ b/test/components/views/dialogs/security/InitialCryptoSetupDialog-test.tsx
@@ -12,14 +12,14 @@ import { mocked } from "jest-mock";
 import { MatrixClient } from "matrix-js-sdk/src/matrix";
 
 import { createCrossSigning } from "../../../../../src/CreateCrossSigning";
-import CreateCrossSigningDialog from "../../../../../src/components/views/dialogs/security/CreateCrossSigningDialog";
+import InitialCryptoSetupDialog from "../../../../../src/components/views/dialogs/security/InitialCryptoSetupDialog";
 import { createTestClient } from "../../../../test-utils";
 
 jest.mock("../../../../../src/CreateCrossSigning", () => ({
     createCrossSigning: jest.fn(),
 }));
 
-describe("CreateCrossSigningDialog", () => {
+describe("InitialCryptoSetupDialog", () => {
     let client: MatrixClient;
     let createCrossSigningResolve: () => void;
     let createCrossSigningReject: (e: Error) => void;
@@ -43,7 +43,7 @@ describe("CreateCrossSigningDialog", () => {
         const onFinished = jest.fn();
 
         render(
-            <CreateCrossSigningDialog
+            <InitialCryptoSetupDialog
                 matrixClient={client}
                 accountPassword="hunter2"
                 tokenLogin={false}
@@ -61,7 +61,7 @@ describe("CreateCrossSigningDialog", () => {
 
     it("should display an error if createCrossSigning fails", async () => {
         render(
-            <CreateCrossSigningDialog
+            <InitialCryptoSetupDialog
                 matrixClient={client}
                 accountPassword="hunter2"
                 tokenLogin={false}
@@ -78,7 +78,7 @@ describe("CreateCrossSigningDialog", () => {
         const onFinished = jest.fn();
 
         render(
-            <CreateCrossSigningDialog
+            <InitialCryptoSetupDialog
                 matrixClient={client}
                 accountPassword="hunter2"
                 tokenLogin={true}
@@ -95,7 +95,7 @@ describe("CreateCrossSigningDialog", () => {
         const onFinished = jest.fn();
 
         render(
-            <CreateCrossSigningDialog
+            <InitialCryptoSetupDialog
                 matrixClient={client}
                 accountPassword="hunter2"
                 tokenLogin={false}
@@ -113,7 +113,7 @@ describe("CreateCrossSigningDialog", () => {
 
     it("should retry when the retry button is clicked", async () => {
         render(
-            <CreateCrossSigningDialog
+            <InitialCryptoSetupDialog
                 matrixClient={client}
                 accountPassword="hunter2"
                 tokenLogin={false}


### PR DESCRIPTION
This is split out of https://github.com/element-hq/element-web/pull/28267 because I'm also going to have to start chopping stuff around to make it work with React 18 strict mode, so otherwise that PR will get huge.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
