### PR TITLE
Fix voice notes rendering at 00:00 when playback had not begun.

### DIFF
--- a/src/audio/PlaybackQueue.ts
+++ b/src/audio/PlaybackQueue.ts
@@ -89,9 +89,15 @@ export class PlaybackQueue {
     private onPlaybackStateChange(playback: Playback, mxEvent: MatrixEvent, newState: PlaybackState): void {
         // Remember where the user got to in playback
         const wasLastPlaying = this.currentPlaybackId === mxEvent.getId();
-        if (newState === PlaybackState.Stopped && this.clockStates.has(mxEvent.getId()!) && !wasLastPlaying) {
-            // noinspection JSIgnoredPromiseFromCall
-            playback.skipTo(this.clockStates.get(mxEvent.getId()!)!);
+        const currentClockState = this.clockStates.get(mxEvent.getId()!);
+        if (newState === PlaybackState.Stopped && currentClockState !== undefined && !wasLastPlaying) {
+            if (currentClockState > 0) {
+                // skipTo will pause playback, which causes the clock to render the current
+                // playback seconds. If the clock state is 0, then we can just ignore
+                // skipping entirely.
+                // noinspection JSIgnoredPromiseFromCall
+                playback.skipTo(currentClockState);
+            }
         } else if (newState === PlaybackState.Stopped) {
             // Remove the now-useless clock for some space savings
             this.clockStates.delete(mxEvent.getId()!);


### PR DESCRIPTION
Fixes #30958 

Needs a test.

## Checklist

- [ ] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
