### PR TITLE
Add a background color to left panel for macos titlebar in element desktop

### DIFF
--- a/res/css/structures/_LeftPanel.pcss
+++ b/res/css/structures/_LeftPanel.pcss
@@ -28,12 +28,6 @@ Please see LICENSE files in the repository root for full details.
     --collapsedWidth: 68px;
 }
 
-.mx_LeftPanel_newRoomList {
-    /* Thew new rooms list is not designed to be collapsed to just icons. */
-    /* 224 + 68(spaces bar) was deemed by design to be a good minimum for the left panel. */
-    --collapsedWidth: 224px;
-}
-
 .mx_LeftPanel_wrapper {
     display: flex;
     flex-direction: row;
@@ -245,4 +239,11 @@ Please see LICENSE files in the repository root for full details.
             }
         }
     }
+}
+
+.mx_LeftPanel_newRoomList {
+    /* Thew new rooms list is not designed to be collapsed to just icons. */
+    /* 224 + 68(spaces bar) was deemed by design to be a good minimum for the left panel. */
+    --collapsedWidth: 224px;
+    background-color: var(--cpd-color-bg-canvas-default);
 }


### PR DESCRIPTION
Add a background color to override the default left panel color of the old room list. This is needed for https://github.com/element-hq/element-desktop/pull/2446.

When we will delabse the new room list, we will able to clean all these background color overrides.