### PR TITLE
[feature] add nextcloud picker button in chat box

### DIFF
--- a/res/css/views/rooms/_MessageComposer.pcss
+++ b/res/css/views/rooms/_MessageComposer.pcss
@@ -277,6 +277,19 @@ Please see LICENSE files in the repository root for full details.
     mask-size: 24px;
 }
 
+.mx_MessageComposer_nextcloudPickerButtonIcon {
+    color: var(--cpd-color-icon-tertiary);
+    padding: 0;
+
+    &:hover {
+        color: var(--cpd-color-icon-primary);
+    }
+
+    &::before, &::after {
+        display: none;
+    }
+}
+
 .mx_MessageComposer_sendMessage {
     cursor: pointer;
     position: relative;

--- a/src/components/views/rooms/MessageComposerButtons.tsx
+++ b/src/components/views/rooms/MessageComposerButtons.tsx
@@ -8,7 +8,8 @@ Please see LICENSE files in the repository root for full details.
 
 import classNames from "classnames";
 import { IEventRelation, Room, MatrixClient, THREAD_RELATION_TYPE, M_POLL_START } from "matrix-js-sdk/src/matrix";
-import React, { createContext, ReactElement, ReactNode, useContext, useRef } from "react";
+import React, {createContext, ReactElement, ReactNode, useContext, useRef, useState, useEffect} from "react";
+import ReactDOM from 'react-dom';
 
 import { _t } from "../../../languageHandler";
 import { CollapsibleButton } from "./CollapsibleButton";
@@ -76,6 +77,7 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
         ];
         moreButtons = [
             uploadButton(), // props passed via UploadButtonContext
+            nextcloudPickerButton(),
             showStickersButton(props),
             voiceRecordingButton(props, narrow),
             props.showPollsButton ? pollButton(room, props.relation) : null,
@@ -93,6 +95,7 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
                 emojiButton(props)
             ),
             uploadButton(), // props passed via UploadButtonContext
+            nextcloudPickerButton(),
         ];
         moreButtons = [
             showStickersButton(props),
@@ -136,6 +139,129 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
         </UploadButtonContextProvider>
     );
 };
