### PR TITLE
New Room List: Prevent potential scroll jump/flicker when switching spaces

### DIFF
--- a/src/stores/spaces/SpaceStore.ts
+++ b/src/stores/spaces/SpaceStore.ts
@@ -270,7 +270,7 @@ export class SpaceStoreClass extends AsyncStoreWithClient<EmptyObject> {
 
         if (contextSwitch) {
             // view last selected room from space
-            const roomId = window.localStorage.getItem(getSpaceContextKey(space));
+            const roomId = this.getLastSelectedRoomIdForSpace(space);
 
             // if the space being selected is an invite then always view that invite
             // else if the last viewed room in this space is joined then view that
@@ -318,6 +318,17 @@ export class SpaceStoreClass extends AsyncStoreWithClient<EmptyObject> {
                 false,
             );
         }
+    }
+
+    /**
+     * Returns the room-id of the last active room in a given space.
+     * This is the room that would be opened when you switch to a given space.
+     * @param space The space you're interested in.
+     * @returns room-id of the room or null if there's no last active room.
+     */
+    public getLastSelectedRoomIdForSpace(space: SpaceKey): string | null {
+        const roomId = window.localStorage.getItem(getSpaceContextKey(space));
+        return roomId;
     }
 
     private async loadSuggestedRooms(space: Room): Promise<void> {


### PR DESCRIPTION
This issue happens when you are in space `X` with active room `R` and you switch to another space `Y` that also includes room `R` but `R` is not the active room in that space. In this case there's a brief delay between being told that the space has changed and that the active room has changed. This means that you might see a new list with the tile for old room (R) selected and then later a different tile being selected.