### PR TITLE
Use correct translation for content protection in settings file

### DIFF
--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2844,6 +2844,7 @@
             "composer_heading": "Composer",
             "default_timezone": "Browser default (%(timezone)s)",
             "dialog_title": "<strong>Settings:</strong> Preferences",
+            "enable_content_protection": "Enable content protection",
             "enable_hardware_acceleration": "Enable hardware acceleration",
             "enable_tray_icon": "Show tray icon and minimise window to it on close",
             "keyboard_heading": "Keyboard shortcuts",

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -1394,7 +1394,7 @@ export const SETTINGS: Settings = {
     },
     "Electron.enableContentProtection": {
         supportedLevels: [SettingLevel.PLATFORM],
-        displayName: _td("settings|preferences|enable_hardware_acceleration"),
+        displayName: _td("settings|preferences|enable_content_protection"),
         default: false,
     },
     "Developer.elementCallUrl": {


### PR DESCRIPTION
The translation is overrided so the user doesn't see this error. 

Overrided in:
https://github.com/element-hq/element-web/blob/a333856c50a0f96aafaee5f18027bff6824713bc/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx#L362-L367
