### PR TITLE
fix: /tmp/element-web-config may already exist preventing the container from booting up

### DIFF
--- a/docker/docker-entrypoint.d/18-load-element-modules.sh
+++ b/docker/docker-entrypoint.d/18-load-element-modules.sh
@@ -11,7 +11,7 @@ entrypoint_log() {
 }
 
 # Copy these config files as a base
-mkdir /tmp/element-web-config || true
+mkdir -p /tmp/element-web-config
 cp /app/config*.json /tmp/element-web-config/
 
 # If there are modules to be loaded

--- a/docker/docker-entrypoint.d/18-load-element-modules.sh
+++ b/docker/docker-entrypoint.d/18-load-element-modules.sh
@@ -11,7 +11,7 @@ entrypoint_log() {
 }
 
 # Copy these config files as a base
-mkdir /tmp/element-web-config
+mkdir /tmp/element-web-config || true
 cp /app/config*.json /tmp/element-web-config/
 
 # If there are modules to be loaded


### PR DESCRIPTION
Closes: #29371

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
