### PR TITLE
Encryption tab: display correct encryption panel when user cancels the reset identity flow

### DIFF
--- a/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.tsx
@@ -102,20 +102,12 @@ export function EncryptionUserSettingsTab({ initialState = "loading" }: Encrypti
             );
             break;
         case "reset_identity_compromised":
-            content = (
-                <ResetIdentityPanel
-                    variant="compromised"
-                    onCancelClick={() => setState("main")}
-                    onFinish={() => setState("main")}
-                />
-            );
-            break;
         case "reset_identity_forgot":
             content = (
                 <ResetIdentityPanel
-                    variant="forgot"
-                    onCancelClick={() => setState("main")}
-                    onFinish={() => setState("main")}
+                    variant={state === "reset_identity_compromised" ? "compromised" : "forgot"}
+                    onCancelClick={checkEncryptionState}
+                    onFinish={checkEncryptionState}
                 />
             );
             break;

--- a/test/unit-tests/components/views/settings/tabs/user/EncryptionUserSettingsTab-test.tsx
+++ b/test/unit-tests/components/views/settings/tabs/user/EncryptionUserSettingsTab-test.tsx
@@ -144,4 +144,30 @@ describe("<EncryptionUserSettingsTab />", () => {
             screen.getByRole("heading", { name: "Forgot your recovery key? You’ll need to reset your identity." }),
         ).toBeVisible();
     });
+
+    it("should re-check the encryption state and displays the correct panel when the user clicks cancel the reset identity flow", async () => {
+        const user = userEvent.setup();
+
+        // Secrets are not cached
+        jest.spyOn(matrixClient.getCrypto()!, "getCrossSigningStatus").mockResolvedValue({
+            privateKeysInSecretStorage: true,
+            publicKeysOnDevice: true,
+            privateKeysCachedLocally: {
+                masterKey: false,
+                selfSigningKey: true,
+                userSigningKey: true,
+            },
+        });
+
+        renderComponent({ initialState: "reset_identity_forgot" });
+
+        expect(
+            screen.getByRole("heading", { name: "Forgot your recovery key? You’ll need to reset your identity." }),
+        ).toBeVisible();
+
+        await user.click(screen.getByRole("button", { name: "Back" }));
+        await waitFor(() =>
+            screen.getByText("Your key storage is out of sync. Click one of the buttons below to fix the problem."),
+        );
+    });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)

We weren't checking the encryption state when the user cancels the reset identity flow.

### Before

https://github.com/user-attachments/assets/e7c43f5e-547f-4e37-9155-30bb8688bed3

### After

https://github.com/user-attachments/assets/26d9c1bb-7601-4e8c-9006-d2aae8b400b5
