### PR TITLE
Defer to Element Call for skipping the lobby when starting or joining a call

### DIFF
--- a/src/components/structures/RoomView.tsx
+++ b/src/components/structures/RoomView.tsx
@@ -2609,7 +2609,6 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                         <CallView
                             room={this.state.room}
                             resizing={this.state.resizing}
-                            skipLobby={this.context.roomViewStore.skipCallLobby() ?? false}
                             role="main"
                             onClose={this.onCallClose}
                         />

--- a/src/components/views/voip/CallView.tsx
+++ b/src/components/views/voip/CallView.tsx
@@ -21,12 +21,11 @@ interface JoinCallViewProps {
     room: Room;
     resizing: boolean;
     call: Call;
-    skipLobby?: boolean;
     role?: AriaRole;
     onClose: () => void;
 }
 
-const JoinCallView: FC<JoinCallViewProps> = ({ room, resizing, call, skipLobby, role, onClose }) => {
+const JoinCallView: FC<JoinCallViewProps> = ({ room, resizing, call, role, onClose }) => {
     const cli = useContext(MatrixClientContext);
     useTypedEventEmitter(call, CallEvent.Close, onClose);
 
@@ -34,12 +33,6 @@ const JoinCallView: FC<JoinCallViewProps> = ({ room, resizing, call, skipLobby, 
         // We'll take this opportunity to tidy up our room state
         call.clean();
     }, [call]);
-
-    useEffect(() => {
-        // Always update the widget data so that we don't ignore "skipLobby" accidentally.
-        call.widget.data ??= {};
-        call.widget.data.skipLobby = skipLobby;
-    }, [call.widget, skipLobby]);
 
     const disconnectAllOtherCalls: () => Promise<void> = useCallback(async () => {
         // The stickyPromise has to resolve before the widget actually becomes sticky.
@@ -69,7 +62,6 @@ const JoinCallView: FC<JoinCallViewProps> = ({ room, resizing, call, skipLobby, 
 interface CallViewProps {
     room: Room;
     resizing: boolean;
-    skipLobby?: boolean;
     role?: AriaRole;
     /**
      * Callback for when the user closes the call.
@@ -77,19 +69,8 @@ interface CallViewProps {
     onClose: () => void;
 }
 
-export const CallView: FC<CallViewProps> = ({ room, resizing, skipLobby, role, onClose }) => {
+export const CallView: FC<CallViewProps> = ({ room, resizing, role, onClose }) => {
     const call = useCall(room.roomId);
 
-    return (
-        call && (
-            <JoinCallView
-                room={room}
-                resizing={resizing}
-                call={call}
-                skipLobby={skipLobby}
-                role={role}
-                onClose={onClose}
-            />
-        )
-    );
+    return call && <JoinCallView room={room} resizing={resizing} call={call} role={role} onClose={onClose} />;
 };

--- a/src/stores/CallStore.ts
+++ b/src/stores/CallStore.ts
@@ -8,8 +8,6 @@ Please see LICENSE files in the repository root for full details.
 
 import { logger } from "matrix-js-sdk/src/logger";
 import { GroupCallEventHandlerEvent } from "matrix-js-sdk/src/webrtc/groupCallEventHandler";
-import { type MatrixRTCSession, MatrixRTCSessionManagerEvents } from "matrix-js-sdk/src/matrixrtc";
-
 import type { EmptyObject, GroupCall, Room } from "matrix-js-sdk/src/matrix";
 import defaultDispatcher from "../dispatcher/dispatcher";
 import { UPDATE_EVENT } from "./AsyncStore";
@@ -55,7 +53,6 @@ export class CallStore extends AsyncStoreWithClient<EmptyObject> {
         }
         this.matrixClient.on(GroupCallEventHandlerEvent.Incoming, this.onGroupCall);
         this.matrixClient.on(GroupCallEventHandlerEvent.Outgoing, this.onGroupCall);
-        this.matrixClient.matrixRTC.on(MatrixRTCSessionManagerEvents.SessionStarted, this.onRTCSessionStart);
         WidgetStore.instance.on(UPDATE_EVENT, this.onWidgets);
 
         // If the room ID of a previously connected call is still in settings at
@@ -89,7 +86,6 @@ export class CallStore extends AsyncStoreWithClient<EmptyObject> {
             this.matrixClient.off(GroupCallEventHandlerEvent.Incoming, this.onGroupCall);
             this.matrixClient.off(GroupCallEventHandlerEvent.Outgoing, this.onGroupCall);
             this.matrixClient.off(GroupCallEventHandlerEvent.Ended, this.onGroupCall);
-            this.matrixClient.matrixRTC.off(MatrixRTCSessionManagerEvents.SessionStarted, this.onRTCSessionStart);
         }
         WidgetStore.instance.off(UPDATE_EVENT, this.onWidgets);
     }
@@ -187,7 +183,4 @@ export class CallStore extends AsyncStoreWithClient<EmptyObject> {
     };
 
     private onGroupCall = (groupCall: GroupCall): void => this.updateRoom(groupCall.room);
-    private onRTCSessionStart = (roomId: string, session: MatrixRTCSession): void => {
-        this.updateRoom(session.room);
-    };
 }

--- a/src/stores/RoomViewStore.tsx
+++ b/src/stores/RoomViewStore.tsx
@@ -359,7 +359,7 @@ export class RoomViewStore extends EventEmitter {
                 let call = CallStore.instance.getCall(payload.room_id);
                 // Start a call if not already there
                 if (call === null) {
-                    ElementCall.create(room, false);
+                    ElementCall.create(room, { skipLobby: payload.skipLobby });
                     call = CallStore.instance.getCall(payload.room_id)!;
                 }
                 call.presented = true;

--- a/test/unit-tests/components/views/voip/CallView-test.tsx
+++ b/test/unit-tests/components/views/voip/CallView-test.tsx
@@ -82,13 +82,13 @@ describe("CallView", () => {
         client.reEmitter.stopReEmitting(room, [RoomStateEvent.Events]);
     });
 
-    const renderView = async (skipLobby = false, role: string | undefined = undefined): Promise<void> => {
-        render(<CallView room={room} resizing={false} skipLobby={skipLobby} role={role} onClose={() => {}} />);
+    const renderView = async (role: string | undefined = undefined): Promise<void> => {
+        render(<CallView room={room} resizing={false} role={role} onClose={() => {}} />);
         await act(() => Promise.resolve()); // Let effects settle
     };
 
     it("accepts an accessibility role", async () => {
-        await renderView(undefined, "main");
+        await renderView("main");
         screen.getByRole("main");
     });
 
@@ -99,7 +99,7 @@ describe("CallView", () => {
     });
 
     it("updates the call's skipLobby parameter", async () => {
-        await renderView(true);
+        await renderView();
         expect(call.widget.data?.skipLobby).toBe(true);
     });
 });


### PR DESCRIPTION
This **removes** support for Element Call to preload the widget, allowing synchronous setting up of the widget rather than doing so in parallel. This is actually helpful as it now simplifies the call creation logic, and allows us to pass in parameters based on the way the user joins the call. The upshot of all of this is we can now rely on Element Call's intent feature to properly set `skipLobby` rather than hardcoding the value.

We discussed the preloading of widgets internally, but came to the conclusion that since the widget is now embedded with Element Web it makes less sense to preload, and causes a lot of problems for us.

## Checklist

- [ ] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
