### PR TITLE
 Fix truncated emoji label during emoji SAS

### DIFF
--- a/res/css/views/verification/_VerificationShowSas.pcss
+++ b/res/css/views/verification/_VerificationShowSas.pcss
@@ -46,10 +46,8 @@ Please see LICENSE files in the repository root for full details.
 }
 
 .mx_VerificationShowSas_emojiSas_label {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
     font-size: $font-12px;
+    word-break: break-all;
 }
 
 .mx_VerificationShowSas_emojiSas_break {


### PR DESCRIPTION
Emoji label was truncated during emoji SAS in languages with long word. 
Closes https://github.com/element-hq/customer-success/issues/450

| Before  | After |
| ------------- | ------------- |
| <img width="649" alt="Screenshot 2025-04-01 at 17 08 15" src="https://github.com/user-attachments/assets/73a7526c-2d24-4267-8e0f-77494ff00e16" />| <img width="649" alt="Screenshot 2025-04-01 at 17 38 46" src="https://github.com/user-attachments/assets/9d3cdf56-54f4-4259-a1e5-fbdf4068f0bd" />|   


