### PR TITLE
Force ED titlebar color for new room list

### DIFF
--- a/res/css/structures/_LeftPanel.pcss
+++ b/res/css/structures/_LeftPanel.pcss
@@ -245,5 +245,6 @@ Please see LICENSE files in the repository root for full details.
     /* Thew new rooms list is not designed to be collapsed to just icons. */
     /* 224 + 68(spaces bar) was deemed by design to be a good minimum for the left panel. */
     --collapsedWidth: 224px;
-    background-color: var(--cpd-color-bg-canvas-default);
+    /* Important to force the color on ED titlebar until we remove the old room list */
+    background-color: var(--cpd-color-bg-canvas-default) !important;
 }


### PR DESCRIPTION
https://github.com/element-hq/element-web/pull/30328 tries to fix the grey background on the titlebar on ED. Somehow the fix is working on ED in dev but doesn't work when built.

## The issue
<img width="350" height="85" alt="image" src="https://github.com/user-attachments/assets/bc1cddc7-f329-4ea0-9e6e-61541082bce0" />

