### PR TITLE
Fix widget persistence in React development mode

### DIFF
--- a/src/components/views/elements/AppTile.tsx
+++ b/src/components/views/elements/AppTile.tsx
@@ -445,11 +445,12 @@ export default class AppTile extends React.Component<IProps, IState> {
      * Callback ref for the parent div of the iframe.
      */
     private iframeParentRef = (element: HTMLElement | null): void => {
+        if (this.unmounted) return;
         // Detach the existing iframe (if any) from the document so we know not
         // to do anything further with it, like starting up the messaging
         this.iframeParent?.querySelector("iframe")?.remove();
         this.iframeParent = element;
-        if (this.unmounted) return;
+
         if (element && this.sgWidget) {
             this.startMessaging();
         } else {


### PR DESCRIPTION
15f1291cbcbb5920f87fd0ea73dba27ce12d91b1 was really close to making widgets just work again in React development mode following the upgrade to React 19, but I forgot to test one thing: that persistent widgets (such as Element Call) still reuse the same iframe across their entire lifecycle as expected. The solution is to not manually destroy the iframe when AppTile is being unmounted; even if it turns out that the widget isn't actually persistent, React will still destroy it automatically for us.