### PR TITLE
Use 'Dismiss' to close pinned identity changes, instead of 'Ok'

### DIFF
--- a/src/components/views/rooms/UserIdentityWarning.tsx
+++ b/src/components/views/rooms/UserIdentityWarning.tsx
@@ -104,7 +104,7 @@ function getTitleAndAction(prompt: ViolationPrompt): [title: React.ReactNode, ac
                 },
             );
         }
-        action = _t("action|ok");
+        action = _t("action|dismiss");
     }
     return [title, action];
 }


### PR DESCRIPTION
As specified in https://github.com/element-hq/element-meta/issues/2792 , use "Dismiss" instead of "Ok" for this prompt, since the user has no other choice.