### PR TITLE
Use 22.18 for engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -313,7 +313,7 @@
         "relativePaths": true
     },
     "engines": {
-        "node": ">=24"
+        "node": ">=22.18"
     },
     "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Running `test:screenshots` locally currently results in the following error:

```
error element-web@1.12.3: The engine "node" is incompatible with this module. Expected version ">=24". Got "22.20.0"
```

We don't need 24 yet, so reverting to a version the test will run with that supports type stripping as discussed [here](https://matrix.to/#/!fLeHeojWgBGJlLNdLC:matrix.org/$E8e3PUUFDOmufysGpE2kCfGUFKco1wJdgfCtCmcBllg?via=matrix.org&via=element.io&via=beta.matrix.org).