### PR TITLE
Add space to the bottom of the room summary actions below leave room

### DIFF
--- a/res/css/views/right_panel/_RoomSummaryCard.pcss
+++ b/res/css/views/right_panel/_RoomSummaryCard.pcss
@@ -10,6 +10,10 @@ Please see LICENSE files in the repository root for full details.
     --cpd-separator-inset: var(--cpd-space-4x);
     --cpd-separator-spacing: var(--cpd-space-4x);
 
+    .mx_AutoHideScrollbar {
+        margin-bottom: var(--cpd-space-6x);
+    }
+
     .mx_RoomSummaryCard_container {
         text-align: center;
         margin: $spacing-20 var(--cpd-space-4x) 0;

--- a/res/css/views/right_panel/_RoomSummaryCard.pcss
+++ b/res/css/views/right_panel/_RoomSummaryCard.pcss
@@ -11,7 +11,7 @@ Please see LICENSE files in the repository root for full details.
     --cpd-separator-spacing: var(--cpd-space-4x);
 
     .mx_AutoHideScrollbar {
-        margin-bottom: var(--cpd-space-6x);
+        margin-bottom: var(--cpd-space-8x);
     }
 
     .mx_RoomSummaryCard_container {


### PR DESCRIPTION
As a part of design review in https://github.com/element-hq/wat-internal/issues/242 

## What does this PR do?
Adds space under the menu items in the room summary panel. When screen size is reduced such that the actions scroll there is no padding under the lat action (Leave Room).

What does it looks like?

**Before**
![image](https://github.com/user-attachments/assets/9a007c15-7f6e-4315-b9ec-380ed9416252)

**After**
![image](https://github.com/user-attachments/assets/9f3985fa-becd-48a2-892d-af1b1c44134f)
