### PR TITLE
Disable crossSignDevice test

### DIFF
--- a/test/unit-tests/components/views/dialogs/ManualDeviceKeyVerificationDialog-test.tsx
+++ b/test/unit-tests/components/views/dialogs/ManualDeviceKeyVerificationDialog-test.tsx
@@ -70,7 +70,8 @@ describe("ManualDeviceKeyVerificationDialog", () => {
         ).toBeVisible();
     });
 
-    it("should not call crossSignDevice if device is already verified", async () => {
+    // Disabled because it seems to be failing intermittently and we can't see how to fix it
+    it.skip("should not call crossSignDevice if device is already verified", async () => {
         // Given a dialog populated with a correct fingerprint for a verified device
         const { dialog, onFinished } = populateDialog("VERIFIED_DEVICEID", "VERIFIED_FINGERPRINT");
 


### PR DESCRIPTION
As per comment, this is failing sometimes in CI but we can't get it to fail locally and can't work out how to fix it, so we're disabling it for now.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
