### PR TITLE
Allow for unknown event shield reasons

### DIFF
--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -729,11 +729,6 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
         if (this.state.shieldColour !== EventShieldColour.NONE) {
             let shieldReasonMessage: string;
             switch (this.state.shieldReason) {
-                case null:
-                case EventShieldReason.UNKNOWN:
-                    shieldReasonMessage = _t("error|unknown");
-                    break;
-
                 case EventShieldReason.UNVERIFIED_IDENTITY:
                     shieldReasonMessage = _t("encryption|event_shield_reason_unverified_identity");
                     break;
@@ -760,6 +755,10 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
 
                 case EventShieldReason.VERIFICATION_VIOLATION:
                     shieldReasonMessage = _t("timeline|decryption_failure|sender_identity_previously_verified");
+                    break;
+
+                default:
+                    shieldReasonMessage = _t("error|unknown");
                     break;
             }
 


### PR DESCRIPTION
A forthcoming change to the js-sdk will add a new event shield reason. To avoid a compile-time failure, add a `default` case to the code handling those reasons.