### PR TITLE
Continue button is disabled when uploading a recovery key file

### DIFF
--- a/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
+++ b/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
@@ -148,11 +148,14 @@ export default class AccessSecretStorageDialog extends React.PureComponent<IProp
             // right number of characters, but it's really just to make sure that what we're reading is
             // text because we'll put it in the text field.
             if (/^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz\s]+$/.test(contents)) {
-                this.setState({
-                    recoveryKeyFileError: null,
-                    recoveryKey: contents.trim(),
+                await new Promise((resolve, reject) => {
+                    this.setState({
+                        recoveryKeyFileError: null,
+                        recoveryKey: contents.trim(),
+                    }, () => {
+                        this.validateRecoveryKey().then(resolve).catch(reject);
+                    });
                 });
-                await this.validateRecoveryKey();
             } else {
                 this.setState({
                     recoveryKeyFileError: true,

--- a/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
+++ b/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
@@ -86,11 +86,11 @@ export default class AccessSecretStorageDialog extends React.PureComponent<IProp
     };
 
     private validateRecoveryKeyOnChange = debounce(async (): Promise<void> => {
-        await this.validateRecoveryKey();
+        await this.validateRecoveryKey(this.state.recoveryKey);
     }, VALIDATION_THROTTLE_MS);
 
-    private async validateRecoveryKey(): Promise<void> {
-        if (this.state.recoveryKey === "") {
+    private async validateRecoveryKey(recoveryKey: string): Promise<void> {
+        if (recoveryKey === "") {
             this.setState({
                 recoveryKeyValid: null,
                 recoveryKeyCorrect: null,
@@ -100,7 +100,7 @@ export default class AccessSecretStorageDialog extends React.PureComponent<IProp
 
         try {
             const cli = MatrixClientPeg.safeGet();
-            const decodedKey = decodeRecoveryKey(this.state.recoveryKey);
+            const decodedKey = decodeRecoveryKey(recoveryKey);
             const correct = await cli.secretStorage.checkKey(decodedKey, this.props.keyInfo);
             this.setState({
                 recoveryKeyValid: true,
@@ -148,17 +148,12 @@ export default class AccessSecretStorageDialog extends React.PureComponent<IProp
             // right number of characters, but it's really just to make sure that what we're reading is
             // text because we'll put it in the text field.
             if (/^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz\s]+$/.test(contents)) {
-                await new Promise((resolve, reject) => {
-                    this.setState(
-                        {
-                            recoveryKeyFileError: null,
-                            recoveryKey: contents.trim(),
-                        },
-                        () => {
-                            this.validateRecoveryKey().then(resolve).catch(reject);
-                        },
-                    );
+                const recoveryKey = contents.trim();
+                this.setState({
+                    recoveryKeyFileError: null,
+                    recoveryKey,
                 });
+                await this.validateRecoveryKey(recoveryKey);
             } else {
                 this.setState({
                     recoveryKeyFileError: true,

--- a/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
+++ b/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
@@ -149,12 +149,15 @@ export default class AccessSecretStorageDialog extends React.PureComponent<IProp
             // text because we'll put it in the text field.
             if (/^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz\s]+$/.test(contents)) {
                 await new Promise((resolve, reject) => {
-                    this.setState({
-                        recoveryKeyFileError: null,
-                        recoveryKey: contents.trim(),
-                    }, () => {
-                        this.validateRecoveryKey().then(resolve).catch(reject);
-                    });
+                    this.setState(
+                        {
+                            recoveryKeyFileError: null,
+                            recoveryKey: contents.trim(),
+                        },
+                        () => {
+                            this.validateRecoveryKey().then(resolve).catch(reject);
+                        },
+                    );
                 });
             } else {
                 this.setState({


### PR DESCRIPTION
1. Login
2. Choose to enter a recovery key
3. Click the "Upload" button and pick a recovery key file.

Expected: The continue button should be enabled
Actual: The continue button is disabled

The problem: the code isn't waiting for a setState statement to complete before checking the state.

![image](https://github.com/user-attachments/assets/2c388f01-64ed-485b-b209-2c61e1894efe)

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x[ New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
