### PR TITLE
New Room List: Fix mentions filter matching rooms with any highlight

### DIFF
--- a/src/stores/room-list-v3/skip-list/filters/MentionsFilter.ts
+++ b/src/stores/room-list-v3/skip-list/filters/MentionsFilter.ts
@@ -11,7 +11,7 @@ import { RoomNotificationStateStore } from "../../../notifications/RoomNotificat
 
 export class MentionsFilter implements Filter {
     public matches(room: Room): boolean {
-        return RoomNotificationStateStore.instance.getRoomState(room).hasMentions;
+        return RoomNotificationStateStore.instance.getRoomState(room).isMention;
     }
 
     public get key(): FilterKey.MentionsFilter {

--- a/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
+++ b/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
@@ -569,7 +569,7 @@ describe("RoomListStoreV3", () => {
                 // Let's say 8, 27 have mentions
                 jest.spyOn(RoomNotificationStateStore.instance, "getRoomState").mockImplementation((room) => {
                     const state = {
-                        hasMentions: [rooms[8], rooms[27]].includes(room),
+                        isMention: [rooms[8], rooms[27]].includes(room),
                     } as unknown as RoomNotificationState;
                     return state;
                 });


### PR DESCRIPTION
Uses the new `isMention` which is true only for mentions and not for any highlight (invites etc..)

Would have written a playwright test but secondary filters are not yet implemented in the UI.