### PR TITLE
Ensure container starts if it is mounted with an empty /modules directory.

### DIFF
--- a/docker/docker-entrypoint.d/18-load-element-modules.sh
+++ b/docker/docker-entrypoint.d/18-load-element-modules.sh
@@ -14,23 +14,20 @@ entrypoint_log() {
 mkdir -p /tmp/element-web-config
 cp /app/config*.json /tmp/element-web-config/
 
-# If the module directory exists
-if [ -d "/modules" ]; then
-    # ...and the module directory has modules in it
-    if [ "$( ls -A '/modules' )" ]; then
-        cd /modules
-        for MODULE in *
-        do
-            # If the module has a package.json, use its main field as the entrypoint
-            ENTRYPOINT="index.js"
-            if [ -f "/modules/$MODULE/package.json" ]; then
-                ENTRYPOINT=$(jq -r '.main' "/modules/$MODULE/package.json")
-            fi
+# If the module directory exists AND the module directory has modules in it
+if [ -d "/modules" ] && [ "$( ls -A '/modules' )" ]; then
+    cd /modules
+    for MODULE in *
+    do
+        # If the module has a package.json, use its main field as the entrypoint
+        ENTRYPOINT="index.js"
+        if [ -f "/modules/$MODULE/package.json" ]; then
+            ENTRYPOINT=$(jq -r '.main' "/modules/$MODULE/package.json")
+        fi
 
-            entrypoint_log "Loading module $MODULE with entrypoint $ENTRYPOINT"
+        entrypoint_log "Loading module $MODULE with entrypoint $ENTRYPOINT"
 
-            # Append the module to the config
-            jq ".modules += [\"/modules/$MODULE/$ENTRYPOINT\"]" /tmp/element-web-config/config.json | sponge /tmp/element-web-config/config.json
-        done
-    fi
+        # Append the module to the config
+        jq ".modules += [\"/modules/$MODULE/$ENTRYPOINT\"]" /tmp/element-web-config/config.json | sponge /tmp/element-web-config/config.json
+    done
 fi

--- a/docker/docker-entrypoint.d/18-load-element-modules.sh
+++ b/docker/docker-entrypoint.d/18-load-element-modules.sh
@@ -4,6 +4,10 @@
 
 set -e
 
+# Ensures an empty list when a glob expression doesn't match (see /modules for loop)
+# See https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#index-shopt
+shopt -s nullglob
+
 entrypoint_log() {
     if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
         echo "$@"


### PR DESCRIPTION
Bash is great. So great in fact, that if your glob expression doesn't match any files then the loop will run once with your glob expression *as* the only item.

This causes Element Web to fail to run when the `/modules` directory is present, as it thinks it has found a module under `*`. This sets `nullglob` which works as you'd expect by skipping the for loop if a glob expression doesn't match. 

## Checklist

- [ ] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
