### PR TITLE
Support for creator/owner power level

### DIFF
--- a/src/components/viewmodels/memberlist/tiles/MemberTileViewModel.tsx
+++ b/src/components/viewmodels/memberlist/tiles/MemberTileViewModel.tsx
@@ -31,11 +31,13 @@ export interface MemberTileViewState extends MemberTileViewModelProps {
 }
 
 export enum PowerStatus {
+    Creator = "creator",
     Admin = "admin",
     Moderator = "moderator",
 }
 
 const PowerLabel: Record<PowerStatus, TranslationKey> = {
+    [PowerStatus.Creator]: _td("power_level|creator"),
     [PowerStatus.Admin]: _td("power_level|admin"),
     [PowerStatus.Moderator]: _td("power_level|moderator"),
 };
@@ -115,6 +117,7 @@ export function useMemberTileViewModel(props: MemberTileViewModelProps): MemberT
     const name = props.member.name;
 
     const powerStatusMap = new Map([
+        [Infinity, PowerStatus.Creator],
         [100, PowerStatus.Admin],
         [50, PowerStatus.Moderator],
     ]);

--- a/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
@@ -348,10 +348,7 @@ export default class RolesRoomSettingsTab extends React.Component<IProps, RolesR
             powerLevelDescriptors.users_default.defaultValue,
         );
 
-        let currentUserLevel = userLevels[client.getUserId()!];
-        if (currentUserLevel === undefined) {
-            currentUserLevel = defaultUserLevel;
-        }
+        const currentUserLevel = room.getMember(client.getSafeUserId())?.powerLevel ?? defaultUserLevel;
 
         this.populateDefaultPlEvents(
             eventsLevels,

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1763,6 +1763,7 @@
     },
     "power_level": {
         "admin": "Admin",
+        "creator": "Owner",
         "custom": "Custom (%(level)s)",
         "custom_level": "Custom level",
         "default": "Default",


### PR DESCRIPTION
This just shows them as 'Owner' in the list.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
