### PR TITLE
Fix 3pid timeout flakes

### DIFF
--- a/test/unit-tests/components/views/settings/AddRemoveThreepids-test.tsx
+++ b/test/unit-tests/components/views/settings/AddRemoveThreepids-test.tsx
@@ -172,7 +172,7 @@ describe("AddRemoveThreepids", () => {
 
         const countryDropdown = await screen.findByRole("button", { name: /Country Dropdown/ });
         await userEvent.click(countryDropdown);
-        const gbOption = screen.getByRole("option", { name: "🇬🇧 United Kingdom (+44)" });
+        const gbOption = screen.getByText("United Kingdom (+44)");
         await userEvent.click(gbOption);
 
         const input = screen.getByRole("textbox", { name: "Phone Number" });
@@ -511,7 +511,7 @@ describe("AddRemoveThreepids", () => {
 
         const countryDropdown = screen.getByRole("button", { name: /Country Dropdown/ });
         await userEvent.click(countryDropdown);
-        const gbOption = screen.getByRole("option", { name: "🇬🇧 United Kingdom (+44)" });
+        const gbOption = screen.getByText("United Kingdom (+44)");
         await userEvent.click(gbOption);
 
         const input = screen.getByRole("textbox", { name: "Phone Number" });


### PR DESCRIPTION
Hopefully fixes:
- https://github.com/element-hq/element-web/issues/29137
- https://github.com/element-hq/element-web/issues/28048

`getByRole` is slow on large trees([as per the docs](https://testing-library.com/docs/queries/byrole/#performance)), using `getByText` for the long list of country codes sped this up for me locally from 2.5s to 400ms.