### PR TITLE
New Room List: Move tests that are in the wrong location

### DIFF
--- a/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
+++ b/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
@@ -94,40 +94,4 @@ test.describe("Room list", () => {
         await expect(roomListView.getByRole("gridcell", { name: "Open room room0" })).toBeVisible();
     });
 
-    test("unread filter should only match unread rooms that have a count", async ({ page, app, bot }) => {
-        const roomListView = getRoomList(page);
-        // Let's create a new room and invite the bot
-        const room1Id = await app.client.createRoom({
-            name: "Unread Room 1",
-            invite: [bot.credentials?.userId],
-        });
-        await bot.awaitRoomMembership(room1Id);
-
-        // Let's create another room as well
-        const room2Id = await app.client.createRoom({
-            name: "Unread Room 2",
-            invite: [bot.credentials?.userId],
-        });
-        await bot.awaitRoomMembership(room2Id);
-
-        // Let's configure unread room 1 so that we only get notification for mentions and keywords
-        await app.viewRoomById(room1Id);
-        await app.settings.openRoomSettings("Notifications");
-        await page.getByText("@mentions & keywords").click();
-        await app.settings.closeDialog();
-
-        // Let's open a room other than room 1 or room 2
-        await roomListView.getByRole("gridcell", { name: "Open room room29" }).click();
-
-        // Let's make the bot send a new message in both room 1 and room 2
-        await bot.sendMessage(room1Id, "Hello!");
-        await bot.sendMessage(room2Id, "Hello!");
-
-        // Let's activate the unread filter now
-        await page.getByRole("option", { name: "Unread" }).click();
-
-        // Unread filter should only show room 2!!
-        await expect(roomListView.getByRole("gridcell", { name: "Open room Unread Room 2" })).toBeVisible();
-        await expect(roomListView.getByRole("gridcell", { name: "Open room Unread Room 1" })).not.toBeVisible();
-    });
 });

--- a/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
+++ b/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
@@ -93,5 +93,4 @@ test.describe("Room list", () => {
         await filters.getByRole("option", { name: "People" }).click();
         await expect(roomListView.getByRole("gridcell", { name: "Open room room0" })).toBeVisible();
     });
-
 });

--- a/test/unit-tests/components/viewmodels/roomlist/RoomListViewModel-test.tsx
+++ b/test/unit-tests/components/viewmodels/roomlist/RoomListViewModel-test.tsx
@@ -239,7 +239,9 @@ describe("RoomListViewModel", () => {
                 expect(vm.current.primaryFilters.find((f) => f.name === primaryFilterName)).toBeUndefined();
             });
         });
+    });
 
+    describe("Sorting", () => {
         it("should change sort order", () => {
             mockAndCreateRooms();
             const { result: vm } = renderHook(() => useRoomListViewModel());


### PR DESCRIPTION
- Moves a playwright test from `room-list.spec.ts` to `room-list-filter-sort.spec.ts` since it's related to filters.
- Two jest tests related to sorting are moved to a separate block.