### PR TITLE
Room List Store: Support filters by implementing just the favourite filter

### DIFF
--- a/src/stores/room-list-v3/skip-list/RoomNode.ts
+++ b/src/stores/room-list-v3/skip-list/RoomNode.ts
@@ -6,6 +6,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import type { Room } from "matrix-js-sdk/src/matrix";
+import type { Filter, FilterKey } from "./filters";
 import SpaceStore from "../../spaces/SpaceStore";
 
 /**
@@ -47,5 +48,32 @@ export class RoomNode {
     public checkIfRoomBelongsToActiveSpace(): void {
         const activeSpace = SpaceStore.instance.activeSpace;
         this._isInActiveSpace = SpaceStore.instance.isRoomInSpace(activeSpace, this.room.roomId);
+    }
+
+    /**
+     * Aggregates all the filter keys that apply to this room.
+     * eg: if filterKeysMap.get(Filter.FavouriteFilter) is true, then this room is a favourite room.
+     */
+    private filterKeysMap: Map<FilterKey, boolean> = new Map();
+
+    /**
+     * Returns true if the associated room matches all the provided filters.
+     * Returns false otherwise.
+     * @param filterKeys An array of filter keys to check against.
+     */
+    public doesRoomMatchFilters(filterKeys: FilterKey[]): boolean {
+        return !filterKeys.some((key) => !this.filterKeysMap.get(key));
+    }
+
+    /**
+     * Populates {@link RoomNode#filterKeysMap} by checking if the associated room
+     * satisfies the given filters.
+     * @param filters A list of filters
+     */
+    public applyFilters(filters: Filter[]): void {
+        for (const filter of filters) {
+            const matchesFilter = filter.matches(this.room);
+            this.filterKeysMap.set(filter.key, matchesFilter);
+        }
     }
 }

--- a/src/stores/room-list-v3/skip-list/RoomNode.ts
+++ b/src/stores/room-list-v3/skip-list/RoomNode.ts
@@ -52,9 +52,9 @@ export class RoomNode {
 
     /**
      * Aggregates all the filter keys that apply to this room.
-     * eg: if filterKeysMap.get(Filter.FavouriteFilter) is true, then this room is a favourite room.
+     * eg: if filterKeysSet.has(Filter.FavouriteFilter) is true, then this room is a favourite room.
      */
-    private filterKeysMap: Map<FilterKey, boolean> = new Map();
+    private filterKeysSet: Set<FilterKey> = new Set();
 
     /**
      * Returns true if the associated room matches all the provided filters.
@@ -62,18 +62,18 @@ export class RoomNode {
      * @param filterKeys An array of filter keys to check against.
      */
     public doesRoomMatchFilters(filterKeys: FilterKey[]): boolean {
-        return !filterKeys.some((key) => !this.filterKeysMap.get(key));
+        return !filterKeys.some((key) => !this.filterKeysSet.has(key));
     }
 
     /**
-     * Populates {@link RoomNode#filterKeysMap} by checking if the associated room
+     * Populates {@link RoomNode#filterKeysSet} by checking if the associated room
      * satisfies the given filters.
      * @param filters A list of filters
      */
     public applyFilters(filters: Filter[]): void {
+        this.filterKeysSet = new Set();
         for (const filter of filters) {
-            const matchesFilter = filter.matches(this.room);
-            this.filterKeysMap.set(filter.key, matchesFilter);
+            if (filter.matches(this.room)) this.filterKeysSet.add(filter.key);
         }
     }
 }

--- a/src/stores/room-list-v3/skip-list/RoomSkipList.ts
+++ b/src/stores/room-list-v3/skip-list/RoomSkipList.ts
@@ -7,9 +7,11 @@ Please see LICENSE files in the repository root for full details.
 
 import type { Room } from "matrix-js-sdk/src/matrix";
 import type { Sorter } from "./sorters";
+import type { Filter, FilterKey } from "./filters";
 import { RoomNode } from "./RoomNode";
 import { shouldPromote } from "./utils";
 import { Level } from "./Level";
