### PR TITLE
Remove old filter test

### DIFF
--- a/test/unit-tests/components/viewmodels/roomlist/RoomListViewModel-test.tsx
+++ b/test/unit-tests/components/viewmodels/roomlist/RoomListViewModel-test.tsx
@@ -238,27 +238,6 @@ describe("RoomListViewModel", () => {
         ];
 
         describe.each(testcases)("For secondary filter: %s", (secondaryFilterName, secondary, primaryFilterName) => {
-            it(`should unapply incompatible primary filter that is already active: ${primaryFilterName}`, () => {
-                const { fn } = mockAndCreateRooms();
-                const { result: vm } = renderHook(() => useRoomListViewModel());
-
-                // Apply the primary filter
-                const i = vm.current.primaryFilters.findIndex((f) => f.name === primaryFilterName);
-                act(() => {
-                    vm.current.primaryFilters[i].toggle();
-                });
-
-                // Apply the secondary filter
-                act(() => {
-                    vm.current.activateSecondaryFilter(secondary.secondary);
-                });
-
-                // RLS call should only include the secondary filter
-                expect(fn).toHaveBeenLastCalledWith([secondary.filterKey]);
-                // Primary filter should have been unapplied
-                expect(vm.current.primaryFilters[i].active).toEqual(false);
-            });
-
             it(`should hide incompatible primary filter: ${primaryFilterName}`, () => {
                 mockAndCreateRooms();
                 const { result: vm } = renderHook(() => useRoomListViewModel());


### PR DESCRIPTION
This wasn't testing what it thought it was testing because the primary filters aren't present at all after selecting a secondary filter that's not compatible with them, so it was just asserting that some other filter (which had the same index as the old one) was disabled. It breaks if the primary filters get reordered.

@MidhunSureshR says it should be removed, and I agree as it can't test the thing it claims to.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
