### PR TITLE
Fix go home shortcut on macos and change toggle action events shortcut

### DIFF
--- a/src/accessibility/KeyboardShortcuts.ts
+++ b/src/accessibility/KeyboardShortcuts.ts
@@ -521,7 +521,8 @@ export const KEYBOARD_SHORTCUTS: IKeyboardShortcuts = {
     [KeyBindingAction.GoToHome]: {
         default: {
             ctrlKey: true,
-            altKey: true,
+            altKey: !IS_MAC,
+            shiftKey: IS_MAC,
             key: Key.H,
         },
         displayName: _td("keyboard|go_home_view"),
@@ -586,7 +587,7 @@ export const KEYBOARD_SHORTCUTS: IKeyboardShortcuts = {
         default: {
             ctrlKey: true,
             shiftKey: true,
-            key: Key.H,
+            key: Key.J,
         },
         displayName: _td("keyboard|toggle_hidden_events"),
     },


### PR DESCRIPTION
Closes https://github.com/element-hq/element-web/issues/29640
Regression due to https://github.com/element-hq/element-web/pull/29374

The go to home shortcut (`ctrl + option + h`) doesn't work on macos. The `alt/option`  is modifier on azerty/qwerty/xxx macos layout. `option + h`  produces `Ì` on an azerty layout.

The proposal is to change the shortcut on macos to be `ctrl + shift + h`. `cmd + shift + h` is already used by safari to jump on the home page.

But  `ctrl + shift + h` is already used by toggle action events. So I propose to change this shortcut to `ctrl + shift + j`. Go to home shortcut is in my opinion more important and vastly used than the toggle action events which is more a debug thing.