### PR TITLE
Shared component: move i18n.tsx into utils folder

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -5,7 +5,7 @@ import "../res/css/shared.pcss";
 import "./preview.css";
 import React, { useLayoutEffect } from "react";
 import { FORCE_RE_RENDER } from "storybook/internal/core-events";
-import { setLanguage } from "../src/shared-components/i18n";
+import { setLanguage } from "../src/shared-components/utils/i18n";
 import { TooltipProvider } from "@vector-im/compound-web";
 
 export const globalTypes = {

--- a/src/accessibility/KeyboardShortcuts.ts
+++ b/src/accessibility/KeyboardShortcuts.ts
@@ -9,7 +9,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 // Import i18n.tsx instead of languageHandler to avoid circular deps
-import { _td, type TranslationKey } from "../shared-components/i18n";
+import { _td, type TranslationKey } from "../shared-components/utils/i18n";
 import { IS_MAC, IS_ELECTRON, Key } from "../Keyboard";
 import { type IBaseSetting } from "../settings/Settings";
 import { type KeyCombo } from "../KeyBindingsManager";

--- a/src/languageHandler.tsx
+++ b/src/languageHandler.tsx
@@ -25,7 +25,7 @@ import {
     type IVariables,
     KEY_SEPARATOR,
     getLangsJson,
-} from "./shared-components/i18n";
+} from "./shared-components/utils/i18n";
 
 export {
     _t,
@@ -40,7 +40,7 @@ export {
     normalizeLanguageKey,
     getNormalizedLanguageKeys,
     substitute,
-} from "./shared-components/i18n";
+} from "./shared-components/utils/i18n";
 
 const i18nFolder = "i18n/";
 

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -12,7 +12,7 @@ import { UNSTABLE_MSC4133_EXTENDED_PROFILES } from "matrix-js-sdk/src/matrix";
 
 import { type MediaPreviewConfig } from "../@types/media_preview.ts";
 // Import i18n.tsx instead of languageHandler to avoid circular deps
-import { _t, _td, type TranslationKey } from "../shared-components/i18n";
+import { _t, _td, type TranslationKey } from "../shared-components/utils/i18n";
 import DeviceIsolationModeController from "./controllers/DeviceIsolationModeController.ts";
 import {
     NotificationBodyEnabledController,

--- a/src/shared-components/utils/i18n.tsx
+++ b/src/shared-components/utils/i18n.tsx
@@ -25,7 +25,7 @@ import React from "react";
 import { type TranslationKey as _TranslationKey, KEY_SEPARATOR } from "matrix-web-i18n";
 import counterpart from "counterpart";
 
-import type Translations from "../i18n/strings/en_EN.json";
+import type Translations from "../../i18n/strings/en_EN.json";
 
 // @ts-ignore - $webapp is a webpack resolve alias pointing to the output directory, see webpack config
 import webpackLangJsonUrl from "$webapp/i18n/languages.json";


### PR DESCRIPTION
With incoming other utils files, this PR moves the i18n into the utils folder to keep the root folder clean.
