### PR TITLE
UserInfo panel: Ensure displayname and userId can be viewed

### DIFF
--- a/res/css/views/right_panel/_UserInfo.pcss
+++ b/res/css/views/right_panel/_UserInfo.pcss
@@ -119,6 +119,9 @@ Please see LICENSE files in the repository root for full details.
             word-break: break-all;
             text-overflow: ellipsis;
 
+            /* Don't spill over the container */
+            width: 90%;
+
             /* E2E icon wrapper */
             .mx_Flex > span {
                 display: inline-block;
@@ -127,11 +130,15 @@ Please see LICENSE files in the repository root for full details.
 
         .mx_UserInfo_profile_name {
             height: 30px;
+            text-wrap: nowrap;
         }
 
         .mx_UserInfo_profile_mxid {
             color: var(--cpd-color-text-secondary);
             height: 28px;
+            max-width: 100%;
+            /* MXIDs are one long "word" */
+            word-break: break-all;
         }
 
         .mx_UserInfo_profileStatus {

--- a/src/components/views/right_panel/UserInfo.tsx
+++ b/src/components/views/right_panel/UserInfo.tsx
@@ -1409,7 +1409,11 @@ export const UserInfoHeader: React.FC<{
                 <Flex direction="column" align="center" className="mx_UserInfo_profile">
                     <Heading size="sm" weight="semibold" as="h1" dir="auto">
                         <Flex className="mx_UserInfo_profile_name" direction="row-reverse" align="center">
-                            {displayName}
+                            <Tooltip isTriggerInteractive={true} placement="left" label={displayName}>
+                                <span>
+                                    {displayName}
+                                </span>
+                            </Tooltip>
                         </Flex>
                     </Heading>
                     {presenceLabel}
@@ -1422,11 +1426,13 @@ export const UserInfoHeader: React.FC<{
                             </Flex>
                         </Tooltip>
                     )}
-                    <Text size="sm" weight="semibold" className="mx_UserInfo_profile_mxid">
-                        <CopyableText getTextToCopy={() => userIdentifier} border={false}>
-                            {userIdentifier}
-                        </CopyableText>
-                    </Text>
+                    {userIdentifier && (
+                        <Text size="sm" weight="semibold" className="mx_UserInfo_profile_mxid">
+                            <CopyableText getTextToCopy={() => userIdentifier} border={false}>
+                                {userIdentifier}
+                            </CopyableText>
+                        </Text>
+                    )}
                 </Flex>
                 {!hideVerificationSection && <VerificationSection member={member} devices={devices} />}
             </Container>

--- a/src/components/views/right_panel/UserInfo.tsx
+++ b/src/components/views/right_panel/UserInfo.tsx
@@ -1418,13 +1418,13 @@ export const UserInfoHeader: React.FC<{
                     </Heading>
                     {presenceLabel}
                     {timezoneInfo && (
-                        <Tooltip label={timezoneInfo?.timezone ?? ""}>
-                            <Flex align="center" className="mx_UserInfo_timezone">
-                                <Text size="sm" weight="regular">
-                                    {timezoneInfo?.friendly ?? ""}
-                                </Text>
-                            </Flex>
-                        </Tooltip>
+                        <Flex align="center" className="mx_UserInfo_timezone">
+                            <Text size="sm" weight="regular">
+                                <Tooltip label={timezoneInfo?.timezone ?? ""}>
+                                    <span>{timezoneInfo?.friendly ?? ""}</span>
+                                </Tooltip>
+                            </Text>
+                        </Flex>
                     )}
                     {userIdentifier && (
                         <Text size="sm" weight="semibold" className="mx_UserInfo_profile_mxid">


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Changes:
 - The displayname is now sensibly width limited, with a tooltip for viewing the full name.
 - The userId now spans multiple lines (should it?).
 - The timezone tooltip was broken and is now fixed.

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
