### PR TITLE
Reduce margin for RR gutter to 10px

### DIFF
--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -523,7 +523,7 @@ $left-gutter: 64px;
         }
 
         .mx_RoomView_timeline_rr_enabled & {
-            $inline-end-margin: 80px;
+            $inline-end-margin: 10px;
 
             .mx_ThreadSummary,
             .mx_ThreadSummary_icon,


### PR DESCRIPTION
Hi,
I am using Element Desktop on a small laptop screen, where half the screen is emails and half is Element. Thus, I have a rather narrow and tall layout of my Element Desktop and the 80px right-hand margin for read receipts really hurts there, especially when a thread is open on the sidebar, making stuff hardly readable.

I have been running Element Desktop with a reduced right-hand margin for months now, and have to say, it looks and works way better, and overlay between read receipts and other content does not happen.

This is the same as issue #30358 which also has a nice screenshot.

Fixes #30358

## Checklist

- [x] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
~~- [ ] Tests written for new code (and old code if feasible).~~
~~- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.~~
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
