### PR TITLE
Spacestore should emit event after rebuilding home space

### DIFF
--- a/src/stores/spaces/SpaceStore.ts
+++ b/src/stores/spaces/SpaceStore.ts
@@ -1302,11 +1302,11 @@ export class SpaceStoreClass extends AsyncStoreWithClient<EmptyObject> {
                         const newValue = SettingsStore.getValue("Spaces.allRoomsInHome");
                         if (this.allRoomsInHome !== newValue) {
                             this._allRoomsInHome = newValue;
-                            this.emit(UPDATE_HOME_BEHAVIOUR, this.allRoomsInHome);
                             if (this.enabledMetaSpaces.includes(MetaSpace.Home)) {
                                 this.rebuildHomeSpace();
                             }
                             this.sendUserProperties();
+                            this.emit(UPDATE_HOME_BEHAVIOUR, this.allRoomsInHome);
                         }
                         break;
                     }


### PR DESCRIPTION
Otherwise the list of rooms shown in the home space will be incorrect.