### PR TITLE
Hide an event notification if it is redacted

### DIFF
--- a/src/BasePlatform.ts
+++ b/src/BasePlatform.ts
@@ -16,6 +16,7 @@ import {
     type SSOAction,
     encodeUnpaddedBase64,
     type OidcRegistrationClientMetadata,
+    MatrixEventEvent,
 } from "matrix-js-sdk/src/matrix";
 import { logger } from "matrix-js-sdk/src/logger";
 
@@ -227,6 +228,14 @@ export default abstract class BasePlatform {
             dis.dispatch(payload);
             window.focus();
         };
+
+        const closeHandler = () => notification.close();
+
+        // Clear a notification from a redacted event.
+        ev?.once(MatrixEventEvent.BeforeRedaction, closeHandler);
+        notification.onclose = () => {
+            ev?.off(MatrixEventEvent.BeforeRedaction, closeHandler);
+        }
 
         return notification;
     }

--- a/src/BasePlatform.ts
+++ b/src/BasePlatform.ts
@@ -235,7 +235,7 @@ export default abstract class BasePlatform {
         ev?.once(MatrixEventEvent.BeforeRedaction, closeHandler);
         notification.onclose = () => {
             ev?.off(MatrixEventEvent.BeforeRedaction, closeHandler);
-        }
+        };
 
         return notification;
     }

--- a/src/BasePlatform.ts
+++ b/src/BasePlatform.ts
@@ -232,10 +232,12 @@ export default abstract class BasePlatform {
         const closeHandler = (): void => notification.close();
 
         // Clear a notification from a redacted event.
-        ev?.once(MatrixEventEvent.BeforeRedaction, closeHandler);
-        notification.onclose = () => {
-            ev?.off(MatrixEventEvent.BeforeRedaction, closeHandler);
-        };
+        if (ev) {
+            ev.once(MatrixEventEvent.BeforeRedaction, closeHandler);
+            notification.onclose = () => {
+                ev.off(MatrixEventEvent.BeforeRedaction, closeHandler);
+            };
+        }
 
         return notification;
     }

--- a/src/BasePlatform.ts
+++ b/src/BasePlatform.ts
@@ -229,7 +229,7 @@ export default abstract class BasePlatform {
             window.focus();
         };
 
-        const closeHandler = () => notification.close();
+        const closeHandler = (): void => notification.close();
 
         // Clear a notification from a redacted event.
         ev?.once(MatrixEventEvent.BeforeRedaction, closeHandler);


### PR DESCRIPTION
The intention here is to reduce the effectiveness of notification spam by reducing the amount of noise a properly moderated room can generate.

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
