### PR TITLE
Room List Store: Save preferred sorting algorithm and use that on app launch

### DIFF
--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -44,6 +44,7 @@ import { type ReleaseAnnouncementData } from "../stores/ReleaseAnnouncementStore
 import { type Json, type JsonValue } from "../@types/json.ts";
 import { type RecentEmojiData } from "../emojipicker/recent.ts";
 import { type Assignable } from "../@types/common.ts";
+import { SortingAlgorithm } from "../stores/room-list-v3/skip-list/sorters/index.ts";
 
 export const defaultWatchManager = new WatchManager();
 
@@ -311,6 +312,7 @@ export interface Settings {
     "lowBandwidth": IBaseSetting<boolean>;
     "fallbackICEServerAllowed": IBaseSetting<boolean | null>;
     "showImages": IBaseSetting<boolean>;
+    "RoomList.preferredSorting": IBaseSetting<SortingAlgorithm>;
     "RightPanel.phasesGlobal": IBaseSetting<IRightPanelForRoomStored | null>;
     "RightPanel.phases": IBaseSetting<IRightPanelForRoomStored | null>;
     "enableEventIndexing": IBaseSetting<boolean>;
@@ -1113,6 +1115,10 @@ export const SETTINGS: Settings = {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         displayName: _td("settings|image_thumbnails"),
         default: true,
+    },
+    "RoomList.preferredSorting": {
+        supportedLevels: [SettingLevel.DEVICE],
+        default: SortingAlgorithm.Recency,
     },
     "RightPanel.phasesGlobal": {
         supportedLevels: [SettingLevel.DEVICE],

--- a/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -93,8 +93,21 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
     }
 
     /**
-     * Re-sort the list of rooms by alphabetic order.
+     * Resort the list of rooms using a different algorithm.
+     * @param algorithm The sorting algorithm to use.
      */
+    public resort(algorithm: SortingAlgorithm): void {
+        if (!this.roomSkipList) throw new Error("Cannot resort room list before skip list is created.");
+        if (!this.matrixClient) throw new Error("Cannot resort room list without matrix client.");
+        if (this.roomSkipList.activeSortAlgorithm === algorithm) return;
+        const sorter =
+            algorithm === SortingAlgorithm.Alphabetic
+                ? new AlphabeticSorter()
+                : new RecencySorter(this.matrixClient.getSafeUserId());
+        this.roomSkipList.useNewSorter(sorter, this.getRooms());
+        this.emit(LISTS_UPDATE_EVENT);
+        SettingsStore.setValue("RoomList.preferredSorting", null, SettingLevel.DEVICE, algorithm);
+    }
 
     /**
      * Currently active sorting algorithm if the store is ready or undefined otherwise.

--- a/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -95,21 +95,12 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
     /**
      * Re-sort the list of rooms by alphabetic order.
      */
-    public useAlphabeticSorting(): void {
-        if (this.roomSkipList) {
-            const sorter = new AlphabeticSorter();
-            this.roomSkipList.useNewSorter(sorter, this.getRooms());
-        }
-    }
 
     /**
-     * Re-sort the list of rooms by recency.
+     * Currently active sorting algorithm if the store is ready or undefined otherwise.
      */
-    public useRecencySorting(): void {
-        if (this.roomSkipList && this.matrixClient) {
-            const sorter = new RecencySorter(this.matrixClient?.getSafeUserId() ?? "");
-            this.roomSkipList.useNewSorter(sorter, this.getRooms());
-        }
+    public get activeSortAlgorithm(): SortingAlgorithm | undefined {
+        return this.roomSkipList?.activeSortAlgorithm;
     }
 
     protected async onReady(): Promise<any> {

--- a/src/stores/room-list-v3/skip-list/RoomSkipList.ts
+++ b/src/stores/room-list-v3/skip-list/RoomSkipList.ts
@@ -6,7 +6,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import type { Room } from "matrix-js-sdk/src/matrix";
-import type { Sorter } from "./sorters";
+import type { Sorter, SortingAlgorithm } from "./sorters";
 import type { Filter, FilterKey } from "./filters";
 import { RoomNode } from "./RoomNode";
 import { shouldPromote } from "./utils";
@@ -203,5 +203,12 @@ export class RoomSkipList implements Iterable<Room> {
      */
     public get size(): number {
         return this.levels[0].size;
+    }
+
+    /**
+     * The currently active sorting algorithm.
+     */
+    public get activeSortAlgorithm(): SortingAlgorithm {
+        return this.sorter.type;
     }
 }

--- a/src/stores/room-list-v3/skip-list/sorters/AlphabeticSorter.ts
+++ b/src/stores/room-list-v3/skip-list/sorters/AlphabeticSorter.ts
@@ -6,7 +6,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import type { Room } from "matrix-js-sdk/src/matrix";
-import type { Sorter } from ".";
+import { type Sorter, SortingAlgorithm } from ".";
 
 export class AlphabeticSorter implements Sorter {
     private readonly collator = new Intl.Collator();
@@ -19,5 +19,9 @@ export class AlphabeticSorter implements Sorter {
 
     public comparator(roomA: Room, roomB: Room): number {
         return this.collator.compare(roomA.name, roomB.name);
+    }
+
+    public get type(): SortingAlgorithm.Alphabetic {
+        return SortingAlgorithm.Alphabetic;
     }
 }

--- a/src/stores/room-list-v3/skip-list/sorters/RecencySorter.ts
+++ b/src/stores/room-list-v3/skip-list/sorters/RecencySorter.ts
@@ -6,7 +6,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import type { Room } from "matrix-js-sdk/src/matrix";
-import type { Sorter } from ".";
+import { type Sorter, SortingAlgorithm } from ".";
 import { getLastTs } from "../../../room-list/algorithms/tag-sorting/RecentAlgorithm";
 
 export class RecencySorter implements Sorter {
@@ -21,6 +21,10 @@ export class RecencySorter implements Sorter {
         const roomALastTs = this.getTs(roomA, cache);
         const roomBLastTs = this.getTs(roomB, cache);
         return roomBLastTs - roomALastTs;
+    }
+
+    public get type(): SortingAlgorithm.Recency {
+        return SortingAlgorithm.Recency;
     }
 
     private getTs(room: Room, cache?: { [roomId: string]: number }): number {

--- a/src/stores/room-list-v3/skip-list/sorters/index.ts
+++ b/src/stores/room-list-v3/skip-list/sorters/index.ts
@@ -8,6 +8,29 @@ Please see LICENSE files in the repository root for full details.
 import type { Room } from "matrix-js-sdk/src/matrix";
 
 export interface Sorter {
+    /**
+     * Performs an initial sort of rooms and returns a new array containing
+     * the result.
+     * @param rooms An array of rooms.
+     */
     sort(rooms: Room[]): Room[];
+    /**
+     * The comparator used for sorting.
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#comparefn
+     * @param roomA Room
+     * @param roomB Room
+     */
     comparator(roomA: Room, roomB: Room): number;
+    /**
+     * A string that uniquely identifies this given sorter.
+     */
+    type: SortingAlgorithm;
+}
+
+/**
+ * All the available sorting algorithms.
+ */
+export const enum SortingAlgorithm {
+    Recency = "Recency",
+    Alphabetic = "Alphabetic",
 }


### PR DESCRIPTION
- Adds a device level setting that stores the user's sorting preference.
- Adds a `type` property to the sorter so that it can be uniquely identified.
- Replace `useAlphabeticSorting()` and `useRecencySorting()` with a single `resort(type)` method.
- RLS will use the preferred sorter at start .