### PR TITLE
Docker: run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM --platform=$BUILDPLATFORM node:22-bullseye as builder
+FROM --platform=$BUILDPLATFORM node:22-bullseye AS builder
 
 # Support custom branch of the js-sdk. This also helps us build images of element-web develop.
 ARG USE_CUSTOM_SDKS=false
@@ -28,8 +28,22 @@ COPY --from=builder /src/webapp /app
 # through `envsubst` by the nginx docker image entry point.
 COPY /docker/nginx-templates/* /etc/nginx/templates/
 
+# Override main nginx config, to make it suitable for use with non-root user
+RUN sed -i \
+      -e '/user *nginx;/d' \
+      -e  's,/var/run/nginx.pid,/tmp/nginx.pid,' \
+      -e "/^http {/a \    proxy_temp_path /tmp/proxy_temp;\n    client_body_temp_path /tmp/client_temp;\n    fastcgi_temp_path /tmp/fastcgi_temp;\n    uwsgi_temp_path /tmp/uwsgi_temp;\n    scgi_temp_path /tmp/scgi_temp;\n" \
+      /etc/nginx/nginx.conf
+
+# nginx user must own the cache and etc directory to write cache and tweak the nginx config
+RUN chown -R nginx:0 /var/cache/nginx /etc/nginx
+RUN chmod -R g+w /var/cache/nginx /etc/nginx
+
 RUN rm -rf /usr/share/nginx/html \
   && ln -s /app /usr/share/nginx/html
+
+# Run as nginx user by default
+USER nginx
 
 # HTTP listen port
 ENV ELEMENT_WEB_PORT=80

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,8 @@ COPY --from=builder /src/webapp /app
 # through `envsubst` by the nginx docker image entry point.
 COPY /docker/nginx-templates/* /etc/nginx/templates/
 
-# Override main nginx config, to make it suitable for use with non-root user
-RUN sed -i \
-      -e '/user *nginx;/d' \
-      -e  's,/var/run/nginx.pid,/tmp/nginx.pid,' \
-      -e "/^http {/a \    proxy_temp_path /tmp/proxy_temp;\n    client_body_temp_path /tmp/client_temp;\n    fastcgi_temp_path /tmp/fastcgi_temp;\n    uwsgi_temp_path /tmp/uwsgi_temp;\n    scgi_temp_path /tmp/scgi_temp;\n" \
-      /etc/nginx/nginx.conf
+# Tell nginx to put its pidfile elsewhere, so it can run as non-root
+RUN sed -i -e 's,/var/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf
 
 # nginx user must own the cache and etc directory to write cache and tweak the nginx config
 RUN chown -R nginx:0 /var/cache/nginx /etc/nginx

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,12 @@ FROM nginx:alpine-slim
 
 COPY --from=builder /src/webapp /app
 
-# Override default nginx config
-COPY /nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
+# Override default nginx config. Templates in `/etc/nginx/templates` are passed
+# through `envsubst` by the nginx docker image entry point.
+COPY /docker/nginx-templates/* /etc/nginx/templates/
 
 RUN rm -rf /usr/share/nginx/html \
   && ln -s /app /usr/share/nginx/html
+
+# HTTP listen port
+ENV ELEMENT_WEB_PORT=80

--- a/docker/nginx-templates/default.conf.template
+++ b/docker/nginx-templates/default.conf.template
@@ -1,6 +1,6 @@
 server {
-    listen       80;
-    listen  [::]:80;
+    listen       ${ELEMENT_WEB_PORT};
+    listen  [::]:${ELEMENT_WEB_PORT};
     server_name  localhost;
 
     root   /usr/share/nginx/html;

--- a/docs/install.md
+++ b/docs/install.md
@@ -60,7 +60,7 @@ would be:
 docker run --rm -p 127.0.0.1:80:80 -v /etc/element-web/config.json:/app/config.json vectorim/element-web
 ```
 
-The behaviour of the dockker image can be customised via the following
+The behaviour of the docker image can be customised via the following
 environment variables:
 
  * `ELEMENT_WEB_PORT`

--- a/docs/install.md
+++ b/docs/install.md
@@ -63,10 +63,10 @@ docker run --rm -p 127.0.0.1:80:80 -v /etc/element-web/config.json:/app/config.j
 The behaviour of the docker image can be customised via the following
 environment variables:
 
- * `ELEMENT_WEB_PORT`
+- `ELEMENT_WEB_PORT`
 
-   The port to listen on (within the docker container) for HTTP
-   traffic. Defaults to `80`.
+    The port to listen on (within the docker container) for HTTP
+    traffic. Defaults to `80`.
 
 ### Building the docker image
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -60,6 +60,12 @@ would be:
 docker run --rm -p 127.0.0.1:80:80 -v /etc/element-web/config.json:/app/config.json vectorim/element-web
 ```
 
+The Docker image is configured to run as an unprivileged (non-root) user by
+default. This should be fine on modern Docker runtimes, but binding to port 80
+on other runtimes may require root privileges. To resolve this, either run the
+image as root (`docker run --user 0`) or, better, change the port that nginx
+listens on via the `ELEMENT_WEB_PORT` environment variable.
+
 The behaviour of the docker image can be customised via the following
 environment variables:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -60,6 +60,16 @@ would be:
 docker run --rm -p 127.0.0.1:80:80 -v /etc/element-web/config.json:/app/config.json vectorim/element-web
 ```
 
+The behaviour of the dockker image can be customised via the following
+environment variables:
+
+ * `ELEMENT_WEB_PORT`
+
+   The port to listen on (within the docker container) for HTTP
+   traffic. Defaults to `80`.
+
+### Building the docker image
+
 To build the image yourself:
 
 ```bash


### PR DESCRIPTION
Notes: The docker image now runs as a non-root user

Empirically, listening on port 80 with non-root works just fine nowadays, so we may as well do that.

~~The hacks to `nginx.conf` are based on "Running nginx as a non-root user" in https://hub.docker.com/_/nginx (and the dockerfile for `nginxinc/nginx-unprivileged`).~~ Turns out we don't need many hacks, for our usecase.

~~Based on #28840~~
Fixes #25926