### PR TITLE
Make fetchdep check out matching branch name

### DIFF
--- a/scripts/fetchdep.sh
+++ b/scripts/fetchdep.sh
@@ -45,10 +45,7 @@ getPRInfo() {
 
 # Some CIs don't give us enough info, so we just get the PR number and ask the
 # GH API for more info - "fork:branch". Some give us this directly.
-if [ -n "$BUILDKITE_BRANCH" ]; then
-    # BuildKite
-    head=$BUILDKITE_BRANCH
-elif [ -n "$PR_NUMBER" ]; then
+if [ -n "$PR_NUMBER" ]; then
     # GitHub
     getPRInfo $PR_NUMBER
 elif [ -n "$REVIEW_ID" ]; then

--- a/scripts/fetchdep.sh
+++ b/scripts/fetchdep.sh
@@ -79,11 +79,14 @@ if [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
     clone $deforg $defrepo ${withoutPrefix%%/pr-*}
 fi
 
-# Try the target branch of the push or PR.
-if [ -n "$GITHUB_BASE_REF" ]; then
-    clone $deforg $defrepo $GITHUB_BASE_REF
-elif [ -n "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ]; then
-    clone $deforg $defrepo $BUILDKITE_PULL_REQUEST_BASE_BRANCH
+# Try the target branch of the push or PR, or the branch that was pushed to
+# (ie. the 'master' branch should use matching 'master' dependencies)
+base_or_branch=$GITHUB_BASE_REF
+if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+    base_or_branch=${GITHUB_REF}
+fi
+if [ -n "$base_or_branch" ]; then
+    clone $deforg $defrepo $base_or_branch
 fi
 
 # Try HEAD which is the branch name in Netlify (not BRANCH which is pull/xxxx/head for PR builds)


### PR DESCRIPTION
on a push to a branch.

We previously checked out develop js-sdk even when building / testing mster. This would have worked usually, except when we have non-backwards compat changes on the js-sdk which we sometimes do with unstable interfaces (like sliding sync).

Alternative to https://github.com/element-hq/element-web/pull/29596

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
