### PR TITLE
Remove auto-bump step from share component publishing

### DIFF
--- a/.github/workflows/shared-component-publish.yaml
+++ b/.github/workflows/shared-component-publish.yaml
@@ -5,7 +5,7 @@ on:
 concurrency: release
 jobs:
     publish:
-        name: "Release & Publish"
+        name: "Publish"
         runs-on: ubuntu-latest
         permissions:
             contents: write


### PR DESCRIPTION
Avoids having to give release bot permission to commit directly to the branch for now.

Tested by running it from the branch and, after a few more tweaks (which I've just included here for expedience) it's now working.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
