### PR TITLE
MVVM - Introduce the concept of disposables to track event listeners, sub vms and so on

### DIFF
--- a/src/viewmodels/base/BaseViewModel.ts
+++ b/src/viewmodels/base/BaseViewModel.ts
@@ -6,6 +6,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import type { ViewModelNew } from "../../shared-components/ViewModel";
+import { Disposables } from "./Disposables";
 
 export abstract class BaseViewModel<P> implements ViewModelNew {
     /**
@@ -15,6 +16,7 @@ export abstract class BaseViewModel<P> implements ViewModelNew {
      */
     private snapshot: unknown = {};
     private callbacks: Set<() => void> = new Set();
+    protected disposables = new Disposables();
 
     public constructor(protected props: P) {}
 
@@ -44,5 +46,12 @@ export abstract class BaseViewModel<P> implements ViewModelNew {
         for (const callback of this.callbacks) {
             callback();
         }
+    }
+
+    /**
+     * Relinquish any resources held by this view-model.
+     */
+    public dispose(): void {
+        this.disposables.dispose();
     }
 }

--- a/src/viewmodels/base/Disposables.ts
+++ b/src/viewmodels/base/Disposables.ts
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import type { EventEmitter } from "events";
+
+/**
+ * Something that needs to be eventually disposed. This can be:
+ * - A function that does the disposing
+ * - An object containing a dispose method which does the disposing
+ */
+export type DisposableItem = { dispose: () => void } | (() => void);
+
+/**
+ * This class provides a way for the view-model to track any resource
+ * that it needs to eventually relinquish.
+ */
+export class Disposables {
+    private readonly disposables: DisposableItem[] = [];
+    private _isDisposed: boolean = false;
+
+    /**
+     * Relinquish all tracked disposable values
+     */
+    public dispose(): void {
+        this.throwIfDisposed();
+        this._isDisposed = true;
+        for (const disposable of this.disposables) {
+            if (typeof disposable === "function") {
+                disposable();
+            } else {
+                disposable.dispose();
+            }
+        }
+    }
+
+    /**
+     * Track a value that needs to be eventually relinquished
+     */
+    public track<T extends DisposableItem>(disposable: T): T {
+        this.throwIfDisposed();
+        this.disposables.push(disposable);
+        return disposable;
+    }
+
+    /**
+     * Add an event listener that will be removed on dispose
+     */
+    public trackListener(emitter: EventEmitter, event: string, callback: (...args: unknown[]) => void): void {
+        emitter.on(event, callback);
+        this.track(() => {
+            emitter.off(event, callback);
+        });
+    }
+
+    private throwIfDisposed(): void {
+        if (this.isDisposed) throw new Error("Disposable is already disposed");
+    }
+
+    /**
+     * Whether this disposable has been disposed
+     */
+    public get isDisposed(): boolean {
+        return this._isDisposed;
+    }
+}

--- a/test/viewmodels/base/Disposables-test.ts
+++ b/test/viewmodels/base/Disposables-test.ts
@@ -1,0 +1,58 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { EventEmitter } from "events";
+
+import { Disposables } from "../../../src/viewmodels/base/Disposables";
+
+describe("Disposable", () => {
+    it("isDisposed is true after dispose() is called", () => {
+        const disposables = new Disposables();
+        expect(disposables.isDisposed).toEqual(false);
+        disposables.dispose();
+        expect(disposables.isDisposed).toEqual(true);
+    });
+
+    it("dispose() calls the correct disposing function", () => {
+        const disposables = new Disposables();
+
+        const item1 = {
+            foo: 5,
+            dispose: jest.fn(),
+        };
+        disposables.track(item1);
+
+        const item2 = jest.fn();
+        disposables.track(item2);
+
+        disposables.dispose();
+
+        expect(item1.dispose).toHaveBeenCalledTimes(1);
+        expect(item2).toHaveBeenCalledTimes(1);
+    });
+
+    it("Throws error if acting on already disposed disposables", () => {
+        const disposables = new Disposables();
+        disposables.dispose();
+        expect(() => {
+            disposables.track(jest.fn);
+        }).toThrow();
+    });
+
+    it("Removes tracked event listeners on dispose", () => {
+        const disposables = new Disposables();
+        const emitter = new EventEmitter();
+
+        const fn = jest.fn();
+        disposables.trackListener(emitter, "FooEvent", fn);
+        emitter.emit("FooEvent");
+        expect(fn).toHaveBeenCalled();
+
+        disposables.dispose();
+        expect(emitter.listenerCount("FooEvent", fn)).toEqual(0);
+    });
+});


### PR DESCRIPTION
Builds on from https://github.com/element-hq/element-web/pull/30418

Previously, `SubscriptionViewModel` had the following mechanism for adding/removing any event listeners that the vm needs:
- [addDownstreamSubscription](https://github.com/element-hq/element-web/blob/develop/src/viewmodels/SubscriptionViewModel.ts#L45) is called when the number of view subscriptions change from 0 to 1.
- [removeDownstreamSubscription](https://github.com/element-hq/element-web/blob/develop/src/viewmodels/SubscriptionViewModel.ts#L50) is called when the number of view subscriptions reduce to 0.

This means that the vm only listens to any relevant events (that it needs to keep its state correct) as long as there is at least one view subscribed to it. This is a problem because if the view unmounts and then mounts again, meaning that it goes through `subscribe -> unsubscribe -> subscribe`, the view model can present the wrong state because it wasn't listening to relevant events. Therefore, the lifetime of the event listeners should equal the lifetime of the view model itself.

This PR borrows the concept of `Disposables` from hydrogen:
 It provides a way to track any resource that needs to be relinquished eventually. This will usually be sub view models or event listeners. 
Whoever creates the view model has the responsibility to call `dispose()` method on it to indicate that it is no longer needed. 

#### Tracking sub view-models
```ts
class FooViewModel extends BaseViewModel {
    private barViewModel: BarViewModel;
    constructor() {
        // barViewModel will be disposed whenever this vm is disposed
        this.barViewModel = this.disposables.track(new BarViewModel());
    }
}
```

#### Tracking event listeners
```ts
class FooViewModel extends BaseViewModel {
    constructor() {
        // This listener will be removed whenever this vm is disposed
        this.disposables.trackListener(props.someEmitter, "SOME_EVENT", () => { this.doSomething(); });
    }
   
   doSomething() {
      // ...
   }
}
```