### PR TITLE
Room List Store: Fetch rooms after space store is ready + attach store to window

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -47,6 +47,7 @@ import { type DeepReadonly } from "./common";
 import type MatrixChat from "../components/structures/MatrixChat";
 import { type InitialCryptoSetupStore } from "../stores/InitialCryptoSetupStore";
 import { type ModuleApiType } from "../modules/Api.ts";
+import type { RoomListStoreV3Class } from "../stores/room-list-v3/RoomListStoreV3.ts";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -99,6 +100,7 @@ declare global {
         mxToastStore: ToastStore;
         mxDeviceListener: DeviceListener;
         mxRoomListStore: RoomListStore;
+        mxRoomListStoreV3: RoomListStoreV3Class;
         mxRoomListLayoutStore: RoomListLayoutStore;
         mxPlatformPeg: PlatformPeg;
         mxIntegrationManagers: typeof IntegrationManagers;

--- a/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -228,3 +228,5 @@ export default class RoomListStoreV3 {
         return this.internalInstance;
     }
 }
+
+window.mxRoomListStoreV3 = RoomListStoreV3.instance;

--- a/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -105,8 +105,8 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
         if (this.roomSkipList?.initialized || !this.matrixClient) return;
         const sorter = new RecencySorter(this.matrixClient.getSafeUserId());
         this.roomSkipList = new RoomSkipList(sorter, FILTERS);
-        const rooms = this.getRooms();
         await SpaceStore.instance.storeReadyPromise;
+        const rooms = this.getRooms();
         this.roomSkipList.seed(rooms);
         this.emit(LISTS_UPDATE_EVENT);
     }


### PR DESCRIPTION
- Attaches store to window object
- If we fetch rooms and then wait for the store to be ready, we will miss any updates that happened while we were waiting (because `onAction` returns early if the skip list isn't ready). So fetch the rooms after the space store is ready.