### PR TITLE
Add `?no_universal_links=true` to OIDC cb url so EX doesn't try to handle

### DIFF
--- a/src/BasePlatform.ts
+++ b/src/BasePlatform.ts
@@ -466,6 +466,7 @@ export default abstract class BasePlatform {
         // The redirect URL has to exactly match that registered at the OIDC server, so
         // ensure that the fragment part of the URL is empty.
         url.hash = "";
+        url.searchParams.set("no_universal_links", "true");
         return url;
     }
 


### PR DESCRIPTION
This is specific to macOS and only affects cases where auth is attempted in the non-default browser

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
