### PR TITLE
Remove remaining support for outdated .well-known settings

### DIFF
--- a/src/SecurityManager.ts
+++ b/src/SecurityManager.ts
@@ -14,7 +14,6 @@ import { logger as rootLogger } from "matrix-js-sdk/src/logger";
 import Modal from "./Modal";
 import { MatrixClientPeg } from "./MatrixClientPeg";
 import { _t } from "./languageHandler";
-import { isSecureBackupRequired } from "./utils/WellKnownUtils";
 import AccessSecretStorageDialog, {
     type KeyParams,
 } from "./components/views/dialogs/security/AccessSecretStorageDialog";
@@ -232,15 +231,6 @@ async function doAccessSecretStorage(func: () => Promise<void>, opts: AccessSecr
                 undefined,
                 /* priority = */ false,
                 /* static = */ true,
-                /* options = */ {
-                    onBeforeClose: async (reason): Promise<boolean> => {
-                        // If Secure Backup is required, you cannot leave the modal.
-                        if (reason === "backgroundClick") {
-                            return !isSecureBackupRequired(cli);
-                        }
-                        return true;
-                    },
-                },
             );
             const [confirmed] = await finished;
             if (!confirmed) {

--- a/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
+++ b/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
@@ -25,11 +25,7 @@ import StyledRadioButton from "../../../../components/views/elements/StyledRadio
 import AccessibleButton from "../../../../components/views/elements/AccessibleButton";
 import DialogButtons from "../../../../components/views/elements/DialogButtons";
 import InlineSpinner from "../../../../components/views/elements/InlineSpinner";
-import {
-    getSecureBackupSetupMethods,
-    isSecureBackupRequired,
-    SecureBackupSetupMethod,
-} from "../../../../utils/WellKnownUtils";
+import { isSecureBackupRequired } from "../../../../utils/WellKnownUtils";
 import { ModuleRunner } from "../../../../modules/ModuleRunner";
 import type Field from "../../../../components/views/elements/Field";
 import BaseDialog from "../../../../components/views/dialogs/BaseDialog";
@@ -38,6 +34,11 @@ import InteractiveAuthDialog from "../../../../components/views/dialogs/Interact
 import { type IValidationResult } from "../../../../components/views/elements/Validation";
 import PassphraseConfirmField from "../../../../components/views/auth/PassphraseConfirmField";
 import { initialiseDehydrationIfEnabled } from "../../../../utils/device/dehydration";
+
+enum SecureBackupSetupMethod {
+    Key = "key",
+    Passphrase = "passphrase",
+}
 
 // I made a mistake while converting this and it has to be fixed!
 enum Phase {
@@ -95,14 +96,6 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
 
         const cli = MatrixClientPeg.safeGet();
 
-        let passPhraseKeySelected: SecureBackupSetupMethod;
-        const setupMethods = getSecureBackupSetupMethods(cli);
-        if (setupMethods.includes(SecureBackupSetupMethod.Key)) {
-            passPhraseKeySelected = SecureBackupSetupMethod.Key;
-        } else {
-            passPhraseKeySelected = SecureBackupSetupMethod.Passphrase;
-        }
-
         const keyFromCustomisations = ModuleRunner.instance.extensions.cryptoSetup.createSecretStorageKey();
         const phase = keyFromCustomisations ? Phase.Loading : Phase.ChooseKeyPassphrase;
 
@@ -115,7 +108,7 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
             downloaded: false,
             setPassphrase: false,
             canSkip: !isSecureBackupRequired(cli),
-            passPhraseKeySelected,
+            passPhraseKeySelected: SecureBackupSetupMethod.Key,
         };
     }
 