+
+const NextcloudPickerButton: React.FC = () => {
+    const [isOverlayVisible, setOverlayVisible] = useState(false);
+    const [isIframeLoaded, setIframeLoaded] = useState(false);
+    const overflowMenuCloser = useContext(OverflowMenuContext);
+
+    const handleButtonOnClick = (event: React.MouseEvent<HTMLInputElement>): void => {
+        overflowMenuCloser?.();
+        setOverlayVisible(true);
+        setIframeLoaded(false);
+    };
+
+    const closeOverlay = () => {
+        setOverlayVisible(false);
+    };
+
+    const handleIframeLoad = () => {
+        setIframeLoaded(true);
+    };
+
+    const frameUrl = () => {
+        return window.location.origin + '/index.php/apps/picker/single-link?option=Clipboard';
+    };
+
+    useEffect(() => {
+        // @ts-ignore
+        window.closePickerIframe = () => {
+            setTimeout(() => {
+                setOverlayVisible(false);
+            }, 500);
+        };
+
+        return () => {
+            // @ts-ignore
+            delete window.closePickerIframe;
+        };
+    }, []);
+
+    return (
+        <>
+            <CollapsibleButton
+                key="nextcloud_picker_button"
+                className="mx_MessageComposer_button"
+                iconClassName="mx_MessageComposer_nextcloudPickerButtonIcon"
+                onClick={handleButtonOnClick}
+                title={_t("Nextcloud Picker")}
+            >
+                <svg width="26" height="26" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M 2.4 1.2 A 2.4 2.4 0 0 0 0 3.6 L 0 20.4 A 2.4 2.4 0 0 0 2.4 22.8 L 21.6 22.8 A 2.4 2.4 0 0 0 24 20.4 L 24 7.2 A 2.4 2.4 0 0 0 21.6 4.8 L 13.692012 4.8 L 10.8 1.9079883 A 2.4 2.4 0 0 0 9.1079883 1.2 L 2.4 1.2 z M 12.015293 9.1495898 C 14.128085 9.1487404 15.902746 10.587886 16.45834 12.528223 C 16.941727 11.501136 17.973094 10.772227 19.176035 10.772227 A 3.0319929 3.0319929 0 0 1 22.194434 13.790625 A 3.0311433 3.0311433 0 0 1 19.176035 16.809023 C 17.973944 16.809023 16.942602 16.080963 16.459219 15.053027 C 15.902774 16.993365 14.128085 18.43166 12.015293 18.43166 C 9.8914562 18.43166 8.1066027 16.97725 7.5620508 15.019922 C 7.0863114 16.066548 6.0396784 16.809023 4.8231445 16.809023 A 3.0319929 3.0319929 0 0 1 1.8055664 13.790625 A 3.0319929 3.0319929 0 0 1 4.8231445 10.772227 C 6.0396784 10.772227 7.0871316 11.51388 7.5628711 12.560508 C 8.107423 10.604028 9.8914562 9.1495898 12.015293 9.1495898 z M 12.015293 10.920879 C 10.420718 10.920879 9.1464258 12.195199 9.1464258 13.790625 A 2.856139 2.856139 0 0 0 12.015293 16.660371 C 13.610721 16.660371 14.885039 15.38605 14.885039 13.790625 C 14.885039 12.195199 13.610721 10.920879 12.015293 10.920879 z M 4.8231445 12.543516 L 4.8231445 12.544336 C 4.1239774 12.544336 3.5768555 13.091459 3.5768555 13.790625 A 1.2335258 1.2335258 0 0 0 4.8231445 15.037734 C 5.5223118 15.036884 6.069375 14.489792 6.069375 13.790625 C 6.069375 13.091459 5.5214622 12.543516 4.8231445 12.543516 z M 19.176035 12.543516 L 19.176035 12.544336 C 18.476868 12.544336 17.929746 13.091459 17.929746 13.790625 A 1.2335258 1.2335258 0 0 0 19.176035 15.037734 C 19.875202 15.037734 20.423145 14.489792 20.423145 13.790625 C 20.423145 13.091459 19.875202 12.543516 19.176035 12.543516 z" fill="currentColor" />
+                </svg>
+            </CollapsibleButton>
+
+            {isOverlayVisible && ReactDOM.createPortal(
+                <div
+                    id="nextcloudPickerContainer"
+                    style={{
+                        position: 'fixed',
+                        top: 0,
+                        left: 0,
+                        width: '100vw',
+                        height: '100vh',
+                        backgroundColor: 'rgba(0, 0, 0, 0.7)',
+                        zIndex: 999999,
+                    }}
+                    onClick={closeOverlay}
+                >
+                    {!isIframeLoaded && (
+                        <div
+                            style={{
+                                position: 'absolute',
+                                top: '50%',
+                                left: '50%',
+                                transform: 'translate(-50%, -50%)',
+                                color: '#fff',
+                                fontSize: '20px',
+                            }}
+                        >
+                            {_t("Loading...")}
+                        </div>
+                    )}
+                    <iframe
+                        id="nextcloudPickerFrame"
+                        src={frameUrl()}
+                        style={{
+                            height: '700px',
+                            width: '800px',
+                            maxHeight: '80vh',
+                            maxWidth: '100%',
+                            border: 'none',
+                            borderRadius: '15px',
+                            position: 'fixed',
+                            top: '50%',
+                            left: '50%',
+                            transform: 'translate(-50%, -50%)',
+                            zIndex: 999999999,
+                            display: isIframeLoaded ? 'block' : 'none',
+                        }}
+                        onLoad={handleIframeLoad}
+                        onClick={(e) => e.stopPropagation()}
+                    />
+                </div>,
+                document.body
+            )}
+        </>
+    );
+};
+
+function nextcloudPickerButton(): ReactElement | null {
+    const isPickerEnabled = (() => {
+        if (window.parent && typeof window.parent._oc_appswebroots !== "undefined" && window.parent._oc_appswebroots) {
+            // @ts-ignore
+            const appsWebRoots = window.parent._oc_appswebroots;
+            return Object.values(appsWebRoots).includes("/apps/picker");
+        }
+        return false;
+    })();
+
+    if (!isPickerEnabled) {
+        return null;
+    }
+
+    return (<NextcloudPickerButton/>)
+}
 
 function emojiButton(props: IProps): ReactElement {
     return (


### PR DESCRIPTION
## Checklist

This PR adds a new button to the chatbox for Nextcloud Picker integration. 
- [] The button is conditionally displayed if the user is on Nextcloud and the Picker plugin is enabled.
- [] Includes corresponding styles for the button in `_MessageComposer.pcss`.
