### PR TITLE
Fix: Allow triple-click text selection to flow around pills

### DIFF
--- a/res/css/views/elements/_Pill.pcss
+++ b/res/css/views/elements/_Pill.pcss
@@ -11,7 +11,7 @@ Please see LICENSE files in the repository root for full details.
     line-height: $font-17px;
     border-radius: $font-16px;
     vertical-align: text-top;
-    display: inline-flex;
+    display: inline;
     align-items: center;
     box-sizing: border-box;
     max-width: 100%;
@@ -57,6 +57,8 @@ Please see LICENSE files in the repository root for full details.
         margin-inline-start: -0.3em; /* Otherwise the gap is too large */
         margin-inline-end: 0.2em;
         min-width: $font-16px; /* ensure the avatar is not compressed */
+        user-select: text;
+        vertical-align: -2.5px;
     }
 
     .mx_Pill_text {


### PR DESCRIPTION
Fixes #30296

Fixes an issue where triple clicking to select message text would stop at pills instead of selecting the entire line. 

**Changes made:**
- Changed `.mx_Pill` display from `inline-flex` to `inline` to allow proper text flow
- Added `user-select: text` to `.mx_BaseAvatar` to ensure avatars don't block selection
- Adjusted avatar vertical alignment with `vertical-align: -2.5px` to maintain visual consistency

### Before/After

**Before:** Triple clicking a message line would stop selection at pill boundaries
**After:** Triple clicking selects the entire message line as expected

### Testing Strategy

1. Find any message containing a pill (keyword pill, user pill, message pill, room pill, etc.)
2. Triple click on the message line
3. Verify that the entire line is selected, not just text up to the pill

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
