### PR TITLE
Remove duplicate jitsi link

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -46,7 +46,6 @@
 - [Skinning](skinning.md)
 - [Cider editor](ciderEditor.md)
 - [Iconography](icons.md)
-- [Jitsi](jitsi.md)
 - [Local echo](local-echo-dev.md)
 - [Media](media-handling.md)
 - [Room List Store](room-list-store.md)


### PR DESCRIPTION
jitsi.md was linked both here and in the 'setup' section and I think it's more relevant to setup. The duplicate links are now breaking the deploy for some reason. We probably shouldn't have both.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
