### PR TITLE
Un-gitignore `modules.ts`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ electron/pub
 .env
 /coverage
 # Auto-generated file
-/src/modules.ts
 /src/modules.js
 /build_config.yaml
 /book


### PR DESCRIPTION
As of #29089, `modules.ts` is no longer auto-generated, so should not be
gitignored. Indeed, having a copy sitting around in your working copy can
produce unexpected results, and removing it from the ignorelist at least gives
maintainers a hint about what might be going wrong.


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)