### PR TITLE
Room List Store: Filter rooms by active space

### DIFF
--- a/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -62,7 +62,7 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
     /**
      * Get a list of sorted rooms that belong to the currently active space.
      */
-    public getSortedRoomInActiveSpace(): Room[] {
+    public getSortedRoomsInActiveSpace(): Room[] {
         if (this.roomSkipList?.initialized) return Array.from(this.roomSkipList.getRoomsInActiveSpace());
         else return [];
     }

--- a/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -92,7 +92,7 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
         const sorter = new RecencySorter(this.matrixClient.getSafeUserId());
         this.roomSkipList = new RoomSkipList(sorter);
         const rooms = this.getRooms();
-        await SpaceStore.instance.isReady;
+        await SpaceStore.instance.storeReadyPromise;
         this.roomSkipList.seed(rooms);
         this.emit(LISTS_UPDATE_EVENT);
     }

--- a/src/stores/room-list-v3/skip-list/RoomNode.ts
+++ b/src/stores/room-list-v3/skip-list/RoomNode.ts
@@ -6,6 +6,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import type { Room } from "matrix-js-sdk/src/matrix";
+import SpaceStore from "../../spaces/SpaceStore";
 
 /**
  * Room skip list stores room nodes.
@@ -13,6 +14,8 @@ import type { Room } from "matrix-js-sdk/src/matrix";
  * in different levels.
  */
 export class RoomNode {
+    private _isInActiveSpace: boolean = false;
+
     public constructor(public readonly room: Room) {}
 
     /**
@@ -26,4 +29,23 @@ export class RoomNode {
      * eg: previous[i] gives the previous room node from this room node in level i.
      */
     public previous: RoomNode[] = [];
+
+    /**
+     * Whether the room associated with this room node belongs to
+     * the currently active space.
+     * @see {@link SpaceStoreClass#activeSpace} to understand what active
+     * space means.
+     */
+    public get isInActiveSpace(): boolean {
+        return this._isInActiveSpace;
+    }
+
+    /**
+     * Check if this room belongs to the active space and store the result
+     * in {@link RoomNode#isInActiveSpace}.
+     */
+    public checkIfRoomBelongsToActiveSpace(): void {
+        const activeSpace = SpaceStore.instance.activeSpace;
+        this._isInActiveSpace = SpaceStore.instance.isRoomInSpace(activeSpace, this.room.roomId);
+    }
 }

