### PR TITLE
Update ChangePassword / PassphraseField to use Compound

### DIFF
--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 New Vector Ltd.
+Copyright 2024, 2025 New Vector Ltd.
 Copyright 2019-2023 The Matrix.org Foundation C.I.C
 Copyright 2017-2019 New Vector Ltd
 Copyright 2017 Vector Creations Ltd
@@ -217,7 +217,7 @@ textarea {
 }
 
 input[type="text"]:focus,
-input[type="password"]:focus,
+:not(.mx_ChangePasswordForm input) > input[type="password"],
 textarea:focus {
     outline: none;
     box-shadow: none;
@@ -592,6 +592,7 @@ legend {
  */
 .mx_Dialog
     button:not(
+        .mx_ChangePasswordForm button,
         .mx_EncryptionUserSettingsTab button,
         .mx_UserProfileSettings button,
         .mx_ShareDialog button,
@@ -620,6 +621,7 @@ legend {
 
 .mx_Dialog
     button:not(
+        .mx_ChangePasswordForm button,
         .mx_Dialog_nonDialogButton,
         [class|="maplibregl"],
         .mx_AccessibleButton,
@@ -634,6 +636,7 @@ legend {
 
 .mx_Dialog
     button:not(
+        .mx_ChangePasswordForm button,
         .mx_Dialog_nonDialogButton,
         [class|="maplibregl"],
         .mx_AccessibleButton,
@@ -653,6 +656,7 @@ legend {
 .mx_Dialog input[type="submit"].mx_Dialog_primary,
 .mx_Dialog_buttons
     button:not(
+        .mx_ChangePasswordForm button,
         .mx_Dialog_nonDialogButton,
         .mx_AccessibleButton,
         .mx_UserProfileSettings button,
@@ -672,6 +676,7 @@ legend {
 .mx_Dialog input[type="submit"].danger,
 .mx_Dialog_buttons
     button.danger:not(
+        .mx_ChangePasswordForm button,
         .mx_Dialog_nonDialogButton,
         .mx_AccessibleButton,
         .mx_UserProfileSettings button,
@@ -694,6 +699,7 @@ legend {
 
 .mx_Dialog
     button:not(
+        .mx_ChangePasswordForm button,
         .mx_Dialog_nonDialogButton,
         [class|="maplibregl"],
         .mx_AccessibleButton,

--- a/src/components/views/auth/PassphraseField.tsx
+++ b/src/components/views/auth/PassphraseField.tsx
@@ -52,8 +52,8 @@ const DEFAULT_PROPS = {
     labelAllowedButUnsafe: _td("auth|password_field_weak_label"),
 };
 
-const NewPassphraseField: React.FC<IProps> = (props) => {
-    const { labelEnterPassword, userInputs, minScore, label, labelStrongPassword, labelAllowedButUnsafe, className, id, fieldRef, autoFocus} = {...DEFAULT_PROPS, ...props};
+const PassphraseField: React.FC<IProps> = (props) => {
+    const { labelEnterPassword, userInputs, minScore, label, labelStrongPassword, labelAllowedButUnsafe, className, id, fieldRef, autoFocus, onChange, onValidate} = {...DEFAULT_PROPS, ...props};
     const validateFn = useMemo(() => withValidation<{}, ZxcvbnResult | null>({
         description: function (complexity) {
             const score = complexity ? complexity.score : 0;
@@ -103,12 +103,14 @@ const NewPassphraseField: React.FC<IProps> = (props) => {
     const [feedback, setFeedback]= useState<string|JSX.Element>();
 
     const onInputChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>((ev) => {
+        onChange(ev);
         validateFn({
             value: ev.target.value,
             focused: true,
         }).then((v) => {
             setFeedback(v.feedback);
-        })
+            onValidate?.(v);
+        });
     }, [validateFn]);
 
 
@@ -119,4 +121,4 @@ const NewPassphraseField: React.FC<IProps> = (props) => {
     </Field>
 }
 
-export default NewPassphraseField;
+export default PassphraseField;


### PR DESCRIPTION
Which in turn should make this component more accessible.

Changes are as follows:
- PassphraseField is now a functional component implementing the https://compound.element.io/?path=/docs/compound-web_form-password-form--docs password form
- ChangePassword now uses compound components.
- TODO: Update other usages of PassphraseField
- TODO: Fixup grouping of components 

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
