### PR TITLE
Fix expand button of space panel getting cut off at the edges

### DIFF
--- a/res/css/structures/_LeftPanel.pcss
+++ b/res/css/structures/_LeftPanel.pcss
@@ -18,9 +18,6 @@ Please see LICENSE files in the repository root for full details.
     flex-direction: column;
     max-width: 50%;
     position: relative;
-
-    /* Contain the amount of layers rendered by constraining what actually needs re-layering via css */
-    contain: layout paint;
 }
 
 .mx_LeftPanel_wrapper,


### PR DESCRIPTION
<img width="188" height="477" alt="image" src="https://github.com/user-attachments/assets/5c280f76-d482-4861-97e4-6019e72e2692" />

The contain property was explicitly asking for this behaviour , from [mdn](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/contain#paint): 
>  If a descendant overflows the containing element's bounds, then that descendant will be clipped to the containing element's border-box.