### PR TITLE
Fix Read Receipt Test

### DIFF
--- a/test/unit-tests/components/views/rooms/ReadReceiptGroup-test.tsx
+++ b/test/unit-tests/components/views/rooms/ReadReceiptGroup-test.tsx
@@ -10,6 +10,7 @@ import React, { ComponentProps } from "react";
 import { render, screen, waitFor } from "jest-matrix-react";
 import { RoomMember } from "matrix-js-sdk/src/matrix";
 import userEvent from "@testing-library/user-event";
+import { mocked } from "jest-mock";
 
 import {
     determineAvatarPosition,
@@ -20,6 +21,9 @@ import * as languageHandler from "../../../../../src/languageHandler";
 import { stubClient } from "../../../../test-utils";
 import dispatcher from "../../../../../src/dispatcher/dispatcher";
 import { Action } from "../../../../../src/dispatcher/actions";
+import { formatDate } from "../../../../../src/DateUtils";
+
+jest.mock("../../../../../src/DateUtils");
 
 describe("ReadReceiptGroup", () => {
     describe("TooltipText", () => {
@@ -86,6 +90,10 @@ describe("ReadReceiptGroup", () => {
 
     describe("<ReadReceiptPerson />", () => {
         stubClient();
+
+        // We pick a fixed time but this can still vary depending on the locale
+        // the tests are run in. We are not testing date formatting here, so stub it out.
+        mocked(formatDate).mockReturnValue("==MOCK FORMATTED DATE==");
 
         const ROOM_ID = "roomId";
         const USER_ID = "@alice:example.org";

--- a/test/unit-tests/components/views/rooms/__snapshots__/ReadReceiptGroup-test.tsx.snap
+++ b/test/unit-tests/components/views/rooms/__snapshots__/ReadReceiptGroup-test.tsx.snap
@@ -84,7 +84,7 @@ exports[`ReadReceiptGroup <ReadReceiptPerson /> should render 1`] = `
         <p
           class="mx_ReadReceiptGroup_secondary"
         >
-          Wed, May 15, 00:00
+          ==MOCK FORMATTED DATE==
         </p>
       </div>
     </div>

--- a/test/unit-tests/components/views/rooms/__snapshots__/ReadReceiptGroup-test.tsx.snap
+++ b/test/unit-tests/components/views/rooms/__snapshots__/ReadReceiptGroup-test.tsx.snap
@@ -84,7 +84,7 @@ exports[`ReadReceiptGroup <ReadReceiptPerson /> should render 1`] = `
         <p
           class="mx_ReadReceiptGroup_secondary"
         >
-          Wed, 15 May, 0:00
+          Wed, May 15, 00:00
         </p>
       </div>
     </div>


### PR DESCRIPTION
The date formatting appears to have changed and somehow got through the merge tests on the dependency bump.

As per comment, mock it out.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
