### PR TITLE
Widgets: Use the new `ClientEvent.ReceivedToDeviceMessage` instead of `ToDeviceEvent`

### DIFF
--- a/test/unit-tests/stores/widgets/StopGapWidget-test.ts
+++ b/test/unit-tests/stores/widgets/StopGapWidget-test.ts
@@ -83,16 +83,42 @@ describe("StopGapWidget", () => {
     });
 
     it("feeds incoming to-device messages to the widget", async () => {
-        const event = mkEvent({
-            event: true,
-            type: "org.example.foo",
-            user: "@alice:example.org",
-            content: { hello: "world" },
-        });
+        const receivedToDevice = {
+            message: {
+                type: "org.example.foo",
+                sender: "@alice:example.org",
+                content: {
+                    hello: "world",
+                },
+            },
+            encryptionInfo: null,
+        };
 
-        client.emit(ClientEvent.ToDeviceEvent, event);
+        client.emit(ClientEvent.ReceivedToDeviceMessage, receivedToDevice);
         await Promise.resolve(); // flush promises
-        expect(messaging.feedToDevice).toHaveBeenCalledWith(event.getEffectiveEvent(), false);
+        expect(messaging.feedToDevice).toHaveBeenCalledWith(receivedToDevice.message, false);
+    });
+
+    it("feeds incoming encrypted to-device messages to the widget", async () => {
+        const receivedToDevice = {
+            message: {
+                type: "org.example.foo",
+                sender: "@alice:example.org",
+                content: {
+                    hello: "world",
+                },
+            },
+            encryptionInfo: {
+                senderVerified: false,
+                sender: "@alice:example.org",
+                senderCurve25519KeyBase64: "",
+                senderDevice: "ABCDEFGHI",
+            },
+        };
+
+        client.emit(ClientEvent.ReceivedToDeviceMessage, receivedToDevice);
+        await Promise.resolve(); // flush promises
+        expect(messaging.feedToDevice).toHaveBeenCalledWith(receivedToDevice.message, true);
     });
 
     it("feeds incoming state updates to the widget", () => {


### PR DESCRIPTION
Use the new `ClientEvent.ReceivedToDeviceMessage` introduced in https://github.com/matrix-org/matrix-js-sdk/pull/4891

This allow to see if a to-device was sent encrypted or not.


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
