### PR TITLE
fix typo in comment and reinstate logging of variables

### DIFF
--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -406,9 +406,15 @@ export default class DeviceListener {
                 }
             } else {
                 // If we get here, then we are verified, have key backup, and
-                // 4S, but crypto.isCrossSigningReady returned false, which
+                // 4S, but crypto.isSecretStorageReady returned false, which
                 // means that 4S doesn't have all the secrets.
-                logSpan.warn("4S is missing secrets");
+                logSpan.warn("4S is missing secrets", {
+                    crossSigningReady,
+                    secretStorageReady,
+                    allCrossSigningSecretsCached,
+                    isCurrentDeviceTrusted,
+                    defaultKeyId,
+                });
                 showSetupEncryptionToast(SetupKind.KEY_STORAGE_OUT_OF_SYNC_STORE);
             }
         } else {


### PR DESCRIPTION
Follow-up to https://github.com/element-hq/element-web/pull/30230: the comment referenced the wrong function, and Rich asked to re-add the logging.