### PR TITLE
New room list: add compose menu for spaces in header

### DIFF
--- a/playwright/e2e/left-panel/room-list-view/room-list-header.spec.ts
+++ b/playwright/e2e/left-panel/room-list-view/room-list-header.spec.ts
@@ -53,6 +53,6 @@ test.describe("Header section of the room list", () => {
 
         const roomListHeader = getHeaderSection(page);
         await expect(roomListHeader.getByRole("heading", { name: "MySpace" })).toBeVisible();
-        await expect(roomListHeader.getByRole("button", { name: "Add" })).not.toBeVisible();
+        await expect(roomListHeader.getByRole("button", { name: "Add" })).toBeVisible();
     });
 });

--- a/src/components/viewmodels/roomlist/RoomListHeaderViewModel.tsx
+++ b/src/components/viewmodels/roomlist/RoomListHeaderViewModel.tsx
@@ -102,8 +102,11 @@ export function useRoomListHeaderViewModel(): RoomListHeaderViewState {
 
     const createRoom = useCallback(
         (e: Event) => {
-            if (activeSpace) showCreateNewRoom(activeSpace);
-            else defaultDispatcher.fire(Action.CreateRoom);
+            if (activeSpace) {
+                showCreateNewRoom(activeSpace);
+            } else {
+                defaultDispatcher.fire(Action.CreateRoom);
+            }
             PosthogTrackers.trackInteraction("WebRoomListHeaderPlusMenuCreateRoomItem", e);
         },
         [activeSpace],
@@ -112,12 +115,14 @@ export function useRoomListHeaderViewModel(): RoomListHeaderViewState {
     const elementCallVideoRoomsEnabled = useFeatureEnabled("feature_element_call_video_rooms");
     const createVideoRoom = useCallback(() => {
         const type = elementCallVideoRoomsEnabled ? RoomType.UnstableCall : RoomType.ElementVideo;
-        if (activeSpace) showCreateNewRoom(activeSpace, type);
-        else
+        if (activeSpace) {
+            showCreateNewRoom(activeSpace, type);
+        } else {
             defaultDispatcher.dispatch({
                 action: Action.CreateRoom,
-                type: elementCallVideoRoomsEnabled ? RoomType.UnstableCall : RoomType.ElementVideo,
+                type,
             });
+        }
     }, [activeSpace, elementCallVideoRoomsEnabled]);
 
     return {

--- a/src/components/viewmodels/roomlist/RoomListHeaderViewModel.tsx
+++ b/src/components/viewmodels/roomlist/RoomListHeaderViewModel.tsx
@@ -23,6 +23,7 @@ import {
     UPDATE_SELECTED_SPACE,
 } from "../../../stores/spaces";
 import SpaceStore from "../../../stores/spaces/SpaceStore";
+import { showCreateNewRoom } from "../../../utils/space";
 
 /**
  * Hook to get the active space and its title.
@@ -55,7 +56,7 @@ export interface RoomListHeaderViewState {
     title: string;
     /**
      * Whether to display the compose menu
-     * True if the user can create rooms and is not in a Space
+     * True if the user can create rooms
      */
     displayComposeMenu: boolean;
     /**
@@ -84,15 +85,13 @@ export interface RoomListHeaderViewState {
 
 /**
  * View model for the RoomListHeader.
- * The actions don't work when called in a space yet.
  */
 export function useRoomListHeaderViewModel(): RoomListHeaderViewState {
     const { activeSpace, title } = useSpace();
 
     const canCreateRoom = shouldShowComponent(UIComponent.CreateRooms);
     const canCreateVideoRoom = useFeatureEnabled("feature_video_rooms");
-    // Temporary: don't display the compose menu when in a Space
-    const displayComposeMenu = canCreateRoom && !activeSpace;
+    const displayComposeMenu = canCreateRoom;
 
     /* Actions */
 
@@ -101,20 +100,25 @@ export function useRoomListHeaderViewModel(): RoomListHeaderViewState {
         PosthogTrackers.trackInteraction("WebRoomListHeaderPlusMenuCreateChatItem", e);
     }, []);
 
-    const createRoom = useCallback((e: Event) => {
-        defaultDispatcher.fire(Action.CreateRoom);
-        PosthogTrackers.trackInteraction("WebRoomListHeaderPlusMenuCreateRoomItem", e);
-    }, []);
+    const createRoom = useCallback(
+        (e: Event) => {
+            if (activeSpace) showCreateNewRoom(activeSpace);
+            else defaultDispatcher.fire(Action.CreateRoom);
+            PosthogTrackers.trackInteraction("WebRoomListHeaderPlusMenuCreateRoomItem", e);
+        },
+        [activeSpace],
+    );
 
     const elementCallVideoRoomsEnabled = useFeatureEnabled("feature_element_call_video_rooms");
-    const createVideoRoom = useCallback(
-        () =>
+    const createVideoRoom = useCallback(() => {
+        const type = elementCallVideoRoomsEnabled ? RoomType.UnstableCall : RoomType.ElementVideo;
+        if (activeSpace) showCreateNewRoom(activeSpace, type);
+        else
             defaultDispatcher.dispatch({
                 action: Action.CreateRoom,
                 type: elementCallVideoRoomsEnabled ? RoomType.UnstableCall : RoomType.ElementVideo,
-            }),
-        [elementCallVideoRoomsEnabled],
-    );
+            });
+    }, [activeSpace, elementCallVideoRoomsEnabled]);
 
     return {
         title,


### PR DESCRIPTION
[Figma design](https://www.figma.com/design/vlmt46QDdE4dgXDiyBJXqp/Left-Panel-2025?node-id=751-22786)
Task https://github.com/element-hq/wat-internal/issues/204

Add the compose menu for spaces in the new room list header
<img width="378" alt="image" src="https://github.com/user-attachments/assets/1435cb35-fd51-4e24-92bd-ef30085739d7" />
