### PR TITLE
Ensure interactive elements have descriptions

### DIFF
--- a/res/css/views/settings/_SetIntegrationManager.pcss
+++ b/res/css/views/settings/_SetIntegrationManager.pcss
@@ -7,19 +7,13 @@ Please see LICENSE files in the repository root for full details.
 */
 
 .mx_SetIntegrationManager {
-    .mx_SettingsFlag {
+    .mx_SetIntegrationManager_heading_manager {
+        display: flex;
         align-items: center;
-
-        .mx_SetIntegrationManager_heading_manager {
-            display: flex;
-            align-items: center;
-            flex-wrap: wrap;
-            column-gap: $spacing-4;
-        }
-
-        .mx_ToggleSwitch {
-            align-self: flex-start;
-            min-width: var(--ToggleSwitch-min-width); /* avoid compression */
-        }
+        flex-wrap: wrap;
+        column-gap: $spacing-4;
+    }
+    form {
+        margin-top: var(--cpd-space-3x);
     }
 }

--- a/src/components/views/settings/AvatarSetting.tsx
+++ b/src/components/views/settings/AvatarSetting.tsx
@@ -188,6 +188,7 @@ const AvatarSetting: React.FC<IProps> = ({
             <AccessibleButton
                 element="img"
                 className="mx_AvatarSetting_avatarDisplay"
+                aria-labelledby={disabled ? undefined : a11yId}
                 src={avatarURL}
                 alt={avatarAltText}
                 onClick={uploadAvatar}
@@ -211,7 +212,7 @@ const AvatarSetting: React.FC<IProps> = ({
     }
 
     const content = (
-        <div className="mx_AvatarSetting_avatar" role="group" aria-label={avatarAltText}>
+        <div className="mx_AvatarSetting_avatar" role="group" id={a11yId} aria-label={avatarAltText}>
             {avatarElement}
             {uploadAvatarBtn}
         </div>

--- a/src/components/views/settings/SetIntegrationManager.tsx
+++ b/src/components/views/settings/SetIntegrationManager.tsx
@@ -15,10 +15,10 @@ import { IntegrationManagers } from "../../../integrations/IntegrationManagers";
 import { type IntegrationManagerInstance } from "../../../integrations/IntegrationManagerInstance";
 import SettingsStore from "../../../settings/SettingsStore";
 import { SettingLevel } from "../../../settings/SettingLevel";
-import ToggleSwitch from "../elements/ToggleSwitch";
 import Heading from "../typography/Heading";
 import { SettingsSubsectionText } from "./shared/SettingsSubsection";
 import { UIFeature } from "../../../settings/UIFeature";
+import { Root, InlineField, Label, ToggleInput } from "@vector-im/compound-web";
 
 interface IState {
     currentManager: IntegrationManagerInstance | null;
@@ -66,26 +66,24 @@ export default class SetIntegrationManager extends React.Component<EmptyObject, 
         if (!SettingsStore.getValue(UIFeature.Widgets)) return null;
 
         return (
-            <label
+            <div
                 className="mx_SetIntegrationManager"
                 data-testid="mx_SetIntegrationManager"
-                htmlFor="toggle_integration"
             >
                 <div className="mx_SettingsFlag">
                     <div className="mx_SetIntegrationManager_heading_manager">
                         <Heading size="3">{_t("integration_manager|manage_title")}</Heading>
                         <Heading size="4">{managerName}</Heading>
                     </div>
-                    <ToggleSwitch
-                        id="toggle_integration"
-                        checked={this.state.provisioningEnabled}
-                        disabled={false}
-                        onChange={this.onProvisioningToggled}
-                    />
                 </div>
                 <SettingsSubsectionText>{bodyText}</SettingsSubsectionText>
                 <SettingsSubsectionText>{_t("integration_manager|explainer")}</SettingsSubsectionText>
-            </label>
+                <Root>
+                    <InlineField name="enable_im" control={<ToggleInput id={"mx_SetIntegrationManager_Toggle"} checked={this.state.provisioningEnabled} onChange={this.onProvisioningToggled}></ToggleInput>}>
+                        <Label htmlFor={"mx_SetIntegrationManager_Toggle"}>{_t("integration_manager|toggle_label")}</Label>
+                    </InlineField>
+                </Root>
+            </div>
         );
     }
 }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1299,6 +1299,7 @@
         "error_connecting_heading": "Cannot connect to integration manager",
         "explainer": "Integration managers receive configuration data, and can modify widgets, send room invites, and set power levels on your behalf.",
         "manage_title": "Manage integrations",
+        "toggle_label": "Enable the integration manager",
         "use_im": "Use an integration manager to manage bots, widgets, and sticker packs.",
         "use_im_default": "Use an integration manager <b>(%(serverName)s)</b> to manage bots, widgets, and sticker packs."
     },


### PR DESCRIPTION
There are a few places where the labels for interactive elements are not clear, this PR attempts to clean those up.

- [x] Integration manager toggle functionality now states function a7c94cd06ab49c87efe0f039bdea0660ad3bea4d
- [x] Avatar menu button is now labelled b00083131086ebec03e48fe440047db5745dbcee
- [ ] Under **Settings - Sidebar** there is a checkbox for "Home" that lacks an accessible name
- [ ] The two checkboxes under **Settings - Security & Privacy - Unverified devices** have a visual label, but it's not in the label element belonging to each checkbox. 
- [ ] Home welcome close button is nested?
- [ ] "Click to read topic" isn't accessible.

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
