### PR TITLE
Restore the accessibility role on call views

### DIFF
--- a/src/components/views/voip/CallView.tsx
+++ b/src/components/views/voip/CallView.tsx
@@ -58,7 +58,7 @@ const JoinCallView: FC<JoinCallViewProps> = ({ room, resizing, call, skipLobby, 
         await Promise.all(calls.map(async (call) => await call.disconnect()));
     }, []);
     return (
-        <div className="mx_CallView">
+        <div className="mx_CallView" role={role}>
             <AppTile
                 app={call.widget}
                 room={room}

--- a/test/unit-tests/components/views/voip/CallView-test.tsx
+++ b/test/unit-tests/components/views/voip/CallView-test.tsx
@@ -69,8 +69,8 @@ describe("CallView", () => {
         client.reEmitter.stopReEmitting(room, [RoomStateEvent.Events]);
     });
 
-    const renderView = async (skipLobby = false): Promise<void> => {
-        render(<CallView room={room} resizing={false} waitForCall={false} skipLobby={skipLobby} />);
+    const renderView = async (skipLobby = false, role: string | undefined = undefined): Promise<void> => {
+        render(<CallView room={room} resizing={false} waitForCall={false} skipLobby={skipLobby} role={role} />);
         await act(() => Promise.resolve()); // Let effects settle
     };
 
@@ -94,6 +94,11 @@ describe("CallView", () => {
             cleanup(); // Unmount before we do any cleanup that might update the component
             call.destroy();
             WidgetMessagingStore.instance.stopMessaging(widget, room.roomId);
+        });
+
+        it("accepts an accessibility role", async () => {
+            await renderView(undefined, "main");
+            screen.getByRole("main");
         });
 
         it("calls clean on mount", async () => {


### PR DESCRIPTION
This was mistakenly removed in a370a5cfa43. You can tell it was unintentional because the 'role' variable was just left unused.