### PR TITLE
Close call options popup menu when option has been selected

### DIFF
--- a/src/components/views/rooms/RoomHeader/RoomHeader.tsx
+++ b/src/components/views/rooms/RoomHeader/RoomHeader.tsx
@@ -178,7 +178,10 @@ export default function RoomHeader({
                                 aria-label={label}
                                 children={children}
                                 className="mx_RoomHeader_videoCallOption"
-                                onClick={(ev) => videoCallClick(ev, option)}
+                                onClick={(ev) => {
+                                    setMenuOpen(false);
+                                    videoCallClick(ev, option);
+                                }}
                                 Icon={VideoCallIcon}
                                 onSelect={() => {} /* Dummy handler since we want the click event.*/}
                             />


### PR DESCRIPTION
To avoid locking the user into the popup due to focus lock clash

Fixes #29985
