### PR TITLE
Re-enable matrixchat test

### DIFF
--- a/test/unit-tests/components/structures/MatrixChat-test.tsx
+++ b/test/unit-tests/components/structures/MatrixChat-test.tsx
@@ -1604,7 +1604,7 @@ describe("<MatrixChat />", () => {
         });
 
         // Flaky test, see https://github.com/element-hq/element-web/issues/30337
-        it.skip("waits for other tab to stop during startup", async () => {
+        it("waits for other tab to stop during startup", async () => {
             fetchMock.get("/welcome.html", { body: "<h1>Hello</h1>" });
             jest.spyOn(Lifecycle, "attemptDelegatedAuthLogin");
 


### PR DESCRIPTION
Now that we have better logging for our tests (https://github.com/element-hq/element-web/pull/30405), I'd like to re-enable this test so we can try and understand what makes it fail.

related: https://github.com/element-hq/element-web/issues/30337