### PR TITLE
babel.config.js: support browsers Firefox ESR and Icecat

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -7,6 +7,8 @@ module.exports = {
                 targets: [
                     "last 2 Chrome versions",
                     "last 2 Firefox versions",
+                    "Firefox ESR", // latest extended support release
+                    "Firefox 115", // required for icecat
                     "last 2 Safari versions",
                     "last 2 Edge versions",
                 ],


### PR DESCRIPTION
Icecat is the default browser on Guix but still on FF 115, so polyfills are missing when only using the latest two FF versions.

The polyfill for Promise.withResolvers is missing, breaking app.element.io on Icecat.

FF ESR is often several versions behind the latest Firefox but is the official stable version.

According to Mozilla,¹ 8.8% of Firefox users use version 115.

According to statscounter,² 4.64% of desktop users use Chrome 109 or 112.

I see both as a far too big group to exclude, especially since supporting them just requires keeping the old browsers in the browserlist.

¹ https://firefoxgraphics.github.io/telemetry/ 
² https://gs.statcounter.com/browser-version-market-share/desktop/worldwide/#monthly-202505-202506-bar

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] ~~Tests written for new code (and old code if feasible).~~ not applicable to config change
- [X] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass. (don’t know: they decline to run without CLA)
- [ ] ~~I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)~~ trivial change, does not reach the bar of copyrightablility. My Employers copyright waiver only covers free software projects.
