### PR TITLE
Add sanity checks to prevent users from ignoring themselves

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -1783,6 +1783,9 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             return;
         }
         try {
+            this.setState({
+                rejecting: true,
+            });
             await this.context.client.leave(this.state.room.roomId);
             defaultDispatcher.dispatch({ action: Action.ViewHomePage });
             this.setState({

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1957,6 +1957,7 @@
         },
         "face_pile_tooltip_shortcut": "Including %(commaSeparatedMembers)s",
         "face_pile_tooltip_shortcut_joined": "Including you, %(commaSeparatedMembers)s",
+        "failed_determine_user": "Cannot determine which user to ignore since the member event has changed.",
         "failed_reject_invite": "Failed to reject invite",
         "forget_room": "Forget this room",
         "forget_space": "Forget this space",

--- a/test/unit-tests/components/structures/__snapshots__/RoomView-test.tsx.snap
+++ b/test/unit-tests/components/structures/__snapshots__/RoomView-test.tsx.snap
@@ -1363,7 +1363,7 @@ exports[`RoomView should not display the timeline when the room encryption is lo
             aria-label="Open room settings"
             aria-live="off"
             class="_avatar_1qbcf_8 mx_BaseAvatar _avatar-imageless_1qbcf_52"
-            data-color="4"
+            data-color="5"
             data-testid="avatar-img"
             data-type="round"
             role="button"
@@ -1390,7 +1390,7 @@ exports[`RoomView should not display the timeline when the room encryption is lo
                 <span
                   class="mx_RoomHeader_truncated mx_lineClamp"
                 >
-                  !11:example.org
+                  !12:example.org
                 </span>
               </div>
             </div>
@@ -1571,7 +1571,7 @@ exports[`RoomView should not display the timeline when the room encryption is lo
             aria-label="Open room settings"
             aria-live="off"
             class="_avatar_1qbcf_8 mx_BaseAvatar _avatar-imageless_1qbcf_52"
-            data-color="4"
+            data-color="5"
             data-testid="avatar-img"
             data-type="round"
             role="button"
@@ -1598,7 +1598,7 @@ exports[`RoomView should not display the timeline when the room encryption is lo
                 <span
                   class="mx_RoomHeader_truncated mx_lineClamp"
                 >
-                  !11:example.org
+                  !12:example.org
                 </span>
               </div>
             </div>
@@ -1952,7 +1952,7 @@ exports[`RoomView video rooms should render joined video room view 1`] = `
             aria-label="Open room settings"
             aria-live="off"
             class="_avatar_1qbcf_8 mx_BaseAvatar _avatar-imageless_1qbcf_52"
-            data-color="3"
+            data-color="4"
             data-testid="avatar-img"
             data-type="round"
             role="button"
@@ -1979,7 +1979,7 @@ exports[`RoomView video rooms should render joined video room view 1`] = `
                 <span
                   class="mx_RoomHeader_truncated mx_lineClamp"
                 >
-                  !16:example.org
+                  !17:example.org
                 </span>
               </div>
             </div>


### PR DESCRIPTION
For https://github.com/element-hq/element-web/issues/29969

- It's not clear to me how the membership event could change without the UI changing but nevertheless this PR adds an explicit check to ensure that users don't ignore themselves. 
- `onDeclineButtonClicked` should set `rejecting` state to true so that the UI reflects an ongoing decline.