### PR TITLE
Fix transparent verification checkmark in dark mode

### DIFF
--- a/res/css/views/rooms/_E2EIcon.pcss
+++ b/res/css/views/rooms/_E2EIcon.pcss
@@ -59,3 +59,8 @@ Please see LICENSE files in the repository root for full details.
     mask-image: url("$(res)/img/e2e/verified.svg");
     background-color: $e2e-verified-color;
 }
+
+.mx_E2EIcon_verified .mx_E2EIcon_normal::after {
+    mask-size: 90%;
+    background-color: white;
+}

--- a/src/components/views/rooms/E2EIcon.tsx
+++ b/src/components/views/rooms/E2EIcon.tsx
@@ -76,7 +76,11 @@ const E2EIcon: React.FC<Props> = ({
     if (onClick) {
         content = <AccessibleButton onClick={onClick} className={classes} style={style} />;
     } else {
-        content = <div className={classes} style={style} />;
+        if (status === E2EStatus.Verified) {
+            content = <div className={classes} style={style}><div className="mx_E2EIcon_normal" /></div>;
+        } else {
+            content = <div className={classes} style={style} />;
+        }
     }
 
     if (!e2eTitle || hideTooltip) {

--- a/test/unit-tests/components/structures/__snapshots__/RoomView-test.tsx.snap
+++ b/test/unit-tests/components/structures/__snapshots__/RoomView-test.tsx.snap
@@ -1809,7 +1809,11 @@ exports[`RoomView should not display the timeline when the room encryption is lo
                   <div
                     aria-labelledby="«r3e»"
                     class="mx_E2EIcon mx_E2EIcon_verified mx_MessageComposer_e2eIcon"
-                  />
+                  >
+                    <div
+                      class="mx_E2EIcon_normal"
+                    />
+                  </div>
                 </span>
               </div>
               <div


### PR DESCRIPTION
fixes element-hq/element-web#28285

What did I change?
I added a white version of the verification shield as a background to the verification symbol (checkmark) when authenticating a new web-device with another device.

Before:
![Checkmark_before](https://github.com/user-attachments/assets/39fb4a29-7c6c-41f0-a9b5-ab883525e8e8)

After:
![Checkmark_after](https://github.com/user-attachments/assets/33afcdb5-d6cf-4ed3-a45a-1c5eea09e386)

Why did I change it?
The checkmark in the verification icon was transparent, which lead to a black checkmark in darkmode, while the corresponding checkmark in the other device was white. (See issue description.)
Now it is also shown as a white checkmark.

Testing:
- Log into account
- Turn on dark mode
- Verify session with external device
