### PR TITLE
Remember whether sidebar is shown for calls when switching rooms

### DIFF
--- a/src/LegacyCallHandler.tsx
+++ b/src/LegacyCallHandler.tsx
@@ -112,6 +112,7 @@ export enum LegacyCallHandlerEvent {
     CallsChanged = "calls_changed",
     CallChangeRoom = "call_change_room",
     SilencedCallsChanged = "silenced_calls_changed",
+    ShownSidebarsChanged = "shown_sidebars_changed",
     CallState = "call_state",
     ProtocolSupport = "protocol_support",
 }
@@ -120,6 +121,7 @@ type EventEmitterMap = {
     [LegacyCallHandlerEvent.CallsChanged]: (calls: Map<string, MatrixCall>) => void;
     [LegacyCallHandlerEvent.CallChangeRoom]: (call: MatrixCall) => void;
     [LegacyCallHandlerEvent.SilencedCallsChanged]: (calls: Set<string>) => void;
+    [LegacyCallHandlerEvent.ShownSidebarsChanged]: (sidebarsShown: Map<string, boolean>) => void;
     [LegacyCallHandlerEvent.CallState]: (mappedRoomId: string | null, status: CallState) => void;
     [LegacyCallHandlerEvent.ProtocolSupport]: () => void;
 };
@@ -143,6 +145,8 @@ export default class LegacyCallHandler extends TypedEventEmitter<LegacyCallHandl
     private assertedIdentityNativeUsers = new Map<string, string>();
 
     private silencedCalls = new Set<string>(); // callIds
+
+    private shownSidebars = new Map<string, boolean>(); // callId (call) -> sidebar show
 
     private backgroundAudio = new BackgroundAudio();
     private playingSources: Record<string, AudioBufferSourceNode> = {}; // Record them for stopping
@@ -238,6 +242,15 @@ export default class LegacyCallHandler extends TypedEventEmitter<LegacyCallHandl
             }
         }
         return false;
+    }
+
+    public setCallSidebarShown(callId: string, sidebarShown: boolean): void {
+        this.shownSidebars.set(callId, sidebarShown);
+        this.emit(LegacyCallHandlerEvent.ShownSidebarsChanged, this.shownSidebars);
+    }
+
+    public isCallSidebarShown(callId?: string): boolean {
+        return (!!callId && (this.shownSidebars.get(callId) ?? true));
     }
 
     private async checkProtocols(maxTries: number): Promise<void> {

--- a/src/components/structures/PipContainer.tsx
+++ b/src/components/structures/PipContainer.tsx
@@ -245,6 +245,7 @@ class PipContainerInner extends React.Component<IProps, IState> {
                     secondaryCall={this.state.secondaryCall}
                     pipMode={pipMode}
                     onResize={onResize}
+                    sidebarShown={false}
                 />
             ));
         }

--- a/src/components/views/voip/LegacyCallView.tsx
+++ b/src/components/views/voip/LegacyCallView.tsx
@@ -50,6 +50,10 @@ interface IProps {
     onMouseDownOnHeader?: (event: React.MouseEvent<Element, MouseEvent>) => void;
 
     showApps?: boolean;
+
+    sidebarShown: boolean;
+
+    setSidebarShown?: (sidebarShown: boolean) => void;
 }
 
 interface IState {
@@ -62,7 +66,6 @@ interface IState {
     primaryFeed?: CallFeed;
     secondaryFeed?: CallFeed;
     sidebarFeeds: Array<CallFeed>;
-    sidebarShown: boolean;
 }
 
 function getFullScreenElement(): Element | null {
@@ -97,7 +100,6 @@ export default class LegacyCallView extends React.Component<IProps, IState> {
             primaryFeed: primary,
             secondaryFeed: secondary,
             sidebarFeeds: sidebar,
-            sidebarShown: true,
         };
     }
 
@@ -269,8 +271,9 @@ export default class LegacyCallView extends React.Component<IProps, IState> {
             isScreensharing = await this.props.call.setScreensharingEnabled(true);
         }
 
+        this.props.setSidebarShown?.(true);
+
         this.setState({
-            sidebarShown: true,
             screensharing: isScreensharing,
         });
     };
