### PR TITLE
Fix state events being hidden from widgets in read_events actions

### DIFF
--- a/src/stores/widgets/StopGapWidgetDriver.ts
+++ b/src/stores/widgets/StopGapWidgetDriver.ts
@@ -498,9 +498,9 @@ export class StopGapWidgetDriver extends WidgetDriver {
             if (results.length >= limit) break;
             if (since !== undefined && ev.getId() === since) break;
 
-            if (ev.getType() !== eventType || ev.isState()) continue;
+            if (ev.getType() !== eventType) continue;
             if (eventType === EventType.RoomMessage && msgtype && msgtype !== ev.getContent()["msgtype"]) continue;
-            if (ev.getStateKey() !== undefined && stateKey !== undefined && ev.getStateKey() !== stateKey) continue;
+            if (stateKey !== undefined && ev.getStateKey() !== stateKey) continue;
             results.push(ev);
         }
 

--- a/test/unit-tests/stores/widgets/StopGapWidgetDriver-test.ts
+++ b/test/unit-tests/stores/widgets/StopGapWidgetDriver-test.ts
@@ -708,6 +708,7 @@ describe("StopGapWidgetDriver", () => {
             id: "$event-id2",
             type: "org.example.foo",
             user: "@alice:example.org",
+            skey: "",
             content: { hello: "world" },
             room: "!1:example.org",
         });
@@ -724,6 +725,12 @@ describe("StopGapWidgetDriver", () => {
             expect(
                 await driver.readRoomTimeline("!1:example.org", "org.example.foo", undefined, undefined, 10, undefined),
             ).toEqual([event2, event1].map((e) => e.getEffectiveEvent()));
+        });
+
+        it("reads state events", async () => {
+            expect(
+                await driver.readRoomTimeline("!1:example.org", "org.example.foo", undefined, "", 10, undefined),
+            ).toEqual([event2.getEffectiveEvent()]);
         });
 
         it("reads up to a limit", async () => {


### PR DESCRIPTION
This widget driver method was mistakenly filtering all state events out of the responses to `read_events` `fromWidget` actions. This was a hold-over from back when `read_events` had two different behaviors depending on whether you specified a `state_key` (i.e. before the [introduction of the `update_state` action](https://github.com/matrix-org/matrix-spec-proposals/pull/4237)).