### PR TITLE
Fix flaky OIDC test by matching text exactly

### DIFF
--- a/playwright/e2e/oidc/oidc-native.spec.ts
+++ b/playwright/e2e/oidc/oidc-native.spec.ts
@@ -55,7 +55,7 @@ test.describe("OIDC Native", { tag: ["@no-firefox", "@no-webkit"] }, () => {
         const newPage = await newPagePromise;
         await newPage.getByText("Devices").click();
         await newPage.getByText(deviceId).click();
-        await expect(newPage.getByText("Element")).toBeVisible();
+        await expect(newPage.getByText("Element", { exact: true })).toBeVisible();
         await expect(newPage.getByText("http://localhost:8080/")).toBeVisible();
         await expect(newPage).toHaveURL(/\/oauth2_session/);
         await newPage.close();


### PR DESCRIPTION
```
Error: expect.toBeVisible: Error: strict mode violation: getByText('Element') resolved to 2 elements:
    1) <h3 class="_typography_6v6n8_153 _font-heading-md-semibold_6v6n8_112">…</h3> aka getByRole('heading', { name: 'Element: Chrome for Windows' })
    2) <p class="_typography_6v6n8_153 _font-body-md-regular_6v6n8_50 text-ellipsis overflow-hidden">…</p> aka getByText('Element', { exact: true })
```

The devices section in OIDC frontend has changed to include a heading
with the device name. The device name and the client name both contain
"Element", so playwright fails.