### PR TITLE
Force counterpart resolve in jest config

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -40,6 +40,7 @@ const config: Config = {
         "^!!raw-loader!.*": "jest-raw-loader",
         "recorderWorkletFactory": "<rootDir>/__mocks__/empty.js",
         "^fetch-mock$": "<rootDir>/node_modules/fetch-mock",
+        "counterpart": "<rootDir>/node_modules/counterpart",
     },
     transformIgnorePatterns: [
         "/node_modules/(?!(mime|matrix-js-sdk|uuid|p-retry|is-network-error|react-merge-refs)).+$",


### PR DESCRIPTION
When running the test locally, the translations weren't applied. It was due to counterpart instances running.
In webpack, we force the counterpart resolve, let's do the same thing for jest.