### PR TITLE
Change the title of VerificationRequestDialog when a request is cancelled

### DIFF
--- a/src/components/views/dialogs/VerificationRequestDialog.tsx
+++ b/src/components/views/dialogs/VerificationRequestDialog.tsx
@@ -7,7 +7,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import React from "react";
-import { type VerificationRequest } from "matrix-js-sdk/src/crypto-api";
+import { VerificationPhase, VerificationRequestEvent, type VerificationRequest } from "matrix-js-sdk/src/crypto-api";
 import { type User } from "matrix-js-sdk/src/matrix";
 
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
@@ -23,7 +23,17 @@ interface IProps {
 }
 
 interface IState {
+    // The VerificationRequest that is ongoing. This can be replaced if a
+    // promise was supplied in the props and it completes.
     verificationRequest?: VerificationRequest;
+
+    // What phase the VerificationRequest is at. This is part of
+    // verificationRequest but we have it as independent state because we need
+    // to update when it changes.
+    //
+    // We listen to the `Change` event on verificationRequest and update phase
+    // when that fires.
+    phase?: VerificationPhase;
 }
 
 export default class VerificationRequestDialog extends React.Component<IProps, IState> {
@@ -31,22 +41,51 @@ export default class VerificationRequestDialog extends React.Component<IProps, I
         super(props);
         this.state = {
             verificationRequest: this.props.verificationRequest,
+            phase: this.props.verificationRequest?.phase,
         };
     }
 
     public componentDidMount(): void {
+        // Listen to when the verificationRequest changes, so we can keep our
+        // phase up-to-date.
+        this.state.verificationRequest?.on(VerificationRequestEvent.Change, this.onRequestChange);
+
         this.props.verificationRequestPromise?.then((r) => {
-            this.setState({ verificationRequest: r });
+            // The request promise completed, so we have a new request
+
+            // Stop listening to the old request (if we have one, which normally we won't)
+            this.state.verificationRequest?.off(VerificationRequestEvent.Change, this.onRequestChange);
+
+            // And start listening to the new one
+            r.on(VerificationRequestEvent.Change, this.onRequestChange);
+
+            this.setState({ verificationRequest: r, phase: r.phase });
         });
     }
+
+    public componentWillUnmount(): void {
+        // Stop listening for changes to the request when we close
+        this.state.verificationRequest?.off(VerificationRequestEvent.Change, this.onRequestChange);
+    }
+
+    /**
+     * The verificationRequest changed, so we need to make sure we update our
+     * state to have the correct phase.
+     *
+     * Note: this is called when verificationRequest changes in some way, not
+     * when we replace verificationRequest with some new request.
+     */
+    private readonly onRequestChange = (): void => {
+        this.setState((prevState) => ({
+            phase: prevState.verificationRequest?.phase,
+        }));
+    };
 
     public render(): React.ReactNode {
         const request = this.state.verificationRequest;
         const otherUserId = request?.otherUserId;
         const member = this.props.member || (otherUserId ? MatrixClientPeg.safeGet().getUser(otherUserId) : null);
-        const title = request?.isSelfVerification
-            ? _t("encryption|verification|verification_dialog_title_device")
-            : _t("encryption|verification|verification_dialog_title_user");
+        const title = this.dialogTitle(request);
 
         if (!member) return null;
 
@@ -68,5 +107,17 @@ export default class VerificationRequestDialog extends React.Component<IProps, I
                 />
             </BaseDialog>
         );
+    }
+
+    private dialogTitle(request?: VerificationRequest): string {
+        if (request?.isSelfVerification) {
+            if (request.phase === VerificationPhase.Cancelled) {
+                return _t("encryption|verification|verification_dialog_title_failed");
+            } else {
+                return _t("encryption|verification|verification_dialog_title_device");
+            }
+        } else {
+            return _t("encryption|verification|verification_dialog_title_user");
+        }
     }
 }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1068,6 +1068,7 @@
             "use_another_device": "Use another device",
             "use_recovery_key": "Use recovery key",
             "verification_dialog_title_device": "Verify other device",
+            "verification_dialog_title_failed": "Verification failed",
             "verification_dialog_title_user": "Verification Request",
             "verification_skip_warning": "Without verifying, you won't have access to all your messages and may appear as untrusted to others.",
             "verification_success_with_backup": "Your new device is now verified. It has access to your encrypted messages, and other users will see it as trusted.",

