### PR TITLE
fix useParticipants incorrectly returning an array when a map is expected

### DIFF
--- a/src/hooks/useCall.ts
+++ b/src/hooks/useCall.ts
@@ -42,10 +42,11 @@ export const useConnectionState = (call: Call | null): ConnectionState =>
     );
 
 export const useParticipants = (call: Call | null): Map<RoomMember, Set<string>> => {
+    const participants = call?.participants;
     return useTypedEventEmitterState(
         call ?? undefined,
         CallEvent.Participants,
-        useCallback((state) => state ?? call?.participants ?? new Map(), [call]),
+        useCallback((state) => state ?? participants ?? new Map(), [participants]),
     );
 };
 

--- a/src/hooks/useCall.ts
+++ b/src/hooks/useCall.ts
@@ -45,7 +45,7 @@ export const useParticipants = (call: Call | null): Map<RoomMember, Set<string>>
     return useTypedEventEmitterState(
         call ?? undefined,
         CallEvent.Participants,
-        useCallback((state) => state ?? call?.participants ?? [], [call]),
+        useCallback((state) => state ?? call?.participants ?? new Map(), [call]),
     );
 };
 


### PR DESCRIPTION
Relates to https://github.com/element-hq/element-web/pull/30373

particularly the error [here](https://github.com/element-hq/element-web/actions/runs/17267624334/job/49003487404?pr=30373).

```
● RoomHeader › group call enabled › close lobby button is shown if there is an ongoing call but we are viewing the lobby

    TypeError: Cannot read properties of undefined (reading 'length')

      46 |         call ?? undefined,
      47 |         CallEvent.Participants,
    > 48 |         useCallback((state) => state ?? call?.participants ?? [], [call]),
         |                    ^
      49 |     );
      50 | };
   ```

This hook is returning an empty array when a Map is expected,