### PR TITLE
test e2e room list: fix flaky test of activity decoration

### DIFF
--- a/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
+++ b/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
@@ -165,6 +165,8 @@ test.describe("Room list", () => {
         test("should render an activity decoration", { tag: "@screenshot" }, async ({ page, app, user, bot }) => {
             const roomListView = getRoomList(page);
 
+            const otherRoomId = await app.client.createRoom({ name: "other room" });
+
             const roomId = await app.client.createRoom({ name: "activity" });
             await app.client.inviteUser(roomId, bot.credentials.userId);
             await bot.joinRoom(roomId);
@@ -178,6 +180,8 @@ test.describe("Room list", () => {
             await page.getByText("Show all activity in the room list (dots or number of unread messages)").click();
             await app.settings.closeDialog();
 
+            // Switch to the other room to avoid the notification to be cleared
+            await app.viewRoomById(otherRoomId);
             await bot.sendMessage(roomId, "I am a robot. Beep.");
 
             const room = roomListView.getByRole("gridcell", { name: "activity" });


### PR DESCRIPTION
Switch to another room to avoid the notification to be cleared.

Failed runs:
- https://github.com/element-hq/element-web/actions/runs/14091571994/job/39469412291
- https://github.com/element-hq/element-web/actions/runs/14091330003/job/39468619311