### PR TITLE
Docker: remove redundant dos2unix calls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,12 @@ ARG USE_CUSTOM_SDKS=false
 ARG JS_SDK_REPO="https://github.com/matrix-org/matrix-js-sdk.git"
 ARG JS_SDK_BRANCH="master"
 
-RUN apt-get update && apt-get install -y git dos2unix
-
 WORKDIR /src
 
 COPY . /src
-RUN dos2unix /src/scripts/docker-link-repos.sh && bash /src/scripts/docker-link-repos.sh
+RUN /src/scripts/docker-link-repos.sh
 RUN yarn --network-timeout=200000 install
-
-RUN dos2unix /src/scripts/docker-package.sh /src/scripts/get-version-from-git.sh /src/scripts/normalize-version.sh && bash /src/scripts/docker-package.sh
+RUN /src/scripts/docker-package.sh
 
 # Copy the config now so that we don't create another layer in the app image
 RUN cp /src/config.sample.json /src/webapp/config.json


### PR DESCRIPTION
I'm assuming these were here because, at some point, someone checked in some files with CRLF line endings. However, that has been fixed, installing dos2unix slows down the build, and just don't do that, m'kay?