### PR TITLE
White background for 'They do not match' button

### DIFF
--- a/src/components/views/verification/VerificationShowSas.tsx
+++ b/src/components/views/verification/VerificationShowSas.tsx
@@ -165,11 +165,11 @@ export default class VerificationShowSas extends React.Component<IProps, IState>
         } else {
             confirm = (
                 <div className="mx_VerificationShowSas_buttonRow">
-                    <AccessibleButton onClick={this.onDontMatchClick} kind="danger">
-                        {_t("encryption|verification|sas_no_match")}
-                    </AccessibleButton>
                     <AccessibleButton onClick={this.onMatchClick} kind="primary">
                         {_t("encryption|verification|sas_match")}
+                    </AccessibleButton>
+                    <AccessibleButton onClick={this.onDontMatchClick} kind="secondary">
+                        {_t("encryption|verification|sas_no_match")}
                     </AccessibleButton>
                 </div>
             );


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-web/issues/29438 - change the appearance of the "They do not match" button to match how it looks in Element X.

**After**:
![image](https://github.com/user-attachments/assets/d0f0f40c-f315-495c-9f41-208fcef09bab)


**Before**:
![image](https://github.com/user-attachments/assets/1df86490-5cca-4f70-a971-33542eea821c)