--- a/src/stores/spaces/SpaceStore.ts
+++ b/src/stores/spaces/SpaceStore.ts
@@ -153,7 +153,7 @@ export class SpaceStoreClass extends AsyncStoreWithClient<EmptyObject> {
     private _enabledMetaSpaces: MetaSpace[] = [];
     /** Whether the feature flag is set for MSC3946 */
     private _msc3946ProcessDynamicPredecessor: boolean = SettingsStore.getValue("feature_dynamic_room_predecessors");
-    private _isReady = defer();
+    private _storeReadyDeferred = defer();
 
     public constructor() {
         super(defaultDispatcher, {});
@@ -165,11 +165,11 @@ export class SpaceStoreClass extends AsyncStoreWithClient<EmptyObject> {
     }
 
     /**
-     * Returns a promise that resolves when the space store is ready.
+     * A promise that resolves when the space store is ready.
      * This happens after an initial hierarchy of spaces and rooms has been computed.
      */
-    public get isReady(): Promise<void> {
-        return this._isReady.promise;
+    public get storeReadyPromise(): Promise<void> {
+        return this._storeReadyDeferred.promise;
     }
 
     /**
@@ -1211,7 +1211,7 @@ export class SpaceStoreClass extends AsyncStoreWithClient<EmptyObject> {
         } else {
             this.switchSpaceIfNeeded();
         }
-        this._isReady.resolve();
+        this._storeReadyDeferred.resolve();
     }
 
     private sendUserProperties(): void {

--- a/src/stores/spaces/SpaceStore.ts
+++ b/src/stores/spaces/SpaceStore.ts
@@ -21,6 +21,7 @@ import {
 } from "matrix-js-sdk/src/matrix";
 import { KnownMembership } from "matrix-js-sdk/src/types";
 import { logger } from "matrix-js-sdk/src/logger";
+import { defer } from "matrix-js-sdk/src/utils";
 
 import { AsyncStoreWithClient } from "../AsyncStoreWithClient";
 import defaultDispatcher from "../../dispatcher/dispatcher";
@@ -152,6 +153,7 @@ export class SpaceStoreClass extends AsyncStoreWithClient<EmptyObject> {
     private _enabledMetaSpaces: MetaSpace[] = [];
     /** Whether the feature flag is set for MSC3946 */
     private _msc3946ProcessDynamicPredecessor: boolean = SettingsStore.getValue("feature_dynamic_room_predecessors");
+    private _isReady = defer();
 
     public constructor() {
         super(defaultDispatcher, {});
@@ -160,6 +162,14 @@ export class SpaceStoreClass extends AsyncStoreWithClient<EmptyObject> {
         SettingsStore.monitorSetting("Spaces.enabledMetaSpaces", null);
         SettingsStore.monitorSetting("Spaces.showPeopleInSpace", null);
         SettingsStore.monitorSetting("feature_dynamic_room_predecessors", null);
+    }
+
+    /**
+     * Returns a promise that resolves when the space store is ready.
+     * This happens after an initial hierarchy of spaces and rooms has been computed.
+     */
+    public get isReady(): Promise<void> {
+        return this._isReady.promise;
     }
 
     /**
@@ -1201,6 +1211,7 @@ export class SpaceStoreClass extends AsyncStoreWithClient<EmptyObject> {
         } else {
             this.switchSpaceIfNeeded();
         }
+        this._isReady.resolve();
     }
 
     private sendUserProperties(): void {

--- a/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
+++ b/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
@@ -33,7 +33,7 @@ describe("RoomListStoreV3", () => {
     beforeEach(() => {
         jest.spyOn(SpaceStore.instance, "isRoomInSpace").mockImplementation((space) => space === MetaSpace.Home);
         jest.spyOn(SpaceStore.instance, "activeSpace", "get").mockImplementation(() => MetaSpace.Home);
-        jest.spyOn(SpaceStore.instance, "isReady", "get").mockImplementation(() => Promise.resolve());
+        jest.spyOn(SpaceStore.instance, "storeReadyPromise", "get").mockImplementation(() => Promise.resolve());
     });
 
     it("Provides an unsorted list of rooms", async () => {

--- a/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
+++ b/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
@@ -26,9 +26,15 @@ describe("RoomListStoreV3", () => {
         client.getVisibleRooms = jest.fn().mockReturnValue(rooms);
         jest.spyOn(AsyncStoreWithClient.prototype, "matrixClient", "get").mockReturnValue(client);
         const store = new RoomListStoreV3Class(dispatcher);
-        store.start();
+        await store.start();
         return { client, rooms, store, dispatcher };
     }
+
+    beforeEach(() => {
+        jest.spyOn(SpaceStore.instance, "isRoomInSpace").mockImplementation((space) => space === MetaSpace.Home);
+        jest.spyOn(SpaceStore.instance, "activeSpace", "get").mockImplementation(() => MetaSpace.Home);
+        jest.spyOn(SpaceStore.instance, "isReady", "get").mockImplementation(() => Promise.resolve());
+    });
 
     it("Provides an unsorted list of rooms", async () => {
         const { store, rooms } = await getRoomListStore();
@@ -282,7 +288,6 @@ describe("RoomListStoreV3", () => {
                 jest.spyOn(AsyncStoreWithClient.prototype, "matrixClient", "get").mockReturnValue(client);
 
                 // Mock the space store
-                jest.spyOn(SpaceStore.instance, "isReady", "get").mockImplementation(() => Promise.resolve());
                 jest.spyOn(SpaceStore.instance, "isRoomInSpace").mockImplementation((space, id) => {
                     if (space === MetaSpace.Home && !roomIds.includes(id)) return true;
                     if (space === spaceRoom.roomId && roomIds.includes(id)) return true;

--- a/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
+++ b/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
@@ -11,11 +11,13 @@ import { logger } from "matrix-js-sdk/src/logger";
 import { RoomListStoreV3Class } from "../../../../src/stores/room-list-v3/RoomListStoreV3";
 import { AsyncStoreWithClient } from "../../../../src/stores/AsyncStoreWithClient";
 import { RecencySorter } from "../../../../src/stores/room-list-v3/skip-list/sorters/RecencySorter";
-import { mkEvent, mkMessage, stubClient, upsertRoomStateEvents } from "../../../test-utils";
+import { mkEvent, mkMessage, mkSpace, stubClient, upsertRoomStateEvents } from "../../../test-utils";
 import { getMockedRooms } from "./skip-list/getMockedRooms";
 import { AlphabeticSorter } from "../../../../src/stores/room-list-v3/skip-list/sorters/AlphabeticSorter";
 import { LISTS_UPDATE_EVENT } from "../../../../src/stores/room-list/RoomListStore";
 import dispatcher from "../../../../src/dispatcher/dispatcher";
+import SpaceStore from "../../../../src/stores/spaces/SpaceStore";
+import { MetaSpace, UPDATE_SELECTED_SPACE } from "../../../../src/stores/spaces";
 
 describe("RoomListStoreV3", () => {
     async function getRoomListStore() {
@@ -262,6 +264,50 @@ describe("RoomListStoreV3", () => {
                     true,
                 );
                 expect(fn).not.toHaveBeenCalled();
+            });
+        });
+
+        describe("Spaces", () => {
+            it("Filtering by spaces work", async () => {
+                const client = stubClient();
+                const rooms = getMockedRooms(client);
+
+                // Let's choose 5 rooms to put in space
+                const indexes = [6, 8, 13, 27, 75];
+                const roomIds = indexes.map((i) => rooms[i].roomId);
+                const spaceRoom = mkSpace(client, "!space1:matrix.org", [], roomIds);
+                rooms.push(spaceRoom);
+
+                client.getVisibleRooms = jest.fn().mockReturnValue(rooms);
+                jest.spyOn(AsyncStoreWithClient.prototype, "matrixClient", "get").mockReturnValue(client);
+
+                // Mock the space store
+                jest.spyOn(SpaceStore.instance, "isReady", "get").mockImplementation(() => Promise.resolve());
+                jest.spyOn(SpaceStore.instance, "isRoomInSpace").mockImplementation((space, id) => {
+                    if (space === MetaSpace.Home && !roomIds.includes(id)) return true;
+                    if (space === spaceRoom.roomId && roomIds.includes(id)) return true;
+                    return false;
+                });
+
+                const store = new RoomListStoreV3Class(dispatcher);
+                await store.start();
+                const fn = jest.fn();
+                store.on(LISTS_UPDATE_EVENT, fn);
+
+                // The rooms which belong to the space should not be shown
+                const result = store.getSortedRoomInActiveSpace().map((r) => r.roomId);
+                for (const id of roomIds) {
+                    expect(result).not.toContain(id);
+                }
+
+                // Lets switch to the space
+                jest.spyOn(SpaceStore.instance, "activeSpace", "get").mockImplementation(() => spaceRoom.roomId);
+                SpaceStore.instance.emit(UPDATE_SELECTED_SPACE);
+                expect(fn).toHaveBeenCalled();
+                const result2 = store.getSortedRoomInActiveSpace().map((r) => r.roomId);
+                for (const id of roomIds) {
+                    expect(result2).toContain(id);
+                }
             });
         });
     });

--- a/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
+++ b/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
@@ -300,7 +300,7 @@ describe("RoomListStoreV3", () => {
                 store.on(LISTS_UPDATE_EVENT, fn);
 
                 // The rooms which belong to the space should not be shown
-                const result = store.getSortedRoomInActiveSpace().map((r) => r.roomId);
+                const result = store.getSortedRoomsInActiveSpace().map((r) => r.roomId);
                 for (const id of roomIds) {
                     expect(result).not.toContain(id);
                 }
@@ -309,7 +309,7 @@ describe("RoomListStoreV3", () => {
                 jest.spyOn(SpaceStore.instance, "activeSpace", "get").mockImplementation(() => spaceRoom.roomId);
                 SpaceStore.instance.emit(UPDATE_SELECTED_SPACE);
                 expect(fn).toHaveBeenCalled();
-                const result2 = store.getSortedRoomInActiveSpace().map((r) => r.roomId);
+                const result2 = store.getSortedRoomsInActiveSpace().map((r) => r.roomId);
                 for (const id of roomIds) {
                     expect(result2).toContain(id);
                 }

--- a/test/unit-tests/stores/room-list-v3/skip-list/RoomSkipList-test.ts
+++ b/test/unit-tests/stores/room-list-v3/skip-list/RoomSkipList-test.ts
@@ -14,6 +14,8 @@ import { RoomSkipList } from "../../../../../src/stores/room-list-v3/skip-list/R
 import { RecencySorter } from "../../../../../src/stores/room-list-v3/skip-list/sorters/RecencySorter";
 import { AlphabeticSorter } from "../../../../../src/stores/room-list-v3/skip-list/sorters/AlphabeticSorter";
 import { getMockedRooms } from "./getMockedRooms";
+import SpaceStore from "../../../../../src/stores/spaces/SpaceStore";
+import { MetaSpace } from "../../../../../src/stores/spaces";
 
 describe("RoomSkipList", () => {
     function generateSkipList(roomCount?: number): {
@@ -29,6 +31,12 @@ describe("RoomSkipList", () => {
         skipList.seed(rooms);
         return { skipList, rooms, totalRooms: rooms.length, sorter };
     }
+
+    beforeEach(() => {
+        jest.spyOn(SpaceStore.instance, "isRoomInSpace").mockImplementation((space) => space === MetaSpace.Home);
+        jest.spyOn(SpaceStore.instance, "activeSpace", "get").mockImplementation(() => MetaSpace.Home);
+        jest.spyOn(SpaceStore.instance, "isReady", "get").mockImplementation(() => Promise.resolve());
+    });
 
     it("Rooms are in sorted order after initial seed", () => {
         const { skipList, totalRooms } = generateSkipList();

--- a/test/unit-tests/stores/room-list-v3/skip-list/RoomSkipList-test.ts
+++ b/test/unit-tests/stores/room-list-v3/skip-list/RoomSkipList-test.ts
@@ -35,7 +35,7 @@ describe("RoomSkipList", () => {
     beforeEach(() => {
         jest.spyOn(SpaceStore.instance, "isRoomInSpace").mockImplementation((space) => space === MetaSpace.Home);
         jest.spyOn(SpaceStore.instance, "activeSpace", "get").mockImplementation(() => MetaSpace.Home);
-        jest.spyOn(SpaceStore.instance, "isReady", "get").mockImplementation(() => Promise.resolve());
+        jest.spyOn(SpaceStore.instance, "storeReadyPromise", "get").mockImplementation(() => Promise.resolve());
     });
 
     it("Rooms are in sorted order after initial seed", () => {


### PR DESCRIPTION
- Each room node in the skip list has a property that tells you if that node belongs to the currently active space. 
- We redo this calculation for all room nodes whenever active space changes.
- We redo this calculation for a single room when it gets an update and is re-inserted into the skip list.
- A list of sorted rooms that belong to the active space is made available through a custom iterator that skips over any nodes that are not in the active space.

Ideally the room list store would give more information about spaces (and the ability to filter by arbitrary spaces) but this should be sufficient for the time being.