### PR TITLE
Add E2E test for quick settings dialog (and a11y-ing)

### DIFF
--- a/playwright/e2e/settings/quick-settings-menu.spec.ts
+++ b/playwright/e2e/settings/quick-settings-menu.spec.ts
@@ -1,0 +1,18 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { test, expect } from "../../element-web-test";
+
+test.describe("Quick settings menu", () => {
+    test("should be rendered properly", { tag: "@screenshot" }, async ({ app, page, user }) => {
+        await page.getByRole('button', { name: 'Quick settings'}).click();
+        // Assert that the top heading is renderedc
+        const settings = page.getByRole("menu", { name: "Quick settings" });
+        await expect(settings).toBeVisible();
+        await expect(settings).toMatchScreenshot("quick-settings.png");
+    });
+});

--- a/src/components/structures/ContextMenu.tsx
+++ b/src/components/structures/ContextMenu.tsx
@@ -76,6 +76,7 @@ export interface IProps extends MenuProps {
     hasBackground?: boolean;
     // whether this context menu should be focus managed. If false it must handle itself
     managed?: boolean;
+    'aria-labelledby'?: string;
     wrapperClassName?: string;
     menuClassName?: string;
 

--- a/src/components/views/elements/Dropdown.tsx
+++ b/src/components/views/elements/Dropdown.tsx
@@ -75,6 +75,7 @@ export interface DropdownProps {
     id: string;
     // ARIA label
     label: string;
+    role?: string;
     value?: string;
     className?: string;
     autoComplete?: string;
@@ -346,7 +347,7 @@ export default class Dropdown extends React.Component<DropdownProps, IState> {
                         className="mx_Dropdown_option"
                         onChange={this.onInputChange}
                         value={this.state.searchQuery}
-                        role="combobox"
+                        role={this.props.role ?? "combobox"}
                         aria-autocomplete="list"
                         aria-activedescendant={`${this.props.id}__${this.state.highlightedOption}`}
                         aria-expanded={this.state.expanded}

--- a/src/components/views/spaces/QuickSettingsButton.tsx
+++ b/src/components/views/spaces/QuickSettingsButton.tsx
@@ -51,11 +51,11 @@ const QuickSettingsButton: React.FC<{
                 wrapperClassName={classNames("mx_QuickSettingsButton_ContextMenuWrapper", {
                     mx_QuickSettingsButton_ContextMenuWrapper_new_room_list: newRoomListEnabled,
                 })}
+                aria-labelledby="mx_QuickSettings_heading"
                 onFinished={closeMenu}
-                managed={false}
                 focusLock={true}
             >
-                <h2>{_t("quick_settings|title")}</h2>
+                <h2 id="mx_QuickSettings_heading">{_t("quick_settings|title")}</h2>
 
                 <AccessibleButton
                     onClick={() => {
@@ -63,6 +63,7 @@ const QuickSettingsButton: React.FC<{
                         defaultDispatcher.dispatch({ action: Action.ViewUserSettings });
                     }}
                     kind="primary_outline"
+                    role="menuitem button"
                 >
                     {_t("quick_settings|all_settings")}
                 </AccessibleButton>
@@ -80,6 +81,7 @@ const QuickSettingsButton: React.FC<{
                             );
                         }}
                         kind="danger_outline"
+                        role="menuitem button"
                     >
                         {_t("devtools|title")}
                     </AccessibleButton>
@@ -95,6 +97,7 @@ const QuickSettingsButton: React.FC<{
                         <StyledCheckbox
                             className="mx_QuickSettingsButton_favouritesCheckbox"
                             checked={!!favouritesEnabled}
+                            role="menuitem checkbox"
                             onChange={onMetaSpaceChangeFactory(
                                 MetaSpace.Favourites,
                                 "WebQuickSettingsPinToSidebarCheckbox",
@@ -110,6 +113,7 @@ const QuickSettingsButton: React.FC<{
                                 MetaSpace.People,
                                 "WebQuickSettingsPinToSidebarCheckbox",
                             )}
+                            role="menuitem checkbox"
                         >
                             <UserProfileSolidIcon className="mx_QuickSettingsButton_icon" />
                             {_t("common|people")}
@@ -123,6 +127,7 @@ const QuickSettingsButton: React.FC<{
                                     initialTabId: UserTab.Sidebar,
                                 });
                             }}
+                            role="menuitem checkbox"
                         >
                             <OverflowHorizontalIcon className="mx_QuickSettingsButton_icon" />
                             {_t("quick_settings|sidebar_settings")}

--- a/src/components/views/spaces/QuickThemeSwitcher.tsx
+++ b/src/components/views/spaces/QuickThemeSwitcher.tsx
@@ -78,6 +78,7 @@ const QuickThemeSwitcher: React.FC<Props> = ({ requestClose }) => {
                 onOptionChange={onOptionChange}
                 value={selectedTheme}
                 label={_t("common|theme")}
+                role="menuitem combobox"
             >
                 {
                     themeOptions.map((theme) => <div key={theme.id}>{theme.name}</div>) as NonEmptyArray<


### PR DESCRIPTION
https://github.com/element-hq/element-web/pull/29363 makes changes to the rendering of the quick menu by virtue of changing the checkboxes. To kill two birds with one stone I'm writing a simple screenshot test here of the menu as it is now, as well as updating it to use better a11y roles.

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
