### PR TITLE
Hide recovery key when prompting for verification

### DIFF
--- a/playwright/e2e/crypto/device-verification.spec.ts
+++ b/playwright/e2e/crypto/device-verification.spec.ts
@@ -209,7 +209,7 @@ test.describe("Device verification", { tag: "@no-webkit" }, () => {
         const dialog = page.locator(".mx_Dialog");
         // We use `pressSequentially` here to make sure that the FocusLock isn't causing us any problems
         // (cf https://github.com/element-hq/element-web/issues/30089)
-        await dialog.locator("textarea").pressSequentially(recoveryKey);
+        await dialog.getByTitle("Recovery key").pressSequentially(recoveryKey);
         await dialog.getByRole("button", { name: "Continue", disabled: false }).click();
 
         await page.getByRole("button", { name: "Done" }).click();

--- a/playwright/e2e/crypto/utils.ts
+++ b/playwright/e2e/crypto/utils.ts
@@ -228,7 +228,7 @@ export async function logIntoElement(page: Page, credentials: Credentials, secur
             await useSecurityKey.click();
         }
         // Fill in the recovery key
-        await page.locator(".mx_Dialog").locator("textarea").fill(securityKey);
+        await page.locator(".mx_Dialog").getByTitle("Recovery key").fill(securityKey);
         await page.getByRole("button", { name: "Continue", disabled: false }).click();
         await page.getByRole("button", { name: "Done" }).click();
     }
@@ -263,7 +263,7 @@ export async function verifySession(app: ElementAppPage, securityKey: string) {
     const settings = await app.settings.openUserSettings("Encryption");
     await settings.getByRole("button", { name: "Verify this device" }).click();
     await app.page.getByRole("button", { name: "Verify with Recovery Key" }).click();
-    await app.page.locator(".mx_Dialog").locator("textarea").fill(securityKey);
+    await app.page.locator(".mx_Dialog").getByTitle("Recovery key").fill(securityKey);
     await app.page.getByRole("button", { name: "Continue", disabled: false }).click();
     await app.page.getByRole("button", { name: "Done" }).click();
     await app.settings.closeDialog();

--- a/res/css/views/dialogs/security/_AccessSecretStorageDialog.pcss
+++ b/res/css/views/dialogs/security/_AccessSecretStorageDialog.pcss
@@ -15,6 +15,23 @@ Please see LICENSE files in the repository root for full details.
     }
 
     .mx_AccessSecretStorageDialog_primaryContainer {
+        .mx_AccessSecretStorageDialog_recoveryKeyEntry {
+            /*
+             * Be specific here to avoid "margin: 9px" from _common.pcss
+             */
+            :not(.mx_textinput):not(.mx_Field):not(.mx_no_textinput) {
+                input {
+                    /*
+                     * From figma: https://www.figma.com/design/ZodBLtGnKmRTGJo5SGLnH3/ER-137--Excluding-Insecure-Devices?node-id=102-43729&t=QmewENUd7f6Tmw9U-1
+                     */
+                    width: 448px;
+                    height: 70px;
+                    margin: 0px;
+                    border: 1px solid;
+                }
+            }
+        }
+
         .mx_AccessSecretStorageDialog_recoveryKeyFeedback {
             &::before {
                 content: "";

--- a/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
+++ b/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
@@ -6,14 +6,13 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { Button } from "@vector-im/compound-web";
+import { Button, PasswordInput } from "@vector-im/compound-web";
 import LockSolidIcon from "@vector-im/compound-design-tokens/assets/web/icons/lock-solid";
 import { debounce } from "lodash";
 import classNames from "classnames";
 import React, { type ChangeEvent, type FormEvent } from "react";
 import { type SecretStorage } from "matrix-js-sdk/src/matrix";
 
-import Field from "../../elements/Field";
 import { Flex } from "../../../../shared-components/utils/Flex";
 import { _t } from "../../../../languageHandler";
 import { EncryptionCard } from "../../settings/encryption/EncryptionCard";
@@ -53,7 +52,7 @@ interface IState {
  * Access Secure Secret Storage by requesting the user's passphrase.
  */
 export default class AccessSecretStorageDialog extends React.PureComponent<IProps, IState> {
-    private inputRef = React.createRef<HTMLTextAreaElement>();
+    private inputRef = React.createRef<HTMLInputElement>();
 
     public constructor(props: IProps) {
         super(props);
@@ -119,7 +118,7 @@ export default class AccessSecretStorageDialog extends React.PureComponent<IProp
         });
     }
 
-    private onRecoveryKeyChange = (ev: ChangeEvent<HTMLTextAreaElement>): void => {
+    private onRecoveryKeyChange = (ev: ChangeEvent<HTMLInputElement>): void => {
         this.setState({
             recoveryKey: ev.target.value,
         });
@@ -181,17 +180,14 @@ export default class AccessSecretStorageDialog extends React.PureComponent<IProp
                     autoComplete="off"
                 >
                     <div className="mx_AccessSecretStorageDialog_recoveryKeyEntry">
-                        <Field
-                            inputRef={this.inputRef}
-                            element="textarea"
-                            rows={2}
-                            cols={45}
+                        <PasswordInput
+                            ref={this.inputRef}
                             id="mx_securityKey"
-                            label={_t("encryption|access_secret_storage_dialog|security_key_label")}
+                            title={_t("encryption|access_secret_storage_dialog|security_key_label")}
+                            placeholder={_t("encryption|access_secret_storage_dialog|security_key_label")}
                             value={this.state.recoveryKey}
                             onChange={this.onRecoveryKeyChange}
                             autoFocus={true}
-                            forceValidity={this.state.recoveryKeyCorrect ?? undefined}
                             autoComplete="off"
                         />
                     </div>

--- a/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
+++ b/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
@@ -187,7 +187,7 @@ export default class AccessSecretStorageDialog extends React.PureComponent<IProp
                             rows={2}
                             cols={45}
                             id="mx_securityKey"
-                            label={_t("encryption|access_secret_storage_dialog|security_key_title")}
+                            label={_t("encryption|access_secret_storage_dialog|security_key_label")}
                             value={this.state.recoveryKey}
                             onChange={this.onRecoveryKeyChange}
                             autoFocus={true}

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -920,6 +920,7 @@
             },
             "privacy_warning": "Make sure nobody can see this screen!",
             "restoring": "Restoring keys from backup",
+            "security_key_label": "Recovery key",
             "security_key_title": "Recovery key"
         },
         "bootstrap_title": "Setting up keys",

--- a/test/unit-tests/components/views/dialogs/AccessSecretStorageDialog-test.tsx
+++ b/test/unit-tests/components/views/dialogs/AccessSecretStorageDialog-test.tsx
@@ -31,7 +31,7 @@ describe("AccessSecretStorageDialog", () => {
 
     const enterRecoveryKey = async (valueToEnter: string = recoveryKey): Promise<void> => {
         await act(async () => {
-            fireEvent.change(screen.getByRole("textbox"), {
+            fireEvent.change(screen.getByTitle("Recovery key"), {
                 target: {
                     value: valueToEnter,
                 },
@@ -67,7 +67,7 @@ describe("AccessSecretStorageDialog", () => {
         renderComponent({ onFinished, checkPrivateKey });
 
         // check that the input field is focused
-        expect(screen.getByRole("textbox")).toHaveFocus();
+        expect(screen.getByTitle("Recovery key")).toHaveFocus();
 
         await enterRecoveryKey();
         await submitDialog();
@@ -111,7 +111,7 @@ describe("AccessSecretStorageDialog", () => {
         renderComponent({ checkPrivateKey, keyInfo });
 
         await enterRecoveryKey();
-        expect(screen.getByRole("textbox")).toHaveValue(recoveryKey);
+        expect(screen.getByTitle("Recovery key")).toHaveValue(recoveryKey);
 
         await expect(screen.findByText("The recovery key you entered is not correct.")).resolves.toBeInTheDocument();
         expect(screen.getByText("Continue")).toHaveAttribute("aria-disabled", "true");


### PR DESCRIPTION
Improve one of the cases for Web described in https://github.com/element-hq/element-meta/issues/2888

When prompting the user for a recovery key in order to verify (either on login or later), hide the key by default and allow the user to show it:

<img width="574" height="580" alt="image" src="https://github.com/user-attachments/assets/b774ff3e-7baf-4742-b897-a0c66a1f9e24" />
<img width="572" height="576" alt="image" src="https://github.com/user-attachments/assets/4142bb23-ae50-415b-8705-e2e58024e4a0" />
<img width="569" height="576" alt="image" src="https://github.com/user-attachments/assets/08f1c1c7-3d71-480f-b71f-62c2ed07a3c7" />

We do this by using the Compound `PasswordInput` component.

The designs for this are here: https://www.figma.com/design/ZodBLtGnKmRTGJo5SGLnH3/ER-137--Excluding-Insecure-Devices?node-id=102-43729&t=QmewENUd7f6Tmw9U-1

This PR does not bring us fully into line with the designs, but I think it is a step forward:

* Improvement: hides the recovery key and allows showing it
* Improvement: when the [localazy PR](https://github.com/element-hq/element-web/pull/30407) is merged, shows the correct title "Enter your recovery key" instead of just "Recovery key"
* Worse: restricts text entry to a single line
* Still wrong: does not show the text "Recovery key" above the entry box
* Still wrong: does not make the box text red when the recovery key is invalid

I think fixing the remaining problems would require creating a new Compound component, which is probably out of my scope for this task.

(With thanks to @meramsey for working on this under https://github.com/element-hq/element-web/pull/30393 , which this PR supersedes.)