### PR TITLE
Fix test that doesn't make sense in usePublicRoomDirectory-test.tsx

### DIFF
--- a/test/unit-tests/hooks/usePublicRoomDirectory-test.tsx
+++ b/test/unit-tests/hooks/usePublicRoomDirectory-test.tsx
@@ -66,24 +66,6 @@ describe("usePublicRoomDirectory", () => {
         expect(result.current.publicRooms[0].name).toBe(query);
     });
 
-    it("should work with empty queries", async () => {
-        const query = "ROOM NAME";
-        const { result } = render();
-
-        act(() => {
-            result.current.search({
-                limit: 1,
-                query,
-            });
-        });
-
-        await waitFor(() => {
-            expect(result.current.ready).toBe(true);
-        });
-
-        expect(result.current.publicRooms[0].name).toEqual(query);
-    });
-
     it("should recover from a server exception", async () => {
         cli.publicRooms = () => {
             throw new Error("Oops");

--- a/test/unit-tests/hooks/usePublicRoomDirectory-test.tsx
+++ b/test/unit-tests/hooks/usePublicRoomDirectory-test.tsx
@@ -27,17 +27,17 @@ describe("usePublicRoomDirectory", () => {
         cli.getDomain = () => "matrix.org";
         cli.getThirdpartyProtocols = () => Promise.resolve({});
         cli.publicRooms = ({ filter }: IRoomDirectoryOptions) => {
-            const chunk = filter?.generic_search_term
-                ? [
-                      {
-                          room_id: "hello world!",
-                          name: filter.generic_search_term,
-                          world_readable: true,
-                          guest_can_join: true,
-                          num_joined_members: 1,
-                      },
-                  ]
-                : [];
+            console.log("filter 123");
+            console.log(filter);
+            const chunk = [
+                {
+                    room_id: "hello world!",
+                    name: filter?.generic_search_term ?? "",
+                    world_readable: true,
+                    guest_can_join: true,
+                    num_joined_members: 1,
+                },
+            ];
             return Promise.resolve({
                 chunk,
                 total_room_count_estimate: 1,
@@ -64,6 +64,26 @@ describe("usePublicRoomDirectory", () => {
         });
 
         expect(result.current.publicRooms[0].name).toBe(query);
+    });
+
+    it("should work with empty queries", async () => {
+        const query = "";
+        const { result } = render();
+
+        act(() => {
+            result.current.search({
+                limit: 1,
+                query,
+            });
+        });
+
+        await waitFor(() => {
+            expect(result.current.ready).toBe(true);
+        });
+
+        console.log(result.current.publicRooms);
+
+        expect(result.current.publicRooms[0].name).toEqual(query);
     });
 
     it("should recover from a server exception", async () => {

--- a/test/unit-tests/hooks/usePublicRoomDirectory-test.tsx
+++ b/test/unit-tests/hooks/usePublicRoomDirectory-test.tsx
@@ -27,12 +27,10 @@ describe("usePublicRoomDirectory", () => {
         cli.getDomain = () => "matrix.org";
         cli.getThirdpartyProtocols = () => Promise.resolve({});
         cli.publicRooms = ({ filter }: IRoomDirectoryOptions) => {
-            console.log("filter 123");
-            console.log(filter);
             const chunk = [
                 {
                     room_id: "hello world!",
-                    name: filter?.generic_search_term ?? "",
+                    name: filter?.generic_search_term ?? "", // If the query is "" no filter is applied(an is undefined here), in keeping with the pattern let's call the room ""
                     world_readable: true,
                     guest_can_join: true,
                     num_joined_members: 1,
@@ -80,8 +78,6 @@ describe("usePublicRoomDirectory", () => {
         await waitFor(() => {
             expect(result.current.ready).toBe(true);
         });
-
-        console.log(result.current.publicRooms);
 
         expect(result.current.publicRooms[0].name).toEqual(query);
     });


### PR DESCRIPTION
fixes https://github.com/element-hq/element-web/issues/28806

This test no longer makes sense.

It looks like it got mangled [here](https://github.com/matrix-org/matrix-react-sdk/commit/4012f0c591f61627077a739c62ef82fdbb13eb05#diff-3eb367fdb1f6a6c82743841b43ce91f061cd63bde6e914cc09100b5f287cdf06R79-R93).

It seems the intent of the test was to check empty queries but has a query > 0 probably from a copy/paste typo.

[usePublicRoomDirectory](https://github.com/element-hq/element-web/blob/develop/src/hooks/usePublicRoomDirectory.ts#L100) doesn't set a filter for a query that is falsy.

I've fixed up the test to make sense, returning results(no filter) for ""