### PR TITLE
Add FOSDEM module changes.

### DIFF
--- a/src/Avatar.ts
+++ b/src/Avatar.ts
@@ -13,6 +13,7 @@ import DMRoomMap from "./utils/DMRoomMap";
 import { mediaFromMxc } from "./customisations/Media";
 import { isLocalRoom } from "./utils/localRoom/isLocalRoom";
 import { getFirstGrapheme } from "./utils/strings";
+import { ModuleRunner } from "./modules/ModuleRunner";
 
 /**
  * Hardcoded from the Compound colors.
@@ -98,6 +99,12 @@ const colorToDataURLCache = new Map<string, string>();
 
 export function defaultAvatarUrlForString(s: string): string {
     if (!s) return ""; // XXX: should never happen but empirically does by evidence of a rageshake
+
+    const avatar = ModuleRunner.instance.extensions.conference.defaultAvatarUrlForString(s);
+    if (avatar !== null) {
+        return avatar;
+    }
+
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const colorIndex = useIdColorHash(s);
     // overwritten color value in custom themes
@@ -132,6 +139,11 @@ export function getInitialLetter(name: string): string | undefined {
     }
     if (name.length < 1) {
         return undefined;
+    }
+
+    const avatar = ModuleRunner.instance.extensions.conference.getAvatarInitialLetter(name);
+    if (avatar !== null) {
+        return avatar;
     }
 
     const initial = name[0];

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -132,6 +132,7 @@ import { SessionLockStolenView } from "./auth/SessionLockStolenView";
 import { ConfirmSessionLockTheftView } from "./auth/ConfirmSessionLockTheftView";
 import { LoginSplashView } from "./auth/LoginSplashView";
 import { cleanUpDraftsIfRequired } from "../../DraftCleaner";
+import { ClientLifecycle } from "@matrix-org/react-sdk-module-api/lib/lifecycles/ClientLifecycle";
 
 // legacy export
 export { default as Views } from "../../Views";
@@ -1553,6 +1554,8 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
 
             this.firstSyncComplete = true;
             this.firstSyncPromise.resolve();
+            console.log('TEST!!!');
+            ModuleRunner.instance.invoke(ClientLifecycle.FirstSync);
 
             if (Notifier.shouldShowPrompt() && !MatrixClientPeg.userRegisteredWithinLastHours(24)) {
                 showNotificationsToast(false);

--- a/src/components/structures/UserMenu.tsx
+++ b/src/components/structures/UserMenu.tsx
@@ -43,6 +43,7 @@ import { ViewHomePagePayload } from "../../dispatcher/payloads/ViewHomePagePaylo
 import { SDKContext } from "../../contexts/SDKContext";
 import { shouldShowFeedback } from "../../utils/Feedback";
 import DarkLightModeSvg from "../../../res/img/element-icons/roomlist/dark-light-mode.svg";
+import { ModuleRunner } from "../../modules/ModuleRunner";
 
 interface IProps {
     isPanelCollapsed: boolean;
@@ -410,11 +411,15 @@ export default class UserMenu extends React.Component<IProps, IState> {
 
         const userId = MatrixClientPeg.safeGet().getSafeUserId();
         const displayName = OwnProfileStore.instance.displayName || userId;
-        const avatarUrl = OwnProfileStore.instance.getHttpAvatarUrl(avatarSize);
+        let avatarUrl = OwnProfileStore.instance.getHttpAvatarUrl(avatarSize);
 
         let name: JSX.Element | undefined;
         if (!this.props.isPanelCollapsed) {
             name = <div className="mx_UserMenu_name">{displayName}</div>;
+        }
+
+        if (!avatarUrl) {
+            avatarUrl = ModuleRunner.instance.extensions.conference.defaultAvatarUrlForString(userId);
         }
 
         return (

--- a/src/components/views/directory/NetworkDropdown.tsx
+++ b/src/components/views/directory/NetworkDropdown.tsx
@@ -26,6 +26,7 @@ import {
 import TextInputDialog from "../dialogs/TextInputDialog";
 import AccessibleButton from "../elements/AccessibleButton";
 import withValidation from "../elements/Validation";
+import { ModuleRunner } from "../../../modules/ModuleRunner";
 
 const SETTING_NAME = "room_directory_servers";
 
@@ -122,13 +123,17 @@ function useServers(): ServerList {
     removeAll(removableServers, homeServer);
     removeAll(removableServers, ...configServers);
 
+    const allServers = [
+        // we always show our connected HS, this takes precedence over it being configured or user-defined
+        homeServer,
+        ...Array.from(configServers).sort(),
+        ...Array.from(removableServers).sort(),
+    ]
+
+    
+
     return {
-        allServers: [
-            // we always show our connected HS, this takes precedence over it being configured or user-defined
-            homeServer,
-            ...Array.from(configServers).sort(),
-            ...Array.from(removableServers).sort(),
-        ],
+        allServers: ModuleRunner.instance.extensions.conference.filterServerList(allServers),
         homeServer,
         userDefinedServers: Array.from(removableServers).sort(),
         setUserDefinedServers,

--- a/src/components/views/elements/ServerPicker.tsx
+++ b/src/components/views/elements/ServerPicker.tsx
@@ -16,6 +16,7 @@ import SdkConfig from "../../../SdkConfig";
 import Modal from "../../../Modal";
 import ServerPickerDialog from "../dialogs/ServerPickerDialog";
 import InfoDialog from "../dialogs/InfoDialog";
+import { ModuleRunner } from "../../../modules/ModuleRunner";
 
 interface IProps {
     title?: string;
@@ -77,7 +78,10 @@ const ServerPicker: React.FC<IProps> = ({ title, dialogTitle, serverConfig, onSe
     }
 
     let desc;
-    if (serverConfig.hsName === "matrix.org") {
+    const moduleDesc = ModuleRunner.instance.extensions.conference.serverLoginNotice(serverConfig.hsName);
+    if (moduleDesc) {
+        desc = <span className="mx_ServerPicker_desc">{moduleDesc}</span>;
+    } else if (serverConfig.hsName === "matrix.org") {
         desc = <span className="mx_ServerPicker_desc">{_t("auth|server_picker_description_matrix.org")}</span>;
     }
 

--- a/src/modules/ModuleRunner.ts
+++ b/src/modules/ModuleRunner.ts
@@ -17,6 +17,10 @@ import {
     DefaultExperimentalExtensions,
     ProvideExperimentalExtensions,
 } from "@matrix-org/react-sdk-module-api/lib/lifecycles/ExperimentalExtensions";
+import {
+    DefaultConferenceExtensions,
+    ProvideConferenceExtensions,
+} from "@matrix-org/react-sdk-module-api/lib/lifecycles/ConferenceExtensions";
 
 import { AppModule } from "./AppModule";
 import { ModuleFactory } from "./ModuleFactory";
@@ -30,12 +34,16 @@ class ExtensionsManager {
     // Private backing fields for extensions
     private cryptoSetupExtension: ProvideCryptoSetupExtensions;
     private experimentalExtension: ProvideExperimentalExtensions;
+    private conferenceExtension: ProvideConferenceExtensions;
 
     /** `true` if `cryptoSetupExtension` is the default implementation; `false` if it is implemented by a module. */
     private hasDefaultCryptoSetupExtension = true;
 
     /** `true` if `experimentalExtension` is the default implementation; `false` if it is implemented by a module. */
     private hasDefaultExperimentalExtension = true;
