### PR TITLE
Room List Store: Implement rest of the primary filters

### DIFF
--- a/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -25,6 +25,14 @@ import { EffectiveMembership, getEffectiveMembership, getEffectiveMembershipTag 
 import SpaceStore from "../spaces/SpaceStore";
 import { UPDATE_HOME_BEHAVIOUR, UPDATE_SELECTED_SPACE } from "../spaces";
 import { FavouriteFilter } from "./skip-list/filters/FavouriteFilter";
+import { UnreadFilter } from "./skip-list/filters/UnreadFilter";
+import { PeopleFilter } from "./skip-list/filters/PeopleFilter";
+import { RoomsFilter } from "./skip-list/filters/RoomsFilter";
+
+/**
+ * These are the filters passed to the room skip list.
+ */
+const FILTERS = [new FavouriteFilter(), new UnreadFilter(), new PeopleFilter(), new RoomsFilter()];
 
 /**
  * This store allows for fast retrieval of the room list in a sorted and filtered manner.
@@ -96,7 +104,7 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
     protected async onReady(): Promise<any> {
         if (this.roomSkipList?.initialized || !this.matrixClient) return;
         const sorter = new RecencySorter(this.matrixClient.getSafeUserId());
-        this.roomSkipList = new RoomSkipList(sorter, [new FavouriteFilter()]);
+        this.roomSkipList = new RoomSkipList(sorter, FILTERS);
         const rooms = this.getRooms();
         await SpaceStore.instance.storeReadyPromise;
         this.roomSkipList.seed(rooms);

--- a/src/stores/room-list-v3/skip-list/filters/PeopleFilter.ts
+++ b/src/stores/room-list-v3/skip-list/filters/PeopleFilter.ts
@@ -1,0 +1,21 @@
+/*
+Copyright 2025 New Vector Ltd.
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import type { Room } from "matrix-js-sdk/src/matrix";
+import type { Filter } from ".";
+import { FilterKey } from ".";
+import DMRoomMap from "../../../../utils/DMRoomMap";
+
+export class PeopleFilter implements Filter {
+    public matches(room: Room): boolean {
+        // Match rooms that are DMs
+        return !!DMRoomMap.shared().getUserIdForRoomId(room.roomId);
+    }
+
+    public get key(): FilterKey.PeopleFilter {
+        return FilterKey.PeopleFilter;
+    }
+}

--- a/src/stores/room-list-v3/skip-list/filters/RoomsFilter.ts
+++ b/src/stores/room-list-v3/skip-list/filters/RoomsFilter.ts
@@ -1,0 +1,21 @@
+/*
+Copyright 2025 New Vector Ltd.
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import type { Room } from "matrix-js-sdk/src/matrix";
+import type { Filter } from ".";
+import { FilterKey } from ".";
+import DMRoomMap from "../../../../utils/DMRoomMap";
+
+export class RoomsFilter implements Filter {
+    public matches(room: Room): boolean {
+        // This should filter rooms that are not DMs
+        return !DMRoomMap.shared().getUserIdForRoomId(room.roomId);
+    }
+
+    public get key(): FilterKey.RoomsFilter {
+        return FilterKey.RoomsFilter;
+    }
+}

--- a/src/stores/room-list-v3/skip-list/filters/UnreadFilter.ts
+++ b/src/stores/room-list-v3/skip-list/filters/UnreadFilter.ts
@@ -1,0 +1,20 @@
+/*
+Copyright 2025 New Vector Ltd.
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import type { Room } from "matrix-js-sdk/src/matrix";
+import type { Filter } from ".";
+import { FilterKey } from ".";
+import { RoomNotificationStateStore } from "../../../notifications/RoomNotificationStateStore";
+
+export class UnreadFilter implements Filter {
+    public matches(room: Room): boolean {
+        return RoomNotificationStateStore.instance.getRoomState(room).isUnread;
+    }
+
+    public get key(): FilterKey.UnreadFilter {
+        return FilterKey.UnreadFilter;
+    }
+}

--- a/src/stores/room-list-v3/skip-list/filters/index.ts
+++ b/src/stores/room-list-v3/skip-list/filters/index.ts
@@ -8,6 +8,9 @@ import type { Room } from "matrix-js-sdk/src/matrix";
 
 export const enum FilterKey {
     FavouriteFilter,
+    UnreadFilter,
+    PeopleFilter,
+    RoomsFilter,
 }
 
 export interface Filter {


### PR DESCRIPTION
https://github.com/element-hq/element-web/pull/29433 implemented the favourite filter.
This PR implements all the remaining primary filters: Unread, People and Rooms.