### PR TITLE
MVVM - Re-architecture view model

### DIFF
--- a/src/shared-components/ViewModel.ts
+++ b/src/shared-components/ViewModel.ts
@@ -21,3 +21,20 @@ export interface ViewModel<T> {
      */
     subscribe: (listener: () => void) => () => void;
 }
+
+/**
+ * The interface for a generic ViewModel passed to the shared components.
+ */
+export interface ViewModelNew {
+    /**
+     * Subscribes to changes in the view model.
+     * ViewModel will invoke the callback when the UI needs to be updated.
+     */
+    subscribe: (callback: () => void) => () => void;
+
+    /**
+     * React uses the return value of this method to determine if it needs to
+     * re-render the component.
+     */
+    getSnapshot: () => unknown;
+}

--- a/src/viewmodels/base/BaseViewModel.ts
+++ b/src/viewmodels/base/BaseViewModel.ts
@@ -1,0 +1,48 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import type { ViewModelNew } from "../../shared-components/ViewModel";
+
+export abstract class BaseViewModel<P> implements ViewModelNew {
+    /**
+     * We are relying on {@link https://react.dev/reference/react/useSyncExternalStore|useSyncExternalStore}
+     * to keep the react component in sync with view model.
+     * We only use this snapshot as way of convincing react that it should do a re-render when {@link emit} is called.
+     */
+    private snapshot: unknown = {};
+    private callbacks: Set<() => void> = new Set();
+
+    public constructor(protected props: P) {}
+
+    public getSnapshot(): unknown {
+        return this.snapshot;
+    }
+
+    public subscribe(callback: () => void): () => void {
+        this.callbacks.add(callback);
+        return () => {
+            this.callbacks.delete(callback);
+        };
+    }
+
+    /**
+     * Re-render any subscribed components
+     */
+    protected emit(): void {
+        /**
+         * When we invoke the callbacks, react will check if the result of getSnapshot()
+         * matches the previously known snapshot value via Object.is().
+         * Since the intention of calling this method is to make the UI re-render, we want
+         * that comparison to fail.
+         * We can do that by assigning a new empty object to snapshot.
+         */
+        this.snapshot = {};
+        for (const callback of this.callbacks) {
+            callback();
+        }
+    }
+}

--- a/test/viewmodels/base/BaseViewModel-test.ts
+++ b/test/viewmodels/base/BaseViewModel-test.ts
@@ -1,0 +1,82 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { BaseViewModel } from "../../../src/viewmodels/base/BaseViewModel";
+
+interface Props {
+    initialTodos: string[];
+}
+
+/**
+ * BaseViewModel is an abstract class, so we'll have to test it with a dummy view model.
+ */
+class TodoViewModel extends BaseViewModel<Props> {
+    public todos: string[];
+
+    public constructor(props: Props) {
+        super(props);
+        this.todos = [...props.initialTodos];
+    }
+
+    public doEmit(): void {
+        this.emit();
+    }
+}
+
+describe("BaseViewModel", () => {
+    describe("Test integrity of getSnapshot()", () => {
+        it("Multiple calls to getSnapshot returns a cached value", () => {
+            // To be sure that we don't run into
+            // https://react.dev/reference/react/useSyncExternalStore#im-getting-an-error-the-result-of-getsnapshot-should-be-cached
+            const vm = new TodoViewModel({ initialTodos: ["todo1", "todo2"] });
+            const snapshot1 = vm.getSnapshot();
+            const snapshot2 = vm.getSnapshot();
+            expect(snapshot1).toBe(snapshot2);
+        });
+        it("emit() causes snapshot value to change", () => {
+            // When emit() is called, the snapshot should change in order for react to rerender any subscribed components.
+            const vm = new TodoViewModel({ initialTodos: ["todo1", "todo2"] });
+            const snapshot1 = vm.getSnapshot();
+            vm.doEmit();
+            const snapshot2 = vm.getSnapshot();
+            expect(snapshot1).not.toBe(snapshot2);
+        });
+    });
+
+    describe("Subscriptions", () => {
+        it("subscribe() returns unsubscribe callback", () => {
+            const vm = new TodoViewModel({ initialTodos: ["todo1", "todo2"] });
+            const result = vm.subscribe(jest.fn());
+            expect(typeof result).toBe("function");
+        });
+
+        it("emit() calls subscribe callbacks", () => {
+            const vm = new TodoViewModel({ initialTodos: ["todo1", "todo2"] });
+
+            const callbacks = [jest.fn(), jest.fn()];
+            callbacks.forEach((c) => vm.subscribe(c));
+            vm.doEmit();
+
+            callbacks.forEach((c) => expect(c).toHaveBeenCalledTimes(1));
+        });
+
+        it("Invoking unsubscribe callback returned from subscribe() removes subscription", () => {
+            const vm = new TodoViewModel({ initialTodos: ["todo1", "todo2"] });
+
+            const callback1 = jest.fn();
+            const callback2 = jest.fn();
+            const unsubscribe = vm.subscribe(callback1);
+            vm.subscribe(callback2);
+
+            unsubscribe();
+            vm.doEmit();
+
+            expect(callback1).not.toHaveBeenCalled();
+            expect(callback2).toHaveBeenCalledTimes(1);
+        });
+    });
+});


### PR DESCRIPTION
This PR introduces a new `BaseViewModel` class that allows views to consume the view model itself instead of having to rely on a snapshot collated by the view model.  
- A view can consume anything publicly available on the view model class. This means whatever state your view needs can just be public properties on the view model class. 
- When you want the view to re-render with any updated state, you simply call `this.emit()`.

The new interface is called `ViewModelNew` temporarily. 