### PR TITLE
Open the proper integration settings on integrations disabled error

### DIFF
--- a/src/components/views/dialogs/IntegrationsDisabledDialog.tsx
+++ b/src/components/views/dialogs/IntegrationsDisabledDialog.tsx
@@ -13,6 +13,7 @@ import dis from "../../../dispatcher/dispatcher";
 import { Action } from "../../../dispatcher/actions";
 import BaseDialog from "./BaseDialog";
 import DialogButtons from "../elements/DialogButtons";
+import { UserTab } from "./UserTab";
 
 interface IProps {
     onFinished(): void;
@@ -25,7 +26,10 @@ export default class IntegrationsDisabledDialog extends React.Component<IProps> 
 
     private onOpenSettingsClick = (): void => {
         this.props.onFinished();
-        dis.fire(Action.ViewUserSettings);
+        dis.dispatch({
+            action: Action.ViewUserSettings,
+            initialTabId: UserTab.Security,
+        });
     };
 
     public render(): React.ReactNode {


### PR DESCRIPTION
Trivial fix to send you to the correct settings tab when you are told to go enable your integrations.

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
