### PR TITLE
Fix bug which caused startup to hang if the clock was wound back since a previous session

### DIFF
--- a/src/utils/SessionLock.ts
+++ b/src/utils/SessionLock.ts
@@ -57,7 +57,7 @@ export const SESSION_LOCK_CONSTANTS = {
     /**
      * The number of milliseconds after which we consider a lock claim stale
      */
-    LOCK_EXPIRY_TIME_MS: 30000,
+    LOCK_EXPIRY_TIME_MS: 15000,
 };
 
 /**

--- a/test/unit-tests/utils/SessionLock-test.ts
+++ b/test/unit-tests/utils/SessionLock-test.ts
@@ -71,15 +71,15 @@ describe("SessionLock", () => {
         jest.advanceTimersByTime(5000);
         expect(checkSessionLockFree()).toBe(false);
 
-        // second instance tries to start. This should block for 25 more seconds
+        // second instance tries to start. This should block for 10 more seconds
         const onNewInstance2 = jest.fn();
         let session2Result: boolean | undefined;
         getSessionLock(onNewInstance2).then((res) => {
             session2Result = res;
         });
 
-        // after another 24.5 seconds, we are still waiting
-        jest.advanceTimersByTime(24500);
+        // after another 9.5 seconds, we are still waiting
+        jest.advanceTimersByTime(9500);
         expect(session2Result).toBe(undefined);
         expect(checkSessionLockFree()).toBe(false);
 


### PR DESCRIPTION
If a previous session terminated uncleanly, and then the clock is wound back, we could be waiting a very long time for the previous session's claim to expire.

We can fix this by simply treating a future claim the same as "now", and waiting for the normal stale timeout.

We also reduce the "stale" timeout from 30 seconds to 15 seconds, to reduce the amount of time we sit looking at a spinner.

Fixes: https://github.com/element-hq/element-web/issues/28168