### PR TITLE
Fix translation in dev mode

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -214,6 +214,9 @@ module.exports = (env, argv) => {
 
                 // Define a variable so the i18n stuff can load
                 "$webapp": path.resolve(__dirname, "webapp"),
+
+                // Make shared-components imports resolve to EW counterpart
+                "counterpart": path.resolve(__dirname, "node_modules/counterpart"),
             },
             fallback: {
                 // Mock out the NodeFS module: The opus decoder imports this wrongly.


### PR DESCRIPTION
Regression due to https://github.com/element-hq/element-web/pull/31034
If shared components dependencies are installed locally, two instance of counterparts are used (one by EW and one by shared components)