### PR TITLE
Fix font scaling in member list

### DIFF
--- a/res/css/views/rooms/_MemberTileView.pcss
+++ b/res/css/views/rooms/_MemberTileView.pcss
@@ -27,13 +27,11 @@ Please see LICENSE files in the repository root for full details.
 
     .mx_MemberTileView_name {
         font: var(--cpd-font-body-md-medium);
-        font-size: 15px;
         min-width: 0;
     }
 
     .mx_MemberTileView_userLabel {
         font: var(--cpd-font-body-sm-regular);
-        font-size: 13px;
         color: var(--cpd-color-text-secondary);
         margin-left: var(--cpd-space-4x);
     }


### PR DESCRIPTION
Closes https://github.com/element-hq/element-web/issues/29250
Member list font doesn't scale with the font size selected in the user settings or the browser font size.

| Before  | After |
| ------------- | ------------- |
| <img width="1119" alt="image" src="https://github.com/user-attachments/assets/047adf4b-ad58-4ab2-8942-2658d9ba4c63" />  | <img width="1119" alt="image" src="https://github.com/user-attachments/assets/a812f109-a9a1-46f8-a6af-66befb29d8f4" />|