### PR TITLE
Room notification state: add clearer methods, documentation and deprecation

### DIFF
--- a/src/RoomNotifs.ts
+++ b/src/RoomNotifs.ts
@@ -238,25 +238,25 @@ export function determineUnreadState(
     room?: Room,
     threadId?: string,
     includeThreads?: boolean,
-): { level: NotificationLevel; symbol: string | null; count: number } {
+): { level: NotificationLevel; symbol: string | null; count: number; invited: boolean } {
     if (!room) {
-        return { symbol: null, count: 0, level: NotificationLevel.None };
+        return { symbol: null, count: 0, level: NotificationLevel.None, invited: false };
     }
 
     if (getUnsentMessages(room, threadId).length > 0) {
-        return { symbol: "!", count: 1, level: NotificationLevel.Unsent };
+        return { symbol: "!", count: 1, level: NotificationLevel.Unsent, invited: false };
     }
 
     if (getEffectiveMembership(room.getMyMembership()) === EffectiveMembership.Invite) {
-        return { symbol: "!", count: 1, level: NotificationLevel.Highlight };
+        return { symbol: "!", count: 1, level: NotificationLevel.Highlight, invited: true };
     }
 
     if (SettingsStore.getValue("feature_ask_to_join") && isKnockDenied(room)) {
-        return { symbol: "!", count: 1, level: NotificationLevel.Highlight };
+        return { symbol: "!", count: 1, level: NotificationLevel.Highlight, invited: false };
     }
 
     if (getRoomNotifsState(room.client, room.roomId) === RoomNotifState.Mute) {
-        return { symbol: null, count: 0, level: NotificationLevel.None };
+        return { symbol: null, count: 0, level: NotificationLevel.None, invited: false };
     }
 
     const redNotifs = getUnreadNotificationCount(
@@ -269,12 +269,12 @@ export function determineUnreadState(
 
     const trueCount = greyNotifs || redNotifs;
     if (redNotifs > 0) {
-        return { symbol: null, count: trueCount, level: NotificationLevel.Highlight };
+        return { symbol: null, count: trueCount, level: NotificationLevel.Highlight, invited: false };
     }
 
     const markedUnreadState = getMarkedUnreadState(room);
     if (greyNotifs > 0 || markedUnreadState) {
-        return { symbol: null, count: trueCount, level: NotificationLevel.Notification };
+        return { symbol: null, count: trueCount, level: NotificationLevel.Notification, invited: false };
     }
 
     // We don't have any notified messages, but we might have unread messages. Let's find out.
@@ -293,5 +293,6 @@ export function determineUnreadState(
         symbol: null,
         count: trueCount,
         level: hasUnread ? NotificationLevel.Activity : NotificationLevel.None,
+        invited: false,
     };
 }

--- a/src/stores/notifications/NotificationState.ts
+++ b/src/stores/notifications/NotificationState.ts
@@ -98,6 +98,7 @@ export abstract class NotificationState
      * True if the notification is a mention, an invitation, a knock or a unset message.
      *
      * @deprecated because the name is confusing. A mention is not an invitation, a knock or an unsent message.
+     * In case of a {@link RoomNotificationState}, use {@link RoomNotificationState.isMention} instead.
      */
     public get hasMentions(): boolean {
         return this.level >= NotificationLevel.Highlight;

--- a/src/stores/notifications/NotificationState.ts
+++ b/src/stores/notifications/NotificationState.ts
@@ -18,6 +18,7 @@ export interface INotificationStateSnapshotParams {
     level: NotificationLevel;
     muted: boolean;
     knocked: boolean;
+    invited: boolean;
 }
 
 export enum NotificationStateEvents {
@@ -38,6 +39,7 @@ export abstract class NotificationState
     protected _level: NotificationLevel = NotificationLevel.None;
     protected _muted = false;
     protected _knocked = false;
+    protected _invited = false;
 
     private watcherReferences: string[] = [];
 
@@ -68,6 +70,14 @@ export abstract class NotificationState
 
     public get knocked(): boolean {
         return this._knocked;
+    }
+
+    /**
+     * True if the notification is an invitation notification.
+     * Invite notifications are a special case of highlight notifications
+     */
+    public get invited(): boolean {
+        return this._invited;
     }
 
     public get isIdle(): boolean {
@@ -129,6 +139,7 @@ export class NotificationStateSnapshot {
     private readonly level: NotificationLevel;
     private readonly muted: boolean;
     private readonly knocked: boolean;
+    private readonly isInvitation: boolean;
 
     public constructor(state: INotificationStateSnapshotParams) {
         this.symbol = state.symbol;
@@ -136,6 +147,7 @@ export class NotificationStateSnapshot {
         this.level = state.level;
         this.muted = state.muted;
         this.knocked = state.knocked;
+        this.isInvitation = state.invited;
     }
 
     public isDifferentFrom(other: INotificationStateSnapshotParams): boolean {
@@ -145,6 +157,7 @@ export class NotificationStateSnapshot {
             level: this.level,
             muted: this.muted,
             knocked: this.knocked,
+            is: this.isInvitation,
         };
         const after = {
             count: other.count,

--- a/src/stores/notifications/NotificationState.ts
+++ b/src/stores/notifications/NotificationState.ts
@@ -88,7 +88,7 @@ export abstract class NotificationState
     }
 
     /**
-     * True if the notification has a count or a symbol and is greater than an activity notification.
+     * True if the notification has a count or a symbol and is equal or greater than an NotificationLevel.Notification.
      */
     public get hasUnreadCount(): boolean {
         return this.level >= NotificationLevel.Notification && (!!this.count || !!this.symbol);

--- a/src/stores/notifications/NotificationState.ts
+++ b/src/stores/notifications/NotificationState.ts
@@ -74,6 +74,10 @@ export abstract class NotificationState
         return this.level <= NotificationLevel.None;
     }
 
+    /**
+     * True if the notification is higher than an activity notification or if the feature_hidebold is disabled with an activity notification.
+     * The "unread" term used here is different from the "Unread" in the UI. Unread in the UI doesn't include activity notifications even with feature_hidebold disabled.
+     */
     public get isUnread(): boolean {
         if (this.level > NotificationLevel.Activity) {
             return true;
@@ -83,10 +87,18 @@ export abstract class NotificationState
         }
     }
 
+    /**
+     * True if the notification has a count or a symbol and is greater than an activity notification.
+     */
     public get hasUnreadCount(): boolean {
         return this.level >= NotificationLevel.Notification && (!!this.count || !!this.symbol);
     }
 
+    /**
+     * True if the notification is a mention, an invitation, a knock or a unset message.
+     *
+     * @deprecated because the name is confusing. A mention is not an invitation, a knock or an unsent message.
+     */
     public get hasMentions(): boolean {
         return this.level >= NotificationLevel.Highlight;
     }

--- a/src/stores/notifications/RoomNotificationState.ts
+++ b/src/stores/notifications/RoomNotificationState.ts
@@ -92,10 +92,10 @@ export class RoomNotificationState extends NotificationState implements IDestroy
     }
 
     /**
-     * True if the notification is a NotificationLevel.Notification with at least one unread message.
+     * True if the notification is a NotificationLevel.Notification.
      */
     public get isNotification(): boolean {
-        return this.level === NotificationLevel.Notification && this.count > 0;
+        return this.level === NotificationLevel.Notification;
     }
 
     private handleLocalEchoUpdated = (): void => {

--- a/src/stores/notifications/RoomNotificationState.ts
+++ b/src/stores/notifications/RoomNotificationState.ts
@@ -53,20 +53,10 @@ export class RoomNotificationState extends NotificationState implements IDestroy
     }
 
     /**
-     * True if the notification is an invitation notification.
-     * Invite notifications are a special case of highlight notifications
-     */
-    public get isInvitation(): boolean {
-        if (this.knocked) return false;
-
-        return this.level === NotificationLevel.Highlight && this.symbol === "!" && this.count === 1;
-    }
-
-    /**
      * True if the notification is a mention.
      */
     public get isMention(): boolean {
-        if (this.isInvitation || this.knocked) return false;
+        if (this.invited || this.knocked) return false;
 
         return this.level === NotificationLevel.Highlight;
     }
@@ -152,7 +142,11 @@ export class RoomNotificationState extends NotificationState implements IDestroy
     private updateNotificationState(): void {
         const snapshot = this.snapshot();
 
-        const { level, symbol, count } = RoomNotifs.determineUnreadState(this.room, undefined, this.includeThreads);
+        const { level, symbol, count, invited } = RoomNotifs.determineUnreadState(
+            this.room,
+            undefined,
+            this.includeThreads,
+        );
         const muted =
             RoomNotifs.getRoomNotifsState(this.room.client, this.room.roomId) === RoomNotifs.RoomNotifState.Mute;
         const knocked =
@@ -162,6 +156,7 @@ export class RoomNotificationState extends NotificationState implements IDestroy
         this._count = count;
         this._muted = muted;
         this._knocked = knocked;
+        this._invited = invited;
 
         // finally, publish an update if needed
         this.emitIfUpdated(snapshot);

--- a/src/stores/notifications/RoomNotificationState.ts
+++ b/src/stores/notifications/RoomNotificationState.ts
@@ -86,14 +86,19 @@ export class RoomNotificationState extends NotificationState implements IDestroy
     }
 
     /**
-     * True if the notification is silent.
-     * This is the case for notifications with a level lower than None or Activity if feature_hidebold is enabled.
+     * This is the case for notifications with a level:
+     * - is a knock
+     * - greater Activity
+     * - equal Activity and feature_hidebold is disabled.
      */
-    public get isSilent(): boolean {
-        if (this.knocked) return false;
+    public get hasAnyNotificationOrActivity(): boolean {
+        if (this.knocked) return true;
 
+        // If the feature_hidebold is enabled, we don't want to show activity notifications
         const hideBold = SettingsStore.getValue("feature_hidebold");
-        return this.level <= NotificationLevel.None || (hideBold && this.level <= NotificationLevel.Activity);
+        if (!hideBold && this.level === NotificationLevel.Activity) return true;
+
+        return this.level >= NotificationLevel.Notification;
     }
 
     /**

--- a/test/unit-tests/stores/notifications/RoomNotificationState-test.ts
+++ b/test/unit-tests/stores/notifications/RoomNotificationState-test.ts
@@ -214,10 +214,10 @@ describe("RoomNotificationState", () => {
             jest.spyOn(UnreadModule, "doesRoomHaveUnreadMessages").mockReturnValue(false);
         });
 
-        it("should has isInvitation at true", () => {
+        it("should has invited at true", () => {
             room.updateMyMembership(KnownMembership.Invite);
             const roomNotifState = new RoomNotificationState(room, false);
-            expect(roomNotifState.isInvitation).toBe(true);
+            expect(roomNotifState.invited).toBe(true);
         });
 
         it("should has isUnsetMessage at true", () => {

--- a/test/unit-tests/stores/notifications/RoomNotificationState-test.ts
+++ b/test/unit-tests/stores/notifications/RoomNotificationState-test.ts
@@ -258,7 +258,7 @@ describe("RoomNotificationState", () => {
             expect(roomNotifState.isActivityNotification).toBe(true);
         });
 
-        it("should has isSilent at true", () => {
+        it("should has hasAnyNotificationOrActivity at true", () => {
             // Hidebold is disabled
             jest.spyOn(SettingsStore, "getValue").mockReturnValue(false);
             // Unread message, generate activity notification
@@ -267,27 +267,25 @@ describe("RoomNotificationState", () => {
             setUnreads(room, 0, 1);
 
             // There is one highlight notification
-            // The notification should not be silent
             const roomNotifState = new RoomNotificationState(room, false);
-            expect(roomNotifState.isSilent).toBe(false);
+            expect(roomNotifState.hasAnyNotificationOrActivity).toBe(true);
 
             // Activity notification
-            // the notification should not be silent
             setUnreads(room, 0, 0);
             // Trigger update
             room.updateMyMembership(KnownMembership.Join);
-            expect(roomNotifState.isSilent).toBe(false);
+            // hidebold is disabled and we have an activity notification
+            expect(roomNotifState.hasAnyNotificationOrActivity).toBe(true);
 
-            // hidebold is enabled
-            // The notification should be silent
+            // hidebold is enabled and we have an activity notification
             jest.spyOn(SettingsStore, "getValue").mockReturnValue(true);
             room.updateMyMembership(KnownMembership.Join);
-            expect(roomNotifState.isSilent).toBe(true);
+            expect(roomNotifState.hasAnyNotificationOrActivity).toBe(false);
 
             // No unread
             jest.spyOn(UnreadModule, "doesRoomHaveUnreadMessages").mockReturnValue(false);
             room.updateMyMembership(KnownMembership.Join);
-            expect(roomNotifState.isSilent).toBe(true);
+            expect(roomNotifState.hasAnyNotificationOrActivity).toBe(false);
         });
     });
 });

--- a/test/unit-tests/stores/notifications/RoomNotificationState-test.ts
+++ b/test/unit-tests/stores/notifications/RoomNotificationState-test.ts
@@ -24,6 +24,9 @@ import { RoomNotificationState } from "../../../../src/stores/notifications/Room
 import { NotificationStateEvents } from "../../../../src/stores/notifications/NotificationState";
 import { NotificationLevel } from "../../../../src/stores/notifications/NotificationLevel";
 import { createMessageEventContent } from "../../../test-utils/events";
+import SettingsStore from "../../../../src/settings/SettingsStore";
+import * as RoomStatusBarModule from "../../../../src/components/structures/RoomStatusBar";
+import * as UnreadModule from "../../../../src/Unread";
 
 describe("RoomNotificationState", () => {
     let room: Room;
@@ -34,6 +37,10 @@ describe("RoomNotificationState", () => {
         room = new Room("!room:example.com", client, "@user:example.org", {
             pendingEventOrdering: PendingEventOrdering.Detached,
         });
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
     });
 
     function addThread(room: Room): void {
@@ -199,5 +206,88 @@ describe("RoomNotificationState", () => {
 
         expect(roomNotifState.level).toBe(NotificationLevel.Activity);
         expect(roomNotifState.symbol).toBe(null);
+    });
+
+    describe("computed attributes", () => {
+        beforeEach(() => {
+            jest.spyOn(RoomStatusBarModule, "getUnsentMessages").mockReturnValue([]);
+            jest.spyOn(UnreadModule, "doesRoomHaveUnreadMessages").mockReturnValue(false);
+        });
+
+        it("should has isInvitation at true", () => {
+            room.updateMyMembership(KnownMembership.Invite);
+            const roomNotifState = new RoomNotificationState(room, false);
+            expect(roomNotifState.isInvitation).toBe(true);
+        });
+
+        it("should has isUnsetMessage at true", () => {
+            jest.spyOn(RoomStatusBarModule, "getUnsentMessages").mockReturnValue([{} as MatrixEvent]);
+            const roomNotifState = new RoomNotificationState(room, false);
+            expect(roomNotifState.isUnsetMessage).toBe(true);
+        });
+
+        it("should has isMention at false if the notification is invitation, an unset message or a knock", () => {
+            setUnreads(room, 0, 2);
+
+            const roomNotifState = new RoomNotificationState(room, false);
+            expect(roomNotifState.isMention).toBe(true);
+
+            room.updateMyMembership(KnownMembership.Invite);
+            expect(roomNotifState.isMention).toBe(false);
+
+            jest.spyOn(SettingsStore, "getValue").mockReturnValue(true);
+            room.updateMyMembership(KnownMembership.Knock);
+            expect(roomNotifState.isMention).toBe(false);
+
+            jest.spyOn(RoomStatusBarModule, "getUnsentMessages").mockReturnValue([{} as MatrixEvent]);
+            room.updateMyMembership(KnownMembership.Join);
+            expect(roomNotifState.isMention).toBe(false);
+        });
+
+        it("should has isNotification at true", () => {
+            setUnreads(room, 1, 0);
+
+            const roomNotifState = new RoomNotificationState(room, false);
+            expect(roomNotifState.isNotification).toBe(true);
+        });
+
+        it("should has isActivityNotification at true", () => {
+            jest.spyOn(UnreadModule, "doesRoomHaveUnreadMessages").mockReturnValue(true);
+
+            const roomNotifState = new RoomNotificationState(room, false);
+            expect(roomNotifState.isActivityNotification).toBe(true);
+        });
+
+        it("should has isSilent at true", () => {
+            // Hidebold is disabled
+            jest.spyOn(SettingsStore, "getValue").mockReturnValue(false);
+            // Unread message, generate activity notification
+            jest.spyOn(UnreadModule, "doesRoomHaveUnreadMessages").mockReturnValue(true);
+            // Highlight notification
+            setUnreads(room, 0, 1);
+
+            // There is one highlight notification
+            // The notification should not be silent
+            const roomNotifState = new RoomNotificationState(room, false);
+            expect(roomNotifState.isSilent).toBe(false);
+
+            // Activity notification
+            // the notification should not be silent
+            setUnreads(room, 0, 0);
+            // Trigger update
+            room.updateMyMembership(KnownMembership.Join);
+            expect(roomNotifState.isSilent).toBe(false);
+
+            // hidebold is enabled
+            // The notification should be silent
+            jest.spyOn(SettingsStore, "getValue").mockReturnValue(true);
+            room.updateMyMembership(KnownMembership.Join);
+            expect(roomNotifState.isSilent).toBe(true);
+
+            // No unread
+            jest.spyOn(UnreadModule, "doesRoomHaveUnreadMessages").mockReturnValue(false);
+            room.updateMyMembership(KnownMembership.Join);
+            expect(roomNotifState.isSilent).toBe(true);
+        });
     });
 });

--- a/test/unit-tests/stores/room-list/algorithms/list-ordering/ImportanceAlgorithm-test.ts
+++ b/test/unit-tests/stores/room-list/algorithms/list-ordering/ImportanceAlgorithm-test.ts
@@ -67,9 +67,9 @@ describe("ImportanceAlgorithm", () => {
     };
 
     const unreadStates: Record<string, ReturnType<(typeof RoomNotifs)["determineUnreadState"]>> = {
-        red: { symbol: null, count: 1, level: NotificationLevel.Highlight },
-        grey: { symbol: null, count: 1, level: NotificationLevel.Notification },
-        none: { symbol: null, count: 0, level: NotificationLevel.None },
+        red: { symbol: null, count: 1, level: NotificationLevel.Highlight, invited: false },
+        grey: { symbol: null, count: 1, level: NotificationLevel.Notification, invited: false },
+        none: { symbol: null, count: 0, level: NotificationLevel.None, invited: false },
     };
 
     beforeEach(() => {
@@ -77,6 +77,7 @@ describe("ImportanceAlgorithm", () => {
             symbol: null,
             count: 0,
             level: NotificationLevel.None,
+            invited: false,
         });
     });
 
@@ -183,6 +184,7 @@ describe("ImportanceAlgorithm", () => {
                 symbol: null,
                 count: 0,
                 level: NotificationLevel.None,
+                invited: false,
             });
             const algorithm = setupAlgorithm(sortAlgorithm);
 
@@ -353,6 +355,7 @@ describe("ImportanceAlgorithm", () => {
                 symbol: null,
                 count: 0,
                 level: NotificationLevel.None,
+                invited: false,
             });
             const algorithm = setupAlgorithm(sortAlgorithm);
 

--- a/test/unit-tests/stores/room-list/algorithms/list-ordering/NaturalAlgorithm-test.ts
+++ b/test/unit-tests/stores/room-list/algorithms/list-ordering/NaturalAlgorithm-test.ts
@@ -190,6 +190,7 @@ describe("NaturalAlgorithm", () => {
                 symbol: null,
                 count: 0,
                 level: NotificationLevel.None,
+                invited: false,
             });
         });
 


### PR DESCRIPTION
The PR's goal is to put the notification business logic into the `RoomNotificationState`.  The existing `symbol`, `count` and `level` attributes are fairly high level and need to be interpreted to determine which notifications are a mention, an activity etc. In order to have this model as source of truth.

The first usage will be in the [new room list](https://www.figma.com/design/vlmt46QDdE4dgXDiyBJXqp/Left-Panel-2025?node-id=101-13076&t=x5XhFYuXIIqw4OzU-4). The final goal is to have the UI uses this model (room list, thread...) instead of having the different pieces of UI doing their own stuff. 

**State of the art (not all are listed)**
- [`StatelessNotificationBadge`](https://github.com/element-hq/element-web/blob/4a381c2a105c4f26d8e6975ee53c75b7ad204ad7/src/components/views/rooms/NotificationBadge/StatelessNotificationBadge.tsx): use  `symbol`, `count` and `level` and interprets these values to build the UI
- [`UnreadNotificationBadge`](https://github.com/element-hq/element-web/blob/4a381c2a105c4f26d8e6975ee53c75b7ad204ad7/src/components/views/rooms/NotificationBadge/UnreadNotificationBadge.tsx): use [`useUnreadNotification`](https://github.com/element-hq/element-web/blob/69ee8fd96a49f7008a6b16813ffbcc74a0872821/src/hooks/useUnreadNotifications.ts). `useUnreadNotification` doesn't use the model
- [`RoomTile`](https://github.com/element-hq/element-web/blob/4a381c2a105c4f26d8e6975ee53c75b7ad204ad7/src/components/views/rooms/RoomTile.tsx#L122-L121) use the `RoomNotificationState`

Some UI use a notification model, others use a hook (which doesn't use the model).