### PR TITLE
Use compound Button styles for Jitsi button

### DIFF
--- a/src/vector/jitsi/index.pcss
+++ b/src/vector/jitsi/index.pcss
@@ -18,7 +18,6 @@ $res: ../../../res;
     src: url("$(res)/fonts/Nunito/Nunito-Regular.ttf") format("truetype");
 }
 
-
 $dark-fg: #edf3ff;
 $dark-bg: #363c43;
 $light-fg: #2e2f32;


### PR DESCRIPTION
This is a rough cut to replace a rough cut. The old css copied the AccessibleButton styles, and this one copies the Compound Button styles. The difference is at least we import the design tokens now, but copying the whole component would require setting this up in React like (#31147) which is a bit of a waste of time.

|Before|After|
|:---:|:---:|
|<img width="432" height="361" alt="image" src="https://github.com/user-attachments/assets/8441e552-f427-4740-8fef-6dcf751b6cb3" />|<img width="535" height="388" alt="image" src="https://github.com/user-attachments/assets/c3316d2e-aa20-4479-a1f5-cdc5584575a3" />|
|<img width="355" height="290" alt="image" src="https://github.com/user-attachments/assets/d7df916d-ee22-4aee-98d4-a8937ae1561e" />|<img width="428" height="247" alt="image" src="https://github.com/user-attachments/assets/0fbf8823-d7a4-490d-a78d-9cd0ad41044a" />|

## Checklist

- [ ] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
