### PR TITLE
Fix duplicate context menu on right-click in room list item menus

### DIFF
--- a/src/components/views/rooms/RoomListPanel/RoomListItemMenuView.tsx
+++ b/src/components/views/rooms/RoomListPanel/RoomListItemMenuView.tsx
@@ -72,19 +72,26 @@ function MoreOptionsMenu({ vm, setMenuOpen }: MoreOptionsMenuProps): JSX.Element
     const [open, setOpen] = useState(false);
 
     return (
-        <Menu
-            open={open}
-            onOpenChange={(isOpen) => {
-                setOpen(isOpen);
-                setMenuOpen(isOpen);
+        <div
+            onContextMenu={(e) => {
+                // Prevent opening duplicate more options menu via right-click
+                if (open) e.stopPropagation();
             }}
-            title={_t("room_list|room|more_options")}
-            showTitle={false}
-            align="start"
-            trigger={<MoreOptionsButton size="24px" />}
         >
-            <MoreOptionContent vm={vm} />
-        </Menu>
+            <Menu
+                open={open}
+                onOpenChange={(isOpen) => {
+                    setOpen(isOpen);
+                    setMenuOpen(isOpen);
+                }}
+                title={_t("room_list|room|more_options")}
+                showTitle={false}
+                align="start"
+                trigger={<MoreOptionsButton size="24px" />}
+            >
+                <MoreOptionContent vm={vm} />
+            </Menu>
+        </div>
     );
 }
 
@@ -202,6 +209,16 @@ function NotificationMenu({ vm, setMenuOpen }: NotificationMenuProps): JSX.Eleme
         <div
             // We don't want keyboard navigation events to bubble up to the ListView changing the focused item
             onKeyDown={(e) => e.stopPropagation()}
+            onContextMenu={() => {
+                if (open) {
+                    // Close notification menu and allow context menu to open via event bubbling
+                    // setTimeout ensures the menu closes after the current event completes bubbling
+                    setTimeout(() => {
+                        setOpen(false);
+                        setMenuOpen(false);
+                    }, 0);
+                }
+            }}
         >
             <Menu
                 open={open}

--- a/test/unit-tests/components/views/rooms/RoomListPanel/RoomListItemView-test.tsx
+++ b/test/unit-tests/components/views/rooms/RoomListPanel/RoomListItemView-test.tsx
@@ -215,4 +215,31 @@ describe("<RoomListItemView />", () => {
         // But the room item itself should still be rendered
         expect(button).toBeInTheDocument();
     });
+
+    test("should hide hover menu when context menu opens", async () => {
+        const user = userEvent.setup();
+
+        mocked(useRoomListItemViewModel).mockReturnValue({
+            ...defaultValue,
+            showContextMenu: true,
+            showHoverMenu: true,
+        });
+
+        renderRoomListItem();
+
+        const button = screen.getByRole("option", { name: `Open room ${room.name}` });
+
+        // First hover to show hover menu
+        await user.hover(button);
+        await waitFor(() => expect(screen.getByRole("button", { name: "More Options" })).toBeInTheDocument());
+
+        // Then right-click to open context menu
+        await user.pointer([{ target: button }, { keys: "[MouseRight]", target: button }]);
+
+        // Context menu should be open
+        await waitFor(() => expect(screen.getByRole("menu")).toBeInTheDocument());
+
+        // Hover menu (More Options button) should be hidden when context menu is open
+        expect(screen.queryByRole("button", { name: "More Options" })).toBeNull();
+    });
 });

--- a/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomList-test.tsx.snap
+++ b/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomList-test.tsx.snap
@@ -4,6 +4,7 @@ exports[`<RoomList /> should render a room list 1`] = `
 <DocumentFragment>
   <div
     aria-label="Room list"
+    context="[object Object]"
     data-testid="room-list"
     data-virtuoso-scroller="true"
     role="listbox"

--- a/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomListItemMenuView-test.tsx.snap
+++ b/test/unit-tests/components/views/rooms/RoomListPanel/__snapshots__/RoomListItemMenuView-test.tsx.snap
@@ -6,38 +6,40 @@ exports[`<RoomListItemMenuView /> should render the more options menu 1`] = `
     class="flex mx_RoomListItemMenuView"
     style="--mx-flex-display: flex; --mx-flex-direction: row; --mx-flex-align: center; --mx-flex-justify: start; --mx-flex-gap: var(--cpd-space-1x); --mx-flex-wrap: nowrap;"
   >
