### PR TITLE
Add `max_export_size_mb` config option

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -28,6 +28,7 @@
     "features": {},
     "default_federate": true,
     "default_theme": "light",
+    "max_export_size_mb": 2000,
     "room_directory": {
         "servers": ["matrix.org"]
     },

--- a/src/IConfigOptions.ts
+++ b/src/IConfigOptions.ts
@@ -88,6 +88,8 @@ export interface IConfigOptions {
     default_federate?: boolean;
     default_device_display_name?: string; // for device naming on login+registration
 
+    max_export_size_mb?: number;
+
     setting_defaults?: Record<string, any>; // <SettingName, Value>
 
     integrations_ui_url?: string;

--- a/src/SdkConfig.ts
+++ b/src/SdkConfig.ts
@@ -34,6 +34,7 @@ export const DEFAULTS: DeepReadonly<IConfigOptions> = {
         participant_limit: 8,
         brand: "Element Call",
     },
+    max_export_size_mb: 2000,
 
     // @ts-ignore - we deliberately use the camelCase version here so we trigger
     // the fallback behaviour. If we used the snake_case version then we'd break

--- a/src/components/views/dialogs/ExportDialog.tsx
+++ b/src/components/views/dialogs/ExportDialog.tsx
@@ -10,6 +10,7 @@ import React, { type JSX, useRef, useState, type Dispatch, type SetStateAction }
 import { type Room } from "matrix-js-sdk/src/matrix";
 import { logger } from "matrix-js-sdk/src/logger";
 
+import SdkConfig from "../../../SdkConfig";
 import { _t } from "../../../languageHandler";
 import BaseDialog from "./BaseDialog";
 import DialogButtons from "../elements/DialogButtons";
@@ -163,8 +164,9 @@ const ExportDialog: React.FC<IProps> = ({ room, onFinished }) => {
                     return allowEmpty || !!value;
                 },
                 invalid: () => {
+                    const config = SdkConfig.get();
                     const min = 1;
-                    const max = 2000;
+                    const max = config.max_export_size_mb;
                     return _t("export_chat|enter_number_between_min_max", {
                         min,
                         max,
@@ -174,12 +176,16 @@ const ExportDialog: React.FC<IProps> = ({ room, onFinished }) => {
             {
                 key: "number",
                 test: ({ value }) => {
+                    const config = SdkConfig.get();
                     const parsedSize = parseInt(value!, 10);
-                    return validateNumberInRange(1, 2000)(parsedSize);
+                    const max = config.max_export_size_mb;
+                    if (typeof max === "undefined") throw new Error("max export size undefined in settings");
+                    return validateNumberInRange(1, max)(parsedSize);
                 },
                 invalid: () => {
+                    const config = SdkConfig.get();
                     const min = 1;
-                    const max = 2000;
+                    const max = config.max_export_size_mb;
                     return _t("export_chat|size_limit_min_max", { min, max });
                 },
             },


### PR DESCRIPTION
This is a small step towards helping with https://github.com/element-hq/element-web/issues/20445, allowing users/deployers to experiment with larger limits that may be supported by their environment.

## Checklist

- [ ] ~~Tests written for new code (and old code if feasible).~~
- [ ]~~ New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.~~
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
