### PR TITLE
Fix SyntaxHighlight flake

### DIFF
--- a/test/unit-tests/components/views/elements/SyntaxHighlight-test.tsx
+++ b/test/unit-tests/components/views/elements/SyntaxHighlight-test.tsx
@@ -12,8 +12,10 @@ import SyntaxHighlight from "../../../../../src/components/views/elements/Syntax
 
 describe("<SyntaxHighlight />", () => {
     it("renders", async () => {
-        const { container } = render(<SyntaxHighlight>console.log("Hello, World!");</SyntaxHighlight>);
-        await waitFor(() => expect(container.querySelector(".language-arcade")).toBeTruthy());
+        const { container } = render(
+            <SyntaxHighlight language="javascript">console.log("Hello, World!");</SyntaxHighlight>,
+        );
+        await waitFor(() => expect(container.querySelector(".language-javascript")).toBeTruthy());
         expect(container).toMatchSnapshot();
     });
 

--- a/test/unit-tests/components/views/elements/__snapshots__/SyntaxHighlight-test.tsx.snap
+++ b/test/unit-tests/components/views/elements/__snapshots__/SyntaxHighlight-test.tsx.snap
@@ -3,17 +3,17 @@
 exports[`<SyntaxHighlight /> renders 1`] = `
 <div>
   <pre
-    class="mx_SyntaxHighlight hljs language-arcade"
+    class="mx_SyntaxHighlight hljs language-javascript"
   >
     <code>
       <span
-        class="hljs-built_in"
+        class="hljs-variable language_"
       >
         console
       </span>
       .
       <span
-        class="hljs-built_in"
+        class="hljs-title function_"
       >
         log
       </span>


### PR DESCRIPTION
fixes https://github.com/element-hq/element-web/issues/28807

From the logs it looks like the auto detection of the programming language fails and returns undefined [here](https://github.com/element-hq/element-web/blob/develop/src/components/views/elements/SyntaxHighlight.tsx#L26).
I don't think we need to be testing language auto detection as a part of this test, i think we explicitly pass a language in our uses of SyntaxHighlight at the moment. From [the docs](https://highlightjs.readthedocs.io/en/latest/api.html#highlight) it looks like the language gets passed through so this should fix the flake.