### PR TITLE
Grow member list search field when resizing the right panel

### DIFF
--- a/res/css/views/rooms/_MemberListHeaderView.pcss
+++ b/res/css/views/rooms/_MemberListHeaderView.pcss
@@ -16,6 +16,7 @@ Please see LICENSE files in the repository root for full details.
 
     .mx_MemberListHeaderView_invite_small {
         margin-left: var(--cpd-space-3x);
+        margin-right: var(--cpd-space-4x);
     }
 
     .mx_MemberListHeaderView_invite_large {
@@ -33,5 +34,7 @@ Please see LICENSE files in the repository root for full details.
 
     .mx_MemberListHeaderView_search {
         width: 240px;
+        flex-grow: 1;
+        margin-left: var(--cpd-space-4x);
     }
 }


### PR DESCRIPTION
## What's the purpose of this PR?
Allows the member list search field to grow when the right panel is resized

## What does it looks like?

**Before**

https://github.com/user-attachments/assets/605f5c07-68e9-4a48-b060-0a85611fce8d


**After**

https://github.com/user-attachments/assets/66c770f9-c388-47d7-9bc9-11acb44b6ca5