@@ -391,11 +384,8 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
     }
 
     private renderPhaseChooseKeyPassphrase(): JSX.Element {
-        const setupMethods = getSecureBackupSetupMethods(MatrixClientPeg.safeGet());
-        const optionKey = setupMethods.includes(SecureBackupSetupMethod.Key) ? this.renderOptionKey() : null;
-        const optionPassphrase = setupMethods.includes(SecureBackupSetupMethod.Passphrase)
-            ? this.renderOptionPassphrase()
-            : null;
+        const optionKey = this.renderOptionKey();
+        const optionPassphrase = this.renderOptionPassphrase();
 
         return (
             <form onSubmit={this.onChooseKeyPassphraseFormSubmit}>

--- a/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
+++ b/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
@@ -25,7 +25,6 @@ import StyledRadioButton from "../../../../components/views/elements/StyledRadio
 import AccessibleButton from "../../../../components/views/elements/AccessibleButton";
 import DialogButtons from "../../../../components/views/elements/DialogButtons";
 import InlineSpinner from "../../../../components/views/elements/InlineSpinner";
-import { isSecureBackupRequired } from "../../../../utils/WellKnownUtils";
 import { ModuleRunner } from "../../../../modules/ModuleRunner";
 import type Field from "../../../../components/views/elements/Field";
 import BaseDialog from "../../../../components/views/dialogs/BaseDialog";
@@ -69,7 +68,6 @@ interface IState {
     downloaded: boolean;
     setPassphrase: boolean;
 
-    canSkip: boolean;
     passPhraseKeySelected: string;
     error?: boolean;
 }
@@ -94,8 +92,6 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
     public constructor(props: IProps) {
         super(props);
 
-        const cli = MatrixClientPeg.safeGet();
-
         const keyFromCustomisations = ModuleRunner.instance.extensions.cryptoSetup.createSecretStorageKey();
         const phase = keyFromCustomisations ? Phase.Loading : Phase.ChooseKeyPassphrase;
 
@@ -107,7 +103,6 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
             copied: false,
             downloaded: false,
             setPassphrase: false,
-            canSkip: !isSecureBackupRequired(cli),
             passPhraseKeySelected: SecureBackupSetupMethod.Key,
         };
     }
@@ -400,7 +395,6 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
                     primaryButton={_t("action|continue")}
                     onPrimaryButtonClick={this.onChooseKeyPassphraseFormSubmit}
                     onCancel={this.onCancelClick}
-                    hasCancel={this.state.canSkip}
                 />
             </form>
         );
@@ -591,7 +585,6 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
                     <DialogButtons
                         primaryButton={_t("action|retry")}
                         onPrimaryButtonClick={this.onLoadRetryClick}
-                        hasCancel={this.state.canSkip}
                         onCancel={this.onCancel}
                     />
                 </div>
@@ -662,7 +655,6 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
                         <DialogButtons
                             primaryButton={_t("action|retry")}
                             onPrimaryButtonClick={this.bootstrapSecretStorage}
-                            hasCancel={this.state.canSkip}
                             onCancel={this.onCancel}
                         />
                     </div>

--- a/src/utils/WellKnownUtils.ts
+++ b/src/utils/WellKnownUtils.ts
@@ -31,7 +31,6 @@ export interface IE2EEWellKnown {
      */
     force_disable?: boolean;
     secure_backup_required?: boolean;
-    secure_backup_setup_methods?: SecureBackupSetupMethod[];
 }
 
 export interface ITileServerWellKnown {
@@ -77,25 +76,4 @@ export function embeddedPagesFromWellKnown(clientWellKnown?: IClientWellKnown): 
 
 export function isSecureBackupRequired(matrixClient: MatrixClient): boolean {
     return getE2EEWellKnown(matrixClient)?.["secure_backup_required"] === true;
-}
-
-export enum SecureBackupSetupMethod {
-    Key = "key",
-    Passphrase = "passphrase",
-}
-
-export function getSecureBackupSetupMethods(matrixClient: MatrixClient): SecureBackupSetupMethod[] {
-    const wellKnown = getE2EEWellKnown(matrixClient);
-    if (
-        !wellKnown ||
-        !wellKnown["secure_backup_setup_methods"] ||
-        !wellKnown["secure_backup_setup_methods"].length ||
-        !(
-            wellKnown["secure_backup_setup_methods"].includes(SecureBackupSetupMethod.Key) ||
-            wellKnown["secure_backup_setup_methods"].includes(SecureBackupSetupMethod.Passphrase)
-        )
-    ) {
-        return [SecureBackupSetupMethod.Key, SecureBackupSetupMethod.Passphrase];
-    }
-    return wellKnown["secure_backup_setup_methods"];
 }

--- a/src/utils/WellKnownUtils.ts
+++ b/src/utils/WellKnownUtils.ts
@@ -30,7 +30,6 @@ export interface IE2EEWellKnown {
      * Disables the option to enable encryption in room settings for all new and existing rooms
      */
     force_disable?: boolean;
-    secure_backup_required?: boolean;
 }
 
 export interface ITileServerWellKnown {
@@ -72,8 +71,4 @@ export function getEmbeddedPagesWellKnown(matrixClient: MatrixClient | undefined
 
 export function embeddedPagesFromWellKnown(clientWellKnown?: IClientWellKnown): IEmbeddedPagesWellKnown {
     return clientWellKnown?.[EMBEDDED_PAGES_WK_PROPERTY];
-}
-
-export function isSecureBackupRequired(matrixClient: MatrixClient): boolean {
-    return getE2EEWellKnown(matrixClient)?.["secure_backup_required"] === true;
 }


### PR DESCRIPTION
Support for these two `.well-known/matrix/client` settings (`secure_backup_required` and `secure_backup_setup_methods`) has been removed from everywhere in Element Web except in a rather obscure corner of the code. There are many other problems with this area  (https://github.com/element-hq/element-web/issues/29171) but removing support for the outdated option is an easy step, and doing so means we can update the documentation about these options.