@@ -320,12 +323,12 @@ export default class LegacyCallView extends React.Component<IProps, IState> {
     };
 
     private onToggleSidebar = (): void => {
-        this.setState({ sidebarShown: !this.state.sidebarShown });
+        this.props.setSidebarShown?.(!this.props.sidebarShown);
     };
 
     private renderCallControls(): JSX.Element {
-        const { call, pipMode } = this.props;
-        const { callState, micMuted, vidMuted, screensharing, sidebarShown, secondaryFeed, sidebarFeeds } = this.state;
+        const { call, pipMode, sidebarShown } = this.props;
+        const { callState, micMuted, vidMuted, screensharing, secondaryFeed, sidebarFeeds } = this.state;
 
         // If SDPStreamMetadata isn't supported don't show video mute button in voice calls
         const vidMuteButtonShown = call.opponentSupportsSDPStreamMetadata() || call.hasLocalUserMediaVideoTrack;
@@ -372,7 +375,7 @@ export default class LegacyCallView extends React.Component<IProps, IState> {
     }
 
     private renderToast(): JSX.Element | null {
-        const { call } = this.props;
+        const { call, sidebarShown } = this.props;
         const someoneIsScreensharing = call.getFeeds().some((feed) => {
             return feed.purpose === SDPStreamMetadataPurpose.Screenshare;
         });
@@ -380,7 +383,7 @@ export default class LegacyCallView extends React.Component<IProps, IState> {
         if (!someoneIsScreensharing) return null;
 
         const isScreensharing = call.isScreensharing();
-        const { primaryFeed, sidebarShown } = this.state;
+        const { primaryFeed } = this.state;
         const sharerName = primaryFeed?.getMember()?.name;
         if (!sharerName) return null;
 
@@ -393,8 +396,8 @@ export default class LegacyCallView extends React.Component<IProps, IState> {
     }
 
     private renderContent(): JSX.Element {
-        const { pipMode, call, onResize } = this.props;
-        const { isLocalOnHold, isRemoteOnHold, sidebarShown, primaryFeed, secondaryFeed, sidebarFeeds } = this.state;
+        const { pipMode, call, onResize, sidebarShown } = this.props;
+        const { isLocalOnHold, isRemoteOnHold, primaryFeed, secondaryFeed, sidebarFeeds } = this.state;
 
         const callRoomId = LegacyCallHandler.instance.roomIdForCall(call);
         const callRoom = (callRoomId ? MatrixClientPeg.safeGet().getRoom(callRoomId) : undefined) ?? undefined;
@@ -537,8 +540,8 @@ export default class LegacyCallView extends React.Component<IProps, IState> {
     }
 
     public render(): React.ReactNode {
-        const { call, secondaryCall, pipMode, showApps, onMouseDownOnHeader } = this.props;
-        const { sidebarShown, sidebarFeeds } = this.state;
+        const { call, secondaryCall, pipMode, showApps, onMouseDownOnHeader, sidebarShown } = this.props;
+        const { sidebarFeeds } = this.state;
 
         const client = MatrixClientPeg.safeGet();
         const callRoomId = LegacyCallHandler.instance.roomIdForCall(call);

--- a/src/components/views/voip/LegacyCallViewForRoom.tsx
+++ b/src/components/views/voip/LegacyCallViewForRoom.tsx
@@ -25,6 +25,7 @@ interface IProps {
 
 interface IState {
     call: MatrixCall | null;
+    sidebarShown: boolean;
 }
 
 /*
@@ -36,23 +37,30 @@ export default class LegacyCallViewForRoom extends React.Component<IProps, IStat
         super(props);
         this.state = {
             call: this.getCall(),
+            sidebarShown: LegacyCallHandler.instance.isCallSidebarShown(this.props.roomId),
         };
     }
 
     public componentDidMount(): void {
         LegacyCallHandler.instance.addListener(LegacyCallHandlerEvent.CallState, this.updateCall);
         LegacyCallHandler.instance.addListener(LegacyCallHandlerEvent.CallChangeRoom, this.updateCall);
+        LegacyCallHandler.instance.addListener(LegacyCallHandlerEvent.ShownSidebarsChanged, this.updateCall);
     }
 
     public componentWillUnmount(): void {
         LegacyCallHandler.instance.removeListener(LegacyCallHandlerEvent.CallState, this.updateCall);
         LegacyCallHandler.instance.removeListener(LegacyCallHandlerEvent.CallChangeRoom, this.updateCall);
+        LegacyCallHandler.instance.removeListener(LegacyCallHandlerEvent.ShownSidebarsChanged, this.updateCall);
     }
 
     private updateCall = (): void => {
         const newCall = this.getCall();
         if (newCall !== this.state.call) {
             this.setState({ call: newCall });
+        }
+        const newSidebarShown = LegacyCallHandler.instance.isCallSidebarShown(this.props.roomId);
+        if (newSidebarShown !== this.state.sidebarShown) {
+            this.setState({ sidebarShown: newSidebarShown });
         }
     };
 
@@ -73,6 +81,10 @@ export default class LegacyCallViewForRoom extends React.Component<IProps, IStat
 
     private onResizeStop = (): void => {
         this.props.resizeNotifier.stopResizing();
+    };
+
+    private setSidebarShown = (sidebarShown: boolean): void => {
+        LegacyCallHandler.instance.setCallSidebarShown(this.props.roomId, sidebarShown);
     };
 
     public render(): React.ReactNode {
@@ -99,7 +111,7 @@ export default class LegacyCallViewForRoom extends React.Component<IProps, IStat
                     className="mx_LegacyCallViewForRoom_ResizeWrapper"
                     handleClasses={{ bottom: "mx_LegacyCallViewForRoom_ResizeHandle" }}
                 >
-                    <LegacyCallView call={this.state.call} pipMode={false} showApps={this.props.showApps} />
+                    <LegacyCallView call={this.state.call} pipMode={false} showApps={this.props.showApps} sidebarShown={this.state.sidebarShown} setSidebarShown={this.setSidebarShown}/>
                 </Resizable>
             </div>
         );

--- a/test/unit-tests/components/views/voip/LegacyCallView-test.tsx
+++ b/test/unit-tests/components/views/voip/LegacyCallView-test.tsx
@@ -32,7 +32,7 @@ describe("LegacyCallView", () => {
             isScreensharing: jest.fn().mockReturnValue(false),
         } as unknown as MatrixCall;
 
-        const { unmount } = render(<LegacyCallView call={call} />);
+        const { unmount } = render(<LegacyCallView call={call} sidebarShown={false} />);
         expect(document.exitFullscreen).not.toHaveBeenCalled();
         unmount();
         expect(document.exitFullscreen).toHaveBeenCalled();


### PR DESCRIPTION
Stores the sidebar state per-room in LegacyCallHandler, along with other details about calls.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
