### PR TITLE
Do not send empty auth when setting up cross-signing keys

### DIFF
--- a/src/CreateCrossSigning.ts
+++ b/src/CreateCrossSigning.ts
@@ -38,10 +38,10 @@ export async function createCrossSigning(cli: MatrixClient): Promise<void> {
 
 export async function uiAuthCallback(
     matrixClient: MatrixClient,
-    makeRequest: (authData: AuthDict) => Promise<void>,
+    makeRequest: (authData: AuthDict | null) => Promise<void>,
 ): Promise<void> {
     try {
-        await makeRequest({});
+        await makeRequest(null);
     } catch (error) {
         if (!(error instanceof MatrixError) || !error.data || !error.data.flows) {
             // Not a UIA response


### PR DESCRIPTION
My understanding from the spec is that no `auth` parameter should be sent when starting a UIA flow. [This section](https://spec.matrix.org/v1.14/client-server-api/#user-interactive-api-in-the-rest-api) says that "A client should first make a request with no auth parameter" and this is not what element-web is doing (since it is sending an auth parameter with an empty dictionary).

In the upload cross-signing keys endpoint
[documentation](https://spec.matrix.org/v1.14/client-server-api/#post_matrixclientv3keysdevice_signingupload_request_authentication-data) it says that type may be omitted if session is set, but in this specific case neither of the fields is set.

The proposed changes changes the empty dictionary for a `null` value in order to prevent the `auth` field to be sent.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
