### PR TITLE
Don't reload roomview on offline connectivity check

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -1151,13 +1151,14 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                 break;
             case "MatrixActions.sync":
                 if (!this.state.matrixClientIsReady) {
+                    const isReadyNow = Boolean(this.context.client?.isInitialSyncComplete());
                     this.setState(
                         {
-                            matrixClientIsReady: !!this.context.client?.isInitialSyncComplete(),
+                            matrixClientIsReady: isReadyNow,
                         },
                         () => {
                             // send another "initial" RVS update to trigger peeking if needed
-                            this.onRoomViewStoreUpdate(true);
+                            if (isReadyNow) this.onRoomViewStoreUpdate(true);
                         },
                     );
                 }

--- a/test/unit-tests/components/structures/RoomView-test.tsx
+++ b/test/unit-tests/components/structures/RoomView-test.tsx
@@ -223,31 +223,6 @@ describe("RoomView", () => {
         expect(instance.getHiddenHighlightCount()).toBe(0);
     });
 
-    // Regression test for https://github.com/element-hq/element-web/issues/29072
-    it("does not force a reload on sync unless the client is coming back online", async () => {
-        cli.isInitialSyncComplete.mockReturnValue(false);
-
-        const instance = await getRoomViewInstance();
-        const onRoomViewUpdateMock = jest.fn();
-        (instance as any).onRoomViewStoreUpdate = onRoomViewUpdateMock;
-
-        act(() => {
-            // As if a connectivity check happened (we are still offline)
-            defaultDispatcher.dispatch({ action: "MatrixActions.sync" }, true);
-            // ...so it still should not force a reload
-            expect(onRoomViewUpdateMock).not.toHaveBeenCalledWith(true);
-        });
-
-        act(() => {
-            // set us to online again
-            cli.isInitialSyncComplete.mockReturnValue(true);
-            defaultDispatcher.dispatch({ action: "MatrixActions.sync" }, true);
-        });
-
-        // It should now force a reload
-        expect(onRoomViewUpdateMock).toHaveBeenCalledWith(true);
-    });
-
     describe("when there is an old room", () => {
         let instance: RoomView;
         let oldRoom: Room;
@@ -716,6 +691,31 @@ describe("RoomView", () => {
         jest.spyOn(defaultDispatcher, "dispatch");
         await mountRoomView();
         expect(defaultDispatcher.dispatch).toHaveBeenCalledWith({ action: Action.RoomLoaded });
+    });
+
+    // Regression test for https://github.com/element-hq/element-web/issues/29072
+    it("does not force a reload on sync unless the client is coming back online", async () => {
+        cli.isInitialSyncComplete.mockReturnValue(false);
+
+        const instance = await getRoomViewInstance();
+        const onRoomViewUpdateMock = jest.fn();
+        (instance as any).onRoomViewStoreUpdate = onRoomViewUpdateMock;
+
+        act(() => {
+            // As if a connectivity check happened (we are still offline)
+            defaultDispatcher.dispatch({ action: "MatrixActions.sync" }, true);
+            // ...so it still should not force a reload
+            expect(onRoomViewUpdateMock).not.toHaveBeenCalledWith(true);
+        });
+
+        act(() => {
+            // set us to online again
+            cli.isInitialSyncComplete.mockReturnValue(true);
+            defaultDispatcher.dispatch({ action: "MatrixActions.sync" }, true);
+        });
+
+        // It should now force a reload
+        expect(onRoomViewUpdateMock).toHaveBeenCalledWith(true);
     });
 
     describe("when there is a RoomView", () => {


### PR DESCRIPTION
Doesn't look like this was a regression as far as I can see, but you did have to switch rooms while offline for it to start happening.

There's no use reloading the room until we're online again.

Fixes https://github.com/element-hq/element-web/issues/29072

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
