### PR TITLE
Generate/load pickle key on SSO

### DIFF
--- a/src/Lifecycle.ts
+++ b/src/Lifecycle.ts
@@ -414,10 +414,13 @@ export function attemptTokenLogin(
 async function onSuccessfulDelegatedAuthLogin(credentials: IMatrixClientCreds): Promise<void> {
     await clearStorage();
 
-    const userId = credentials.userId;
-    const deviceId = credentials.deviceId;
+    // SSO does not go through setLoggedIn so we need to load/create the pickle key here too
+    // Try to load the pickle key
+    const userId: string = credentials.userId;
+    const deviceId: string | undefined = credentials.deviceId;
     let pickleKey: string | undefined = (await PlatformPeg.get()?.getPickleKey(userId, deviceId ?? "")) ?? undefined;
     if (!pickleKey) {
+        // Create it if it did not exist
         pickleKey = userId && deviceId
                 ? await PlatformPeg.get()?.createPickleKey(userId, deviceId) ?? undefined
                 : undefined;

--- a/src/Lifecycle.ts
+++ b/src/Lifecycle.ts
@@ -408,7 +408,7 @@ export function attemptTokenLogin(
 
 /**
  * Load the pickle key inside the credentials or create it if it does not exist for this device.
- * 
+ *
  * @param credentials Holds the device to load/store the pickle key
  *
  * @returns {Promise} promise which resolves to the loaded or generated pickle key or undefined if
@@ -421,8 +421,9 @@ async function loadOrCreatePickleKey(credentials: IMatrixClientCreds): Promise<s
     let pickleKey = (await PlatformPeg.get()?.getPickleKey(userId, deviceId ?? "")) ?? undefined;
     if (!pickleKey) {
         // Create it if it did not exist
-        pickleKey = userId && deviceId
-                ? await PlatformPeg.get()?.createPickleKey(userId, deviceId) ?? undefined
+        pickleKey =
+            userId && deviceId
+                ? ((await PlatformPeg.get()?.createPickleKey(userId, deviceId)) ?? undefined)
                 : undefined;
         if (pickleKey) {
             logger.log(`Created pickle key for ${credentials.userId}|${credentials.deviceId}`);
@@ -430,7 +431,9 @@ async function loadOrCreatePickleKey(credentials: IMatrixClientCreds): Promise<s
             logger.log("Pickle key not created");
         }
     } else {
-        logger.log(`Pickle key already exists for ${credentials.userId}|${credentials.deviceId} do not create a new one`);
+        logger.log(
+            `Pickle key already exists for ${credentials.userId}|${credentials.deviceId} do not create a new one`,
+        );
     }
 
     return pickleKey;

--- a/src/Lifecycle.ts
+++ b/src/Lifecycle.ts
@@ -408,7 +408,11 @@ export function attemptTokenLogin(
 
 /**
  * Load the pickle key inside the credentials or create it if it does not exist for this device.
- * @param credentials Holds the device to load/store the pickle key, result is stored in credentials.pickleKey
+ * 
+ * @param credentials Holds the device to load/store the pickle key
+ *
+ * @returns {Promise} promise which resolves to the loaded or generated pickle key or undefined if
+ *    none was loaded nor generated
  */
 async function loadOrCreatePickleKey(credentials: IMatrixClientCreds): Promise<string | undefined> {
     // Try to load the pickle key

--- a/src/Lifecycle.ts
+++ b/src/Lifecycle.ts
@@ -413,6 +413,17 @@ export function attemptTokenLogin(
  */
 async function onSuccessfulDelegatedAuthLogin(credentials: IMatrixClientCreds): Promise<void> {
     await clearStorage();
+
+    const userId = credentials.userId;
+    const deviceId = credentials.deviceId;
+    let pickleKey: string | undefined = (await PlatformPeg.get()?.getPickleKey(userId, deviceId ?? "")) ?? undefined;
+    if (!pickleKey) {
+        pickleKey = userId && deviceId
+                ? await PlatformPeg.get()?.createPickleKey(userId, deviceId) ?? undefined
+                : undefined;
+    }
+    credentials.pickleKey = pickleKey;
+
     await persistCredentials(credentials);
 
     // remember that we just logged in


### PR DESCRIPTION
In lifecycle, no pickle key seems to be ever created when logging in through SSO since the pickle key creation is done in `setLoggedIn` which is not called after `attemptDelegatedAuthLogin`. Thus when using SSO login, the indexed DB will be stored in plaintext on disk.

This aims to try to generate and load a pickle key in `onSuccessfulDelegatedAuthLogin`.

Testing strategy:

- On an element-desktop build with `keytar`
- Sign out/Sign in through SSO
- Check the indexed DB in the dev tools, mx_access_token should be encrypted and not in plaintext

I am still unsure on how to write unit tests about this as the OIDC native flow tests all seems to call `setLoggedIn` manually but I do not think that this code is actually reachable in the actual app when doing SSO, only `doSetLoggedIn` is.

I would like to take feedbacks on this before making significant changes to tests I did not write and may not understand completely.