### PR TITLE
Stop URl preview from covering message box

### DIFF
--- a/res/css/structures/_RoomView.pcss
+++ b/res/css/structures/_RoomView.pcss
@@ -35,6 +35,7 @@ Please see LICENSE files in the repository root for full details.
         width: 100%;
         flex: 0 0 auto;
         margin-right: 2px;
+        padding-bottom: 1em;
     }
 }
 


### PR DESCRIPTION
Fixes #23874 by adding a bit of padding.

1em should be sufficient to prevent the browser's URl preview from covering the entry box.

## Before
![Screenshot from 2025-02-07 09-16-55](https://github.com/user-attachments/assets/eb47e2a0-acb2-46cb-aaf2-4316891dd255)

## After
![Screenshot from 2025-02-07 09-16-40](https://github.com/user-attachments/assets/72723b49-628c-4c78-9f78-0c518b63d307)




<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [X] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
