### PR TITLE
Specify Synapse ui_auth.session_timeout only on tests which require it

### DIFF
--- a/playwright/testcontainers/synapse.ts
+++ b/playwright/testcontainers/synapse.ts
@@ -118,9 +118,7 @@ const DEFAULT_CONFIG = {
     password_config: {
         enabled: true,
     },
-    ui_auth: {
-        session_timeout: "300s",
-    },
+    ui_auth: {},
     background_updates: {
         // Inhibit background updates as this Synapse isn't long-lived
         min_batch_size: 100000,


### PR DESCRIPTION
As Dendrite lacks this configuration option

For https://github.com/element-hq/element-web/pull/28888