### PR TITLE
New Room List: Improve robustness of keyboard navigation

### DIFF
--- a/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
+++ b/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
@@ -252,6 +252,26 @@ test.describe("Room list", () => {
                 // Focus should be back on the notification button
                 await expect(notificationButton).toBeFocused();
             });
+
+            test("should navigate to the top and then bottom of the room list", async ({ page, app, user }) => {
+                const roomListView = getRoomList(page);
+
+                const topRoom = roomListView.getByRole("option", { name: "Open room room29" });
+
+                // open the room
+                await topRoom.click();
+                // put focus back on the room list item
+                await topRoom.click();
+                await expect(topRoom).toBeFocused();
+
+                await page.keyboard.press("End");
+                const bottomRoom = roomListView.getByRole("option", { name: "Open room room0" });
+                await expect(bottomRoom).toBeFocused();
+
+                await page.keyboard.press("Home");
+                const topRoomAgain = roomListView.getByRole("option", { name: "Open room room29" });
+                await expect(topRoomAgain).toBeFocused();
+            });
         });
     });
 

--- a/src/components/utils/ListView.tsx
+++ b/src/components/utils/ListView.tsx
@@ -133,13 +133,13 @@ export function ListView<Item, Context = any>(props: IListViewProps<Item, Contex
             }
             if (items[clampedIndex]) {
                 const key = getItemKey(items[clampedIndex]);
-                setTabIndexKey(key);
                 isScrollingToItem.current = true;
                 virtuosoHandleRef.current?.scrollIntoView({
                     index: clampedIndex,
                     align: align,
                     behavior: "auto",
                     done: () => {
+                        setTabIndexKey(key);
                         isScrollingToItem.current = false;
                     },
                 });


### PR DESCRIPTION
In my current testing of the room list, when you page up and down or use home/end to go to the start/end the item is scrolled to and visually gets the background highlighted style but not the browser focus with coloured border.

It's not actually a regression but more of a timing one.

The call to `.focus()`(which is inside the `RoomListItemView`) is being called before the item is fully scrolled to and mounted/visible.

The new code waits for we have finished scrolling to the item before setting the tabIndexKey(which in turn causes the item to focus itself).

The e2e test added reproduces the issue.