### PR TITLE
Storybook: add tooltip provider and sort stories

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,6 +6,7 @@ import "./preview.css";
 import React, { useLayoutEffect } from "react";
 import { FORCE_RE_RENDER } from "storybook/internal/core-events";
 import { setLanguage } from "../src/shared-components/i18n";
+import { TooltipProvider } from "@vector-im/compound-web";
 
 export const globalTypes = {
     theme: {
@@ -82,9 +83,17 @@ export const withLanguageProvider: Decorator = (Story, context) => {
     );
 };
 
+const withTooltipProvider: Decorator = (Story) => {
+    return (
+        <TooltipProvider>
+            <Story />
+        </TooltipProvider>
+    );
+};
+
 const preview: Preview = {
     tags: ["autodocs"],
-    decorators: [withThemeProvider, withLanguageProvider],
+    decorators: [withThemeProvider, withLanguageProvider, withTooltipProvider],
 };
 
 export default preview;

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -94,6 +94,13 @@ const withTooltipProvider: Decorator = (Story) => {
 const preview: Preview = {
     tags: ["autodocs"],
     decorators: [withThemeProvider, withLanguageProvider, withTooltipProvider],
+    parameters: {
+        options: {
+            storySort: {
+                method: "alphabetical",
+            },
+        },
+    },
 };
 
 export default preview;


### PR DESCRIPTION
This PR:
- Add the tooltip provider to the stories as a decorator
- Sort alphabetically the stories
