### PR TITLE
New room list: improve list accessibility

### DIFF
--- a/playwright/e2e/left-panel/room-list-panel/room-list-panel.spec.ts
+++ b/playwright/e2e/left-panel/room-list-panel/room-list-panel.spec.ts
@@ -35,7 +35,7 @@ test.describe("Room list panel", () => {
     test("should render the room list panel", { tag: "@screenshot" }, async ({ page, app, user }) => {
         const roomListView = getRoomListView(page);
         // Wait for the last room to be visible
-        await expect(roomListView.getByRole("gridcell", { name: "Open room room19" })).toBeVisible();
+        await expect(roomListView.getByRole("option", { name: "Open room room19" })).toBeVisible();
         await expect(roomListView).toMatchScreenshot("room-list-panel.png");
     });
 });

--- a/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
+++ b/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
@@ -32,19 +32,19 @@ test.describe("Room list", () => {
 
     test("should render the room list", { tag: "@screenshot" }, async ({ page, app, user }) => {
         const roomListView = getRoomList(page);
-        await expect(roomListView.getByRole("gridcell", { name: "Open room room29" })).toBeVisible();
+        await expect(roomListView.getByRole("option", { name: "Open room room29" })).toBeVisible();
         await expect(roomListView).toMatchScreenshot("room-list.png");
 
         await roomListView.hover();
         // Scroll to the end of the room list
         await page.mouse.wheel(0, 1000);
-        await expect(roomListView.getByRole("gridcell", { name: "Open room room0" })).toBeVisible();
+        await expect(roomListView.getByRole("option", { name: "Open room room0" })).toBeVisible();
         await expect(roomListView).toMatchScreenshot("room-list-scrolled.png");
     });
 
     test("should open the room when it is clicked", async ({ page, app, user }) => {
         const roomListView = getRoomList(page);
-        await roomListView.getByRole("gridcell", { name: "Open room room29" }).click();
+        await roomListView.getByRole("option", { name: "Open room room29" }).click();
         await expect(page.getByRole("heading", { name: "room29", level: 1 })).toBeVisible();
     });
 });

--- a/src/components/views/rooms/RoomListPanel/RoomList.tsx
+++ b/src/components/views/rooms/RoomListPanel/RoomList.tsx
@@ -5,8 +5,9 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-import React, { useCallback, type JSX } from "react";
+import React, { useCallback, type JSX, useEffect, useRef, type RefObject } from "react";
 import { AutoSizer, List, type ListRowProps } from "react-virtualized";
+import { type Room } from "matrix-js-sdk/src/matrix";
 
 import { type RoomListViewState } from "../../../viewmodels/roomlist/RoomListViewModel";
 import { _t } from "../../../../languageHandler";
@@ -30,9 +31,11 @@ export function RoomList({ vm: { rooms, openRoom } }: RoomListProps): JSX.Elemen
         [rooms, openRoom],
     );
 
+    const ref = useAccessibleList(rooms);
+
     // The first div is needed to make the virtualized list take all the remaining space and scroll correctly
     return (
-        <div className="mx_RoomList" data-testid="room-list">
+        <div className="mx_RoomList" data-testid="room-list" ref={ref}>
             <AutoSizer>
                 {({ height, width }) => (
                     <List
@@ -43,9 +46,61 @@ export function RoomList({ vm: { rooms, openRoom } }: RoomListProps): JSX.Elemen
                         rowHeight={48}
                         height={height}
                         width={width}
+                        role="listbox"
                     />
                 )}
             </AutoSizer>
         </div>
     );
+}
+
+/**
+ * Make the list of rooms accessible. The ref should be put on the list node.
+ *
+ * The list rendered by react-virtualized has not the best role and attributes for accessibility.
+ * The react-virtualized list has the following a11y attributes: "grid" -> "row" -> ["gridcell", "gridcell", "gridcell"].
+ * Using a grid role is not the best choice for a list of items, we want instead a listbox role with children having an option role.
+ *
+ * The listbox and option roles can be set directly in the jsx of the `List` and the `RoomListCell` component but the "gridcell" role is remaining.
+ * This hook removes the "gridcell" role from the list items and set "aria-setsize" on the list too.
+ *
+ * @returns The ref to put on the list node.
+ */
+function useAccessibleList(rooms: Room[]): RefObject<HTMLDivElement> {
+    // To be put on the list node
+    const ref = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        const list = ref.current?.querySelector('[role="listbox"]');
+        if (!list) return;
+
+        // The list is virtualized so the number of items in the dom is not the same as the number of rooms
+        list.setAttribute("aria-setsize", `${rooms.length}`);
+
+        // Determine if a node is a row node
+        const isRowNode = (node: HTMLElement): boolean => node.getAttribute("role") === "row";
+
+        // Watch the node with the "row" role to be added to the dom and remove the role
+        // If the role is re-added/modified later, we remove it too
+        const observer = new MutationObserver((mutationList) => {
+            for (const mutation of mutationList) {
+                if (mutation.type === "childList") {
+                    mutation.addedNodes.forEach((node) => {
+                        if (node instanceof HTMLElement && isRowNode(node)) {
+                            node.removeAttribute("role");
+                        }
+                    });
+                } else if (
+                    mutation.type === "attributes" &&
+                    mutation.target instanceof HTMLElement &&
+                    isRowNode(mutation.target)
+                ) {
+                    mutation.target.removeAttribute("role");
+                }
+            }
+        });
+        observer.observe(list, { childList: true, subtree: true, attributeFilter: ["role"] });
+        return () => observer.disconnect();
+    }, [rooms]);
+
+    return ref;
 }

