### PR TITLE
Refactor Jitsi widget to use compound (to solve a11y) concerns.

### DIFF
--- a/src/vector/jitsi/index.html
+++ b/src/vector/jitsi/index.html
@@ -7,16 +7,6 @@
     <body>
         <div id="jitsiContainer"><!-- the js will put the conference here --></div>
         <div id="joinButtonContainer">
-            <div class="joinConferenceFloating">
-                <div class="joinConferencePrompt">
-                    <span class="icon"><!-- managed by CSS --></span>
-                    <!-- TODO: i18n -->
-                    <h2>Jitsi Video Conference</h2>
-                    <div id="widgetActionContainer">
-                        <button type="button" id="joinButton">Join Conference</button>
-                    </div>
-                </div>
-            </div>
         </div>
         <!-- This script is not webpacked, and the script is downloaded at build time -->
         <script src="./jitsi_external_api.min.js"></script>

--- a/src/vector/jitsi/index.pcss
+++ b/src/vector/jitsi/index.pcss
@@ -6,7 +6,8 @@ Please see LICENSE files in the repository root for full details.
 */
 
 /* TODO: Match the user's theme: https://github.com/element-hq/element-web/issues/12794 */
-
+@import url("@vector-im/compound-design-tokens/assets/web/css/compound-design-tokens.css") layer(compound);
+@import url("@vector-im/compound-web/dist/style.css");
 /* Path to `res` dir in the source tree */
 $res: ../../../res;
 
@@ -47,59 +48,25 @@ html {
 }
 
 #joinButtonContainer {
-    display: table;
-    position: absolute;
-    height: 100%;
     width: 100%;
-
-    /* Hidden by default to avoid flashing the prejoin screen at the user when */
-    /* we're supposed to skip it anyways */
-    visibility: hidden;
-}
-
-.joinConferenceFloating {
-    display: table-cell;
-    vertical-align: middle;
+    height: 100%;
+    display: grid;
+    place-items: center;
 }
 
 .joinConferencePrompt {
-    margin-left: auto;
-    margin-right: auto;
-    width: 90%;
-    text-align: center;
-}
+    display: flex;
+    flex-direction: column;
+    margin: auto;
+    width: fit-content;
 
-#joinButton {
-    /* A mix of AccessibleButton styles */
-    cursor: pointer;
-    padding: 7px 18px;
-    text-align: center;
-    border-radius: 4px;
-    display: inline-block;
-    font-size: 14px;
-    color: #ffffff;
-    background-color: #03b381;
-    border: 0;
-}
+    > * {
+        margin-left: auto;
+        margin-right: auto;
 
-.icon {
-    $icon-size: 42px;
-    margin-top: -$icon-size; /* to visually center the form */
-
-    &::before {
-        content: "";
-        background-size: contain;
-        background-color: $dark-fg;
-        mask-repeat: no-repeat;
-        mask-position: center;
-        mask-image: url("$(res)/img/element-icons/call/video-call.svg");
-        mask-size: $icon-size;
-        display: block;
-        width: $icon-size;
-        height: $icon-size;
-        margin: 0 auto; /* center */
     }
 }
+
 
 body.theme-light .icon::before {
     background-color: $light-fg;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -130,7 +130,7 @@ module.exports = (env, argv) => {
         entry: {
             bundle: "./src/vector/index.ts",
             mobileguide: "./src/vector/mobile_guide/index.ts",
-            jitsi: "./src/vector/jitsi/index.ts",
+            jitsi: "./src/vector/jitsi/index.tsx",
             usercontent: "./src/usercontent/index.ts",
             serviceworker: {
                 import: "./src/serviceworker/index.ts",


### PR DESCRIPTION
This is the slightly more involved solution to the problem of the green button being hard to read, but is future proof with compound changes in the future.

## Checklist

- [ ] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
