### PR TITLE
Move rich topics out of labs / stabilise MSC3765

### DIFF
--- a/docs/labs.md
+++ b/docs/labs.md
@@ -101,10 +101,6 @@ Under the hood this stops Element Web from adding the `perParticipantE2EE` flag 
 
 This is useful while we experiment with encryption and to make calling compatible with platforms that don't use encryption yet.
 
-## Rich text in room topics (`feature_html_topic`) [In Development]
-
-Enables rendering of MD / HTML in room topics.
-
 ## Enable the notifications panel in the room header (`feature_notifications`)
 
 Unreliable in encrypted rooms.

--- a/src/HtmlUtils.tsx
+++ b/src/HtmlUtils.tsx
@@ -480,10 +480,6 @@ export function topicToHtml(
     ref?: LegacyRef<HTMLSpanElement>,
     allowExtendedHtml = false,
 ): ReactNode {
-    if (!SettingsStore.getValue("feature_html_topic")) {
-        htmlTopic = undefined;
-    }
-
     let isFormattedTopic = !!htmlTopic;
     let topicHasEmoji = false;
     let safeTopic = "";

--- a/test/unit-tests/HtmlUtils-test.tsx
+++ b/test/unit-tests/HtmlUtils-test.tsx
@@ -17,10 +17,6 @@ import { SettingLevel } from "../../src/settings/SettingLevel";
 import SdkConfig from "../../src/SdkConfig";
 
 describe("topicToHtml", () => {
-    afterEach(() => {
-        SettingsStore.reset();
-    });
-
     function getContent() {
         return screen.getByRole("contentinfo").children[0].innerHTML;
     }
@@ -36,19 +32,16 @@ describe("topicToHtml", () => {
     });
 
     it("converts literal HTML topic to HTML", async () => {
-        SettingsStore.setValue("feature_html_topic", null, SettingLevel.DEVICE, true);
         render(<div role="contentinfo">{topicToHtml("<b>pizza</b>", undefined, null, false)}</div>);
         expect(getContent()).toEqual("&lt;b&gt;pizza&lt;/b&gt;");
     });
 
     it("converts true HTML topic to HTML", async () => {
-        SettingsStore.setValue("feature_html_topic", null, SettingLevel.DEVICE, true);
         render(<div role="contentinfo">{topicToHtml("**pizza**", "<b>pizza</b>", null, false)}</div>);
         expect(getContent()).toEqual("<b>pizza</b>");
     });
 
     it("converts true HTML topic with emoji to HTML", async () => {
-        SettingsStore.setValue("feature_html_topic", null, SettingLevel.DEVICE, true);
         render(<div role="contentinfo">{topicToHtml("**pizza** 🍕", "<b>pizza</b> 🍕", null, false)}</div>);
         expect(getContent()).toEqual('<b>pizza</b> <span class="mx_Emoji" title=":pizza:">🍕</span>');
     });


### PR DESCRIPTION
[MSC3765](https://github.com/matrix-org/matrix-spec-proposals/pull/3765) has been merged so this could move out of labs now – if the product team is ok with it, of course.

Requires: https://github.com/matrix-org/matrix-js-sdk/pull/4767

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
