### PR TITLE
Hopefully fix manual device verification test

### DIFF
--- a/test/unit-tests/components/views/dialogs/ManualDeviceKeyVerificationDialog-test.tsx
+++ b/test/unit-tests/components/views/dialogs/ManualDeviceKeyVerificationDialog-test.tsx
@@ -11,7 +11,7 @@ import { act, fireEvent, render, screen, waitFor } from "jest-matrix-react";
 import { type MatrixClient } from "matrix-js-sdk/src/matrix";
 import { DeviceVerificationStatus } from "matrix-js-sdk/src/crypto-api";
 
-import { stubClient } from "../../../../test-utils";
+import { clearAllModals, stubClient } from "../../../../test-utils";
 import { ManualDeviceKeyVerificationDialog } from "../../../../../src/components/views/dialogs/ManualDeviceKeyVerificationDialog";
 
 describe("ManualDeviceKeyVerificationDialog", () => {
@@ -21,9 +21,10 @@ describe("ManualDeviceKeyVerificationDialog", () => {
         return render(<ManualDeviceKeyVerificationDialog onFinished={onFinished} />);
     }
 
-    beforeEach(() => {
+    beforeEach(async () => {
         mockClient = stubClient();
         mockExistingDevices();
+        await clearAllModals();
     });
 
     it("should render correctly", () => {


### PR DESCRIPTION
Looks like it's failing to clear modals between tests

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
