### PR TITLE
Fix flaky MatrixChat tests

### DIFF
--- a/test/unit-tests/components/structures/MatrixChat-test.tsx
+++ b/test/unit-tests/components/structures/MatrixChat-test.tsx
@@ -487,10 +487,10 @@ describe("<MatrixChat />", () => {
             it("should persist login credentials", async () => {
                 getComponent({ realQueryParams });
 
-                await waitFor(() => expect(localStorage.getItem("mx_hs_url")).toEqual(homeserverUrl));
+                await waitFor(() => expect(localStorage.getItem("mx_device_id")).toEqual(deviceId));
+                expect(localStorage.getItem("mx_hs_url")).toEqual(homeserverUrl);
                 expect(localStorage.getItem("mx_user_id")).toEqual(userId);
                 expect(localStorage.getItem("mx_has_access_token")).toEqual("true");
-                expect(localStorage.getItem("mx_device_id")).toEqual(deviceId);
             });
 
             it("should store clientId and issuer in session storage", async () => {

--- a/test/unit-tests/components/structures/MatrixChat-test.tsx
+++ b/test/unit-tests/components/structures/MatrixChat-test.tsx
@@ -321,7 +321,7 @@ describe("<MatrixChat />", () => {
             await flushPromises();
             const dialog = await screen.findByRole("dialog");
 
-            expect(within(dialog).getByText(errorMessage)).toBeInTheDocument();
+            await waitFor(() => expect(within(dialog).getByText(errorMessage)).toBeInTheDocument());
         };
 
         beforeEach(() => {

--- a/test/unit-tests/components/structures/MatrixChat-test.tsx
+++ b/test/unit-tests/components/structures/MatrixChat-test.tsx
@@ -497,7 +497,7 @@ describe("<MatrixChat />", () => {
                 getComponent({ realQueryParams });
 
                 await waitFor(() => expect(localStorage.getItem("mx_oidc_client_id")).toEqual(clientId));
-                expect(localStorage.getItem("mx_oidc_token_issuer")).toEqual(issuer);
+                await waitFor(() => expect(localStorage.getItem("mx_oidc_token_issuer")).toEqual(issuer));
             });
 
             it("should set logged in and start MatrixClient", async () => {


### PR DESCRIPTION
Fix flaky MatrixChat tests:

- `should persist login credentials` & `should store clientId and issuer in session storage`: moved the last item setted in secret storage in first position in `waitFor`
- `should log and return to welcome page with correct error when login state is not found`

Failures:
- https://github.com/element-hq/element-web/actions/runs/14445140839/job/40503877623 
- https://github.com/element-hq/element-web/actions/runs/14440956114 
- https://github.com/element-hq/element-web/actions/runs/14442109741
- https://github.com/element-hq/element-web/actions/runs/14440459480
- https://github.com/element-hq/element-web/actions/runs/14440100161