--- a/test/unit-tests/components/structures/MatrixChat-test.tsx
+++ b/test/unit-tests/components/structures/MatrixChat-test.tsx
@@ -1106,7 +1106,7 @@ describe("<MatrixChat />", () => {
                 act(() => verify.click());
 
                 // And close the device verification dialog
-                const closeButton = await screen.findByRole("button", { name: "Close dialog" });
+                const closeButton = screen.getByRole("button", { name: "Close dialog" });
                 act(() => closeButton.click());
 
                 // Then we are not allowed in - we are still being asked to verify
@@ -1179,7 +1179,7 @@ describe("<MatrixChat />", () => {
                         .fn()
                         .mockResolvedValue({ signedByOwner: true } as DeviceVerificationStatus),
                     isCrossSigningReady: jest.fn().mockReturnValue(false),
-                    requestOwnUserVerification: jest.fn().mockResolvedValue({ cancel: jest.fn() }),
+                    requestOwnUserVerification: jest.fn().mockResolvedValue({ cancel: jest.fn(), on: jest.fn() }),
                 } as any;
             }
         });

--- a/test/unit-tests/components/views/dialogs/VerificationRequestDialog-test.tsx
+++ b/test/unit-tests/components/views/dialogs/VerificationRequestDialog-test.tsx
@@ -88,7 +88,7 @@ describe("VerificationRequestDialog", () => {
     it("Shows a failure message if verification was cancelled", async () => {
         const dialog = renderComponent(VerificationPhase.Cancelled);
 
-        expect(screen.getByRole("heading", { name: "Verify other device" })).toBeInTheDocument();
+        expect(screen.getByRole("heading", { name: "Verification failed" })).toBeInTheDocument();
         expect(screen.getByRole("heading", { name: "Verification cancelled" })).toBeInTheDocument();
 
         expect(
@@ -118,7 +118,7 @@ describe("VerificationRequestDialog", () => {
         await act(async () => await new Promise(process.nextTick));
 
         // Then it renders the resolved information
-        expect(screen.getByRole("heading", { name: "Verify other device" })).toBeInTheDocument();
+        expect(screen.getByRole("heading", { name: "Verification failed" })).toBeInTheDocument();
         expect(screen.getByRole("heading", { name: "Verification cancelled" })).toBeInTheDocument();
 
         expect(
@@ -148,7 +148,7 @@ describe("VerificationRequestDialog", () => {
         await act(async () => await new Promise(process.nextTick));
 
         // Then it renders the information from the request in the promise
-        expect(screen.getByRole("heading", { name: "Verify other device" })).toBeInTheDocument();
+        expect(screen.getByRole("heading", { name: "Verification failed" })).toBeInTheDocument();
         expect(screen.getByRole("heading", { name: "Verification cancelled" })).toBeInTheDocument();
 
         expect(
@@ -169,7 +169,7 @@ describe("VerificationRequestDialog", () => {
         await act(async () => await request.cancel());
 
         // Then the dialog is updated to reflect that
-        expect(screen.getByRole("heading", { name: "Verify other device" })).toBeInTheDocument();
+        expect(screen.getByRole("heading", { name: "Verification failed" })).toBeInTheDocument();
         expect(screen.getByRole("heading", { name: "Verification cancelled" })).toBeInTheDocument();
 
         expect(

--- a/test/unit-tests/components/views/dialogs/__snapshots__/VerificationRequestDialog-test.tsx.snap
+++ b/test/unit-tests/components/views/dialogs/__snapshots__/VerificationRequestDialog-test.tsx.snap
@@ -236,7 +236,7 @@ exports[`VerificationRequestDialog Shows a failure message if verification was c
         class="mx_Heading_h3 mx_Dialog_title"
         id="mx_BaseDialog_title"
       >
-        Verify other device
+        Verification failed
       </h1>
     </div>
     <div


### PR DESCRIPTION
Part of implementing https://github.com/element-hq/element-meta/issues/2898 but split out as a separate change because it involves making VerificationRequestDialog listen for changes to the verificationRequest so it can update based on changes to phase.
