### PR TITLE
Refactor MultiInviter

### DIFF
--- a/src/RoomInvite.tsx
+++ b/src/RoomInvite.tsx
@@ -26,9 +26,9 @@ export interface IInviteResult {
 }
 
 /**
- * Invites multiple addresses to a room
- * Simpler interface to utils/MultiInviter but with
- * no option to cancel.
+ * Invites multiple addresses to a room.
+ *
+ * Simpler interface to {@link MultiInviter}.
  *
  * @param {string} roomId The ID of the room to invite to
  * @param {string[]} addresses Array of strings of addresses to invite. May be matrix IDs or 3pids.

--- a/src/utils/MultiInviter.ts
+++ b/src/utils/MultiInviter.ts
@@ -181,7 +181,7 @@ export default class MultiInviter {
         }
     }
 
-    private doInvite(address: string, ignoreProfile = false): Promise<void> {
+    private doInvite(address: string, ignoreProfile: boolean): Promise<void> {
         return new Promise<void>((resolve, reject) => {
             logger.log(`Inviting ${address}`);
 
@@ -290,7 +290,7 @@ export default class MultiInviter {
         });
     }
 
-    private inviteMore(nextIndex: number, ignoreProfile = false): void {
+    private inviteMore(nextIndex: number): void {
         if (nextIndex === this.addresses.length) {
             if (Object.keys(this.errors).length > 0) {
                 // There were problems inviting some people - see if we can invite them
@@ -327,9 +327,9 @@ export default class MultiInviter {
             return;
         }
 
-        this.doInvite(addr, ignoreProfile)
+        this.doInvite(addr, false)
             .then(() => {
-                this.inviteMore(nextIndex + 1, ignoreProfile);
+                this.inviteMore(nextIndex + 1);
             })
             .catch(() => this.deferred?.resolve(this.completionStates));
     }


### PR DESCRIPTION
As far as I can tell, the last time most of this code was changed was when Promises were the new hotness and `async` was but a twinkle in ECMA's eye. It is, therefore, somewhat opaque by modern standards.

This refactor aims to be a non-functional update of the code to use loops and `async/await` rather than recursive function invocations and explicit promise chains.

Suggest review commit-by-commit.