-    <button
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="menu"
-      aria-label="More Options"
-      aria-labelledby="«r2»"
-      class="_icon-button_1pz9o_8"
-      data-kind="primary"
-      data-state="closed"
-      id="radix-«r0»"
-      role="button"
-      style="--cpd-icon-button-size: 24px;"
-      tabindex="0"
-      type="button"
-    >
-      <div
-        class="_indicator-icon_zr2a0_17"
-        style="--cpd-icon-button-size: 100%;"
+    <div>
+      <button
+        aria-disabled="false"
+        aria-expanded="false"
+        aria-haspopup="menu"
+        aria-label="More Options"
+        aria-labelledby="«r2»"
+        class="_icon-button_1pz9o_8"
+        data-kind="primary"
+        data-state="closed"
+        id="radix-«r0»"
+        role="button"
+        style="--cpd-icon-button-size: 24px;"
+        tabindex="0"
+        type="button"
       >
-        <svg
-          fill="currentColor"
-          height="1em"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="_indicator-icon_zr2a0_17"
+          style="--cpd-icon-button-size: 100%;"
         >
-          <path
-            d="M6 14q-.824 0-1.412-.588A1.93 1.93 0 0 1 4 12q0-.825.588-1.412A1.93 1.93 0 0 1 6 10q.824 0 1.412.588Q8 11.175 8 12t-.588 1.412A1.93 1.93 0 0 1 6 14m6 0q-.825 0-1.412-.588A1.93 1.93 0 0 1 10 12q0-.825.588-1.412A1.93 1.93 0 0 1 12 10q.825 0 1.412.588Q14 11.175 14 12t-.588 1.412A1.93 1.93 0 0 1 12 14m6 0q-.824 0-1.413-.588A1.93 1.93 0 0 1 16 12q0-.825.587-1.412A1.93 1.93 0 0 1 18 10q.824 0 1.413.588Q20 11.175 20 12t-.587 1.412A1.93 1.93 0 0 1 18 14"
-          />
-        </svg>
-      </div>
-    </button>
+          <svg
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M6 14q-.824 0-1.412-.588A1.93 1.93 0 0 1 4 12q0-.825.588-1.412A1.93 1.93 0 0 1 6 10q.824 0 1.412.588Q8 11.175 8 12t-.588 1.412A1.93 1.93 0 0 1 6 14m6 0q-.825 0-1.412-.588A1.93 1.93 0 0 1 10 12q0-.825.588-1.412A1.93 1.93 0 0 1 12 10q.825 0 1.412.588Q14 11.175 14 12t-.588 1.412A1.93 1.93 0 0 1 12 14m6 0q-.824 0-1.413-.588A1.93 1.93 0 0 1 16 12q0-.825.587-1.412A1.93 1.93 0 0 1 18 10q.824 0 1.413.588Q20 11.175 20 12t-.587 1.412A1.93 1.93 0 0 1 18 14"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
     <div>
       <button
         aria-disabled="false"
