### PR TITLE
Cache the key backup status whether enabled or not

### DIFF
--- a/test/unit-tests/DeviceListener-test.ts
+++ b/test/unit-tests/DeviceListener-test.ts
@@ -445,7 +445,9 @@ describe("DeviceListener", () => {
             it("dispatches keybackup event when key backup is not enabled", async () => {
                 mockCrypto.getActiveSessionBackupVersion.mockResolvedValue(null);
                 await createAndStart();
-                expect(mockDispatcher.dispatch).toHaveBeenCalledWith({ action: Action.ReportKeyBackupNotEnabled });
+                expect(mockDispatcher.dispatch).toHaveBeenCalledWith({
+                    action: Action.ReportKeyBackupNotEnabled,
+                });
             });
 
             it("does not check key backup status again after check is complete", async () => {


### PR DESCRIPTION
Part of https://github.com/element-hq/element-web/issues/29231

Tidy up key backup status in `DeviceListener` a little, making it easier to find out about key backup status, which we will do in later changes.

Includes a small change to behaviour: always cache the answer, instead of only caching it when the answer was `true`. I can't see a way that this will cause problems, but if the reviewer can, it is simple to change it back to only caching positive answers.