### PR TITLE
Update identity reset UI (Make consistent with EX)

### DIFF
--- a/playwright/e2e/settings/encryption-user-tab/encryption-tab.spec.ts
+++ b/playwright/e2e/settings/encryption-user-tab/encryption-tab.spec.ts
@@ -19,126 +19,162 @@ import {
 test.describe("Encryption tab", () => {
     test.use({ displayName: "Alice" });
 
-    let recoveryKey: GeneratedSecretStorageKey;
-    let expectedBackupVersion: string;
+    test.describe("when encryption is set up", () => {
+        let recoveryKey: GeneratedSecretStorageKey;
+        let expectedBackupVersion: string;
 
-    test.beforeEach(async ({ page, homeserver, credentials }) => {
-        // The bot bootstraps cross-signing, creates a key backup and sets up a recovery key
-        const res = await createBot(page, homeserver, credentials);
-        recoveryKey = res.recoveryKey;
-        expectedBackupVersion = res.expectedBackupVersion;
-    });
+        test.beforeEach(async ({ page, homeserver, credentials }) => {
+            // The bot bootstraps cross-signing, creates a key backup and sets up a recovery key
+            const res = await createBot(page, homeserver, credentials);
+            recoveryKey = res.recoveryKey;
+            expectedBackupVersion = res.expectedBackupVersion;
+        });
 
-    test(
-        "should show a 'Verify this device' button if the device is unverified",
-        { tag: "@screenshot" },
-        async ({ page, app, util }) => {
-            const dialog = await util.openEncryptionTab();
-            const content = util.getEncryptionTabContent();
+        test(
+            "should show a 'Verify this device' button if the device is unverified",
+            { tag: "@screenshot" },
+            async ({ page, app, util }) => {
+                const dialog = await util.openEncryptionTab();
+                const content = util.getEncryptionTabContent();
 
-            // The user's device is in an unverified state, therefore the only option available to them here is to verify it
-            const verifyButton = dialog.getByRole("button", { name: "Verify this device" });
-            await expect(verifyButton).toBeVisible();
-            await expect(content).toMatchScreenshot("verify-device-encryption-tab.png");
-            await verifyButton.click();
+                // The user's device is in an unverified state, therefore the only option available to them here is to verify it
+                const verifyButton = dialog.getByRole("button", { name: "Verify this device" });
+                await expect(verifyButton).toBeVisible();
+                await expect(content).toMatchScreenshot("verify-device-encryption-tab.png");
+                await verifyButton.click();
 
-            await util.verifyDevice(recoveryKey);
+                await util.verifyDevice(recoveryKey);
 
-            await expect(content).toMatchScreenshot("default-tab.png", {
-                mask: [content.getByTestId("deviceId"), content.getByTestId("sessionKey")],
-            });
+                await expect(content).toMatchScreenshot("default-tab.png", {
+                    mask: [content.getByTestId("deviceId"), content.getByTestId("sessionKey")],
+                });
 
-            // Check that our device is now cross-signed
-            await checkDeviceIsCrossSigned(app);
+                // Check that our device is now cross-signed
+                await checkDeviceIsCrossSigned(app);
 
-            // Check that the current device is connected to key backup
-            // The backup decryption key should be in cache also, as we got it directly from the 4S
-            await checkDeviceIsConnectedKeyBackup(app, expectedBackupVersion, true);
-        },
-    );
+                // Check that the current device is connected to key backup
+                // The backup decryption key should be in cache also, as we got it directly from the 4S
+                await checkDeviceIsConnectedKeyBackup(app, expectedBackupVersion, true);
+            },
+        );
 
-    // Test what happens if the cross-signing secrets are in secret storage but are not cached in the local DB.
-    //
-    // This can happen if we verified another device and secret-gossiping failed, or the other device itself lacked the secrets.
-    // We simulate this case by deleting the cached secrets in the indexedDB.
-    test(
-        "should prompt to enter the recovery key when the secrets are not cached locally",
-        { tag: "@screenshot" },
-        async ({ page, app, util }) => {
+        // Test what happens if the cross-signing secrets are in secret storage but are not cached in the local DB.
+        //
+        // This can happen if we verified another device and secret-gossiping failed, or the other device itself lacked the secrets.
+        // We simulate this case by deleting the cached secrets in the indexedDB.
+        test(
+            "should prompt to enter the recovery key when the secrets are not cached locally",
+            { tag: "@screenshot" },
+            async ({ page, app, util }) => {
+                await verifySession(app, recoveryKey.encodedPrivateKey);
+                // We need to delete the cached secrets
+                await deleteCachedSecrets(page);
+
+                await util.openEncryptionTab();
+                // We ask the user to enter the recovery key
+                const dialog = util.getEncryptionTabContent();
+                const enterKeyButton = dialog.getByRole("button", { name: "Enter recovery key" });
+                await expect(enterKeyButton).toBeVisible();
+                await expect(dialog).toMatchScreenshot("out-of-sync-recovery.png");
+                await enterKeyButton.click();
+
+                // Fill the recovery key
+                await util.enterRecoveryKey(recoveryKey);
+                await expect(dialog).toMatchScreenshot("default-tab.png", {
+                    mask: [dialog.getByTestId("deviceId"), dialog.getByTestId("sessionKey")],
+                });
+
+                // Check that our device is now cross-signed
+                await checkDeviceIsCrossSigned(app);
+
+                // Check that the current device is connected to key backup
+                // The backup decryption key should be in cache also, as we got it directly from the 4S
+                await checkDeviceIsConnectedKeyBackup(app, expectedBackupVersion, true);
+            },
+        );
+
+        test("should display the reset identity panel when the user clicks on 'Forgot recovery key?'", async ({
+            page,
+            app,
+            util,
+        }) => {
             await verifySession(app, recoveryKey.encodedPrivateKey);
             // We need to delete the cached secrets
             await deleteCachedSecrets(page);
 
+            // The "Key storage is out sync" section is displayed and the user click on the "Forgot recovery key?" button
             await util.openEncryptionTab();
-            // We ask the user to enter the recovery key
             const dialog = util.getEncryptionTabContent();
-            const enterKeyButton = dialog.getByRole("button", { name: "Enter recovery key" });
-            await expect(enterKeyButton).toBeVisible();
-            await expect(dialog).toMatchScreenshot("out-of-sync-recovery.png");
-            await enterKeyButton.click();
+            await dialog.getByRole("button", { name: "Forgot recovery key?" }).click();
 
-            // Fill the recovery key
-            await util.enterRecoveryKey(recoveryKey);
-            await expect(dialog).toMatchScreenshot("default-tab.png", {
-                mask: [dialog.getByTestId("deviceId"), dialog.getByTestId("sessionKey")],
-            });
+            // The user is prompted to reset their identity
+            await expect(
+                dialog.getByText("Forgot your recovery key? You’ll need to reset your identity."),
+            ).toBeVisible();
+        });
 
-            // Check that our device is now cross-signed
-            await checkDeviceIsCrossSigned(app);
+        test("should warn before turning off key storage", { tag: "@screenshot" }, async ({ page, app, util }) => {
+            await verifySession(app, recoveryKey.encodedPrivateKey);
+            await util.openEncryptionTab();
 
-            // Check that the current device is connected to key backup
-            // The backup decryption key should be in cache also, as we got it directly from the 4S
-            await checkDeviceIsConnectedKeyBackup(app, expectedBackupVersion, true);
-        },
-    );
+            await page.getByRole("checkbox", { name: "Allow key storage" }).click();
 
-    test("should display the reset identity panel when the user clicks on 'Forgot recovery key?'", async ({
-        page,
-        app,
-        util,
-    }) => {
-        await verifySession(app, recoveryKey.encodedPrivateKey);
-        // We need to delete the cached secrets
-        await deleteCachedSecrets(page);
+            await expect(
+                page.getByRole("heading", { name: "Are you sure you want to turn off key storage and delete it?" }),
+            ).toBeVisible();
 
-        // The "Key storage is out sync" section is displayed and the user click on the "Forgot recovery key?" button
-        await util.openEncryptionTab();
-        const dialog = util.getEncryptionTabContent();
-        await dialog.getByRole("button", { name: "Forgot recovery key?" }).click();
+            await expect(util.getEncryptionTabContent()).toMatchScreenshot("delete-key-storage-confirm.png");
 
-        // The user is prompted to reset their identity
-        await expect(dialog.getByText("Forgot your recovery key? You’ll need to reset your identity.")).toBeVisible();
+            const deleteRequestPromises = [
+                page.waitForRequest((req) => req.url().endsWith("/account_data/m.cross_signing.master")),
+                page.waitForRequest((req) => req.url().endsWith("/account_data/m.cross_signing.self_signing")),
+                page.waitForRequest((req) => req.url().endsWith("/account_data/m.cross_signing.user_signing")),
+                page.waitForRequest((req) => req.url().endsWith("/account_data/m.megolm_backup.v1")),
+                page.waitForRequest((req) => req.url().endsWith("/account_data/m.secret_storage.default_key")),
+                page.waitForRequest((req) => req.url().includes("/account_data/m.secret_storage.key.")),
+            ];
+
+            await page.getByRole("button", { name: "Delete key storage" }).click();
+
+            await expect(page.getByRole("checkbox", { name: "Allow key storage" })).not.toBeChecked();
+
+            for (const prom of deleteRequestPromises) {
+                const request = await prom;
+                expect(request.method()).toBe("PUT");
+                expect(request.postData()).toBe(JSON.stringify({}));
+            }
+        });
     });
 
-    test("should warn before turning off key storage", { tag: "@screenshot" }, async ({ page, app, util }) => {
-        await verifySession(app, recoveryKey.encodedPrivateKey);
-        await util.openEncryptionTab();
+    test.describe("when encryption is not set up", () => {
+        test("'Verify this device' allows us to become verified", async ({
+            page,
+            user,
+            credentials,
+            app,
+        }, workerInfo) => {
+            const settings = await app.settings.openUserSettings("Encryption");
 
-        await page.getByRole("checkbox", { name: "Allow key storage" }).click();
+            // Initially, our device is not verified
+            await expect(settings.getByRole("heading", { name: "Device not verified" })).toBeVisible();
 
-        await expect(
-            page.getByRole("heading", { name: "Are you sure you want to turn off key storage and delete it?" }),
-        ).toBeVisible();
+            // We will reset our identity
+            await settings.getByRole("button", { name: "Verify this device" }).click();
+            await page.getByRole("button", { name: "Proceed with reset" }).click();
 
-        await expect(util.getEncryptionTabContent()).toMatchScreenshot("delete-key-storage-confirm.png");
+            // First try cancelling and restarting
+            await page.getByRole("button", { name: "Cancel" }).click();
+            await page.getByRole("button", { name: "Proceed with reset" }).click();
 
-        const deleteRequestPromises = [
-            page.waitForRequest((req) => req.url().endsWith("/account_data/m.cross_signing.master")),
-            page.waitForRequest((req) => req.url().endsWith("/account_data/m.cross_signing.self_signing")),
-            page.waitForRequest((req) => req.url().endsWith("/account_data/m.cross_signing.user_signing")),
-            page.waitForRequest((req) => req.url().endsWith("/account_data/m.megolm_backup.v1")),
-            page.waitForRequest((req) => req.url().endsWith("/account_data/m.secret_storage.default_key")),
-            page.waitForRequest((req) => req.url().includes("/account_data/m.secret_storage.key.")),
-        ];
+            // Then click outside the dialog and restart
+            await page.locator("li").filter({ hasText: "Encryption" }).click({ force: true });
+            await page.getByRole("button", { name: "Proceed with reset" }).click();
 
-        await page.getByRole("button", { name: "Delete key storage" }).click();
+            // Finally we actually continue
+            await page.getByRole("button", { name: "Continue" }).click();
 
-        await expect(page.getByRole("checkbox", { name: "Allow key storage" })).not.toBeChecked();
-
-        for (const prom of deleteRequestPromises) {
-            const request = await prom;
-            expect(request.method()).toBe("PUT");
-            expect(request.postData()).toBe(JSON.stringify({}));
-        }
+            // Now we are verified, so we see the Key storage toggle
+            await expect(settings.getByRole("heading", { name: "Key storage" })).toBeVisible();
+        });
     });
 });

--- a/src/components/structures/auth/CompleteSecurity.tsx
+++ b/src/components/structures/auth/CompleteSecurity.tsx
@@ -78,9 +78,6 @@ export default class CompleteSecurity extends React.Component<IProps, IState> {
         } else if (phase === Phase.Busy) {
             icon = <span className="mx_CompleteSecurity_headerIcon mx_E2EIcon_warning" />;
             title = _t("encryption|verification|after_new_login|verify_this_device");
-        } else if (phase === Phase.ConfirmReset) {
-            icon = <span className="mx_CompleteSecurity_headerIcon mx_E2EIcon_warning" />;
-            title = _t("encryption|verification|after_new_login|reset_confirmation");
         } else if (phase === Phase.Finished) {
             // SetupEncryptionBody will take care of calling onFinished, we don't need to do anything
         } else {
@@ -90,7 +87,7 @@ export default class CompleteSecurity extends React.Component<IProps, IState> {
         const forceVerification = SdkConfig.get("force_verification");
 
         let skipButton;
-        if (!forceVerification && (phase === Phase.Intro || phase === Phase.ConfirmReset)) {
+        if (!forceVerification && phase === Phase.Intro) {
             skipButton = (
                 <AccessibleButton
                     onClick={this.onSkipClick}

--- a/src/components/structures/auth/SetupEncryptionBody.tsx
+++ b/src/components/structures/auth/SetupEncryptionBody.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 New Vector Ltd.
+Copyright 2024, 2025 New Vector Ltd.
 Copyright 2020, 2021 The Matrix.org Foundation C.I.C.
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
@@ -19,6 +19,7 @@ import { SetupEncryptionStore, Phase } from "../../../stores/SetupEncryptionStor
 import EncryptionPanel from "../../views/right_panel/EncryptionPanel";
 import AccessibleButton, { type ButtonEvent } from "../../views/elements/AccessibleButton";
 import Spinner from "../../views/elements/Spinner";
+import { ResetIdentityDialog } from "../../views/dialogs/ResetIdentityDialog";
 
 function keyHasPassphrase(keyInfo: SecretStorageKeyDescription): boolean {
     return Boolean(keyInfo.passphrase && keyInfo.passphrase.salt && keyInfo.passphrase.iterations);
@@ -112,19 +113,15 @@ export default class SetupEncryptionBody extends React.Component<IProps, IState>
 
     private onResetClick = (ev: ButtonEvent): void => {
         ev.preventDefault();
-        const store = SetupEncryptionStore.sharedInstance();
-        store.reset();
-    };
-
-    private onResetConfirmClick = (): void => {
-        this.props.onFinished();
-        const store = SetupEncryptionStore.sharedInstance();
-        store.resetConfirm();
-    };
-
-    private onResetBackClick = (): void => {
-        const store = SetupEncryptionStore.sharedInstance();
-        store.returnAfterReset();
+        Modal.createDialog(ResetIdentityDialog, {
+            onReset: () => {
+                // The user completed the reset process - close this dialog
+                this.props.onFinished();
+                const store = SetupEncryptionStore.sharedInstance();
+                store.done();
+            },
+            variant: "confirm",
+        });
     };
 
     private onDoneClick = (): void => {
@@ -157,7 +154,7 @@ export default class SetupEncryptionBody extends React.Component<IProps, IState>
                         <p>{_t("encryption|verification|no_key_or_device")}</p>
 
                         <div className="mx_CompleteSecurity_actionRow">
-                            <AccessibleButton kind="primary" onClick={this.onResetConfirmClick}>
+                            <AccessibleButton kind="primary" onClick={this.onResetClick}>
                                 {_t("encryption|verification|reset_proceed_prompt")}
                             </AccessibleButton>
                         </div>
@@ -241,22 +238,6 @@ export default class SetupEncryptionBody extends React.Component<IProps, IState>
                             {_t("encryption|verification|verify_later")}
                         </AccessibleButton>
                         <AccessibleButton kind="primary" onClick={this.onSkipBackClick}>
-                            {_t("action|go_back")}
-                        </AccessibleButton>
-                    </div>
-                </div>
-            );
-        } else if (phase === Phase.ConfirmReset) {
-            return (
-                <div>
-                    <p>{_t("encryption|verification|verify_reset_warning_1")}</p>
-                    <p>{_t("encryption|verification|verify_reset_warning_2")}</p>
-
-                    <div className="mx_CompleteSecurity_actionRow">
-                        <AccessibleButton kind="danger_outline" onClick={this.onResetConfirmClick}>
-                            {_t("encryption|verification|reset_proceed_prompt")}
-                        </AccessibleButton>
-                        <AccessibleButton kind="primary" onClick={this.onResetBackClick}>
                             {_t("action|go_back")}
                         </AccessibleButton>
                     </div>

--- a/src/components/views/dialogs/ResetIdentityDialog.tsx
+++ b/src/components/views/dialogs/ResetIdentityDialog.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import React, { type JSX } from "react";
+
+import { MatrixClientPeg } from "../../../MatrixClientPeg";
+import MatrixClientContext from "../../../contexts/MatrixClientContext";
+import { ResetIdentityBody, type ResetIdentityBodyVariant } from "../settings/encryption/ResetIdentityBody";
+
+interface ResetIdentityDialogProps {
+    /**
+     * Called when the dialog is complete.
+     *
+     * `ResetIdentityDialog` expects this to be provided by `Modal.createDialog`, and that it will close the dialog.
+     */
+    onFinished: () => void;
+
+    /**
+     * Called when the identity is reset (before onFinished is called).
+     */
+    onReset: () => void;
+
+    /**
+     * Which variant of this dialog to show.
+     */
+    variant: ResetIdentityBodyVariant;
+}
+
+/**
+ * The dialog for resetting the identity of the current user.
+ */
+export function ResetIdentityDialog({ onFinished, onReset, variant }: ResetIdentityDialogProps): JSX.Element {
+    const matrixClient = MatrixClientPeg.safeGet();
+
+    const onResetWrapper: () => void = () => {
+        onReset();
+        // Close the dialog
+        onFinished();
+    };
+    return (
+        <MatrixClientContext.Provider value={matrixClient}>
+            <ResetIdentityBody onReset={onResetWrapper} onCancelClick={onFinished} variant={variant} />
+        </MatrixClientContext.Provider>
+    );
+}

--- a/src/components/views/settings/encryption/ResetIdentityPanel.tsx
+++ b/src/components/views/settings/encryption/ResetIdentityPanel.tsx
@@ -6,7 +6,7 @@
  */
 
 import { Breadcrumb } from "@vector-im/compound-web";
-import React, { type JSX, type MouseEventHandler } from "react";
+import React, { type JSX } from "react";
 
 import { _t } from "../../../../languageHandler";
 import { ResetIdentityBody, type ResetIdentityBodyVariant } from "./ResetIdentityBody";
@@ -15,7 +15,8 @@ interface ResetIdentityPanelProps {
     /**
      * Called when the identity is reset.
      */
-    onFinish: MouseEventHandler<HTMLButtonElement>;
+    onReset: () => void;
+
     /**
      * Called when the cancel button is clicked or when we go back in the breadcrumbs.
      */
@@ -32,7 +33,7 @@ interface ResetIdentityPanelProps {
  *
  * A thin wrapper around {@link ResetIdentityBody}, just adding breadcrumbs.
  */
-export function ResetIdentityPanel({ onCancelClick, onFinish, variant }: ResetIdentityPanelProps): JSX.Element {
+export function ResetIdentityPanel({ onCancelClick, onReset, variant }: ResetIdentityPanelProps): JSX.Element {
     return (
         <>
             <Breadcrumb
@@ -41,7 +42,7 @@ export function ResetIdentityPanel({ onCancelClick, onFinish, variant }: ResetId
                 pages={[_t("settings|encryption|title"), _t("settings|encryption|advanced|breadcrumb_page")]}
                 onPageClick={onCancelClick}
             />
-            <ResetIdentityBody onFinish={onFinish} onCancelClick={onCancelClick} variant={variant} />
+            <ResetIdentityBody onReset={onReset} onCancelClick={onCancelClick} variant={variant} />
         </>
     );
 }

--- a/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.tsx
@@ -128,7 +128,7 @@ export function EncryptionUserSettingsTab({ initialState = "loading" }: Props): 
                 <ResetIdentityPanel
                     variant={findResetVariant(state)}
                     onCancelClick={checkEncryptionState}
-                    onFinish={checkEncryptionState}
+                    onReset={checkEncryptionState}
                 />
             );
             break;

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -993,7 +993,6 @@
             "accepting": "Accepting…",
             "after_new_login": {
                 "device_verified": "Device verified",
-                "reset_confirmation": "Really reset verification keys?",
                 "skip_verification": "Skip verification for now",
                 "unable_to_verify": "Unable to verify this device",
                 "verify_this_device": "Verify this device"
@@ -1064,8 +1063,6 @@
             "verify_emoji_prompt": "Verify by comparing unique emoji.",
             "verify_emoji_prompt_qr": "If you can't scan the code above, verify by comparing unique emoji.",
             "verify_later": "I'll verify later",
-            "verify_reset_warning_1": "Resetting your verification keys cannot be undone. After resetting, you won't have access to old encrypted messages, and any friends who have previously verified you will see security warnings until you re-verify with them.",
-            "verify_reset_warning_2": "Please only proceed if you're sure you've lost all of your other devices and your Recovery Key.",
             "verify_using_device": "Verify with another device",
             "verify_using_key": "Verify with Recovery Key",
             "verify_using_key_or_phrase": "Verify with Recovery Key or Phrase",

--- a/src/stores/SetupEncryptionStore.ts
+++ b/src/stores/SetupEncryptionStore.ts
@@ -29,7 +29,6 @@ export enum Phase {
     Done = 3, // final done stage, but still showing UX
     ConfirmSkip = 4,
     Finished = 5, // UX can be closed
-    ConfirmReset = 6,
 }
 
 /**
@@ -216,38 +215,6 @@ export class SetupEncryptionStore extends EventEmitter {
     }
 
     public returnAfterSkip(): void {
-        this.phase = Phase.Intro;
-        this.emit("update");
-    }
-
-    public reset(): void {
-        this.phase = Phase.ConfirmReset;
-        this.emit("update");
-    }
-
-    public async resetConfirm(): Promise<void> {
-        try {
-            // If we've gotten here, the user presumably lost their
-            // secret storage key if they had one. Start by resetting
-            // secret storage and setting up a new recovery key, then
-            // create new cross-signing keys once that succeeds.
-            await accessSecretStorage(
-                async (): Promise<void> => {
-                    this.phase = Phase.Finished;
-                },
-                {
-                    forceReset: true,
-                    resetCrossSigning: true,
-                },
-            );
-        } catch (e) {
-            logger.error("Error resetting cross-signing", e);
-            this.phase = Phase.Intro;
-        }
-        this.emit("update");
-    }
-
-    public returnAfterReset(): void {
         this.phase = Phase.Intro;
         this.emit("update");
     }

--- a/test/components/views/dialogs/security/ResetIdentityDialog-test.tsx
+++ b/test/components/views/dialogs/security/ResetIdentityDialog-test.tsx
@@ -1,0 +1,63 @@
+/*
+Copyright 2024 New Vector Ltd.
+Copyright 2018-2022 The Matrix.org Foundation C.I.C.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import React, { act } from "react";
+import { render } from "jest-matrix-react";
+import { type CryptoApi } from "matrix-js-sdk/src/crypto-api";
+import { type Mocked } from "jest-mock";
+import { type MatrixClient } from "matrix-js-sdk/src/matrix";
+
+import { getMockClientWithEventEmitter } from "../../../../test-utils";
+import { ResetIdentityDialog } from "../../../../../src/components/views/dialogs/ResetIdentityDialog";
+
+describe("ResetIdentityDialog", () => {
+    afterEach(() => {
+        jest.resetAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    it("should call onReset and onFinished when we click Continue", async () => {
+        const client = mockClient();
+
+        const onFinished = jest.fn();
+        const onReset = jest.fn();
+        const dialog = render(<ResetIdentityDialog onFinished={onFinished} onReset={onReset} variant="compromised" />);
+
+        await act(async () => dialog.getByRole("button", { name: "Continue" }).click());
+
+        expect(onReset).toHaveBeenCalled();
+        expect(onFinished).toHaveBeenCalled();
+
+        expect(client.getCrypto()?.resetEncryption).toHaveBeenCalled();
+    });
+
+    it("should call onFinished when we click Cancel", async () => {
+        const client = mockClient();
+
+        const onFinished = jest.fn();
+        const onReset = jest.fn();
+        const dialog = render(<ResetIdentityDialog onFinished={onFinished} onReset={onReset} variant="compromised" />);
+
+        await act(async () => dialog.getByRole("button", { name: "Cancel" }).click());
+
+        expect(onFinished).toHaveBeenCalled();
+
+        expect(onReset).not.toHaveBeenCalled();
+        expect(client.getCrypto()?.resetEncryption).not.toHaveBeenCalled();
+    });
+});
+
+function mockClient(): Mocked<MatrixClient> {
+    const mockCrypto = {
+        resetEncryption: jest.fn().mockResolvedValue(null),
+    } as unknown as Mocked<CryptoApi>;
+
+    return getMockClientWithEventEmitter({
+        getCrypto: jest.fn().mockReturnValue(mockCrypto),
+    });
+}

--- a/test/components/views/dialogs/security/SetupEncryptionDialog-test.tsx
+++ b/test/components/views/dialogs/security/SetupEncryptionDialog-test.tsx
@@ -1,0 +1,88 @@
+/*
+Copyright 2024 New Vector Ltd.
+Copyright 2018-2022 The Matrix.org Foundation C.I.C.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import React, { act } from "react";
+import { render, screen } from "jest-matrix-react";
+import { type Mocked } from "jest-mock";
+import { type CryptoApi } from "matrix-js-sdk/src/crypto-api";
+
+import SetupEncryptionDialog from "../../../../../src/components/views/dialogs/security/SetupEncryptionDialog";
+import { getMockClientWithEventEmitter } from "../../../../test-utils";
+import { Phase, SetupEncryptionStore } from "../../../../../src/stores/SetupEncryptionStore";
+import Modal from "../../../../../src/Modal";
+
+describe("SetupEncryptionDialog", () => {
+    afterEach(() => {
+        jest.resetAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    it("should launch a dialog when I say Proceed, then be finished when I reset", async () => {
+        mockClient();
+        const store = new SetupEncryptionStore();
+        jest.spyOn(SetupEncryptionStore, "sharedInstance").mockReturnValue(store);
+
+        // Given when you open the reset dialog we immediately reset
+        jest.spyOn(Modal, "createDialog").mockImplementation((_, props) => {
+            // Simulate doing the reset in the dialog
+            props?.onReset();
+
+            return {
+                close: jest.fn(),
+                finished: Promise.resolve([]),
+            };
+        });
+
+        // When we launch the dialog and set it ready to start
+        const onFinished = jest.fn();
+        render(<SetupEncryptionDialog onFinished={onFinished} />);
+        await act(async () => await store.fetchKeyInfo());
+        expect(store.phase).toBe(Phase.Intro);
+
+        // And we hit the Proceed with reset button.
+        // (The createDialog mock above simulates the user doing the reset)
+        await act(async () => screen.getByRole("button", { name: "Proceed with reset" }).click());
+
+        // Then the phase has been set to Finished
+        expect(store.phase).toBe(Phase.Finished);
+    });
+});
+
+function mockClient() {
+    const mockCrypto = {
+        getDeviceVerificationStatus: jest.fn().mockResolvedValue({
+            crossSigningVerified: false,
+        }),
+        getUserDeviceInfo: jest.fn().mockResolvedValue(new Map()),
+        isCrossSigningReady: jest.fn().mockResolvedValue(true),
+        isSecretStorageReady: jest.fn().mockResolvedValue(true),
+        userHasCrossSigningKeys: jest.fn(),
+        getActiveSessionBackupVersion: jest.fn(),
+        getCrossSigningStatus: jest.fn().mockReturnValue({
+            publicKeysOnDevice: true,
+            privateKeysInSecretStorage: true,
+            privateKeysCachedLocally: {
+                masterKey: true,
+                selfSigningKey: true,
+                userSigningKey: true,
+            },
+        }),
+        getSessionBackupPrivateKey: jest.fn(),
+        isEncryptionEnabledInRoom: jest.fn(),
+        getKeyBackupInfo: jest.fn().mockResolvedValue(null),
+        getVerificationRequestsToDeviceInProgress: jest.fn().mockReturnValue([]),
+    } as unknown as Mocked<CryptoApi>;
+
+    const userId = "@user:server";
+
+    getMockClientWithEventEmitter({
+        getCrypto: jest.fn().mockReturnValue(mockCrypto),
+        getUserId: jest.fn().mockReturnValue(userId),
+        secretStorage: { isStored: jest.fn().mockReturnValue({}) },
+    });
+}

--- a/test/unit-tests/components/structures/auth/CompleteSecurity-test.tsx
+++ b/test/unit-tests/components/structures/auth/CompleteSecurity-test.tsx
@@ -6,7 +6,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import React from "react";
-import { render, screen } from "jest-matrix-react";
+import { act, render, screen } from "jest-matrix-react";
 import { mocked } from "jest-mock";
 import EventEmitter from "events";
 
@@ -75,5 +75,21 @@ describe("CompleteSecurity", () => {
         render(<CompleteSecurity onFinished={() => {}} />);
 
         expect(screen.queryByRole("button", { name: "Skip verification for now" })).not.toBeInTheDocument();
+    });
+
+    it("Renders a warning if user hits Reset", async () => {
+        // Given a store and a dialog based on it
+        const store = new SetupEncryptionStore();
+        jest.spyOn(SetupEncryptionStore, "sharedInstance").mockReturnValue(store);
+        const panel = await act(() => render(<CompleteSecurity onFinished={() => {}} />));
+
+        // When we hit reset
+        await act(async () => panel.getByRole("button", { name: "Proceed with reset" }).click());
+
+        // Then the reset identity dialog appears
+        expect(
+            screen.getByRole("heading", { name: "Are you sure you want to reset your identity?" }),
+        ).toBeInTheDocument();
+        expect(panel.getByRole("button", { name: "Continue" })).toBeInTheDocument();
     });
 });

--- a/test/unit-tests/components/views/settings/encryption/ResetIdentityPanel-test.tsx
+++ b/test/unit-tests/components/views/settings/encryption/ResetIdentityPanel-test.tsx
@@ -24,9 +24,9 @@ describe("<ResetIdentityPanel />", () => {
     it("should reset the encryption when the continue button is clicked", async () => {
         const user = userEvent.setup();
 
-        const onFinish = jest.fn();
+        const onReset = jest.fn();
         const { asFragment } = render(
-            <ResetIdentityPanel variant="compromised" onFinish={onFinish} onCancelClick={jest.fn()} />,
+            <ResetIdentityPanel variant="compromised" onReset={onReset} onCancelClick={jest.fn()} />,
             withClientContextRenderOptions(matrixClient),
         );
         expect(asFragment()).toMatchSnapshot();
@@ -43,22 +43,22 @@ describe("<ResetIdentityPanel />", () => {
         await sleep(0);
 
         expect(matrixClient.getCrypto()!.resetEncryption).toHaveBeenCalled();
-        expect(onFinish).toHaveBeenCalled();
+        expect(onReset).toHaveBeenCalled();
     });
 
     it("should display the 'forgot recovery key' variant correctly", async () => {
-        const onFinish = jest.fn();
+        const onReset = jest.fn();
         const { asFragment } = render(
-            <ResetIdentityPanel variant="forgot" onFinish={onFinish} onCancelClick={jest.fn()} />,
+            <ResetIdentityPanel variant="forgot" onReset={onReset} onCancelClick={jest.fn()} />,
             withClientContextRenderOptions(matrixClient),
         );
         expect(asFragment()).toMatchSnapshot();
     });
 
     it("should display the 'sync failed' variant correctly", async () => {
-        const onFinish = jest.fn();
+        const onReset = jest.fn();
         const { asFragment } = render(
-            <ResetIdentityPanel variant="sync_failed" onFinish={onFinish} onCancelClick={jest.fn()} />,
+            <ResetIdentityPanel variant="sync_failed" onReset={onReset} onCancelClick={jest.fn()} />,
             withClientContextRenderOptions(matrixClient),
         );
         expect(asFragment()).toMatchSnapshot();

--- a/test/unit-tests/stores/SetupEncryptionStore-test.ts
+++ b/test/unit-tests/stores/SetupEncryptionStore-test.ts
@@ -9,7 +9,7 @@ Please see LICENSE files in the repository root for full details.
 import { mocked, type Mocked } from "jest-mock";
 import { type MatrixClient, Device } from "matrix-js-sdk/src/matrix";
 import { type SecretStorageKeyDescriptionAesV1, type ServerSideSecretStorage } from "matrix-js-sdk/src/secret-storage";
-import { type BootstrapCrossSigningOpts, type CryptoApi, DeviceVerificationStatus } from "matrix-js-sdk/src/crypto-api";
+import { type CryptoApi, DeviceVerificationStatus } from "matrix-js-sdk/src/crypto-api";
 
 import { accessSecretStorage } from "../../../src/SecurityManager";
 import { SetupEncryptionStore } from "../../../src/stores/SetupEncryptionStore";
@@ -150,23 +150,6 @@ describe("SetupEncryptionStore", () => {
             await setupEncryptionStore.usePassPhrase();
 
             await dehydrationPromise;
-        });
-    });
-
-    it("resetConfirm should work with a cached account password", async () => {
-        const makeRequest = jest.fn();
-        mockCrypto.bootstrapCrossSigning.mockImplementation(async (opts: BootstrapCrossSigningOpts) => {
-            await opts?.authUploadDeviceSigningKeys?.(makeRequest);
-        });
-        mocked(accessSecretStorage).mockImplementation(async (func?: () => Promise<void>) => {
-            await func!();
-        });
-
-        await setupEncryptionStore.resetConfirm();
-
-        expect(mocked(accessSecretStorage)).toHaveBeenCalledWith(expect.any(Function), {
-            forceReset: true,
-            resetCrossSigning: true,
         });
     });
 });


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-web/issues/29227

This adds `IdentityResetDialog`, which wraps `IdentityResetBody` in a dialog, and launches it from `SetupEncryptionBody`, instead of doing the reset directly there.  In the new flow, only the user's cryptographic identity is reset -- recovery is no longer set up at the same time.

![image](https://github.com/user-attachments/assets/6ba8056c-e577-4162-94b1-eef80568050d)

This is mostly work by @uhoreg , rebased and refactored a bit here.

~I recommend reviewing commit-by-commit.~