+import { SortedRoomIterator, SortedSpaceFilteredIterator } from "./iterators";
 
 /**
  * Implements a skip list that stores rooms using a given sorting algorithm.
@@ -20,7 +22,10 @@ export class RoomSkipList implements Iterable<Room> {
     private roomNodeMap: Map<string, RoomNode> = new Map();
     public initialized: boolean = false;
 
-    public constructor(private sorter: Sorter) {}
+    public constructor(
+        private sorter: Sorter,
+        private filters: Filter[] = [],
+    ) {}
 
     private reset(): void {
         this.levels = [new Level(0)];
@@ -35,6 +40,7 @@ export class RoomSkipList implements Iterable<Room> {
         const sortedRoomNodes = this.sorter.sort(rooms).map((room) => new RoomNode(room));
         let currentLevel = this.levels[0];
         for (const node of sortedRoomNodes) {
+            node.applyFilters(this.filters);
             currentLevel.setNext(node);
             this.roomNodeMap.set(node.room.roomId, node);
         }
@@ -95,6 +101,7 @@ export class RoomSkipList implements Iterable<Room> {
 
         const newNode = new RoomNode(room);
         newNode.checkIfRoomBelongsToActiveSpace();
+        newNode.applyFilters(this.filters);
         this.roomNodeMap.set(room.roomId, newNode);
 
         /**
@@ -173,8 +180,22 @@ export class RoomSkipList implements Iterable<Room> {
         return new SortedRoomIterator(this.levels[0].head!);
     }
 
-    public getRoomsInActiveSpace(): SortedSpaceFilteredIterator {
-        return new SortedSpaceFilteredIterator(this.levels[0].head!);
+    /**
+     * Returns an iterator that can be used to generate a list of sorted rooms that belong
+     * to the currently active space. Passing filterKeys will further filter the list such
+     * that only rooms that match the filters are returned.
+     *
+     * @example To get an array of rooms:
+     * Array.from(RLS.getRoomsInActiveSpace());
+     *
+     * @example Use a for ... of loop to iterate over rooms:
+     * for(const room of RLS.getRoomsInActiveSpace()) { something(room); }
+     *
+     * @example Additional filtering:
+     * Array.from(RLS.getRoomsInActiveSpace([FilterKeys.Favourite]));
+     */
+    public getRoomsInActiveSpace(filterKeys: FilterKey[] = []): SortedSpaceFilteredIterator {
+        return new SortedSpaceFilteredIterator(this.levels[0].head!, filterKeys);
     }
 
     /**
@@ -182,38 +203,5 @@ export class RoomSkipList implements Iterable<Room> {
      */
     public get size(): number {
         return this.levels[0].size;
-    }
-}
-
-class SortedRoomIterator implements Iterator<Room> {
-    public constructor(private current: RoomNode) {}
-
-    public next(): IteratorResult<Room> {
-        const current = this.current;
-        if (!current) return { value: undefined, done: true };
-        this.current = current.next[0];
-        return {
-            value: current.room,
-        };
-    }
-}
-
-class SortedSpaceFilteredIterator implements Iterator<Room> {
-    public constructor(private current: RoomNode) {}
-
-    public [Symbol.iterator](): SortedSpaceFilteredIterator {
-        return this;
-    }
-
-    public next(): IteratorResult<Room> {
-        let current = this.current;
-        while (current && !current.isInActiveSpace) {
-            current = current.next[0];
-        }
-        if (!current) return { value: undefined, done: true };
-        this.current = current.next[0];
-        return {
-            value: current.room,
-        };
     }
 }

--- a/src/stores/room-list-v3/skip-list/filters/FavouriteFilter.ts
+++ b/src/stores/room-list-v3/skip-list/filters/FavouriteFilter.ts
@@ -1,0 +1,20 @@
+/*
+Copyright 2025 New Vector Ltd.
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import type { Room } from "matrix-js-sdk/src/matrix";
+import type { Filter } from ".";
+import { FilterKey } from ".";
+import { DefaultTagID } from "../../../room-list/models";
+
+export class FavouriteFilter implements Filter {
+    public matches(room: Room): boolean {
+        return !!room.tags[DefaultTagID.Favourite];
+    }
+
+    public get key(): FilterKey.FavouriteFilter {
+        return FilterKey.FavouriteFilter;
+    }
+}

--- a/src/stores/room-list-v3/skip-list/filters/index.ts
+++ b/src/stores/room-list-v3/skip-list/filters/index.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2025 New Vector Ltd.
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import type { Room } from "matrix-js-sdk/src/matrix";
+
+export const enum FilterKey {
+    FavouriteFilter,
+}
+
+export interface Filter {
+    /**
+     * Boolean return value indicates whether this room satisfies
+     * the filter condition.
+     */
+    matches(room: Room): boolean;
+
+    /**
+     * Used to identify this particular filter.
+     */
+    key: FilterKey;
+}

--- a/src/stores/room-list-v3/skip-list/iterators.ts
+++ b/src/stores/room-list-v3/skip-list/iterators.ts
@@ -36,7 +36,7 @@ export class SortedSpaceFilteredIterator implements Iterator<Room> {
         let current = this.current;
         while (current) {
             if (current.isInActiveSpace && current.doesRoomMatchFilters(this.filters)) break;
-            else current = current.next[0];
+            current = current.next[0];
         }
         if (!current) return { value: undefined, done: true };
         this.current = current.next[0];

--- a/src/stores/room-list-v3/skip-list/iterators.ts
+++ b/src/stores/room-list-v3/skip-list/iterators.ts
@@ -1,0 +1,47 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import type { Room } from "matrix-js-sdk/src/matrix";
+import type { RoomNode } from "./RoomNode";
+import type { FilterKey } from "./filters";
+
+export class SortedRoomIterator implements Iterator<Room> {
+    public constructor(private current: RoomNode) {}
+
+    public next(): IteratorResult<Room> {
+        const current = this.current;
+        if (!current) return { value: undefined, done: true };
+        this.current = current.next[0];
+        return {
+            value: current.room,
+        };
+    }
+}
+
+export class SortedSpaceFilteredIterator implements Iterator<Room> {
+    public constructor(
+        private current: RoomNode,
+        private readonly filters: FilterKey[],
+    ) {}
+
+    public [Symbol.iterator](): SortedSpaceFilteredIterator {
+        return this;
+    }
+
+    public next(): IteratorResult<Room> {
+        let current = this.current;
+        while (current) {
+            if (current.isInActiveSpace && current.doesRoomMatchFilters(this.filters)) break;
+            else current = current.next[0];
+        }
+        if (!current) return { value: undefined, done: true };
+        this.current = current.next[0];
+        return {
+            value: current.room,
+        };
+    }
+}


### PR DESCRIPTION
- A filter has a method to check if a given room satisfies some condition and a key that uniquely identifies it.
- Every room node tracks which filters apply to it and provides methods to recalculate and query this info.
- This calculation is done once for all room nodes when the skip list is built.
- This calculation is repeated only for the rooms that get updated (i.e gets re-inserted into the skiplist).
- Getting a list of filtered rooms is as simple as skipping the rooms that do not have the given filter keys in the iterator.

This PR only implements the favourite filter.