### PR TITLE
Fix the buttons not being displayed with long preview text

### DIFF
--- a/res/css/views/rooms/RoomListPanel/_RoomListItemView.pcss
+++ b/res/css/views/rooms/RoomListPanel/_RoomListItemView.pcss
@@ -36,7 +36,7 @@
             min-width: 0;
 
             .mx_RoomListItemView_text {
-                max-width: 100%;
+                min-width: 0;
             }
 
             .mx_RoomListItemView_roomName {


### PR DESCRIPTION
It needed min-width: 0 to allow the div to get smaller than the size necessary to display its content, apparently.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
