### PR TITLE
Timeline: Replace ScrollPanel with Virtuoso POC

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
         "react-string-replace": "^1.1.1",
         "react-transition-group": "^4.4.1",
         "react-virtualized": "^9.22.5",
+        "react-virtuoso": "^4.12.7",
         "rfc4648": "^1.4.0",
         "sanitize-filename": "^1.6.3",
         "sanitize-html": "2.16.0",

--- a/src/components/structures/TimelinePanel.tsx
+++ b/src/components/structures/TimelinePanel.tsx
@@ -380,7 +380,8 @@ class TimelinePanel extends React.Component<IProps, IState> {
     }
 
     private get messagePanelDiv(): HTMLDivElement | null {
-        return this.messagePanel.current?.scrollPanel.current?.divScroll ?? null;
+        return null;
+        // return this.messagePanel.current?.scrollPanel.current?.divScroll ?? null;
     }
 
     /**

--- a/src/components/views/messages/IBodyProps.ts
+++ b/src/components/views/messages/IBodyProps.ts
@@ -48,4 +48,5 @@ export interface IBodyProps {
     // Set to `true` to disable interactions (e.g. video controls) and to remove controls from the tab order.
     // This may be useful when displaying a preview of the event.
     inhibitInteraction?: boolean;
+    isScrolling?: boolean;
 }

--- a/src/components/views/messages/MessageEvent.tsx
+++ b/src/components/views/messages/MessageEvent.tsx
@@ -308,6 +308,7 @@ export default class MessageEvent extends React.Component<IProps> implements IMe
             getRelationsForEvent: this.props.getRelationsForEvent,
             isSeeingThroughMessageHiddenForModeration: this.props.isSeeingThroughMessageHiddenForModeration,
             inhibitInteraction: this.props.inhibitInteraction,
+            isScrolling: this.props.isScrolling,
         };
         if (hasCaption) {
             return <CaptionBody {...bodyProps} WrappedBodyType={BodyType} />;
@@ -320,9 +321,12 @@ export default class MessageEvent extends React.Component<IProps> implements IMe
 const CaptionBody: React.FunctionComponent<IBodyProps & { WrappedBodyType: React.ComponentType<IBodyProps> }> = ({
     WrappedBodyType,
     ...props
-}) => (
-    <div className="mx_EventTile_content">
-        <WrappedBodyType {...props} />
-        <TextualBody {...{ ...props, ref: undefined }} />
-    </div>
-);
+}) => {
+    console.log(`CaptionBody isScrolling${props.isScrolling}`);
+    return (
+        <div className="mx_EventTile_content">
+            <WrappedBodyType {...props} />
+            <TextualBody {...{ ...props, ref: undefined }} />
+        </div>
+    );
+};

--- a/src/components/views/messages/TextualBody.tsx
+++ b/src/components/views/messages/TextualBody.tsx
@@ -83,7 +83,9 @@ export default class TextualBody extends React.Component<IBodyProps, IState> {
             nextProps.editState !== this.props.editState ||
             nextState.links !== this.state.links ||
             nextState.widgetHidden !== this.state.widgetHidden ||
-            nextProps.isSeeingThroughMessageHiddenForModeration !== this.props.isSeeingThroughMessageHiddenForModeration
+            nextProps.isSeeingThroughMessageHiddenForModeration !==
+                this.props.isSeeingThroughMessageHiddenForModeration ||
+            nextProps.isScrolling !== this.props.isScrolling
         );
     }
 
@@ -378,6 +380,7 @@ export default class TextualBody extends React.Component<IBodyProps, IState> {
                     links={this.state.links}
                     mxEvent={this.props.mxEvent}
                     onCancelClick={this.onCancelClick}
+                    isScrolling={this.props.isScrolling}
                 />
             );
         }

--- a/src/components/views/rooms/LinkPreviewGroup.tsx
+++ b/src/components/views/rooms/LinkPreviewGroup.tsx
@@ -25,9 +25,10 @@ interface IProps {
     links: string[]; // the URLs to be previewed
     mxEvent: MatrixEvent; // the Event associated with the preview
     onCancelClick(): void; // called when the preview's cancel ('hide') button is clicked
+    isScrolling?: boolean;
 }
 
-const LinkPreviewGroup: React.FC<IProps> = ({ links, mxEvent, onCancelClick }) => {
+const LinkPreviewGroup: React.FC<IProps> = ({ links, mxEvent, onCancelClick, isScrolling }) => {
     const cli = useContext(MatrixClientContext);
     const [expanded, toggleExpanded] = useStateToggle();
     const [mediaVisible] = useMediaVisible(mxEvent.getId(), mxEvent.getRoomId());
@@ -55,28 +56,30 @@ const LinkPreviewGroup: React.FC<IProps> = ({ links, mxEvent, onCancelClick }) =
     }
 
     return (
-        <div className="mx_LinkPreviewGroup">
-            {showPreviews.map(([link, preview], i) => (
-                <LinkPreviewWidget
-                    mediaVisible={mediaVisible}
-                    key={link}
-                    link={link}
-                    preview={preview}
-                    mxEvent={mxEvent}
-                >
-                    {i === 0 ? (
-                        <AccessibleButton
-                            className="mx_LinkPreviewGroup_hide"
-                            onClick={onCancelClick}
-                            aria-label={_t("timeline|url_preview|close")}
-                        >
-                            <CloseIcon width="20px" height="20px" />
-                        </AccessibleButton>
-                    ) : undefined}
-                </LinkPreviewWidget>
-            ))}
-            {toggleButton}
-        </div>
+        !isScrolling && (
+            <div className="mx_LinkPreviewGroup">
+                {showPreviews.map(([link, preview], i) => (
+                    <LinkPreviewWidget
+                        mediaVisible={mediaVisible}
+                        key={link}
+                        link={link}
+                        preview={preview}
+                        mxEvent={mxEvent}
+                    >
+                        {i === 0 ? (
+                            <AccessibleButton
+                                className="mx_LinkPreviewGroup_hide"
+                                onClick={onCancelClick}
+                                aria-label={_t("timeline|url_preview|close")}
+                            >
+                                <CloseIcon width="20px" height="20px" />
+                            </AccessibleButton>
+                        ) : undefined}
+                    </LinkPreviewWidget>
+                ))}
+                {toggleButton}
+            </div>
+        )
     );
 };
 

--- a/src/events/EventTileFactory.tsx
+++ b/src/events/EventTileFactory.tsx
@@ -60,6 +60,7 @@ export interface EventTileTypeProps
         | "callEventGrouper"
         | "isSeeingThroughMessageHiddenForModeration"
         | "inhibitInteraction"
+        | "isScrolling"
     > {
     ref?: React.RefObject<any>; // `any` because it's effectively impossible to convince TS of a reasonable type
     timestamp?: JSX.Element;
@@ -278,6 +279,7 @@ export function renderTile(
         isSeeingThroughMessageHiddenForModeration,
         timestamp,
         inhibitInteraction,
+        isScrolling,
     } = props;
 
     switch (renderType) {
@@ -313,6 +315,7 @@ export function renderTile(
                 isSeeingThroughMessageHiddenForModeration,
                 timestamp,
                 inhibitInteraction,
+                isScrolling,
             });
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3720,15 +3720,16 @@
     classnames "^2.5.1"
     vaul "^1.0.0"
 
-"@vector-im/matrix-wysiwyg-wasm@link:../../../.cache/yarn/v6/npm-@vector-im-matrix-wysiwyg-2.38.3-cc54d8b3e9472bcd8e622126ba364ee31952cd8a-integrity/node_modules/bindings/wysiwyg-wasm":
+"@vector-im/matrix-wysiwyg-wasm@link:../../Library/Caches/Yarn/v6/npm-@vector-im-matrix-wysiwyg-2.38.3-cc54d8b3e9472bcd8e622126ba364ee31952cd8a-integrity/node_modules/bindings/wysiwyg-wasm":
   version "0.0.0"
+  uid ""
 
 "@vector-im/matrix-wysiwyg@2.38.3":
   version "2.38.3"
   resolved "https://registry.yarnpkg.com/@vector-im/matrix-wysiwyg/-/matrix-wysiwyg-2.38.3.tgz#cc54d8b3e9472bcd8e622126ba364ee31952cd8a"
   integrity sha512-fqo8P55Vc/t0vxpFar9RDJN5gKEjJmzrLo+O4piDbFda6VrRoqrWAtiu0Au0g6B4hRDPKIuFupk8v9Ja7q8Hvg==
   dependencies:
-    "@vector-im/matrix-wysiwyg-wasm" "link:../../../.cache/yarn/v6/npm-@vector-im-matrix-wysiwyg-2.38.3-cc54d8b3e9472bcd8e622126ba364ee31952cd8a-integrity/node_modules/bindings/wysiwyg-wasm"
+    "@vector-im/matrix-wysiwyg-wasm" "link:../../Library/Caches/Yarn/v6/npm-@vector-im-matrix-wysiwyg-2.38.3-cc54d8b3e9472bcd8e622126ba364ee31952cd8a-integrity/node_modules/bindings/wysiwyg-wasm"
 
 "@webassemblyjs/ast@1.14.1", "@webassemblyjs/ast@^1.14.1":
   version "1.14.1"
@@ -11059,6 +11060,11 @@ react-virtualized@^9.22.5:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-lifecycles-compat "^3.0.4"
+
+react-virtuoso@^4.12.7:
+  version "4.12.7"
+  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-4.12.7.tgz#300f2585c61d213d4d422420f0d43ffc9674e6f5"
+  integrity sha512-njJp764he6Fi1p89PUW0k2kbyWu9w/y+MwdxmwK2kvdwwzVDbz2c2wMj5xdSruBFVgFTsI7Z85hxZR7aSHBrbQ==
 
 react@^19.0.0:
   version "19.1.0"


### PR DESCRIPTION
## What's in this PR?
A POC to learn more about the feasibility of using [react-virtuoso](https://github.com/petyosi/react-virtuoso) for the timeline(whose use is looking promising for the simpler scrolling use cases of [member list](https://github.com/element-hq/element-web/pull/29869) and room list).

It support back pagination and crudely hide images for smooth scrolling, without the noticeable scoll jumps when you get to the top or bottom of each page.
If we use placeholders rather than hiding the images it would looks much less janky that in the video and you wouldn't get the existing scroll jump when scrolling stops the images pop in.

virtuoso supports:
- [aligning the items to the bottom](https://virtuoso.dev/virtuoso-api/interfaces/VirtuosoProps/#aligntobottom) when the viewport is not full
- [sticky bottom](https://virtuoso.dev/virtuoso-api/interfaces/VirtuosoProps/#followoutput) for smoothly scrolling new messages in to view when you are near the bottom of the timeline.
- Good apis for keyboard navigation(as we have already applied in the memberlist use case)
- Good scrollTo apis for jumping to specific messages, top, bottom
- Good scrolling performance(as seen in the memberlist use case)
- Decent [documentation](https://virtuoso.dev/) with and [lots of examples](https://virtuoso.dev/initial-index/)
- [Tests](https://github.com/petyosi/react-virtuoso/tree/master/packages/react-virtuoso/e2e) written in playwright, which might bode well for us writing timeline tests

## What does it look like?
1. Scrolling up with back pagination. You still need to wait for the data to load, will better caching that could be as smooth as going down though.
2. images disappear during scrolling
3. Scrolling down after the data is loaded is smoother and you can quickly get to any point in the timeline.
4. Images start to load in after a timeout

https://github.com/user-attachments/assets/e7e2a967-dce4-4715-bb76-573ac0ea7d0d



## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
