### PR TITLE
Feature/audit 7 make search accessible

### DIFF
--- a/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
+++ b/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
@@ -1155,7 +1155,20 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
                     }
 
                     const idx = nodes.indexOf(rovingContext.state.activeNode);
-                    node = findSiblingElement(nodes, idx + (accessibilityAction === KeyBindingAction.ArrowUp ? -1 : 1));
+
+                    // When the first result is active, we want to make it possible to navigate to the search field
+                    // to make it reade out by the screen reader.
+                    if (idx === 0 && accessibilityAction === KeyBindingAction.ArrowUp) {
+                        const inputFieldNode = inputRef.current;
+                        if (inputFieldNode) {
+                            rovingContext.dispatch({
+                                type: Type.SetFocus,
+                                payload: { node: inputFieldNode },
+                            });
+                        }
+                    } else {
+                        node = findSiblingElement(nodes, idx + (accessibilityAction === KeyBindingAction.ArrowUp ? -1 : 1));
+                    }
                 }
                 break;
 

--- a/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
+++ b/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
@@ -1155,9 +1155,8 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
                     }
 
                     const idx = nodes.indexOf(rovingContext.state.activeNode);
-
-                    // When the first result is active, we want to make it possible to navigate to the search field
-                    // to make it reade out by the screen reader.
+                    // When the first element in the result list is selected, we actively set the focus on the search
+                    // field, so that the screen reader can read it out.
                     if (idx === 0 && accessibilityAction === KeyBindingAction.ArrowUp) {
                         const inputFieldNode = inputRef.current;
                         if (inputFieldNode) {


### PR DESCRIPTION
Improve accessibility of the search dialog.

### Status before change

- When search dialog is open, the first search result is read by the screen reader
- There is no way of making the screen reader read out the search input field

### Goal of this task
- Improve readability of the search dialog

### Changes
- When the first search result is selected and the user presses key up, the screen reader reads out the search input field
- Navigation the results is not changed for all other cases