### PR TITLE
New room list: fix compose menu action in space 

### DIFF
--- a/src/components/views/rooms/RoomListPanel/RoomListHeaderView.tsx
+++ b/src/components/views/rooms/RoomListPanel/RoomListHeaderView.tsx
@@ -42,7 +42,14 @@ export function RoomListHeaderView(): JSX.Element {
                 <h1 title={vm.title}>{vm.title}</h1>
                 {vm.displaySpaceMenu && <SpaceMenu vm={vm} />}
             </Flex>
-            {vm.displayComposeMenu && <ComposeMenu vm={vm} />}
+            {/* If we don't display the compose menu, it means that the user can only send DM */}
+            {vm.displayComposeMenu ? (
+                <ComposeMenu vm={vm} />
+            ) : (
+                <IconButton aria-label={_t("action|new_message")} onClick={(e) => vm.createChatRoom(e.nativeEvent)}>
+                    <ComposeIcon />
+                </IconButton>
+            )}
         </Flex>
     );
 }

--- a/test/unit-tests/components/viewmodels/roomlist/RoomListHeaderViewModel-test.tsx
+++ b/test/unit-tests/components/viewmodels/roomlist/RoomListHeaderViewModel-test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { renderHook } from "jest-matrix-react";
-import { JoinRule, type MatrixClient, type Room, RoomType } from "matrix-js-sdk/src/matrix";
+import { JoinRule, type MatrixClient, type Room, type RoomState, RoomType } from "matrix-js-sdk/src/matrix";
 import { mocked } from "jest-mock";
 
 import { useRoomListHeaderViewModel } from "../../../../../src/components/viewmodels/roomlist/RoomListHeaderViewModel";
@@ -79,10 +79,37 @@ describe("useRoomListHeaderViewModel", () => {
         expect(result.current.canCreateRoom).toBe(true);
     });
 
+    it("should be displayComposeMenu=true if the user can creates video room", () => {
+        mocked(shouldShowComponent).mockReturnValue(false);
+        jest.spyOn(SettingsStore, "getValue").mockReturnValue(true);
+
+        const { result } = render();
+        expect(result.current.displayComposeMenu).toBe(true);
+    });
+
     it("should be displaySpaceMenu=true if the user is in a space", () => {
         jest.spyOn(SpaceStore.instance, "activeSpaceRoom", "get").mockReturnValue(space);
         const { result } = render();
         expect(result.current.displaySpaceMenu).toBe(true);
+    });
+
+    it("should be canCreateRoom=false if the user has not the right to create a room in a space", () => {
+        mocked(shouldShowComponent).mockReturnValue(true);
+        jest.spyOn(SpaceStore.instance, "activeSpaceRoom", "get").mockReturnValue(space);
+
+        const { result } = render();
+        expect(result.current.canCreateRoom).toBe(false);
+    });
+
+    it("should be canCreateRoom=true if the user has the right to create a room in a space", () => {
+        mocked(shouldShowComponent).mockReturnValue(true);
+        jest.spyOn(SpaceStore.instance, "activeSpaceRoom", "get").mockReturnValue(space);
+        jest.spyOn(space.getLiveTimeline(), "getState").mockReturnValue({
+            maySendStateEvent: jest.fn().mockReturnValue(true),
+        } as unknown as RoomState);
+
+        const { result } = render();
+        expect(result.current.canCreateRoom).toBe(true);
     });
 
     it("should be canInviteInSpace=true if the space join rule is public", () => {

--- a/test/unit-tests/components/views/rooms/RoomListPanel/RoomListHeaderView-test.tsx
+++ b/test/unit-tests/components/views/rooms/RoomListPanel/RoomListHeaderView-test.tsx
@@ -51,12 +51,16 @@ describe("<RoomListHeaderView />", () => {
             expect(asFragment()).toMatchSnapshot();
         });
 
-        it("should not display the compose menu", () => {
+        it("should not display the compose menu", async () => {
+            const user = userEvent.setup();
             mocked(useRoomListHeaderViewModel).mockReturnValue({ ...defaultValue, displayComposeMenu: false });
 
             const { asFragment } = render(<RoomListHeaderView />);
             expect(screen.queryByRole("button", { name: "Add" })).toBeNull();
             expect(asFragment()).toMatchSnapshot();
+
+            await user.click(screen.getByRole("button", { name: "New message" }));
+            expect(defaultValue.createChatRoom).toHaveBeenCalled();
         });
 
         it("should display all the buttons when the menu is opened", async () => {

--- a/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomListHeaderView-test.tsx.snap
+++ b/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomListHeaderView-test.tsx.snap
@@ -135,6 +135,35 @@ exports[`<RoomListHeaderView /> compose menu should not display the compose menu
         </div>
       </button>
     </div>
+    <button
+      aria-label="New message"
+      class="_icon-button_m2erp_8"
+      role="button"
+      style="--cpd-icon-button-size: 32px;"
+      tabindex="0"
+    >
+      <div
+        class="_indicator-icon_zr2a0_17"
+        style="--cpd-icon-button-size: 100%;"
+      >
+        <svg
+          fill="currentColor"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M16.937 2.82a2 2 0 0 1 2.828 0l1.415 1.414a2 2 0 0 1 0 2.829l-7.071 7.07c-.195.196-.42.342-.66.44a1 1 0 0 1-.168.072l-3.993 1.331a1 1 0 0 1-1.265-1.265l1.331-3.992q.03-.09.073-.168m10.338-4.903-6.717 6.718-1.414-1.414 6.717-6.718z"
+            fill-rule="evenodd"
+          />
+          <path
+            d="M3 5a2 2 0 0 1 2-2h6a1 1 0 1 1 0 2H5v14h14v-6a1 1 0 1 1 2 0v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"
+          />
+        </svg>
+      </div>
+    </button>
   </header>
 </DocumentFragment>
 `;

--- a/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomListPanel-test.tsx.snap
+++ b/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomListPanel-test.tsx.snap
@@ -23,6 +23,35 @@ exports[`<RoomListPanel /> should not render the RoomListSearch component when U
           Home
         </h1>
       </div>
+      <button
+        aria-label="New message"
+        class="_icon-button_m2erp_8"
+        role="button"
+        style="--cpd-icon-button-size: 32px;"
+        tabindex="0"
+      >
+        <div
+          class="_indicator-icon_zr2a0_17"
+          style="--cpd-icon-button-size: 100%;"
+        >
+          <svg
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M16.937 2.82a2 2 0 0 1 2.828 0l1.415 1.414a2 2 0 0 1 0 2.829l-7.071 7.07c-.195.196-.42.342-.66.44a1 1 0 0 1-.168.072l-3.993 1.331a1 1 0 0 1-1.265-1.265l1.331-3.992q.03-.09.073-.168m10.338-4.903-6.717 6.718-1.414-1.414 6.717-6.718z"
+              fill-rule="evenodd"
+            />
+            <path
+              d="M3 5a2 2 0 0 1 2-2h6a1 1 0 1 1 0 2H5v14h14v-6a1 1 0 1 1 2 0v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"
+            />
+          </svg>
+        </div>
+      </button>
     </header>
     <ul
       aria-label="Room list filters"


### PR DESCRIPTION
Currently in the new room list, the compose menu displays the create room action in a space even if the user doesn't have the rights to create a room.

This PR:
- fix the `canCreateRoom` condition -> check space rights
- fix the compose menu display -> available if the user can create room or video room 
- the compose button display directly the DM dialog if the user can't create room or video room.

https://github.com/user-attachments/assets/6394bcc4-bba7-4f08-8f30-1debf4670aa5

