### PR TITLE
Update Unprivileged Nginx Version, Because of Permission Denied Error in latest image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN /src/scripts/docker-package.sh
 RUN cp /src/config.sample.json /src/webapp/config.json
 
 # App
-FROM nginxinc/nginx-unprivileged:alpine-slim
+FROM nginxinc/nginx-unprivileged:1.27.4-alpine-slim
 
 # Need root user to install packages & manipulate the usr directory
 USER root


### PR DESCRIPTION
# Bug Overview
I'm trying to build Docker Image using Dockerfile in this repo.
I succeeded in creating the image, but when I actually ran it, I encountered a permission issue related to Nginx.
<img width="1003" alt="error-nginx" src="https://github.com/user-attachments/assets/caef072f-c085-47ea-8028-b591439414c8" />

# Solution
After looking into the issue, we found that the cause is the latest nginx unprivileged that is currently provided.

There is currently a related Issue and PR posted.
https://github.com/nginx/docker-nginx-unprivileged/issues/302
https://github.com/nginx/docker-nginx-unprivileged/pull/303

However, we do not know when this PR will be reflected, so for the sake of other users using the program at that time, I suggest temporarily rolling back the Nginx version to 1.27.4.

After rolling back, I tried building the image through Dockerfile and confirmed that it worked normally.
<img width="1195" alt="fix-error" src="https://github.com/user-attachments/assets/382da463-5855-4e0c-a65e-e915b5106026" />



PS. Thank you for providing such great software as open source. I'm glad I can offer you this small suggestion!

## Checklist

- [x] Tests written for new code (and old code if feasible).
- N/A New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
