### PR TITLE
Remove the Apple site association for Element X PR

### DIFF
--- a/res/apple-app-site-association
+++ b/res/apple-app-site-association
@@ -5,8 +5,7 @@
         "appIDs": [
           "7J4U792NQT.im.vector.app",
           "7J4U792NQT.io.element.elementx",
-          "7J4U792NQT.io.element.elementx.nightly",
-          "7J4U792NQT.io.element.elementx.pr"
+          "7J4U792NQT.io.element.elementx.nightly"
         ],
         "components": [
           {
@@ -28,8 +27,7 @@
     "apps": [
       "7J4U792NQT.im.vector.app",
       "7J4U792NQT.io.element.elementx",
-      "7J4U792NQT.io.element.elementx.nightly",
-      "7J4U792NQT.io.element.elementx.pr"
+      "7J4U792NQT.io.element.elementx.nightly"
     ]
   }
 }


### PR DESCRIPTION
This was an old app variant that we've now deleted in favour of making custom TestFlight builds.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
