### PR TITLE
RoomListStore: Unread filter should only filter rooms having unread counts

### DIFF
--- a/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
+++ b/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
@@ -93,4 +93,41 @@ test.describe("Room list", () => {
         await filters.getByRole("option", { name: "People" }).click();
         await expect(roomListView.getByRole("gridcell", { name: "Open room room0" })).toBeVisible();
     });
+
+    test("unread filter should only match unread rooms that have a count", async ({ page, app, bot }) => {
+        const roomListView = getRoomList(page);
+        // Let's create a new room and invite the bot
+        const room1Id = await app.client.createRoom({
+            name: "Unread Room 1",
+            invite: [bot.credentials?.userId],
+        });
+        await bot.awaitRoomMembership(room1Id);
+
+        // Let's create another room as well
+        const room2Id = await app.client.createRoom({
+            name: "Unread Room 2",
+            invite: [bot.credentials?.userId],
+        });
+        await bot.awaitRoomMembership(room2Id);
+
+        // Let's configure unread room 1 so that we only get notification for mentions and keywords
+        await app.viewRoomById(room1Id);
+        await app.settings.openRoomSettings("Notifications");
+        await page.getByText("@mentions & keywords").click();
+        await app.settings.closeDialog();
+
+        // Let's open a room other than room 1 or room 2
+        await roomListView.getByRole("gridcell", { name: "Open room room29" }).click();
+
+        // Let's make the bot send a new message in both room 1 and room 2
+        await bot.sendMessage(room1Id, "Hello!");
+        await bot.sendMessage(room2Id, "Hello!");
+
+        // Let's activate the unread filter now
+        await page.getByRole("option", { name: "Unread" }).click();
+
+        // Unread filter should only show room 2!!
+        await expect(roomListView.getByRole("gridcell", { name: "Open room Unread Room 2" })).toBeVisible();
+        await expect(roomListView.getByRole("gridcell", { name: "Open room Unread Room 1" })).not.toBeVisible();
+    });
 });

--- a/src/stores/room-list-v3/skip-list/filters/UnreadFilter.ts
+++ b/src/stores/room-list-v3/skip-list/filters/UnreadFilter.ts
@@ -11,7 +11,7 @@ import { RoomNotificationStateStore } from "../../../notifications/RoomNotificat
 
 export class UnreadFilter implements Filter {
     public matches(room: Room): boolean {
-        return RoomNotificationStateStore.instance.getRoomState(room).isUnread;
+        return RoomNotificationStateStore.instance.getRoomState(room).hasUnreadCount;
     }
 
     public get key(): FilterKey.UnreadFilter {

--- a/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
+++ b/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
@@ -457,7 +457,7 @@ describe("RoomListStoreV3", () => {
                 // Let's say 8, 27 are unread
                 jest.spyOn(RoomNotificationStateStore.instance, "getRoomState").mockImplementation((room) => {
                     const state = {
-                        isUnread: [rooms[8], rooms[27]].includes(room),
+                        hasUnreadCount: [rooms[8], rooms[27]].includes(room),
                     } as unknown as RoomNotificationState;
                     return state;
                 });
@@ -588,7 +588,7 @@ describe("RoomListStoreV3", () => {
                 // Let's say 8, 27 are unread
                 jest.spyOn(RoomNotificationStateStore.instance, "getRoomState").mockImplementation((room) => {
                     const state = {
-                        isUnread: [rooms[8], rooms[27]].includes(room),
+                        hasUnreadCount: [rooms[8], rooms[27]].includes(room),
                     } as unknown as RoomNotificationState;
                     return state;
                 });


### PR DESCRIPTION
`hasUnreadCount` makes more sense since it corresponds to whether notification is actually shown in the tile.