### PR TITLE
New room list: fix public room icon visibility when filter change

### DIFF
--- a/src/components/viewmodels/avatars/RoomAvatarViewModel.tsx
+++ b/src/components/viewmodels/avatars/RoomAvatarViewModel.tsx
@@ -14,7 +14,7 @@ import {
     type User,
     UserEvent,
 } from "matrix-js-sdk/src/matrix";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useTypedEventEmitter } from "../../../hooks/useEventEmitter";
 import DMRoomMap from "../../../utils/DMRoomMap";
@@ -81,6 +81,11 @@ function useIsPublic(room: Room): boolean {
 
         setIsPublic(isRoomPublic(_room));
     });
+
+    // Reset the value when the room changes
+    useEffect(() => {
+        setIsPublic(isRoomPublic(room));
+    }, [room]);
 
     return isPublic;
 }

--- a/test/unit-tests/components/viewmodels/avatars/RoomAvatarViewModel-test.tsx
+++ b/test/unit-tests/components/viewmodels/avatars/RoomAvatarViewModel-test.tsx
@@ -63,6 +63,17 @@ describe("RoomAvatarViewModel", () => {
         expect(vm.current.hasDecoration).toBe(true);
     });
 
+    it("should recompute isPublic when room changed", async () => {
+        const { result: vm, rerender } = renderHook((props) => useRoomAvatarViewModel(props), { initialProps: room });
+        expect(vm.current.isPublic).toBe(false);
+
+        const publicRoom = mkStubRoom("roomId2", "roomName2", matrixClient);
+        jest.spyOn(publicRoom, "getJoinRule").mockReturnValue(JoinRule.Public);
+        rerender(publicRoom);
+
+        await waitFor(() => expect(vm.current.isPublic).toBe(true));
+    });
+
     describe("presence", () => {
         let user: User;
 


### PR DESCRIPTION
Task https://github.com/element-hq/wat-internal/issues/204
Fix public icon issue in https://github.com/element-hq/element-web/issues/29722 

In the video below, the public icon is rendered on DM *Florian Duros* which is a bug:

https://github.com/user-attachments/assets/da208429-23df-4a1d-85fc-619bf3cca634

