### PR TITLE
Fix gen-workflow-mermaid to be compatible with Node 22.18+

### DIFF
--- a/scripts/gen-workflow-mermaid.ts
+++ b/scripts/gen-workflow-mermaid.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import YAML from "yaml";
 import parseArgs from "minimist";
 import cronstrue from "cronstrue";
-import { partition } from "lodash";
+import _ from "lodash";
 
 const argv = parseArgs<{
     debug: boolean;
@@ -81,7 +81,7 @@ class Graph<T extends Node> {
     public removeNode(node: T): Edge<T>[] {
         if (!this.nodes.has(node.id)) return [];
         this.nodes.delete(node.id);
-        const [removedEdges, keptEdges] = partition(
+        const [removedEdges, keptEdges] = _.partition(
             this.edges,
             ([source, destination]) => source === node || destination === node,
         );


### PR DESCRIPTION
```
/home/runner/work/element-web/element-web/element-web/scripts/gen-workflow-mermaid.ts:406
        title?: string,
        private readonly markdown = false,
                         ^^^^^^^^^^^^^^^^
    ) {

SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]: TypeScript parameter property is not supported in strip-only mode
    at parseTypeScript (node:internal/modules/typescript:68:40)
    at processTypeScriptCode (node:internal/modules/typescript:146:42)
    at stripTypeScriptModuleTypes (node:internal/modules/typescript:209:22)
    at Module._compile (node:internal/modules/cjs/loader:1712:15)
    at Object..js (node:internal/modules/cjs/loader:1893:10)
    at Module.load (node:internal/modules/cjs/loader:1480:32)
    at Module._load (node:internal/modules/cjs/loader:1299:12)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:244:24)
    at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:154:5) {
  code: 'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX'
}