### PR TITLE
Add aria label to emoji picker search

### DIFF
--- a/src/components/views/emojipicker/Search.tsx
+++ b/src/components/views/emojipicker/Search.tsx
@@ -66,6 +66,7 @@ class Search extends React.PureComponent<IProps> {
                     autoFocus
                     type="text"
                     placeholder={_t("action|search")}
+                    aria-label={_t("action|search")}
                     value={this.props.query}
                     onChange={(ev) => this.props.onChange(ev.target.value)}
                     onKeyDown={this.onKeyDown}


### PR DESCRIPTION
Placeholder is not sufficiently accessabile as a label, adding aria-label to the emoji picker search.
