### PR TITLE
Fix html export when feature_jump_to_date is enabled

### DIFF
--- a/src/components/views/messages/DateSeparator.tsx
+++ b/src/components/views/messages/DateSeparator.tsx
@@ -320,7 +320,7 @@ export default class DateSeparator extends React.Component<IProps, IState> {
         const label = this.getLabel();
 
         let dateHeaderContent: JSX.Element;
-        if (this.state.jumpToDateEnabled) {
+        if (this.state.jumpToDateEnabled && !this.props.forExport) {
             dateHeaderContent = this.renderJumpToDateMenu();
         } else {
             dateHeaderContent = (


### PR DESCRIPTION
HTML export fails when feature_jump_to_date is enabled as the ToolTipProvider wasn't applied. The jump to date ui doesn't render well within the export anyway so we can just fall into the else and render the normal separator.