### PR TITLE
RoomListViewModel: Reset any primary filter on secondary filter change

### DIFF
--- a/src/components/viewmodels/roomlist/useFilteredRooms.tsx
+++ b/src/components/viewmodels/roomlist/useFilteredRooms.tsx
@@ -145,22 +145,14 @@ export function useFilteredRooms(): FilteredRooms {
             // SecondaryFilter is an enum for the UI, let's convert it to something
             // that the store will understand.
             const secondary = secondaryFiltersToFilterKeyMap.get(filter);
-
-            // Active primary filter may need to be toggled off when applying this secondary filer.
-            let primary = primaryFilter;
-            if (
-                primaryFilter !== undefined &&
-                secondary !== undefined &&
-                !isPrimaryFilterCompatible(primaryFilter, secondary)
-            ) {
-                primary = undefined;
-            }
-
             setActiveSecondaryFilter(filter);
-            setPrimaryFilter(primary);
-            updateRoomsFromStore(filterUndefined([primary, secondary]));
+
+            // Reset any active primary filters.
+            setPrimaryFilter(undefined);
+
+            updateRoomsFromStore(filterUndefined([secondary]));
         },
-        [activeSecondaryFilter, primaryFilter, updateRoomsFromStore],
+        [activeSecondaryFilter, updateRoomsFromStore],
     );
 
     /**

--- a/test/unit-tests/components/viewmodels/roomlist/RoomListViewModel-test.tsx
+++ b/test/unit-tests/components/viewmodels/roomlist/RoomListViewModel-test.tsx
@@ -162,6 +162,29 @@ describe("RoomListViewModel", () => {
             expect(vm.current.activePrimaryFilter).toEqual(vm.current.primaryFilters[i]);
         });
 
+        it("should remove any active primary filters when secondary filter is changed", async () => {
+            const { fn } = mockAndCreateRooms();
+            const { result: vm } = renderHook(() => useRoomListViewModel());
+
+            // Let's first toggle the People filter
+            const i = vm.current.primaryFilters.findIndex((f) => f.name === "People");
+            act(() => {
+                vm.current.primaryFilters[i].toggle();
+            });
+            expect(vm.current.primaryFilters[i].active).toEqual(true);
+
+            // Let's say we toggle the mentions secondary filter
+            act(() => {
+                vm.current.activateSecondaryFilter(SecondaryFilters.MentionsOnly);
+            });
+
+            // Primary filer should have been unapplied
+            expect(vm.current.primaryFilters[i].active).toEqual(false);
+
+            // RLS call must include only the secondary filter
+            expect(fn).toHaveBeenLastCalledWith(expect.arrayContaining([FilterKey.MentionsFilter]));
+        });
+
         const testcases: Array<[string, { secondary: SecondaryFilters; filterKey: FilterKey }, string]> = [
             [
                 "Mentions only",


### PR DESCRIPTION
Previously we would only reset the active primary filter if it was incompatible with the secondary filter.