### PR TITLE
Update custom component logic to always return a hint.

### DIFF
--- a/src/components/views/elements/ImageView.tsx
+++ b/src/components/views/elements/ImageView.tsx
@@ -607,20 +607,18 @@ function DownloadButton({
             return;
         }
         const hints = ModuleApi.customComponents.getHintsForMessage(mxEvent);
-        if (hints?.allowDownloadingMedia) {
-            // Disable downloading as soon as we know there is a hint.
-            setCanDownload(false);
-            hints
-                .allowDownloadingMedia()
-                .then((downloadable) => {
-                    setCanDownload(downloadable);
-                })
-                .catch((ex) => {
-                    logger.error(`Failed to check if media from ${mxEvent.getId()} could be downloaded`, ex);
-                    // Err on the side of safety.
-                    setCanDownload(false);
-                });
-        }
+        // Disable downloading as soon as we know there is a hint.
+        setCanDownload(false);
+        hints
+            .allowDownloadingMedia()
+            .then((downloadable) => {
+                setCanDownload(downloadable);
+            })
+            .catch((ex) => {
+                logger.error(`Failed to check if media from ${mxEvent.getId()} could be downloaded`, ex);
+                // Err on the side of safety.
+                setCanDownload(false);
+            });
     }, [mxEvent]);
 
     function showError(e: unknown): void {

--- a/src/components/views/elements/ImageView.tsx
+++ b/src/components/views/elements/ImageView.tsx
@@ -606,19 +606,24 @@ function DownloadButton({
             setCanDownload(true);
             return;
         }
+        // Get the hint. If the hint is static then we can immediately set it,
+        // otherwise set to false until the promise completes.
         const hints = ModuleApi.customComponents.getHintsForMessage(mxEvent);
-        // Disable downloading as soon as we know there is a hint.
-        setCanDownload(false);
-        hints
-            .allowDownloadingMedia()
-            .then((downloadable) => {
-                setCanDownload(downloadable);
-            })
-            .catch((ex) => {
-                logger.error(`Failed to check if media from ${mxEvent.getId()} could be downloaded`, ex);
-                // Err on the side of safety.
-                setCanDownload(false);
-            });
+        if (typeof hints.allowDownloadingMedia === "boolean") {
+            setCanDownload(hints.allowDownloadingMedia);
+        } else {
+            setCanDownload(false);
+            hints
+                .allowDownloadingMedia()
+                .then((downloadable) => {
+                    setCanDownload(downloadable);
+                })
+                .catch((ex) => {
+                    logger.error(`Failed to check if media from ${mxEvent.getId()} could be downloaded`, ex);
+                    // Err on the side of safety.
+                    setCanDownload(false);
+                });
+        }
     }, [mxEvent]);
 
     function showError(e: unknown): void {

--- a/src/components/views/messages/DownloadActionButton.tsx
+++ b/src/components/views/messages/DownloadActionButton.tsx
@@ -44,23 +44,20 @@ export default class DownloadActionButton extends React.PureComponent<IProps, IS
         super(props);
 
         const moduleHints = ModuleApi.customComponents.getHintsForMessage(props.mxEvent);
-        const downloadState: Pick<IState, "canDownload"> = { canDownload: true };
-        if (moduleHints?.allowDownloadingMedia) {
-            downloadState.canDownload = null;
-            moduleHints
-                .allowDownloadingMedia()
-                .then((canDownload) => {
-                    this.setState({
-                        canDownload: canDownload,
-                    });
-                })
-                .catch((ex) => {
-                    logger.error(`Failed to check if media from ${props.mxEvent.getId()} could be downloaded`, ex);
-                    this.setState({
-                        canDownload: false,
-                    });
+        const downloadState: Pick<IState, "canDownload"> = { canDownload: null };
+        moduleHints
+            .allowDownloadingMedia()
+            .then((canDownload) => {
+                this.setState({
+                    canDownload,
                 });
-        }
+            })
+            .catch((ex) => {
+                logger.error(`Failed to check if media from ${props.mxEvent.getId()} could be downloaded`, ex);
+                this.setState({
+                    canDownload: false,
+                });
+            });
 
         this.state = {
             loading: false,

--- a/src/events/EventTileFactory.tsx
+++ b/src/events/EventTileFactory.tsx
@@ -427,9 +427,7 @@ export function haveRendererForEvent(
         return false;
     }
 
-    // Check to see if we have any hints for this message, which indicates
-    // there is a custom renderer for the event.
-    if (ModuleApi.customComponents.getHintsForMessage(mxEvent)) {
+    if (ModuleApi.customComponents.hasRendererForEvent(mxEvent)) {
         return true;
     }
 

--- a/src/modules/customComponentApi.ts
+++ b/src/modules/customComponentApi.ts
@@ -31,13 +31,13 @@ interface CustomMessageComponentProps extends Omit<ModuleCustomMessageComponentP
 }
 
 interface CustomMessageRenderHints extends Omit<ModuleCustomCustomMessageRenderHints, "allowDownloadingMedia"> {
-    // Note. This just makes it easier to use this API on Element Web as we already have the moduleized event stored.
-    allowDownloadingMedia?: () => Promise<boolean>;
+    // Note. This just makes it easier to use this API on Element Web as we already have the modularized event stored.
+    allowDownloadingMedia?: (() => Promise<boolean>) | boolean;
 }
 
 const DEFAULT_HINTS: Required<CustomMessageRenderHints> = {
     allowEditingEvent: true,
-    allowDownloadingMedia: () => Promise.resolve(true),
+    allowDownloadingMedia: true,
 };
 
 export class CustomComponentsApi implements ICustomComponentsApi {


### PR DESCRIPTION
Successor to #30320 

This changes the modules custom components API to always the expected hints, filling in with defaults where a renderer does not provide expected values.

Needs playwright tests.

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
