### PR TITLE
RoomListStore: Remove invite rooms on decline

### DIFF
--- a/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -194,7 +194,7 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
             case "MatrixActions.Room.myMembership": {
                 const oldMembership = getEffectiveMembership(payload.oldMembership);
                 const newMembership = getEffectiveMembershipTag(payload.room, payload.membership);
-                if (oldMembership === EffectiveMembership.Join && newMembership === EffectiveMembership.Leave) {
+                if (newMembership === EffectiveMembership.Leave) {
                     this.roomSkipList.removeRoom(payload.room);
                     this.emit(LISTS_UPDATE_EVENT);
                     return;

--- a/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -6,7 +6,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { logger } from "matrix-js-sdk/src/logger";
-import { EventType } from "matrix-js-sdk/src/matrix";
+import { EventType, KnownMembership } from "matrix-js-sdk/src/matrix";
 
 import type { EmptyObject, Room, RoomState } from "matrix-js-sdk/src/matrix";
 import type { MatrixDispatcher } from "../../dispatcher/dispatcher";
@@ -194,7 +194,11 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
             case "MatrixActions.Room.myMembership": {
                 const oldMembership = getEffectiveMembership(payload.oldMembership);
                 const newMembership = getEffectiveMembershipTag(payload.room, payload.membership);
-                if (newMembership === EffectiveMembership.Leave) {
+                if (
+                    (payload.oldMembership === KnownMembership.Invite ||
+                        payload.oldMembership === KnownMembership.Join) &&
+                    newMembership === EffectiveMembership.Leave
+                ) {
                     this.roomSkipList.removeRoom(payload.room);
                     this.emit(LISTS_UPDATE_EVENT);
                     return;

--- a/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
+++ b/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
@@ -122,26 +122,29 @@ describe("RoomListStoreV3", () => {
             expect(store.getSortedRooms()[0].roomId).toEqual(room.roomId);
         });
 
-        it("Room is removed when membership changes from join to leave", async () => {
-            const { store, rooms, dispatcher } = await getRoomListStore();
+        it.each([KnownMembership.Join, KnownMembership.Invite])(
+            "Room is removed when membership changes to leave",
+            async (membership) => {
+                const { store, rooms, dispatcher } = await getRoomListStore();
 
-            // Let's say the user leaves room at index 37
-            const room = rooms[37];
+                // Let's say the user leaves room at index 37
+                const room = rooms[37];
 
-            const payload = {
-                action: "MatrixActions.Room.myMembership",
-                oldMembership: KnownMembership.Join,
-                membership: KnownMembership.Leave,
-                room,
-            };
+                const payload = {
+                    action: "MatrixActions.Room.myMembership",
+                    oldMembership: membership,
+                    membership: KnownMembership.Leave,
+                    room,
+                };
 
-            const fn = jest.fn();
-            store.on(LISTS_UPDATE_EVENT, fn);
-            dispatcher.dispatch(payload, true);
+                const fn = jest.fn();
+                store.on(LISTS_UPDATE_EVENT, fn);
+                dispatcher.dispatch(payload, true);
 
-            expect(fn).toHaveBeenCalled();
-            expect(store.getSortedRooms()).not.toContain(room);
-        });
+                expect(fn).toHaveBeenCalled();
+                expect(store.getSortedRooms()).not.toContain(room);
+            },
+        );
 
         it("Predecessor room is removed on room upgrade", async () => {
             const { store, rooms, client, dispatcher } = await getRoomListStore();


### PR DESCRIPTION
- Invites should be removed from the list when they're declined.
- Kicked rooms should remain in the list until they're explicitly forgotten.