### PR TITLE
Docker: allow configuration of HTTP listen port via env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,12 @@ FROM nginx:alpine-slim
 
 COPY --from=builder /src/webapp /app
 
-# Override default nginx config
-COPY /nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
+# Override default nginx config. Templates in `/etc/nginx/templates` are passed
+# through `envsubst` by the nginx docker image entry point.
+COPY /docker/nginx-templates/* /etc/nginx/templates/
 
 RUN rm -rf /usr/share/nginx/html \
   && ln -s /app /usr/share/nginx/html
+
+# HTTP listen port
+ENV ELEMENT_WEB_PORT=80

--- a/docker/nginx-templates/default.conf.template
+++ b/docker/nginx-templates/default.conf.template
@@ -1,6 +1,6 @@
 server {
-    listen       80;
-    listen  [::]:80;
+    listen       ${ELEMENT_WEB_PORT};
+    listen  [::]:${ELEMENT_WEB_PORT};
     server_name  localhost;
 
     root   /usr/share/nginx/html;

--- a/docs/install.md
+++ b/docs/install.md
@@ -60,7 +60,7 @@ would be:
 docker run --rm -p 127.0.0.1:80:80 -v /etc/element-web/config.json:/app/config.json vectorim/element-web
 ```
 
-The behaviour of the dockker image can be customised via the following
+The behaviour of the docker image can be customised via the following
 environment variables:
 
  * `ELEMENT_WEB_PORT`

--- a/docs/install.md
+++ b/docs/install.md
@@ -63,10 +63,10 @@ docker run --rm -p 127.0.0.1:80:80 -v /etc/element-web/config.json:/app/config.j
 The behaviour of the docker image can be customised via the following
 environment variables:
 
- * `ELEMENT_WEB_PORT`
+- `ELEMENT_WEB_PORT`
 
-   The port to listen on (within the docker container) for HTTP
-   traffic. Defaults to `80`.
+    The port to listen on (within the docker container) for HTTP
+    traffic. Defaults to `80`.
 
 ### Building the docker image
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -60,6 +60,16 @@ would be:
 docker run --rm -p 127.0.0.1:80:80 -v /etc/element-web/config.json:/app/config.json vectorim/element-web
 ```
 
+The behaviour of the dockker image can be customised via the following
+environment variables:
+
+ * `ELEMENT_WEB_PORT`
+
+   The port to listen on (within the docker container) for HTTP
+   traffic. Defaults to `80`.
+
+### Building the docker image
+
 To build the image yourself:
 
 ```bash


### PR DESCRIPTION
Notes: The HTTP listen port for the Docker image can now be configured via an environment variable.

Part of a solution to https://github.com/element-hq/element-web/issues/25926