### PR TITLE
Honour the backup disable flag from Element X

### DIFF
--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -330,7 +330,7 @@ export default class DeviceListener {
             } else if (defaultKeyId === null) {
                 // the user just hasn't set up 4S yet: prompt them to do so (unless they've explicitly said no to key storage)
                 const disabledEvent = cli.getAccountData(BACKUP_DISABLED_ACCOUNT_DATA_KEY);
-                if (!disabledEvent || !disabledEvent.getContent()?.disabled) {
+                if (!disabledEvent?.getContent().disabled) {
                     showSetupEncryptionToast(SetupKind.SET_UP_RECOVERY);
                 }
             } else {


### PR DESCRIPTION
This unfortunately named and unspecced flag is set by Element X to denote that the user has chosen to disable key storage and it should not automatically try to enable it again. This changes Element web to not prompt to enable recovery if this flag is set.

Split out from https://github.com/element-hq/element-web/pull/29113

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
