### PR TITLE
Prefer UIA flows with supported UIA stages

### DIFF
--- a/src/components/structures/InteractiveAuth.tsx
+++ b/src/components/structures/InteractiveAuth.tsx
@@ -20,7 +20,7 @@ import { logger } from "matrix-js-sdk/src/logger";
 
 import getEntryComponentForLoginType, {
     type ContinueKind,
-    type CustomAuthType,
+    CustomAuthType,
     type IStageComponent,
 } from "../views/auth/InteractiveAuthEntryComponents";
 import Spinner from "../views/elements/Spinner";
@@ -117,6 +117,7 @@ export default class InteractiveAuthComponent<T> extends React.Component<Interac
                 AuthType.UnstableRegistrationToken,
                 AuthType.Sso,
                 AuthType.SsoUnstable,
+                CustomAuthType.MasCrossSigningReset,
             ],
         });
     }


### PR DESCRIPTION
https://github.com/element-hq/matrix-react-sdk/pull/34 added support for a custom UIA stage called `org.matrix.cross_signing_reset`, but neglected to add that stage to the list of supported stages that is passed to the js-sdk. As a result, if the server chooses to offer alternative flows that use unsupported steps (as is proposed in MSC4312), the js-sdk will be unable to reliably choose between them.