### PR TITLE
Fix race condition in flaky reply chain test

### DIFF
--- a/playwright/e2e/audio-player/audio-player.spec.ts
+++ b/playwright/e2e/audio-player/audio-player.spec.ts
@@ -19,6 +19,7 @@ const clickButtonReply = async (tile: Locator) => {
         await tile.hover();
         await tile.getByRole("button", { name: "Reply", exact: true }).click();
     }).toPass();
+    await expect(tile.page().getByText("Replying", { exact: true })).toBeVisible();
 };
 
 test.describe("Audio player", { tag: ["@no-firefox", "@no-webkit"] }, () => {


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-web/issues/27451

Switching to the `Replying` state was racing with the media message, causing it to not be a reply