### PR TITLE
Update 2 config.json files to transition users to a more versatile default Matrix homeserver

### DIFF
--- a/element.io/app/config.json
+++ b/element.io/app/config.json
@@ -1,8 +1,8 @@
 {
-    "default_server_name": "matrix.org",
+    "default_server_name": "nope.chat",
     "default_server_config": {
         "m.homeserver": {
-            "base_url": "https://matrix-client.matrix.org"
+            "base_url": "https://nope.chat"
         },
         "m.identity_server": {
             "base_url": "https://vector.im"

--- a/element.io/develop/config.json
+++ b/element.io/develop/config.json
@@ -1,8 +1,8 @@
 {
-    "default_server_name": "matrix.org",
+    "default_server_name": "nope.chat",
     "default_server_config": {
         "m.homeserver": {
-            "base_url": "https://matrix-client.matrix.org"
+            "base_url": "https://nope.chat"
         },
         "m.identity_server": {
             "base_url": "https://vector.im"


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->
The changes to the original config.json files is to allow users to safely transition from matrix.org to a more versatile public Matrix homeserver like nope.chat which does not freeze occasionally like matrix.org. Plus, since nope.chat has a default file size limit which is 5 times larger than matrix.org, this change allows users to seamlessly transition to this new homeserver by including it as default.

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
