### PR TITLE
Ensure Element Call is the default for Video rooms where possible

### DIFF
--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1520,6 +1520,8 @@
         "dynamic_room_predecessors": "Dynamic room predecessors",
         "dynamic_room_predecessors_description": "Enable MSC3946 (to support late-arriving room archives)",
         "element_call_video_rooms": "Element Call video rooms",
+        "element_call_video_rooms_element_call_exclusive": "Element is configured to use Element Call exlusively, so this cannot be disabled.",
+        "element_call_video_rooms_missing_video_rooms": "You must enable video rooms to enable this feature.",
         "exclude_insecure_devices": "Exclude insecure devices when sending/receiving messages",
         "exclude_insecure_devices_description": "When this mode is enabled, encrypted messages will not be shared with unverified devices, and messages from unverified devices will be shown as an error. Note that if you enable this mode, you may be unable to communicate with users who have not verified their devices.",
         "experimental_description": "Feeling experimental? Try out our latest ideas in development. These features are not finalised; they may be unstable, may change, or may be dropped altogether. <a>Learn more</a>.",
@@ -3390,24 +3392,10 @@
         "no_rooms_with_unread_threads": "You don't have rooms with unread threads yet."
     },
     "time": {
-        "about_day_ago": "about a day ago",
-        "about_hour_ago": "about an hour ago",
-        "about_minute_ago": "about a minute ago",
         "date_at_time": "%(date)s at %(time)s",
-        "few_seconds_ago": "a few seconds ago",
         "hours_minutes_seconds_left": "%(hours)sh %(minutes)sm %(seconds)ss left",
-        "in_about_day": "about a day from now",
-        "in_about_hour": "about an hour from now",
-        "in_about_minute": "about a minute from now",
-        "in_few_seconds": "a few seconds from now",
-        "in_n_days": "%(num)s days from now",
-        "in_n_hours": "%(num)s hours from now",
-        "in_n_minutes": "%(num)s minutes from now",
         "left": "%(timeRemaining)s left",
         "minutes_seconds_left": "%(minutes)sm %(seconds)ss left",
-        "n_days_ago": "%(num)s days ago",
-        "n_hours_ago": "%(num)s hours ago",
-        "n_minutes_ago": "%(num)s minutes ago",
         "seconds_left": "%(seconds)ss left",
         "short_days": "%(value)sd",
         "short_days_hours_minutes_seconds": "%(days)sd %(hours)sh %(minutes)sm %(seconds)ss",
@@ -3462,11 +3450,9 @@
             "unable_to_find": "Tried to load a specific point in this room's timeline, but was unable to find it."
         },
         "m.audio": {
-            "audio_player": "Audio player",
             "error_downloading_audio": "Error downloading audio",
             "error_processing_audio": "Error processing audio message",
-            "error_processing_voice_message": "Error processing voice message",
-            "unnamed_audio": "Unnamed audio"
+            "error_processing_voice_message": "Error processing voice message"
         },
         "m.beacon_info": {
             "view_live_location": "View live location"

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -50,6 +50,8 @@ import { SortingAlgorithm } from "../stores/room-list-v3/skip-list/sorters/index
 import MediaPreviewConfigController from "./controllers/MediaPreviewConfigController.ts";
 import InviteRulesConfigController from "./controllers/InviteRulesConfigController.ts";
 import { type ComputedInviteConfig } from "../@types/invite-rules.ts";
+import IncompatibleConfigController from "./controllers/IncompatibleConfigController.ts";
+import CombinationIncompatbleController from "./controllers/CombinationIncompatbleController.ts";
 
 export const defaultWatchManager = new WatchManager();
 
@@ -623,8 +625,13 @@ export const SETTINGS: Settings = {
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG_PRIORITISED,
         supportedLevelsAreOrdered: true,
         displayName: _td("labs|element_call_video_rooms"),
-        controller: new ReloadOnChangeController(),
-        default: false,
+        controller: new CombinationIncompatbleController([
+            // Video rooms need to be enabled to enable this.
+            new IncompatibleController("feature_video_rooms", false, false, _t("labs|element_call_video_rooms_missing_video_rooms")),
+            // If the config only allows Element Call, force enable
+            new IncompatibleConfigController((c) => !!c.element_call?.use_exclusively, true, true, _t("labs|element_call_video_rooms_element_call_exclusive")),
+        ]),
+        default: true,
     },
     "feature_group_calls": {
         isFeature: true,

--- a/src/settings/controllers/CombinationIncompatbleController.ts
+++ b/src/settings/controllers/CombinationIncompatbleController.ts
@@ -1,0 +1,54 @@
+/*
+Copyright 2024 New Vector Ltd.
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import SettingController from "./SettingController.ts";
+import { type SettingLevel } from "../SettingLevel.ts";
+import IncompatibleController from "./IncompatibleController.ts";
+import IncompatibleConfigController from "./IncompatibleConfigController.ts";
+
+/**
+ * Enforces that a boolean setting cannot be enabled if the incompatible setting
+ * is also enabled, to prevent cascading undefined behaviour between conflicting
+ * labs flags.
+ */
+export default class CombinationIncompatbleController extends SettingController {
+    public constructor(
+        private readonly controllers: (IncompatibleConfigController|IncompatibleController)[]
+    ) {
+        super();
+    }
+
+    public getValueOverride(
+        level: SettingLevel,
+        roomId: string,
+        calculatedValue: any,
+        calculatedAtLevel: SettingLevel | null,
+    ): any {
+        for (const controller of this.controllers) {
+            const res = controller.getValueOverride(level, roomId, calculatedValue, calculatedAtLevel);
+            if (res !== null) {
+                return res;
+            }
+        }
+        return null;
+    }
+
+    public get settingDisabled(): boolean|string {
+        for (const controller of this.controllers) {
+            const res = controller.settingDisabled;
+            if (res) {
+                return res;
+            }
+        }
+        return false;
+    }
+
+    public get incompatibleSetting(): boolean {
+        return this.controllers.some(s => s.incompatibleSetting);
+    }
+}


### PR DESCRIPTION
This refactors a bunch of things around using Element Call for video rooms, namely:

 -  `element_call_video_rooms` is now *on* by default, so that Video rooms do not default to Jitsi.
 -  If `feature_video_rooms` is off, users cannot enable `element_call_video_rooms`.
 -  If  `element_call.use_exclusively` is on in the config.json, this setting is also forced on.

This still need ample tests, hence draft.

## Checklist

- [ ] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