@@ -85,38 +87,40 @@ exports[`<RoomListItemMenuView /> should render the notification options menu 1`
     class="flex mx_RoomListItemMenuView"
     style="--mx-flex-display: flex; --mx-flex-direction: row; --mx-flex-align: center; --mx-flex-justify: start; --mx-flex-gap: var(--cpd-space-1x); --mx-flex-wrap: nowrap;"
   >
-    <button
-      aria-disabled="false"
-      aria-expanded="false"
-      aria-haspopup="menu"
-      aria-label="More Options"
-      aria-labelledby="«ri»"
-      class="_icon-button_1pz9o_8"
-      data-kind="primary"
-      data-state="closed"
-      id="radix-«rg»"
-      role="button"
-      style="--cpd-icon-button-size: 24px;"
-      tabindex="0"
-      type="button"
-    >
-      <div
-        class="_indicator-icon_zr2a0_17"
-        style="--cpd-icon-button-size: 100%;"
+    <div>
+      <button
+        aria-disabled="false"
+        aria-expanded="false"
+        aria-haspopup="menu"
+        aria-label="More Options"
+        aria-labelledby="«ri»"
+        class="_icon-button_1pz9o_8"
+        data-kind="primary"
+        data-state="closed"
+        id="radix-«rg»"
+        role="button"
+        style="--cpd-icon-button-size: 24px;"
+        tabindex="0"
+        type="button"
       >
-        <svg
-          fill="currentColor"
-          height="1em"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="_indicator-icon_zr2a0_17"
+          style="--cpd-icon-button-size: 100%;"
         >
-          <path
-            d="M6 14q-.824 0-1.412-.588A1.93 1.93 0 0 1 4 12q0-.825.588-1.412A1.93 1.93 0 0 1 6 10q.824 0 1.412.588Q8 11.175 8 12t-.588 1.412A1.93 1.93 0 0 1 6 14m6 0q-.825 0-1.412-.588A1.93 1.93 0 0 1 10 12q0-.825.588-1.412A1.93 1.93 0 0 1 12 10q.825 0 1.412.588Q14 11.175 14 12t-.588 1.412A1.93 1.93 0 0 1 12 14m6 0q-.824 0-1.413-.588A1.93 1.93 0 0 1 16 12q0-.825.587-1.412A1.93 1.93 0 0 1 18 10q.824 0 1.413.588Q20 11.175 20 12t-.587 1.412A1.93 1.93 0 0 1 18 14"
-          />
-        </svg>
-      </div>
-    </button>
+          <svg
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M6 14q-.824 0-1.412-.588A1.93 1.93 0 0 1 4 12q0-.825.588-1.412A1.93 1.93 0 0 1 6 10q.824 0 1.412.588Q8 11.175 8 12t-.588 1.412A1.93 1.93 0 0 1 6 14m6 0q-.825 0-1.412-.588A1.93 1.93 0 0 1 10 12q0-.825.588-1.412A1.93 1.93 0 0 1 12 10q.825 0 1.412.588Q14 11.175 14 12t-.588 1.412A1.93 1.93 0 0 1 12 14m6 0q-.824 0-1.413-.588A1.93 1.93 0 0 1 16 12q0-.825.587-1.412A1.93 1.93 0 0 1 18 10q.824 0 1.413.588Q20 11.175 20 12t-.587 1.412A1.93 1.93 0 0 1 18 14"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
     <div>
       <button
         aria-disabled="false"


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Problem
When a room list item menu is open (three dots or notification bell), right-clicking on menu items causes a duplicate context menu to appear, overlaying the existing menu. This creates a confusing UX where users see two identical menus stacked on top of each other.

## Root cause
The context menu event bubbles up from menu content to the parent room list item, which has its own context menu handler, triggering a second menu to open.

## Solution
Implemented conditional event handling based on menu type and state:

1. More Options Menu: Added conditional `e.stopPropagation()` only when the menu is open `if (open)`. This prevents duplicate menus when the more options menu is active, but allows right-click functionality when the menu is closed.
2. Notification Menu: Added `setTimeout(() => { setOpen(false);  setMenuOpen(false); }, 0)` to close the notification menu when right-clicked, allowing the parent context menu to open naturally without duplication.
3. Context Menu Coordination: Enhanced `setMenuOpen` logic in `RoomListItemView` to hide hover menus when context menus open, preventing overlapping UI elements.

The solution provides consistent right-click behavior across different menu types while preventing the original duplication issue.

## Before/After videos
### Before (bug reproduction):
https://github.com/user-attachments/assets/059c6206-eb1d-4a86-b042-53cb9b4fc63b

### After (fixed):
https://github.com/user-attachments/assets/e7d0a204-acf8-4caf-b4b1-c3a8f990f8d3

## Checklist
- [x] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
