### PR TITLE
ShareDialog: fix share on Twitter URL

### DIFF
--- a/src/components/views/dialogs/ShareDialog.tsx
+++ b/src/components/views/dialogs/ShareDialog.tsx
@@ -32,7 +32,7 @@ const SOCIALS = [
     {
         name: "Twitter",
         img: require("../../../../res/img/social/twitter-2.png"),
-        url: (url: string) => `https://twitter.com/home?status=${url}`,
+        url: (url: string) => `https://twitter.com/intent/tweet?text=${url}`,
     },
     {
         name: "LinkedIn",


### PR DESCRIPTION
At some point, X (Formerly known as Twitter) changed the URL to share Tweets. This changes it to the now correct URL.

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
