### PR TITLE
Add a playwright test for backup reset / deleted

### DIFF
--- a/playwright/e2e/csAPI.ts
+++ b/playwright/e2e/csAPI.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2024 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { APIRequestContext } from "playwright-core";
+import { KeyBackupInfo } from "matrix-js-sdk/src/crypto-api";
+
+import { HomeserverInstance } from "../plugins/homeserver";
+
+/**
+ * A small subset of the Client-Server API used to manipulate the state of the
+ * account on the homeserver independently of the client under test.
+ */
+export class TestClientServerAPI {
+    public constructor(
+        private request: APIRequestContext,
+        private homeserver: HomeserverInstance,
+        private accessToken: string,
+    ) {}
+
+    public async getCurrentBackupInfo(): Promise<KeyBackupInfo | null> {
+        const res = await this.request.get(`${this.homeserver.config.baseUrl}/_matrix/client/v3/room_keys/version`, {
+            headers: { Authorization: `Bearer ${this.accessToken}` },
+        });
+
+        const body = await res.json();
+
+        return body;
+    }
+
+    /**
+     * Calls the API directly to create a new backup version.
+     * @param algorithm The backup algorithm to use.
+     * @param authData The backup auth data
+     * @returns The version number of the new backup
+     */
+    public async deleteBackupVersion(version: string): Promise<void> {
+        const res = await this.request.delete(
+            `${this.homeserver.config.baseUrl}/_matrix/client/v3/room_keys/version/${version}`,
+            {
+                headers: { Authorization: `Bearer ${this.accessToken}` },
+            },
+        );
+
+        if (!res.ok) {
+            throw new Error(`Failed to delete backup version: ${res.status}`);
+        }
+    }
+}

--- a/playwright/e2e/csAPI.ts
+++ b/playwright/e2e/csAPI.ts
@@ -30,10 +30,8 @@ export class TestClientServerAPI {
     }
 
     /**
-     * Calls the API directly to create a new backup version.
-     * @param algorithm The backup algorithm to use.
-     * @param authData The backup auth data
-     * @returns The version number of the new backup
+     * Calls the API directly to delete the given backup version
+     * @param version The version to delete
      */
     public async deleteBackupVersion(version: string): Promise<void> {
         const res = await this.request.delete(

--- a/playwright/e2e/csAPI.ts
+++ b/playwright/e2e/csAPI.ts
@@ -26,9 +26,7 @@ export class TestClientServerAPI {
             headers: { Authorization: `Bearer ${this.accessToken}` },
         });
 
-        const body = await res.json();
-
-        return body;
+        return await res.json();
     }
 
     /**


### PR DESCRIPTION
A slightly tricky one to test but an important case that people can hit, and one that otherwise wouldn't get hit a lot during normal usage, so I think probably quite a useful test to have. Mostly though, I'm about to change this to a toast, so I'd like a test to assert that it still works.

Requires https://github.com/matrix-org/matrix-js-sdk/pull/4601

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
