### PR TITLE
Avoid using /tmp/ for bind mounts and non-tmpfs binds

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -77,7 +77,7 @@ jobs:
                           --rm \
                           -e "ELEMENT_WEB_PORT=$ELEMENT_WEB_PORT" \
                           -dp "$ELEMENT_WEB_PORT:$ELEMENT_WEB_PORT" \
-                          -v $(pwd)/modules:/tmp/element-web-modules \
+                          -v $(pwd)/modules:/modules \
                           "$IMAGEID" \
                   )
 

--- a/docker/docker-entrypoint.d/18-load-element-modules.sh
+++ b/docker/docker-entrypoint.d/18-load-element-modules.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Loads modules from `/tmp/element-web-modules` into config.json's `modules` field
+# Loads modules from `/modules` into config.json's `modules` field
 
 set -e
 
@@ -15,15 +15,15 @@ mkdir -p /tmp/element-web-config
 cp /app/config*.json /tmp/element-web-config/
 
 # If there are modules to be loaded
-if [ -d "/tmp/element-web-modules" ]; then
-    cd /tmp/element-web-modules
+if [ -d "/modules" ]; then
+    cd /modules
 
     for MODULE in *
     do
         # If the module has a package.json, use its main field as the entrypoint
         ENTRYPOINT="index.js"
-        if [ -f "/tmp/element-web-modules/$MODULE/package.json" ]; then
-            ENTRYPOINT=$(jq -r '.main' "/tmp/element-web-modules/$MODULE/package.json")
+        if [ -f "/modules/$MODULE/package.json" ]; then
+            ENTRYPOINT=$(jq -r '.main' "/modules/$MODULE/package.json")
         fi
 
         entrypoint_log "Loading module $MODULE with entrypoint $ENTRYPOINT"

--- a/docker/nginx-templates/default.conf.template
+++ b/docker/nginx-templates/default.conf.template
@@ -22,7 +22,7 @@ server {
         add_header Cache-Control "no-cache";
     }
     location /modules {
-        alias /tmp/element-web-modules;
+        alias /modules;
     }
     # redirect server error pages to the static page /50x.html
     #

--- a/docs/install.md
+++ b/docs/install.md
@@ -67,7 +67,7 @@ image as root (`docker run --user 0`) or, better, change the port that nginx
 listens on via the `ELEMENT_WEB_PORT` environment variable.
 
 [Element Web Modules](https://github.com/element-hq/element-modules/tree/main/packages/element-web-module-api) can be dynamically loaded
-by being made available (e.g. via bind mount) in a directory within `/tmp/element-web-modules/`.
+by being made available (e.g. via bind mount) in a directory within `/modules/`.
 The default entrypoint will be index.js in that directory but can be overridden if a package.json file is found with a `main` directive.
 These modules will be presented in a `/modules` subdirectory within the webroot, and automatically added to the config.json `modules` field.
 
@@ -75,7 +75,7 @@ If you wish to use docker in read-only mode,
 you should follow the [upstream instructions](https://hub.docker.com/_/nginx#:~:text=Running%20nginx%20in%20read%2Donly%20mode)
 but additionally include the following directories:
 
-- /tmp/element-web-config/
+- /tmp/
 - /etc/nginx/conf.d/
 
 The behaviour of the docker image can be customised via the following


### PR DESCRIPTION
Switches to `/modules` to match https://github.com/element-hq/element-modules/tree/main/modules/restricted-guests/synapse#production-installation