### PR TITLE
New Room List: Prevent old tombstoned rooms from appearing in the list

### DIFF
--- a/playwright/e2e/left-panel/room-list-panel/room-list-filter-sort.spec.ts
+++ b/playwright/e2e/left-panel/room-list-panel/room-list-filter-sort.spec.ts
@@ -5,10 +5,11 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-import { Visibility } from "matrix-js-sdk/src/matrix";
+import { type Visibility } from "matrix-js-sdk/src/matrix";
+import { type Locator, type Page } from "@playwright/test";
+
 import { expect, test } from "../../../element-web-test";
 import { SettingLevel } from "../../../../src/settings/SettingLevel";
-import { type Locator, type Page } from "@playwright/test";
 
 test.describe("Room list filters and sort", () => {
     test.use({
@@ -43,7 +44,7 @@ test.describe("Room list filters and sort", () => {
 
     test("Tombstoned rooms are not shown even when they receive updates", async ({ page, app, bot }) => {
         // This bug shows up with this setting turned on
-        app.settings.setValue("Spaces.allRoomsInHome", null, SettingLevel.DEVICE, true);
+        await app.settings.setValue("Spaces.allRoomsInHome", null, SettingLevel.DEVICE, true);
 
         /*
         We will first create a room named 'Old Room' and will invite the bot user to this room.
@@ -60,7 +61,7 @@ test.describe("Room list filters and sort", () => {
         */
         const roomListView = getRoomList(page);
         const oldRoomTile = roomListView.getByRole("gridcell", { name: "Open room Old Room" });
-        expect(oldRoomTile).toBeVisible();
+        await expect(oldRoomTile).toBeVisible();
 
         /*
         Now let's tombstone 'Old Room'.
@@ -74,7 +75,7 @@ test.describe("Room list filters and sort", () => {
                     room_id: oldRoomId,
                 },
             },
-            visibility: Visibility.Public,
+            visibility: "public" as Visibility,
         });
 
         /*
@@ -89,7 +90,7 @@ test.describe("Room list filters and sort", () => {
         await app.client.joinRoom(newRoomId);
 
         // We expect 'Old Room' to be hidden from the room list.
-        expect(oldRoomTile).not.toBeVisible();
+        await expect(oldRoomTile).not.toBeVisible();
 
         /*
         Let's say some user in the 'Old Room' changes their display name.
@@ -97,7 +98,7 @@ test.describe("Room list filters and sort", () => {
         Nevertheless, the replaced room should not be shown in the room list.
         */
         await bot.setDisplayName("MyNewName");
-        expect(oldRoomTile).not.toBeVisible();
+        await expect(oldRoomTile).not.toBeVisible();
     });
 
     test.describe("Scroll behaviour", () => {

--- a/playwright/e2e/left-panel/room-list-panel/room-list-filter-sort.spec.ts
+++ b/playwright/e2e/left-panel/room-list-panel/room-list-filter-sort.spec.ts
@@ -5,8 +5,10 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
+import { Visibility } from "matrix-js-sdk/src/matrix";
 import { expect, test } from "../../../element-web-test";
-import type { Locator, Page } from "@playwright/test";
+import { SettingLevel } from "../../../../src/settings/SettingLevel";
+import { type Locator, type Page } from "@playwright/test";
 
 test.describe("Room list filters and sort", () => {
     test.use({
@@ -37,6 +39,65 @@ test.describe("Room list filters and sort", () => {
     test.beforeEach(async ({ page, app, bot, user }) => {
         // The notification toast is displayed above the search section
         await app.closeNotificationToast();
+    });
+
+    test("Tombstoned rooms are not shown even when they receive updates", async ({ page, app, bot }) => {
+        // This bug shows up with this setting turned on
+        app.settings.setValue("Spaces.allRoomsInHome", null, SettingLevel.DEVICE, true);
+
+        /*
+        We will first create a room named 'Old Room' and will invite the bot user to this room.
+        We will also send a simple message in this room.
+        */
+        const oldRoomId = await app.client.createRoom({ name: "Old Room" });
+        await app.client.inviteUser(oldRoomId, bot.credentials.userId);
+        await bot.joinRoom(oldRoomId);
+        const response = await app.client.sendMessage(oldRoomId, "Hello!");
+
+        /*
+        At this point, we haven't done anything interesting.
+        So we expect 'Old Room' to show up in the room list.
+        */
+        const roomListView = getRoomList(page);
+        const oldRoomTile = roomListView.getByRole("gridcell", { name: "Open room Old Room" });
+        expect(oldRoomTile).toBeVisible();
+
+        /*
+        Now let's tombstone 'Old Room'.
+        First we create a new room ('New Room') with the predecessor set to the old room..
+        */
+        const newRoomId = await bot.createRoom({
+            name: "New Room",
+            creation_content: {
+                predecessor: {
+                    event_id: response.event_id,
+                    room_id: oldRoomId,
+                },
+            },
+            visibility: Visibility.Public,
+        });
+
+        /*
+        Now we can send the tombstone event itself to the 'Old Room'.
+        */
+        await app.client.sendStateEvent(oldRoomId, "m.room.tombstone", {
+            body: "This room has been replaced",
+            replacement_room: newRoomId,
+        });
+
+        // Let's join the replaced room.
+        await app.client.joinRoom(newRoomId);
+
+        // We expect 'Old Room' to be hidden from the room list.
+        expect(oldRoomTile).not.toBeVisible();
+
+        /*
+        Let's say some user in the 'Old Room' changes their display name.
+        This will send events to the all the rooms including 'Old Room'.
+        Nevertheless, the replaced room should not be shown in the room list.
+        */
+        await bot.setDisplayName("MyNewName");
+        expect(oldRoomTile).not.toBeVisible();
     });
 
     test.describe("Scroll behaviour", () => {

--- a/src/stores/room-list-v3/skip-list/RoomSkipList.ts
+++ b/src/stores/room-list-v3/skip-list/RoomSkipList.ts
@@ -90,15 +90,34 @@ export class RoomSkipList implements Iterable<Room> {
     }
 
     /**
-     * Adds a given room to the correct sorted position in the list.
-     * If the room is already present in the list, it is first removed.
+     * Re-inserts a room that is already in the skiplist.
+     * This method does nothing if the room isn't already in the skiplist.
+     * @param room the room to add
      */
-    public addRoom(room: Room): void {
-        /**
-         * Remove this room from the skip list if necessary.
-         */
+    public reInsertRoom(room: Room): void {
+        if (!this.roomNodeMap.has(room.roomId)) {
+            return;
+        }
         this.removeRoom(room);
+        this.addNewRoom(room);
+    }
 
+    /**
+     * Adds a new room to the skiplist.
+     * This method will throw an error if the room is already in the skiplist.
+     * @param room the room to add
+     */
+    public addNewRoom(room: Room): void {
+        if (this.roomNodeMap.has(room.roomId)) {
+            throw new Error(`Can't add room to skiplist: ${room.roomId} is already in the skiplist!`);
+        }
+        this.insertRoom(room);
+    }
+
+    /**
+     * Adds a given room to the correct sorted position in the list.
+     */
+    private insertRoom(room: Room): void {
         const newNode = new RoomNode(room);
         newNode.checkIfRoomBelongsToActiveSpace();
         newNode.applyFilters(this.filters);

--- a/test/unit-tests/stores/room-list-v3/skip-list/RoomSkipList-test.ts
+++ b/test/unit-tests/stores/room-list-v3/skip-list/RoomSkipList-test.ts
@@ -93,6 +93,12 @@ describe("RoomSkipList", () => {
         }
     });
 
+    it("Throws error when same room is added via addNewRoom", () => {
+        const { skipList, rooms } = generateSkipList();
+        const room = rooms[5];
+        expect(() => skipList.addNewRoom(room)).toThrow("Can't add room to skiplist");
+    });
+
     it("Re-sort works when sorter is swapped", () => {
         const { skipList, rooms, sorter } = generateSkipList();
         const sortedByRecency = [...rooms].sort((a, b) => sorter.comparator(a, b));

--- a/test/unit-tests/stores/room-list-v3/skip-list/RoomSkipList-test.ts
+++ b/test/unit-tests/stores/room-list-v3/skip-list/RoomSkipList-test.ts
@@ -62,7 +62,7 @@ describe("RoomSkipList", () => {
         for (const room of toInsert) {
             // Insert this room 10 times
             for (let i = 0; i < 10; ++i) {
-                skipList.addRoom(room);
+                skipList.reInsertRoom(room);
             }
         }
         // Sorting order should be the same as before
@@ -84,7 +84,7 @@ describe("RoomSkipList", () => {
                 event: true,
             });
             room.timeline.push(event);
-            skipList.addRoom(room);
+            skipList.reInsertRoom(room);
             expect(skipList.size).toEqual(rooms.length);
         }
         const sortedRooms = [...skipList];
@@ -120,7 +120,7 @@ describe("RoomSkipList", () => {
 
             // Shuffle and insert the rooms
             for (const room of shuffle(rooms)) {
-                roomSkipList.addRoom(room);
+                roomSkipList.addNewRoom(room);
             }
 
             expect(roomSkipList.size).toEqual(totalRooms);


### PR DESCRIPTION
When somebody changes their display name, `m.room.member` state event and read receipts are sent to all rooms including tombstoned or upgraded rooms. Previously, the RLS would add the room associated with such events into the skiplist regardless of whether they should be shown in the list or not. This would sometime cause old upgraded rooms to show in the list. 

This PR prevents such rooms from being added into the skip list:
- Remove the old `addRoom` method.
- Introduces `reInsertRoom` method which will only insert the room if the room is already in the skiplist. This is the method that will be used most frequently.
- Introduces `addNewRoom` method that adds new rooms that are not in the skiplist. This method will throw an error if the room is already in the skiplist.