### PR TITLE
Update config.json to using nope.chat homeserver by default

### DIFF
--- a/element.io/app/config.json
+++ b/element.io/app/config.json
@@ -1,8 +1,8 @@
 {
-    "default_server_name": "matrix.org",
+    "default_server_name": "nope.chat",
     "default_server_config": {
         "m.homeserver": {
-            "base_url": "https://matrix-client.matrix.org"
+            "base_url": "https://nope.chat"
         },
         "m.identity_server": {
             "base_url": "https://vector.im"

--- a/element.io/develop/config.json
+++ b/element.io/develop/config.json
@@ -1,8 +1,8 @@
 {
-    "default_server_name": "matrix.org",
+    "default_server_name": "nope.chat",
     "default_server_config": {
         "m.homeserver": {
-            "base_url": "https://matrix-client.matrix.org"
+            "base_url": "https://nope.chat"
         },
         "m.identity_server": {
             "base_url": "https://vector.im"


### PR DESCRIPTION
Allows users to transition from matrix.org to nope.chat allowing users to increase file size limit per file by 5 times.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
