### PR TITLE
RoomListViewModel: Reset primary and secondary filters on space change

### DIFF
--- a/src/components/viewmodels/roomlist/useFilteredRooms.tsx
+++ b/src/components/viewmodels/roomlist/useFilteredRooms.tsx
@@ -13,6 +13,8 @@ import { _t, _td, type TranslationKey } from "../../../languageHandler";
 import RoomListStoreV3 from "../../../stores/room-list-v3/RoomListStoreV3";
 import { LISTS_UPDATE_EVENT } from "../../../stores/room-list/RoomListStore";
 import { useEventEmitter } from "../../../hooks/useEventEmitter";
+import SpaceStore from "../../../stores/spaces/SpaceStore";
+import { UPDATE_SELECTED_SPACE } from "../../../stores/spaces";
 
 /**
  * Provides information about a primary filter.
@@ -118,6 +120,12 @@ export function useFilteredRooms(): FilteredRooms {
         const newRooms = RoomListStoreV3.instance.getSortedRoomsInActiveSpace(filters);
         setRooms(newRooms);
     }, []);
+
+    // Reset filters when active space changes
+    useEventEmitter(SpaceStore.instance, UPDATE_SELECTED_SPACE, () => {
+        setPrimaryFilter(undefined);
+        activateSecondaryFilter(SecondaryFilters.AllActivity);
+    });
 
     const filterUndefined = (array: (FilterKey | undefined)[]): FilterKey[] =>
         array.filter((f) => f !== undefined) as FilterKey[];

--- a/test/unit-tests/components/viewmodels/roomlist/RoomListViewModel-test.tsx
+++ b/test/unit-tests/components/viewmodels/roomlist/RoomListViewModel-test.tsx
@@ -22,6 +22,8 @@ import { hasCreateRoomRights, createRoom } from "../../../../../src/components/v
 import dispatcher from "../../../../../src/dispatcher/dispatcher";
 import { Action } from "../../../../../src/dispatcher/actions";
 import { SdkContextClass } from "../../../../../src/contexts/SDKContext";
+import SpaceStore from "../../../../../src/stores/spaces/SpaceStore";
+import { UPDATE_SELECTED_SPACE } from "../../../../../src/stores/spaces";
 
 jest.mock("../../../../../src/components/viewmodels/roomlist/utils", () => ({
     hasCreateRoomRights: jest.fn().mockReturnValue(false),
@@ -183,6 +185,33 @@ describe("RoomListViewModel", () => {
 
             // RLS call must include only the secondary filter
             expect(fn).toHaveBeenLastCalledWith(expect.arrayContaining([FilterKey.MentionsFilter]));
+        });
+
+        it("should remove all filters when active space is changed", async () => {
+            mockAndCreateRooms();
+            const { result: vm } = renderHook(() => useRoomListViewModel());
+
+            // Let's first toggle the People filter
+            const i = vm.current.primaryFilters.findIndex((f) => f.name === "People");
+            act(() => {
+                vm.current.primaryFilters[i].toggle();
+            });
+            expect(vm.current.primaryFilters[i].active).toEqual(true);
+
+            // Let's say we toggle the mentions secondary filter
+            act(() => {
+                vm.current.activateSecondaryFilter(SecondaryFilters.MentionsOnly);
+            });
+            expect(vm.current.activeSecondaryFilter).toEqual(SecondaryFilters.MentionsOnly);
+
+            // Simulate a space change
+            await act(() => SpaceStore.instance.emit(UPDATE_SELECTED_SPACE));
+
+            // Primary filer should have been unapplied
+            expect(vm.current.activePrimaryFilter).toEqual(undefined);
+
+            // Secondary filter should be reset to "All Activity"
+            expect(vm.current.activeSecondaryFilter).toEqual(SecondaryFilters.AllActivity);
         });
 
         const testcases: Array<[string, { secondary: SecondaryFilters; filterKey: FilterKey }, string]> = [


### PR DESCRIPTION
When you change to a different space, you don't want the old active filters to follow you.