### PR TITLE
RLS: Remove forgotten room from skiplist

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -107,6 +107,7 @@ import Views from "../../Views";
 import { type FocusNextType, type ViewRoomPayload } from "../../dispatcher/payloads/ViewRoomPayload";
 import { type ViewHomePagePayload } from "../../dispatcher/payloads/ViewHomePagePayload";
 import { type AfterLeaveRoomPayload } from "../../dispatcher/payloads/AfterLeaveRoomPayload";
+import { type AfterForgetRoomPayload } from "../../dispatcher/payloads/AfterForgetRoomPayload";
 import { type DoAfterSyncPreparedPayload } from "../../dispatcher/payloads/DoAfterSyncPreparedPayload";
 import { type ViewStartChatOrReusePayload } from "../../dispatcher/payloads/ViewStartChatOrReusePayload";
 import { leaveRoomBehaviour } from "../../utils/leave-behaviour";
@@ -1273,6 +1274,8 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                 // be notified to us, therefore the room list will have no other way of knowing
                 // the room is forgotten.
                 if (room) RoomListStore.instance.manualRoomUpdate(room, RoomUpdateCause.RoomRemoved);
+
+                dis.dispatch<AfterForgetRoomPayload>({ action: Action.AfterForgetRoom, room_id: roomId });
             })
             .catch((err) => {
                 const errCode = err.errcode || _td("error|unknown_error_code");

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -1270,12 +1270,12 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                     dis.dispatch({ action: Action.ViewHomePage });
                 }
 
-                // We have to manually update the room list because the forgotten room will not
-                // be notified to us, therefore the room list will have no other way of knowing
-                // the room is forgotten.
-                if (room) RoomListStore.instance.manualRoomUpdate(room, RoomUpdateCause.RoomRemoved);
-
-                dis.dispatch<AfterForgetRoomPayload>({ action: Action.AfterForgetRoom, room_id: roomId });
+                if (room) {
+                    // Legacy room list store needs to be told to manually remove this room
+                    RoomListStore.instance.manualRoomUpdate(room, RoomUpdateCause.RoomRemoved);
+                    // New room list store will remove the room on the following dispatch
+                    dis.dispatch<AfterForgetRoomPayload>({ action: Action.AfterForgetRoom, room });
+                }
             })
             .catch((err) => {
                 const errCode = err.errcode || _td("error|unknown_error_code");

--- a/src/dispatcher/actions.ts
+++ b/src/dispatcher/actions.ts
@@ -237,6 +237,7 @@ export enum Action {
 
     /**
      * Dispatched after a room has been successfully forgotten
+     * Should be used with AfterForgetRoomPayload.
      */
     AfterForgetRoom = "after_forget_room",
 

--- a/src/dispatcher/actions.ts
+++ b/src/dispatcher/actions.ts
@@ -236,6 +236,11 @@ export enum Action {
     AfterLeaveRoom = "after_leave_room",
 
     /**
+     * Dispatched after a room has been successfully forgotten
+     */
+    AfterForgetRoom = "after_forget_room",
+
+    /**
      * Used to defer actions until after sync is complete
      * LifecycleStore will emit deferredAction payload after 'MatrixActions.sync'
      */

--- a/src/dispatcher/payloads/AfterForgetRoomPayload.ts
+++ b/src/dispatcher/payloads/AfterForgetRoomPayload.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import { type Room } from "matrix-js-sdk/src/matrix";
+
+import { type Action } from "../actions";
+import { type ActionPayload } from "../payloads";
+
+export interface AfterForgetRoomPayload extends ActionPayload {
+    action: Action.AfterForgetRoom;
+    // eslint-disable-next-line camelcase
+    room_id?: Room["roomId"];
+}

--- a/src/dispatcher/payloads/AfterForgetRoomPayload.ts
+++ b/src/dispatcher/payloads/AfterForgetRoomPayload.ts
@@ -12,6 +12,5 @@ import { type ActionPayload } from "../payloads";
 
 export interface AfterForgetRoomPayload extends ActionPayload {
     action: Action.AfterForgetRoom;
-    // eslint-disable-next-line camelcase
-    room_id?: Room["roomId"];
+    room: Room;
 }

--- a/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -34,6 +34,7 @@ import { type Sorter, SortingAlgorithm } from "./skip-list/sorters";
 import { SettingLevel } from "../../settings/SettingLevel";
 import { MARKED_UNREAD_TYPE_STABLE, MARKED_UNREAD_TYPE_UNSTABLE } from "../../utils/notifications";
 import { getChangedOverrideRoomMutePushRules } from "../room-list/utils/roomMute";
+import { Action } from "../../dispatcher/actions";
 
 /**
  * These are the filters passed to the room skip list.
@@ -243,6 +244,13 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
                 }
 
                 this.addRoomAndEmit(payload.room, true);
+                break;
+            }
+
+            case Action.AfterForgetRoom: {
+                const room = payload.room;
+                this.roomSkipList.removeRoom(room);
+                this.emit(LISTS_UPDATE_EVENT);
                 break;
             }
         }

--- a/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
+++ b/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
@@ -27,6 +27,7 @@ import { SortingAlgorithm } from "../../../../src/stores/room-list-v3/skip-list/
 import SettingsStore from "../../../../src/settings/SettingsStore";
 import * as utils from "../../../../src/utils/notifications";
 import * as roomMute from "../../../../src/stores/room-list/utils/roomMute";
+import { Action } from "../../../../src/dispatcher/actions";
 
 describe("RoomListStoreV3", () => {
     async function getRoomListStore() {
@@ -119,6 +120,27 @@ describe("RoomListStoreV3", () => {
 
             expect(fn).toHaveBeenCalled();
             expect(store.getSortedRooms()[0].roomId).toEqual(room.roomId);
+        });
+
+        it("Forgotten room is removed", async () => {
+            const { store, rooms, dispatcher } = await getRoomListStore();
+            const room = rooms[37];
+
+            // Room at index 37 should be in the store now
+            expect(store.getSortedRooms().map((r) => r.roomId)).toContain(room.roomId);
+
+            // Forget room at index 37
+            const payload = {
+                action: Action.AfterForgetRoom,
+                room: room,
+            };
+            const fn = jest.fn();
+            store.on(LISTS_UPDATE_EVENT, fn);
+            dispatcher.dispatch(payload, true);
+
+            // Room at index 37 should no longer be in the store
+            expect(fn).toHaveBeenCalled();
+            expect(store.getSortedRooms().map((r) => r.roomId)).not.toContain(room.roomId);
         });
 
         it.each([KnownMembership.Join, KnownMembership.Invite])(


### PR DESCRIPTION
- Adds an action `after_forget_room` to indicate when a room has been successfully forgotten. Similar to `after_leave_room`.
- RLS removes such rooms from the skiplist on this event.