### PR TITLE
Fix i18n of message when a setting is disabled

### DIFF
--- a/src/settings/SettingsStore.ts
+++ b/src/settings/SettingsStore.ts
@@ -340,7 +340,7 @@ export default class SettingsStore {
     }
 
     /**
-     * Retrieves the reason a setting is disabled if one is assigned.
+     * Retrieves the internationalised reason a setting is disabled if one is assigned.
      * If a setting is not disabled, or no reason is given by the `SettingController`,
      * this will return undefined.
      * @param {string} settingName The setting to look up.

--- a/src/settings/controllers/ServerSupportUnstableFeatureController.ts
+++ b/src/settings/controllers/ServerSupportUnstableFeatureController.ts
@@ -11,6 +11,7 @@ import MatrixClientBackedController from "./MatrixClientBackedController";
 import { type WatchManager } from "../WatchManager";
 import SettingsStore from "../SettingsStore";
 import { type SettingKey } from "../Settings.tsx";
+import { _t, type TranslationKey } from "../../languageHandler.tsx";
 
 /**
  * Disables a given setting if the server unstable feature it requires is not supported
@@ -33,7 +34,7 @@ export default class ServerSupportUnstableFeatureController extends MatrixClient
         private readonly watchers: WatchManager,
         private readonly unstableFeatureGroups: string[][],
         private readonly stableVersion?: string,
-        private readonly disabledMessage?: string,
+        private readonly disabledMessage?: TranslationKey,
         private readonly forcedValue: any = false,
     ) {
         super();
@@ -96,7 +97,7 @@ export default class ServerSupportUnstableFeatureController extends MatrixClient
 
     public get settingDisabled(): boolean | string {
         if (this.disabled) {
-            return this.disabledMessage ?? true;
+            return this.disabledMessage ? _t(this.disabledMessage) : true;
         }
         return false;
     }


### PR DESCRIPTION
The function was supposed to return an i18ned string but lacked a _t

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
