### PR TITLE
Add delay in test to allow Alice to fetch Bob's device keys

### DIFF
--- a/playwright/e2e/crypto/user-verification.spec.ts
+++ b/playwright/e2e/crypto/user-verification.spec.ts
@@ -155,7 +155,7 @@ async function createDMRoom(client: Client, userId: string): Promise<string> {
     });
 }
 
-/** 
+/**
  * Wait until we get the other user's device keys.
  * In newer rust-crypto versions, the verification request will be ignored if we
  * don't have the sender's device keys.

--- a/playwright/e2e/crypto/user-verification.spec.ts
+++ b/playwright/e2e/crypto/user-verification.spec.ts
@@ -155,8 +155,8 @@ async function createDMRoom(client: Client, userId: string): Promise<string> {
     });
 }
 
-/** Wait until we get the other user's device keys.
- *
+/** 
+ * Wait until we get the other user's device keys.
  * In newer rust-crypto versions, the verification request will be ignored if we
  * don't have the sender's device keys.
  */

--- a/playwright/e2e/crypto/user-verification.spec.ts
+++ b/playwright/e2e/crypto/user-verification.spec.ts
@@ -48,6 +48,10 @@ test.describe("User verification", () => {
                     });
                 }
 
+                // Wait a bit so that Alice can retrieve our device keys.
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 500);
+                });
                 return client.getCrypto().requestVerificationDM(aliceCredentials.userId, dmRoomId);
             },
             { dmRoomId, aliceCredentials },
@@ -97,6 +101,10 @@ test.describe("User verification", () => {
                     });
                 }
 
+                // Wait a bit so that Alice can retrieve our device keys.
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 500);
+                });
                 return client.getCrypto().requestVerificationDM(aliceCredentials.userId, dmRoomId);
             },
             { dmRoomId, aliceCredentials },


### PR DESCRIPTION
The latest Rust crypto crate (used by rust-sdk-crypto-wasm 11.0) requires the device keys of the device requesting verification before it accepts an incoming verification, and will drop the verification request if it doesn't have it.  This causes CI failures because the CI requests the verification too quickly, before the test user has a chance to get the bot's device keys.

Fixes a CI failure for https://github.com/matrix-org/matrix-js-sdk/pull/4566 (https://github.com/matrix-org/matrix-js-sdk/actions/runs/12158968697/job/33908198078)

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
