### PR TITLE
Replace `focus_room_filter` dispatch by `Action.OpenSpotlight`

### DIFF
--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -501,9 +501,7 @@ class LoggedInView extends React.Component<IProps, IState> {
                 handled = true;
                 break;
             case KeyBindingAction.FilterRooms:
-                dis.dispatch({
-                    action: "focus_room_filter",
-                });
+                dis.fire(Action.OpenSpotlight);
                 handled = true;
                 break;
             case KeyBindingAction.ToggleUserMenu:

--- a/src/components/structures/RoomSearch.tsx
+++ b/src/components/structures/RoomSearch.tsx
@@ -11,7 +11,6 @@ import * as React from "react";
 
 import { ALTERNATE_KEY_NAME } from "../../accessibility/KeyboardShortcuts";
 import defaultDispatcher from "../../dispatcher/dispatcher";
-import { type ActionPayload } from "../../dispatcher/payloads";
 import { IS_MAC, Key } from "../../Keyboard";
 import { _t } from "../../languageHandler";
 import AccessibleButton from "../views/elements/AccessibleButton";
@@ -22,25 +21,9 @@ interface IProps {
 }
 
 export default class RoomSearch extends React.PureComponent<IProps> {
-    private dispatcherRef?: string;
-
-    public componentDidMount(): void {
-        this.dispatcherRef = defaultDispatcher.register(this.onAction);
-    }
-
-    public componentWillUnmount(): void {
-        defaultDispatcher.unregister(this.dispatcherRef);
-    }
-
     private openSpotlight(): void {
         defaultDispatcher.fire(Action.OpenSpotlight);
     }
-
-    private onAction = (payload: ActionPayload): void => {
-        if (payload.action === "focus_room_filter") {
-            this.openSpotlight();
-        }
-    };
 
     public render(): React.ReactNode {
         const classes = classNames(

--- a/test/unit-tests/components/structures/LoggedInView-test.tsx
+++ b/test/unit-tests/components/structures/LoggedInView-test.tsx
@@ -421,6 +421,14 @@ describe("<LoggedInView />", () => {
         expect(defaultDispatcher.dispatch).not.toHaveBeenCalledWith({ action: Action.ViewHomePage });
     });
 
+    it("should open spotlight when Ctrl+k is fired", async () => {
+        jest.spyOn(defaultDispatcher, "fire");
+
+        getComponent();
+        await userEvent.keyboard("{Control>}k{/Control}");
+        expect(defaultDispatcher.fire).toHaveBeenCalledWith(Action.OpenSpotlight);
+    });
+
     describe("timezone updates", () => {
         const userTimezone = "Europe/London";
         const originalController = SETTINGS["userTimezonePublish"].controller;


### PR DESCRIPTION
This PR removes the `focus_room_filter` action and replaces it by `Action.OpenSpotlight`.

1. `focus_room_filter` is fired when `KeyBindingAction.FilterRooms` is triggered:
https://github.com/element-hq/element-web/blob/4b9382f888e1e37830aebb0baaaf756f9991f9f8/src/components/structures/LoggedInView.tsx#L503-L508

2. Which is handled by `RoomSearch`, to directly open the spotlight:
https://github.com/element-hq/element-web/blob/4b9382f888e1e37830aebb0baaaf756f9991f9f8/src/components/structures/RoomSearch.tsx#L27-L43

3. We can directly ditch `focus_room_filter` and opens the spotlight:
https://github.com/element-hq/element-web/blob/1aba639c827a76a6230b02d7aa2301e33baefcda/src/components/structures/LoggedInView.tsx#L503-L506