### PR TITLE
New room list: fix outdated message preview when space or filter change

### DIFF
--- a/src/components/viewmodels/roomlist/RoomListItemViewModel.tsx
+++ b/src/components/viewmodels/roomlist/RoomListItemViewModel.tsx
@@ -220,7 +220,7 @@ function useRoomMessagePreview(room: Room): string | undefined {
             room,
             roomIsDM ? DefaultTagID.DM : DefaultTagID.Untagged,
         );
-        if (messagePreview) setPreviewText(messagePreview.text);
+        setPreviewText(messagePreview?.text);
     }, [room, shouldShowMessagePreview]);
 
     // MessagePreviewStore and the other AsyncStores need to be converted to TypedEventEmitter

--- a/test/unit-tests/components/viewmodels/roomlist/RoomListItemViewModel-test.tsx
+++ b/test/unit-tests/components/viewmodels/roomlist/RoomListItemViewModel-test.tsx
@@ -138,6 +138,28 @@ describe("RoomListItemViewModel", () => {
         expect(vm.current.messagePreview).toBe(undefined);
     });
 
+    it("should check message preview when room change", async () => {
+        const otherRoom = mkStubRoom("roomId2", "roomName2", room.client);
+
+        jest.spyOn(MessagePreviewStore.instance, "getPreviewForRoom").mockResolvedValue({
+            text: "Message look like this",
+        } as MessagePreview);
+        mocked(useMessagePreviewToggle).mockReturnValue({
+            shouldShowMessagePreview: true,
+            toggleMessagePreview: jest.fn(),
+        });
+
+        const { result: vm, rerender } = renderHook((props) => useRoomListItemViewModel(props), {
+            initialProps: room,
+            ...withClientContextRenderOptions(room.client),
+        });
+        await waitFor(() => expect(vm.current.messagePreview).toBe("Message look like this"));
+
+        jest.spyOn(MessagePreviewStore.instance, "getPreviewForRoom").mockResolvedValue(null);
+        rerender(otherRoom);
+        await waitFor(() => expect(vm.current.messagePreview).toBe(undefined));
+    });
+
     describe("notification", () => {
         let notificationState: RoomNotificationState;
         beforeEach(() => {


### PR DESCRIPTION
Closes https://github.com/element-hq/element-web/issues/29862

This PR fixes a bug where the message preview is not re-calculated when the space or the filter change. Before, it the new room doesn't have a preview, we don't set the message preview. The previous message preview was displayed.

## Before

[Screencast_20250512_154418.webm](https://github.com/user-attachments/assets/10052575-fb3d-4bcc-a1f0-4a777c45a55b)

## After

[Screencast_20250512_145229.webm](https://github.com/user-attachments/assets/fa6c8d09-1b7f-4d8d-a43c-b75e1de774da)
