### PR TITLE
Emoji Picker: Focused emoji does not move with the arrow keys

### DIFF
--- a/src/components/views/emojipicker/EmojiPicker.tsx
+++ b/src/components/views/emojipicker/EmojiPicker.tsx
@@ -187,6 +187,7 @@ class EmojiPicker extends React.Component<IProps, IState> {
         }
 
         if (focusNode) {
+            focusNode?.focus();
             dispatch({
                 type: Type.SetFocus,
                 payload: { node: focusNode },


### PR DESCRIPTION
## Before
https://github.com/user-attachments/assets/c5895ef9-231a-4843-86a9-e63c4005a026

## After
https://github.com/user-attachments/assets/dd125485-a0d8-4503-886d-951061ab8ef9

## Fix
We should focus the node in the DOM node so that the browser focus(with outline) matches the our internal RovingIndex state.