### PR TITLE
fix: padding when not active for SearchBox

### DIFF
--- a/res/css/structures/_SearchBox.pcss
+++ b/res/css/structures/_SearchBox.pcss
@@ -9,8 +9,11 @@ Please see LICENSE files in the repository root for full details.
 .mx_SearchBox {
     flex: 1 1 0;
     min-width: 0;
-    padding-top: 10px;
-    padding-bottom: 10px;
+
+    .mx_textinput_search {
+      padding-top: 10px;
+      padding-bottom: 10px;
+    }
 
     &.mx_SearchBox_blurred:not(:hover) {
         background-color: transparent;

--- a/res/css/structures/_SearchBox.pcss
+++ b/res/css/structures/_SearchBox.pcss
@@ -9,6 +9,8 @@ Please see LICENSE files in the repository root for full details.
 .mx_SearchBox {
     flex: 1 1 0;
     min-width: 0;
+    padding-top: 10px;
+    padding-bottom: 10px;
 
     &.mx_SearchBox_blurred:not(:hover) {
         background-color: transparent;


### PR DESCRIPTION
When the searchbox is not active, there are some missing margins

![image](https://github.com/user-attachments/assets/3fcc1898-1248-4de7-9fb7-99cd0d2bb104)

When it becomes active, the X widget resizes it correctly

![image](https://github.com/user-attachments/assets/f2de0c2a-306a-49de-a043-9d1d7209ff37)

This small padding makes it correctly sized when not active

![image](https://github.com/user-attachments/assets/6fc5755a-bce3-42f6-92bb-9b3d0540f52b)
