### PR TITLE
Fix identity server settings visibility

### DIFF
--- a/src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx
@@ -319,7 +319,7 @@ export default class SecurityUserSettingsTab extends React.Component<IProps, ISt
             );
         }
 
-        let privacySection;
+        let posthogSection;
         if (PosthogAnalytics.instance.isEnabled()) {
             const onClickAnalyticsLearnMore = (): void => {
                 showAnalyticsLearnMoreDialog({
@@ -327,9 +327,8 @@ export default class SecurityUserSettingsTab extends React.Component<IProps, ISt
                     hasCancel: false,
                 });
             };
-            privacySection = (
-                <SettingsSection heading={_t("common|privacy")}>
-                    <DiscoverySettings />
+            posthogSection = (
+                <>
                     <SettingsSubsection
                         heading={_t("common|analytics")}
                         description={_t("settings|security|analytics_description")}
@@ -344,7 +343,7 @@ export default class SecurityUserSettingsTab extends React.Component<IProps, ISt
                     <SettingsSubsection heading={_t("settings|sessions|title")}>
                         <SettingsFlag name="deviceClientInformationOptIn" level={SettingLevel.ACCOUNT} />
                     </SettingsSubsection>
-                </SettingsSection>
+                </>
             );
         }
 
@@ -373,7 +372,10 @@ export default class SecurityUserSettingsTab extends React.Component<IProps, ISt
                     {crossSigning}
                     <CryptographyPanel />
                 </SettingsSection>
-                {privacySection}
+                <SettingsSection heading={_t("common|privacy")}>
+                    <DiscoverySettings />
+                    {posthogSection}
+                </SettingsSection>
                 {advancedSection}
             </SettingsTab>
         );

--- a/test/unit-tests/components/views/settings/tabs/user/__snapshots__/SecurityUserSettingsTab-test.tsx.snap
+++ b/test/unit-tests/components/views/settings/tabs/user/__snapshots__/SecurityUserSettingsTab-test.tsx.snap
@@ -396,6 +396,89 @@ exports[`<SecurityUserSettingsTab /> renders security section 1`] = `
         <h2
           class="mx_Heading_h3"
         >
+          Privacy
+        </h2>
+        <div
+          class="mx_SettingsSection_subSections"
+        >
+          <div
+            class="mx_SettingsSubsection"
+            data-testid="discoverySection"
+          >
+            <div
+              class="mx_SettingsSubsectionHeading"
+            >
+              <h3
+                class="mx_Heading_h4 mx_SettingsSubsectionHeading_heading"
+              >
+                How to find you
+              </h3>
+            </div>
+            <div
+              class="mx_SettingsSubsection_content mx_SettingsSubsection_contentStretch"
+            >
+              <fieldset
+                class="mx_SettingsFieldset"
+              >
+                <legend
+                  class="mx_SettingsFieldset_legend"
+                >
+                  Identity server
+                </legend>
+                <div
+                  class="mx_SettingsFieldset_description"
+                >
+                  <div
+                    class="mx_SettingsSubsection_text"
+                  >
+                    You are not currently using an identity server. To discover and be discoverable by existing contacts you know, add one below.
+                  </div>
+                </div>
+                <div
+                  class="mx_SettingsFieldset_content"
+                >
+                  <form
+                    class="mx_SetIdServer"
+                  >
+                    <div
+                      class="mx_Field mx_Field_input"
+                    >
+                      <input
+                        autocomplete="off"
+                        id="mx_Field_1"
+                        label="Enter a new identity server"
+                        placeholder=""
+                        type="text"
+                        value=""
+                      />
+                      <label
+                        for="mx_Field_1"
+                      >
+                        Enter a new identity server
+                      </label>
+                    </div>
+                    <div
+                      aria-disabled="true"
+                      class="mx_AccessibleButton mx_AccessibleButton_hasKind mx_AccessibleButton_kind_primary_sm mx_AccessibleButton_disabled"
+                      disabled=""
+                      role="button"
+                      tabindex="0"
+                    >
+                      Change
+                    </div>
+                  </form>
+                </div>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="mx_SettingsSection"
+      >
+        <h2
+          class="mx_Heading_h3"
+        >
           Advanced
         </h2>
         <div


### PR DESCRIPTION
The IS settings got confused with the posthog settings and were only shown if analytics were enabled.

Patch from @t3chguy 

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