--- a/src/components/views/rooms/RoomListPanel/RoomList.tsx
+++ b/src/components/views/rooms/RoomListPanel/RoomList.tsx
@@ -26,7 +26,14 @@ interface RoomListProps {
 export function RoomList({ vm: { rooms, openRoom } }: RoomListProps): JSX.Element {
     const roomRendererMemoized = useCallback(
         ({ key, index, style }: ListRowProps) => (
-            <RoomListCell room={rooms[index]} key={key} style={style} onClick={() => openRoom(rooms[index].roomId)} />
+            <RoomListCell
+                room={rooms[index]}
+                key={key}
+                style={style}
+                aria-setsize={rooms.length}
+                aria-posinset={index + 1}
+                onClick={() => openRoom(rooms[index].roomId)}
+            />
         ),
         [rooms, openRoom],
     );
@@ -72,9 +79,6 @@ function useAccessibleList(rooms: Room[]): RefObject<HTMLDivElement> {
     useEffect(() => {
         const list = ref.current?.querySelector('[role="listbox"]');
         if (!list) return;
-
-        // The list is virtualized so the number of items in the dom is not the same as the number of rooms
-        list.setAttribute("aria-setsize", `${rooms.length}`);
 
         // Determine if a node is a row node
         const isRowNode = (node: HTMLElement): boolean => node.getAttribute("role") === "row";

--- a/src/components/views/rooms/RoomListPanel/RoomListCell.tsx
+++ b/src/components/views/rooms/RoomListPanel/RoomListCell.tsx
@@ -29,6 +29,8 @@ export function RoomListCell({ room, ...props }: RoomListCellProps): JSX.Element
             type="button"
             aria-label={_t("room_list|room|open_room", { roomName: room.name })}
             {...props}
+            role="option"
+            aria-selected={false}
         >
             {/* We need this extra div between the button and the content in order to add a padding which is not messing with the virtualized list */}
             <Flex className="mx_RoomListCell_container" gap="var(--cpd-space-3x)" align="center">

--- a/test/unit-tests/components/views/rooms/RoomListPanel/RoomList-test.tsx
+++ b/test/unit-tests/components/views/rooms/RoomListPanel/RoomList-test.tsx
@@ -44,8 +44,6 @@ describe("<RoomList />", () => {
     it("should render a room list", async () => {
         const { asFragment } = await renderList();
         expect(asFragment()).toMatchSnapshot();
-
-        expect(screen.getByRole("listbox").getAttribute("aria-setsize")).toBe(`${vm.rooms.length}`);
     });
 
     it("should open the room", async () => {

--- a/test/unit-tests/components/views/rooms/RoomListPanel/RoomListCell-test.tsx
+++ b/test/unit-tests/components/views/rooms/RoomListPanel/RoomListCell-test.tsx
@@ -38,7 +38,7 @@ describe("<RoomListCell />", () => {
         const onClick = jest.fn();
         render(<RoomListCell room={room} onClick={onClick} />);
 
-        await user.click(screen.getByRole("button", { name: `Open room ${room.name}` }));
+        await user.click(screen.getByRole("option", { name: `Open room ${room.name}` }));
         expect(onClick).toHaveBeenCalled();
     });
 });

--- a/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomList-test.tsx.snap
+++ b/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomList-test.tsx.snap
@@ -12,20 +12,21 @@ exports[`<RoomList /> should render a room list 1`] = `
       <div
         aria-label="Room list"
         aria-readonly="true"
+        aria-setsize="10"
         class="ReactVirtualized__Grid ReactVirtualized__List mx_RoomList_List"
-        role="grid"
+        role="listbox"
         style="box-sizing: border-box; direction: ltr; height: 1500px; position: relative; width: 1500px; will-change: transform; overflow-x: hidden; overflow-y: hidden;"
         tabindex="0"
       >
         <div
           class="ReactVirtualized__Grid__innerScrollContainer"
-          role="row"
           style="width: auto; height: 480px; max-width: 1500px; max-height: 480px; overflow: hidden; position: relative;"
         >
           <button
             aria-label="Open room room0"
+            aria-selected="false"
             class="mx_RoomListCell"
-            role="gridcell"
+            role="option"
             style="height: 48px; left: 0px; position: absolute; top: 0px; width: 100%;"
             type="button"
           >
@@ -70,8 +71,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room1"
+            aria-selected="false"
             class="mx_RoomListCell"
-            role="gridcell"
+            role="option"
             style="height: 48px; left: 0px; position: absolute; top: 48px; width: 100%;"
             type="button"
           >
@@ -116,8 +118,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room2"
+            aria-selected="false"
             class="mx_RoomListCell"
-            role="gridcell"
+            role="option"
             style="height: 48px; left: 0px; position: absolute; top: 96px; width: 100%;"
             type="button"
           >
@@ -162,8 +165,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room3"
+            aria-selected="false"
             class="mx_RoomListCell"
-            role="gridcell"
+            role="option"
             style="height: 48px; left: 0px; position: absolute; top: 144px; width: 100%;"
             type="button"
           >
@@ -208,8 +212,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room4"
+            aria-selected="false"
             class="mx_RoomListCell"
-            role="gridcell"
+            role="option"
             style="height: 48px; left: 0px; position: absolute; top: 192px; width: 100%;"
             type="button"
           >
@@ -254,8 +259,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room5"
+            aria-selected="false"
             class="mx_RoomListCell"
-            role="gridcell"
+            role="option"
             style="height: 48px; left: 0px; position: absolute; top: 240px; width: 100%;"
             type="button"
           >
@@ -300,8 +306,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room6"
+            aria-selected="false"
             class="mx_RoomListCell"
-            role="gridcell"
+            role="option"
             style="height: 48px; left: 0px; position: absolute; top: 288px; width: 100%;"
             type="button"
           >
@@ -346,8 +353,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room7"
+            aria-selected="false"
             class="mx_RoomListCell"
-            role="gridcell"
+            role="option"
             style="height: 48px; left: 0px; position: absolute; top: 336px; width: 100%;"
             type="button"
           >
@@ -392,8 +400,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room8"
+            aria-selected="false"
             class="mx_RoomListCell"
-            role="gridcell"
+            role="option"
             style="height: 48px; left: 0px; position: absolute; top: 384px; width: 100%;"
             type="button"
           >
@@ -438,8 +447,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room9"
+            aria-selected="false"
             class="mx_RoomListCell"
-            role="gridcell"
+            role="option"
             style="height: 48px; left: 0px; position: absolute; top: 432px; width: 100%;"
             type="button"
           >

--- a/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomList-test.tsx.snap
+++ b/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomList-test.tsx.snap
@@ -12,7 +12,6 @@ exports[`<RoomList /> should render a room list 1`] = `
       <div
         aria-label="Room list"
         aria-readonly="true"
-        aria-setsize="10"
         class="ReactVirtualized__Grid ReactVirtualized__List mx_RoomList_List"
         role="listbox"
         style="box-sizing: border-box; direction: ltr; height: 1500px; position: relative; width: 1500px; will-change: transform; overflow-x: hidden; overflow-y: hidden;"
@@ -24,7 +23,9 @@ exports[`<RoomList /> should render a room list 1`] = `
         >
           <button
             aria-label="Open room room0"
+            aria-posinset="1"
             aria-selected="false"
+            aria-setsize="10"
             class="mx_RoomListCell"
             role="option"
             style="height: 48px; left: 0px; position: absolute; top: 0px; width: 100%;"
@@ -71,7 +72,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room1"
+            aria-posinset="2"
             aria-selected="false"
+            aria-setsize="10"
             class="mx_RoomListCell"
             role="option"
             style="height: 48px; left: 0px; position: absolute; top: 48px; width: 100%;"
@@ -118,7 +121,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room2"
+            aria-posinset="3"
             aria-selected="false"
+            aria-setsize="10"
             class="mx_RoomListCell"
             role="option"
             style="height: 48px; left: 0px; position: absolute; top: 96px; width: 100%;"
@@ -165,7 +170,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room3"
+            aria-posinset="4"
             aria-selected="false"
+            aria-setsize="10"
             class="mx_RoomListCell"
             role="option"
             style="height: 48px; left: 0px; position: absolute; top: 144px; width: 100%;"
@@ -212,7 +219,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room4"
+            aria-posinset="5"
             aria-selected="false"
+            aria-setsize="10"
             class="mx_RoomListCell"
             role="option"
             style="height: 48px; left: 0px; position: absolute; top: 192px; width: 100%;"
@@ -259,7 +268,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room5"
+            aria-posinset="6"
             aria-selected="false"
+            aria-setsize="10"
             class="mx_RoomListCell"
             role="option"
             style="height: 48px; left: 0px; position: absolute; top: 240px; width: 100%;"
@@ -306,7 +317,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room6"
+            aria-posinset="7"
             aria-selected="false"
+            aria-setsize="10"
             class="mx_RoomListCell"
             role="option"
             style="height: 48px; left: 0px; position: absolute; top: 288px; width: 100%;"
@@ -353,7 +366,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room7"
+            aria-posinset="8"
             aria-selected="false"
+            aria-setsize="10"
             class="mx_RoomListCell"
             role="option"
             style="height: 48px; left: 0px; position: absolute; top: 336px; width: 100%;"
@@ -400,7 +415,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room8"
+            aria-posinset="9"
             aria-selected="false"
+            aria-setsize="10"
             class="mx_RoomListCell"
             role="option"
             style="height: 48px; left: 0px; position: absolute; top: 384px; width: 100%;"
@@ -447,7 +464,9 @@ exports[`<RoomList /> should render a room list 1`] = `
           </button>
           <button
             aria-label="Open room room9"
+            aria-posinset="10"
             aria-selected="false"
+            aria-setsize="10"
             class="mx_RoomListCell"
             role="option"
             style="height: 48px; left: 0px; position: absolute; top: 432px; width: 100%;"

--- a/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomListCell-test.tsx.snap
+++ b/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomListCell-test.tsx.snap
@@ -4,7 +4,9 @@ exports[`<RoomListCell /> should render a room cell 1`] = `
 <DocumentFragment>
   <button
     aria-label="Open room room1"
+    aria-selected="false"
     class="mx_RoomListCell"
+    role="option"
     type="button"
   >
     <div

--- a/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomListPanel-test.tsx.snap
+++ b/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomListPanel-test.tsx.snap
@@ -34,7 +34,6 @@ exports[`<RoomListPanel /> should not render the RoomListSearch component when U
         <div
           aria-label="Room list"
           aria-readonly="true"
-          aria-setsize="0"
           class="ReactVirtualized__Grid ReactVirtualized__List mx_RoomList_List"
           role="listbox"
           style="box-sizing: border-box; direction: ltr; height: 0px; position: relative; width: 0px; will-change: transform; overflow-x: hidden; overflow-y: hidden;"
@@ -185,7 +184,6 @@ exports[`<RoomListPanel /> should render the RoomListSearch component when UICom
         <div
           aria-label="Room list"
           aria-readonly="true"
-          aria-setsize="0"
           class="ReactVirtualized__Grid ReactVirtualized__List mx_RoomList_List"
           role="listbox"
           style="box-sizing: border-box; direction: ltr; height: 0px; position: relative; width: 0px; will-change: transform; overflow-x: hidden; overflow-y: hidden;"

--- a/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomListPanel-test.tsx.snap
+++ b/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomListPanel-test.tsx.snap
@@ -34,8 +34,9 @@ exports[`<RoomListPanel /> should not render the RoomListSearch component when U
         <div
           aria-label="Room list"
           aria-readonly="true"
+          aria-setsize="0"
           class="ReactVirtualized__Grid ReactVirtualized__List mx_RoomList_List"
-          role="grid"
+          role="listbox"
           style="box-sizing: border-box; direction: ltr; height: 0px; position: relative; width: 0px; will-change: transform; overflow-x: hidden; overflow-y: hidden;"
           tabindex="0"
         />
@@ -184,8 +185,9 @@ exports[`<RoomListPanel /> should render the RoomListSearch component when UICom
         <div
           aria-label="Room list"
           aria-readonly="true"
+          aria-setsize="0"
           class="ReactVirtualized__Grid ReactVirtualized__List mx_RoomList_List"
-          role="grid"
+          role="listbox"
           style="box-sizing: border-box; direction: ltr; height: 0px; position: relative; width: 0px; will-change: transform; overflow-x: hidden; overflow-y: hidden;"
           tabindex="0"
         />


### PR DESCRIPTION
Task https://github.com/element-hq/element-web/pull/29368
https://github.com/element-hq/element-web/pull/29368 introduced a new room list with accessibility drawbacks. The list was using accessibility roles related to grid instead of listbox.

https://github.com/bvaughn/react-virtualized/issues/1657 gives a good summary of the situation some years ago. The missing roles in the issues have been fixed since but *react-virtualized* sticks with grid role instead of listbox.

This PR aims to replace the a11y roles. Sadly, we need to mutate one node rendered by *react-virtualized* in order to fully migrate to listbox.

NB: the `aria-selected` attribute is always set to `false` because the view model of the room list doesn't return **yet** the current selected room. It will change in the following week/days.


| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/231334e6-b4a4-4d10-b58b-932246bbeec2)| <img width="573" alt="image" src="https://github.com/user-attachments/assets/d53a5277-f2c7-4995-80aa-967f99c0b545" /> |

