### PR TITLE
Fix missing ambiguous url tooltips on Element Desktop

### DIFF
--- a/src/components/views/messages/EditHistoryMessage.tsx
+++ b/src/components/views/messages/EditHistoryMessage.tsx
@@ -140,6 +140,7 @@ export default class EditHistoryMessage extends React.PureComponent<IProps, ISta
                         content={content}
                         highlights={[]}
                         stripReply
+                        renderTooltipsForAmbiguousLinks
                         renderMentionPills
                         renderCodeBlocks
                         renderSpoilers

--- a/src/components/views/messages/TextualBody.tsx
+++ b/src/components/views/messages/TextualBody.tsx
@@ -332,6 +332,7 @@ export default class TextualBody extends React.Component<IBodyProps, IState> {
                 linkify
                 highlights={this.props.highlights}
                 ref={this.contentRef}
+                renderTooltipsForAmbiguousLinks
                 renderKeywordPills
                 renderMentionPills
                 renderCodeBlocks


### PR DESCRIPTION
Regressed by https://github.com/element-hq/element-web/pull/29586