### PR TITLE
Fix: Prevent page refresh on Enter key in right panel member search

### DIFF
--- a/src/components/views/rooms/MemberList/MemberListView.tsx
+++ b/src/components/views/rooms/MemberList/MemberListView.tsx
@@ -95,7 +95,7 @@ const MemberListView: React.FC<IProps> = (props: IProps) => {
                         className="mx_MemberListView_container"
                         onKeyDown={onKeyDownHandler}
                     >
-                        <Form.Root>
+                        <Form.Root onSubmit={(e) => e.preventDefault()}>
                             <MemberListHeaderView vm={vm} />
                         </Form.Root>
                         <AutoSizer>

--- a/test/unit-tests/components/views/rooms/memberlist/MemberListView-test.tsx
+++ b/test/unit-tests/components/views/rooms/memberlist/MemberListView-test.tsx
@@ -8,7 +8,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { act } from "react";
-import { waitFor } from "jest-matrix-react";
+import { waitFor, fireEvent } from "jest-matrix-react";
 import { type Room, type RoomMember, MatrixEvent } from "matrix-js-sdk/src/matrix";
 import { type JSX } from "react";
 
@@ -153,6 +153,16 @@ describe("MemberListView and MemberlistHeaderView", () => {
             await waitFor(() => {
                 expect(root.container.querySelector(".mx_PresenceIconView_unavailable")).not.toBeNull();
             });
+        });
+
+        it("should prevent default form submission", async () => {
+            const { root } = rendered;
+            const form = root.container.querySelector("form");
+            expect(form).not.toBeNull();
+            const submitEvent = new Event("submit", { bubbles: true, cancelable: true });
+            const preventDefaultSpy = jest.spyOn(submitEvent, "preventDefault");
+            fireEvent(form!, submitEvent);
+            expect(preventDefaultSpy).toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
Notes: Fix a bug (#30253) where pressing Enter in the right panel member search would refresh the page.

Fixes #30253 

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
