### PR TITLE
Use master of js-sdk when running CI on master

### DIFF
--- a/.github/workflows/end-to-end-tests.yaml
+++ b/.github/workflows/end-to-end-tests.yaml
@@ -37,6 +37,8 @@ env:
     PR_NUMBER: ${{ github.event.pull_request.number }}
     # Use 6 runners in the default case, but 4 when running on a schedule where we run all 5 projects (20 runners total)
     NUM_RUNNERS: ${{ github.event_name == 'schedule' && 4 || 6 }}
+    # If run on the master branch, we need to fetch matching branches
+    DEFAULT_BRANCH: ${{ github.ref == 'refs/heads/master' && 'master' || '' }}
 
 permissions: {} # No permissions required
 
@@ -65,7 +67,7 @@ jobs:
                   # tell layered.sh to check out the right sha of the JS-SDK & EW, if they were given one
                   JS_SDK_GITHUB_BASE_REF: ${{ inputs.matrix-js-sdk-sha }}
               run: |
-                  scripts/layered.sh
+                  scripts/layered.sh "$DEFAULT_BRANCH"
                   JSSDK_SHA=$(git -C matrix-js-sdk rev-parse --short=12 HEAD)
                   VECTOR_SHA=$(git rev-parse --short=12 HEAD)
                   echo "VERSION=$VECTOR_SHA--js-$JSSDK_SHA" >> $GITHUB_OUTPUT

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -15,6 +15,8 @@ env:
     # These must be set for fetchdep.sh to get the right branch
     REPOSITORY: ${{ github.repository }}
     PR_NUMBER: ${{ github.event.pull_request.number }}
+    # If run on the master branch, we need to fetch matching branches
+    DEFAULT_BRANCH: ${{ github.ref == 'refs/heads/master' && 'master' || '' }}
 
 permissions: {} # No permissions required
 
@@ -31,7 +33,8 @@ jobs:
                   node-version: "lts/*"
 
             - name: Install Dependencies
-              run: "./scripts/layered.sh"
+              run: |
+                  ./scripts/layered.sh "$DEFAULT_BRANCH"
 
             - name: Typecheck
               run: "yarn run lint:types"

--- a/scripts/layered.sh
+++ b/scripts/layered.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+DEFAULT_BRANCH=${1:-develop}
+
 # Creates a layered environment with the full repo for the app and SDKs cloned
 # and linked. This gives an element-web dev environment ready to build with
 # matching branches of react-sdk's dependencies so that changes can be tested
@@ -21,7 +23,7 @@ export PR_ORG=element-hq
 export PR_REPO=element-web
 
 # Set up the js-sdk first
-scripts/fetchdep.sh matrix-org matrix-js-sdk develop
+scripts/fetchdep.sh matrix-org matrix-js-sdk $DEFAULT_BRANCH
 pushd matrix-js-sdk
 [ -n "$JS_SDK_GITHUB_BASE_REF" ] && git fetch --depth 1 origin $JS_SDK_GITHUB_BASE_REF && git checkout $JS_SDK_GITHUB_BASE_REF
 yarn link


### PR DESCRIPTION
We previously checked out develop js-sdk even when building / testing mster. This would have worked usually, except when we have non-backwards compat changes on the js-sdk which we sometimes do with unstable interfaces (like sliding sync).

This changes to use the master branch.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
