### PR TITLE
Fix call permissions check confusion around element call

### DIFF
--- a/src/hooks/room/useRoomCall.tsx
+++ b/src/hooks/room/useRoomCall.tsx
@@ -213,11 +213,12 @@ export const useRoomCall = (
             return State.NoOneHere;
         }
 
-        if (!mayCreateElementCalls && !mayEditWidgets) {
+        if (!callOptions.includes(PlatformCallType.LegacyCall) && !mayCreateElementCalls && !mayEditWidgets) {
             return State.NoPermission;
         }
         return State.NoCall;
     }, [
+        callOptions,
         connectedCalls,
         canInviteGuests,
         hasGroupCall,


### PR DESCRIPTION
It would previously say no permission if you had no perms for an EC call but had perms for a legacy call.

Fixes https://github.com/element-hq/element-web/issues/30502
