### PR TITLE
e2e test: by default the bot should not use a passphrase to create the recovery key

### DIFF
--- a/playwright/e2e/crypto/device-verification.spec.ts
+++ b/playwright/e2e/crypto/device-verification.spec.ts
@@ -29,7 +29,7 @@ test.describe("Device verification", { tag: "@no-webkit" }, () => {
     let expectedBackupVersion: string;
 
     test.beforeEach(async ({ page, homeserver, credentials }) => {
-        const res = await createBot(page, homeserver, credentials);
+        const res = await createBot(page, homeserver, credentials, true);
         aliceBotClient = res.botClient;
         expectedBackupVersion = res.expectedBackupVersion;
     });

--- a/playwright/e2e/crypto/toasts.spec.ts
+++ b/playwright/e2e/crypto/toasts.spec.ts
@@ -34,7 +34,6 @@ test.describe("Key storage out of sync toast", () => {
         await expect(page.getByRole("alert").first()).toMatchScreenshot("key-storage-out-of-sync-toast.png");
 
         await page.getByRole("button", { name: "Enter recovery key" }).click();
-        await page.locator(".mx_Dialog").getByRole("button", { name: "use your Security Key" }).click();
 
         await page.getByRole("textbox", { name: "Security key" }).fill(recoveryKey.encodedPrivateKey);
         await page.getByRole("button", { name: "Continue" }).click();

--- a/playwright/e2e/crypto/utils.ts
+++ b/playwright/e2e/crypto/utils.ts
@@ -28,11 +28,13 @@ import { Bot } from "../../pages/bot";
  * @param page - the playwright `page` fixture
  * @param homeserver - the homeserver to use
  * @param credentials - the credentials to use for the bot client
+ * @param usePassphrase - whether to use a passphrase when creating the recovery key
  */
 export async function createBot(
     page: Page,
     homeserver: HomeserverInstance,
     credentials: Credentials,
+    usePassphrase = false,
 ): Promise<{ botClient: Bot; recoveryKey: GeneratedSecretStorageKey; expectedBackupVersion: string }> {
     // Visit the login page of the app, to load the matrix sdk
     await page.goto("/#/login");
@@ -44,6 +46,7 @@ export async function createBot(
     const botClient = new Bot(page, homeserver, {
         bootstrapCrossSigning: true,
         bootstrapSecretStorage: true,
+        usePassphrase,
     });
     botClient.setCredentials(credentials);
     // Backup is prepared in the background. Poll until it is ready.

--- a/playwright/e2e/settings/encryption-user-tab/encryption-tab.spec.ts
+++ b/playwright/e2e/settings/encryption-user-tab/encryption-tab.spec.ts
@@ -67,7 +67,7 @@ test.describe("Encryption tab", () => {
         "should prompt to enter the recovery key when the secrets are not cached locally",
         { tag: "@screenshot" },
         async ({ page, app, util }) => {
-            await verifySession(app, "new passphrase");
+            await verifySession(app, recoveryKey.encodedPrivateKey);
             // We need to delete the cached secrets
             await deleteCachedSecrets(page);
 
@@ -99,7 +99,7 @@ test.describe("Encryption tab", () => {
         app,
         util,
     }) => {
-        await verifySession(app, "new passphrase");
+        await verifySession(app, recoveryKey.encodedPrivateKey);
         // We need to delete the cached secrets
         await deleteCachedSecrets(page);
 

--- a/playwright/e2e/settings/encryption-user-tab/index.ts
+++ b/playwright/e2e/settings/encryption-user-tab/index.ts
@@ -43,7 +43,7 @@ class Helpers {
      */
     async verifyDevice(recoveryKey: GeneratedSecretStorageKey) {
         // Select the security phrase
-        await this.page.getByRole("button", { name: "Verify with Security Key or Phrase" }).click();
+        await this.page.getByRole("button", { name: "Verify with Security Key" }).click();
         await this.enterRecoveryKey(recoveryKey);
         await this.page.getByRole("button", { name: "Done" }).click();
     }
@@ -53,9 +53,6 @@ class Helpers {
      * @param recoveryKey
      */
     async enterRecoveryKey(recoveryKey: GeneratedSecretStorageKey) {
-        // Select to use recovery key
-        await this.page.getByRole("button", { name: "use your Security Key" }).click();
-
         // Fill the recovery key
         const dialog = this.page.locator(".mx_Dialog");
         await dialog.getByRole("textbox").fill(recoveryKey.encodedPrivateKey);

--- a/playwright/pages/bot.ts
+++ b/playwright/pages/bot.ts
@@ -41,6 +41,10 @@ export interface CreateBotOpts {
      * Whether to bootstrap the secret storage
      */
     bootstrapSecretStorage?: boolean;
+    /**
+     * Whether to use a passphrase when creating the recovery key
+     */
+    usePassphrase?: boolean;
 }
 
 const defaultCreateBotOptions = {
@@ -48,6 +52,7 @@ const defaultCreateBotOptions = {
     autoAcceptInvites: true,
     startClient: true,
     bootstrapCrossSigning: true,
+    usePassphrase: false,
 } satisfies CreateBotOpts;
 
 type ExtendedMatrixClient = MatrixClient & { __playwright_recovery_key: GeneratedSecretStorageKey };
@@ -206,8 +211,8 @@ export class Bot extends Client {
         }
 
         if (this.opts.bootstrapSecretStorage) {
-            await clientHandle.evaluate(async (cli) => {
-                const passphrase = "new passphrase";
+            await clientHandle.evaluate(async (cli, usePassphrase) => {
+                const passphrase = usePassphrase ? "new passphrase" : undefined;
                 const recoveryKey = await cli.getCrypto().createRecoveryKeyFromPassphrase(passphrase);
                 Object.assign(cli, { __playwright_recovery_key: recoveryKey });
 
@@ -216,7 +221,7 @@ export class Bot extends Client {
                     setupNewKeyBackup: true,
                     createSecretStorageKey: () => Promise.resolve(recoveryKey),
                 });
-            });
+            }, this.opts.usePassphrase);
         }
 
         return clientHandle;


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)

In the e2e test, the bot creates a the recovery key from a passphrase. We tend to not generate recovery key from a passphrase and this is adding complexity in the e2e test.

`verifySession` was in fact not working when using a recovery key, the UI was expecting a passphrase.
https://github.com/element-hq/element-web/blob/3c690e685a7e8c76b8b2310ced668995af942f6c/playwright/e2e/crypto/utils.ts#L248-L262