### PR TITLE
Change *All rooms* meta space name to *All Chats*

### DIFF
--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -455,7 +455,7 @@
         "access_token": "Access Token",
         "accessibility": "Accessibility",
         "advanced": "Advanced",
-        "all_rooms": "All rooms",
+        "all_chats": "All Chats",
         "analytics": "Analytics",
         "and_n_others": {
             "one": "and one other...",

--- a/src/stores/spaces/index.ts
+++ b/src/stores/spaces/index.ts
@@ -30,7 +30,7 @@ export enum MetaSpace {
 export const getMetaSpaceName = (spaceKey: MetaSpace, allRoomsInHome = false): string => {
     switch (spaceKey) {
         case MetaSpace.Home:
-            return allRoomsInHome ? _t("common|all_rooms") : _t("common|home");
+            return allRoomsInHome ? _t("common|all_chats") : _t("common|home");
         case MetaSpace.Favourites:
             return _t("common|favourites");
         case MetaSpace.People:


### PR DESCRIPTION
In [the new room list figma](https://www.figma.com/design/vlmt46QDdE4dgXDiyBJXqp/Left-Panel-2025?node-id=751-22730&t=SZFDhP2cixQhPRSZ-4), the *All rooms* title is replaced by *All Chats*.

After discussion with @gaelledel, the renaming makes also sense for the current room list. Technically, DM are rooms but for the end users rooms and DM can be two separate things in their mind. *All Chats* wording contains room and DM.
