### PR TITLE
Remove NoOneHere disabled reason.

### DIFF
--- a/src/hooks/room/useRoomCall.tsx
+++ b/src/hooks/room/useRoomCall.tsx
@@ -73,7 +73,6 @@ export const getPlatformCallTypeProps = (
 
 const enum State {
     NoCall,
-    NoOneHere,
     NoPermission,
     Unpinned,
     Ongoing,
@@ -209,9 +208,6 @@ export const useRoomCall = (
         if (hasLegacyCall) {
             return State.Ongoing;
         }
-        if (memberCount <= 1 && !canInviteGuests) {
-            return State.NoOneHere;
-        }
 
         if (!mayCreateElementCalls && !mayEditWidgets) {
             return State.NoPermission;
@@ -264,10 +260,6 @@ export const useRoomCall = (
         case State.Ongoing:
             voiceCallDisabledReason = _t("voip|disabled_ongoing_call");
             videoCallDisabledReason = _t("voip|disabled_ongoing_call");
-            break;
-        case State.NoOneHere:
-            voiceCallDisabledReason = _t("voip|disabled_no_one_here");
-            videoCallDisabledReason = _t("voip|disabled_no_one_here");
             break;
         case State.Unpinned:
         case State.NotJoined:


### PR DESCRIPTION
This was used to prohibit starting calls if the user is alone in the room.
Since there are currently issues with the user count calculation this can disable the button even when not appropriate.

On top of that, there is a reason to start a call if the room was just created and the user is still waiting for the others to join the room to then join the call.

Signed-off-by: Timo K <toger5@hotmail.de>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
