### PR TITLE
Fix a test of SetupEncryptionToast

### DIFF
--- a/test/unit-tests/toasts/SetupEncryptionToast-test.tsx
+++ b/test/unit-tests/toasts/SetupEncryptionToast-test.tsx
@@ -23,6 +23,7 @@ jest.mock("../../../src/dispatcher/dispatcher", () => ({
 
 describe("SetupEncryptionToast", () => {
     beforeEach(() => {
+        jest.resetAllMocks();
         render(<ToastContainer />);
     });
 
@@ -65,7 +66,7 @@ describe("SetupEncryptionToast", () => {
             });
         });
 
-        it("should open settings to the reset flow when recovering fails clicked", async () => {
+        it("should open settings to the reset flow when recovering fails", async () => {
             jest.spyOn(SecurityManager, "accessSecretStorage").mockImplementation(async () => {
                 throw new Error("Something went wrong while recovering!");
             });
@@ -78,7 +79,7 @@ describe("SetupEncryptionToast", () => {
             expect(dis.dispatch).toHaveBeenCalledWith({
                 action: "view_user_settings",
                 initialTabId: "USER_ENCRYPTION_TAB",
-                props: { initialEncryptionState: "reset_identity_forgot" },
+                props: { initialEncryptionState: "reset_identity_sync_failed" },
             });
         });
     });


### PR DESCRIPTION
Part of https://github.com/element-hq/element-web/issues/29231

Fix a test that only passes when run in the right sequence with other tests, because it actually asserts something that happens in another test.

Adjust the test setup so the tests are independent, and then fix the assertion to expect the behaviour we have in this case.