+
+    /** `true` if `conferenceExtension` is the default implementation; `false` if it is implemented by a module. */
+    private hasDefaultConferenceExtension = true;
 
     /**
      * Create a new instance.
@@ -44,6 +52,7 @@ class ExtensionsManager {
         // Set up defaults
         this.cryptoSetupExtension = new DefaultCryptoSetupExtensions();
         this.experimentalExtension = new DefaultExperimentalExtensions();
+        this.conferenceExtension = new DefaultConferenceExtensions();
     }
 
     /**
@@ -65,6 +74,15 @@ class ExtensionsManager {
      */
     public get experimental(): ProvideExperimentalExtensions {
         return this.experimentalExtension;
+    }
+
+    /**
+     * Provides extensions useful to conferences.
+     *
+     * @returns The registered extension. If no module provides this extension, a default implementation is returned.
+     */
+    public get conference(): ProvideConferenceExtensions {
+        return this.conferenceExtension;
     }
 
     /**
@@ -97,6 +115,18 @@ class ExtensionsManager {
             } else {
                 throw new Error(
                     `adding experimental extension implementation from module ${runtimeModule.moduleName} but an implementation was already provided.`,
+                );
+            }
+        }
+
+        /* Add the experimental extension if any */
+        if (runtimeModule.extensions?.conference) {
+            if (this.hasDefaultConferenceExtension) {
+                this.conferenceExtension = runtimeModule.extensions.conference;
+                this.hasDefaultConferenceExtension = false;
+            } else {
+                throw new Error(
+                    `adding conference extension implementation from module ${runtimeModule.moduleName} but an implementation was already provided.`,
                 );
             }
         }


### PR DESCRIPTION
Rather than forking Element Web again this year, I decided to rewrite the FOSDEM modifications we usually make as a separate module and added a few new Module APIs in the process.

This pairs with https://github.com/matrix-org/matrix-react-sdk-module-api/pull/53 

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
