### PR TITLE
Handle errors returned from Seshat

### DIFF
--- a/src/vector/platform/IPCManager.ts
+++ b/src/vector/platform/IPCManager.ts
@@ -11,7 +11,7 @@ import { type ElectronChannel } from "../../@types/global";
 
 interface IPCPayload {
     id?: number;
-    error?: string;
+    error?: string | { message: string };
     reply?: any;
 }
 
@@ -53,7 +53,12 @@ export class IPCManager {
         const callbacks = this.pendingIpcCalls[payload.id];
         delete this.pendingIpcCalls[payload.id];
         if (payload.error) {
-            callbacks.reject(payload.error);
+            // `seshat.ts` sends a JavaScript object with a `message` property. Turn it into a proper Error.
+            let error = payload.error;
+            if ((error as any).message) {
+                error = new Error((error as any).message);
+            }
+            callbacks.reject(error);
         } else {
             callbacks.resolve(payload.reply);
         }


### PR DESCRIPTION
Fix a bug which caused errors from Seshat to be swallowed, giving only "Unknown error".

Related: https://github.com/element-hq/element-desktop/issues/1609