### PR TITLE
RoomListStore: Unread filter should match rooms that were marked as unread

### DIFF
--- a/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -33,6 +33,7 @@ import { MentionsFilter } from "./skip-list/filters/MentionsFilter";
 import { LowPriorityFilter } from "./skip-list/filters/LowPriorityFilter";
 import { type Sorter, SortingAlgorithm } from "./skip-list/sorters";
 import { SettingLevel } from "../../settings/SettingLevel";
+import { MARKED_UNREAD_TYPE_STABLE, MARKED_UNREAD_TYPE_UNSTABLE } from "../../utils/notifications";
 
 /**
  * These are the filters passed to the room skip list.
@@ -153,6 +154,15 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
             case "MatrixActions.Room.tags": {
                 const room = payload.room;
                 this.addRoomAndEmit(room);
+                break;
+            }
+
+            case "MatrixActions.Room.accountData": {
+                const eventType = payload.event_type;
+                if (eventType === MARKED_UNREAD_TYPE_STABLE || eventType === MARKED_UNREAD_TYPE_UNSTABLE) {
+                    const room = payload.room;
+                    this.addRoomAndEmit(room);
+                }
                 break;
             }
 

--- a/src/stores/room-list-v3/skip-list/filters/UnreadFilter.ts
+++ b/src/stores/room-list-v3/skip-list/filters/UnreadFilter.ts
@@ -8,10 +8,11 @@ import type { Room } from "matrix-js-sdk/src/matrix";
 import type { Filter } from ".";
 import { FilterKey } from ".";
 import { RoomNotificationStateStore } from "../../../notifications/RoomNotificationStateStore";
+import { getMarkedUnreadState } from "../../../../utils/notifications";
 
 export class UnreadFilter implements Filter {
     public matches(room: Room): boolean {
-        return RoomNotificationStateStore.instance.getRoomState(room).hasUnreadCount;
+        return RoomNotificationStateStore.instance.getRoomState(room).hasUnreadCount || !!getMarkedUnreadState(room);
     }
 
     public get key(): FilterKey.UnreadFilter {

--- a/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
+++ b/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
@@ -26,6 +26,7 @@ import { RoomNotificationStateStore } from "../../../../src/stores/notifications
 import DMRoomMap from "../../../../src/utils/DMRoomMap";
 import { SortingAlgorithm } from "../../../../src/stores/room-list-v3/skip-list/sorters";
 import SettingsStore from "../../../../src/settings/SettingsStore";
+import * as utils from "../../../../src/utils/notifications";
 
 describe("RoomListStoreV3", () => {
     async function getRoomListStore() {
@@ -472,6 +473,36 @@ describe("RoomListStoreV3", () => {
                 for (const i of [8, 27]) {
                     expect(result).toContain(rooms[i]);
                 }
+            });
+
+            it("unread filter matches rooms that are marked as unread", async () => {
+                const { client, rooms } = getClientAndRooms();
+                // Let's choose 5 rooms to put in space
+                const { spaceRoom, roomIds } = createSpace(rooms, [6, 8, 13, 27, 75], client);
+
+                setupMocks(spaceRoom, roomIds);
+                const store = new RoomListStoreV3Class(dispatcher);
+                await store.start();
+
+                // Since there's no unread yet, we expect zero results
+                let result = store.getSortedRoomsInActiveSpace([FilterKey.UnreadFilter]);
+                expect(result).toHaveLength(0);
+
+                // Mock so that room at index 8 is marked as unread
+                jest.spyOn(utils, "getMarkedUnreadState").mockImplementation((room) => room.roomId === rooms[8].roomId);
+                dispatcher.dispatch(
+                    {
+                        action: "MatrixActions.Room.accountData",
+                        room: rooms[8],
+                        event_type: utils.MARKED_UNREAD_TYPE_STABLE,
+                    },
+                    true,
+                );
+
+                // Now we expect room at index 8 to show as unread
+                result = store.getSortedRoomsInActiveSpace([FilterKey.UnreadFilter]);
+                expect(result).toHaveLength(1);
+                expect(result).toContain(rooms[8]);
             });
 
             it("supports filtering by people and rooms", async () => {


### PR DESCRIPTION
- `UnreadFilter` matches rooms that are marked as unread.
- `RoomListStoreV3` re-inserts rooms that are marked as unread/read into the skip list.