### PR TITLE
Disable flaky jest test: `<MatrixChat /> › Multi-tab lockout › waits for other tab to stop during startup`

### DIFF
--- a/test/unit-tests/components/structures/MatrixChat-test.tsx
+++ b/test/unit-tests/components/structures/MatrixChat-test.tsx
@@ -1603,7 +1603,8 @@ describe("<MatrixChat />", () => {
             Lifecycle.setSessionLockNotStolen();
         });
 
-        it("waits for other tab to stop during startup", async () => {
+        // Flaky test, see https://github.com/element-hq/element-web/issues/30337
+        it.skip("waits for other tab to stop during startup", async () => {
             fetchMock.get("/welcome.html", { body: "<h1>Hello</h1>" });
             jest.spyOn(Lifecycle, "attemptDelegatedAuthLogin");
 


### PR DESCRIPTION
- Can't reproduce locally
- Can't reproduce in the CI when only running this particular test file multiple times
- Can't reproduce in a test PR running all the tests though it still seems to flake in other unrelated PRs

When the test flakes, [a toast for unsupported browser](https://github.com/element-hq/element-web/blob/develop/src/SupportedBrowser.ts#L90) is shown. Further debugging would require having some tooling to output the stack trace of how the app reached that function. 

We can't spend any more time on this, so disabling this test for now.