### PR TITLE
Settings: flip local video feed by default

### DIFF
--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -882,7 +882,7 @@ export const SETTINGS: Settings = {
     "VideoView.flipVideoHorizontally": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         displayName: _td("settings|voip|mirror_local_feed"),
-        default: false,
+        default: true,
     },
     "theme": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,


### PR DESCRIPTION
Most (if not all) video chat apps show my local video mirrored. Element not doing it by default is makes it confusing at first. Even my phone camera app does it.

Not only matching other video chat tools out there, 99% of times you see yourself in your day to day life is through a mirror, which flips the image. So matching that makes the most sense, to preserve continuity.

This setting was made optional in https://github.com/element-hq/element-web/pull/5437 but not defaulted to true.

Fixes https://github.com/element-hq/element-web/issues/10651

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
