### PR TITLE
Fix enabling key backup not working if there is an untrusted key back…

### DIFF
--- a/src/components/viewmodels/settings/encryption/KeyStoragePanelViewModel.ts
+++ b/src/components/viewmodels/settings/encryption/KeyStoragePanelViewModel.ts
@@ -79,12 +79,26 @@ export function useKeyStoragePanelViewModel(): KeyStoragePanelState {
                     return;
                 }
                 if (enable) {
+                    logger.info("User requested enabling key backup");
+                    let currentKeyBackup = await crypto.checkKeyBackupAndEnable();
+                    if (currentKeyBackup) {
+                        logger.info(`Existing key backup is present. version: ${currentKeyBackup.backupInfo.version}`, currentKeyBackup.trustInfo);
+                        // Check if the current key backup can be used. Either of these properties causes the key backup to be used.
+                        if (currentKeyBackup?.trustInfo.trusted || currentKeyBackup.trustInfo.matchesDecryptionKey) {
+                            logger.info("Existing key backup can be used");
+                        } else {
+                            logger.warn("Existing key backup cannot be used, creating new backup");
+                            // There aren't any *usable* backups, so we need to create a new one.
+                            currentKeyBackup = null;
+                        }
+                    } else {
+                        logger.info("No existing key backup versions are present, creating new backup");
+                    }
+
                     // If there is no existing key backup on the server, create one.
                     // `resetKeyBackup` will delete any existing backup, so we only do this if there is no existing backup.
-                    const currentKeyBackup = await crypto.checkKeyBackupAndEnable();
                     if (currentKeyBackup === null) {
                         await crypto.resetKeyBackup();
-
                         // resetKeyBackup fires this off in the background without waiting, so we need to do it
                         // explicitly and wait for it, otherwise it won't be enabled yet when we check again.
                         await crypto.checkKeyBackupAndEnable();
@@ -93,6 +107,7 @@ export function useKeyStoragePanelViewModel(): KeyStoragePanelState {
                     // Set the flag so that EX no longer thinks the user wants backup disabled
                     await matrixClient.setAccountData(BACKUP_DISABLED_ACCOUNT_DATA_KEY, { disabled: false });
                 } else {
+                    logger.info("User requested disabling key backup");
                     // This method will delete the key backup as well as server side recovery keys and other
                     // server-side crypto data.
                     await crypto.disableKeyStorage();


### PR DESCRIPTION
Fixes #30706 

This a **proposed** fix for the linked issue, albeit this is mostly working off my debugging assumptions and needs crypto scrutiny here.

The summary of #30706 is users may have untrusted key backups on their account that are unusable by Element Web, and in those cases we should proceed to resetting and creating a new backup rather than flaking out. I've also added abundant logging to this section as it's important to understand the state of the user's account for future debugging.

**This needs tests**

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
