### PR TITLE
Only export `setLanguage` for shared-component build

### DIFF
--- a/packages/shared-components/src/index.ts
+++ b/packages/shared-components/src/index.ts
@@ -21,7 +21,7 @@ export * from "./utils/Box";
 export * from "./utils/Flex";
 
 // Utils
-export * from "./utils/i18n";
+export { setLanguage } from "./utils/i18n";
 export * from "./utils/humanize";
 export * from "./utils/DateUtils";
 export * from "./utils/numbers";


### PR DESCRIPTION
If we export all `i18n.tsx`, we export imports related to EW.

Example of failure:
- https://github.com/element-hq/element-modules-private/actions/runs/18682387546/job/53266265222?pr=6
- `Error: ../../../node_modules/@element-hq/web-shared-components/dist/element-web-shared-components.d.ts(5,38): error TS2307: Cannot find module '../../../../src/i18n/strings/en_EN.json' or its corresponding type declarations.`