### PR TITLE
Change timeoutIdRef type number to ReturnType<typeof setTimout>

### DIFF
--- a/src/components/views/dialogs/ShareDialog.tsx
+++ b/src/components/views/dialogs/ShareDialog.tsx
@@ -103,7 +103,7 @@ export function ShareDialog({ target, customTitle, onFinished, permalinkCreator 
     const showQrCode = useSettingValue(UIFeature.ShareQRCode);
     const showSocials = useSettingValue(UIFeature.ShareSocial);
 
-    const timeoutIdRef = useRef<number>(undefined);
+    const timeoutIdRef = useRef<ReturnType<typeof setTimeout>>(undefined);
     const [isCopied, setIsCopied] = useState(false);
 
     const [linkToSpecificEvent, setLinkToSpecificEvent] = useState(target instanceof MatrixEvent);


### PR DESCRIPTION
# Bug Overview
During the code check using the yarn lint script, the following error was found.
<img width="1477" alt="error" src="https://github.com/user-attachments/assets/8b8cbfb7-210a-4f96-b12e-68c762ad5c8e" />

# Solution
After looking into the cause, I found out that the browser return type of the setTimeout function is a number type, but in NodeJS, it is returned as a Timeout type.

Because of this, it worked normally in the browser environment, but an error occurred during lint verification.

Therefore, I used ReturnType to handle it so that it could pass lint verification without being affected by the environment.

The solution was completed after that.
<img width="1252" alt="solution" src="https://github.com/user-attachments/assets/6cdafd06-6c07-44f1-a245-09fd4dfacf00" />


- [x] Tests written for new code (and old code if feasible).
- N/A New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
