### PR TITLE
Force `preload` to be false when setting an intent on an Element Call.

### DIFF
--- a/src/models/Call.ts
+++ b/src/models/Call.ts
@@ -596,7 +596,7 @@ export class ElementCall extends Call {
             const oldestCallMember = client.matrixRTC.getRoomSession(room).getOldestMembership();
             const hasCallStarted = !!oldestCallMember && oldestCallMember.sender !== client.getSafeUserId();
             // XXX: @element-hq/element-call-embedded <= 0.15.0 sets the wrong parameter for
-            // preload by default so we override here. This can be removed when that package 
+            // preload by default so we override here. This can be removed when that package
             // is released and upgraded.
             if (isDM) {
                 params.append("sendNotificationType", "ring");


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-web/pull/30730#issuecomment-3290864296

Short term fix until https://github.com/element-hq/element-call/pull/3488 lands in an Element Call release. This only overrides a default that will be changed on the next release, so can be removed once that package is updated. Keeping it in also won't be an issue, although deferring to Element Call's defaults is preferred whenever possible.

## Checklist

- [ ] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
