### PR TITLE
Remove obsolete checks that the server supports cross-signing

### DIFF
--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -318,12 +318,6 @@ export default class DeviceListener {
 
         const cli = this.client;
 
-        // cross-signing support was added to Matrix in MSC1756, which landed in spec v1.1
-        if (!(await cli.isVersionSupported("v1.1"))) {
-            logSpan.debug("cross-signing not supported");
-            return;
-        }
-
         const crypto = cli.getCrypto();
         if (!crypto) {
             logSpan.debug("crypto not enabled");

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -427,10 +427,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
             } else {
                 this.setStateForNewView({ view: Views.COMPLETE_SECURITY });
             }
-        } else if (
-            (await cli.doesServerSupportUnstableFeature("org.matrix.e2e_cross_signing")) &&
-            !(await shouldSkipSetupEncryption(cli))
-        ) {
+        } else if (!(await shouldSkipSetupEncryption(cli))) {
             // if cross-signing is not yet set up, do so now if possible.
             InitialCryptoSetupStore.sharedInstance().startInitialCryptoSetup(
                 cli,

--- a/test/unit-tests/DeviceListener-test.ts
+++ b/test/unit-tests/DeviceListener-test.ts
@@ -275,13 +275,6 @@ describe("DeviceListener", () => {
     });
 
     describe("recheck", () => {
-        it("does nothing when cross signing feature is not supported", async () => {
-            mockClient!.isVersionSupported.mockResolvedValue(false);
-            await createAndStart();
-
-            expect(mockClient!.isVersionSupported).toHaveBeenCalledWith("v1.1");
-            expect(mockCrypto!.isCrossSigningReady).not.toHaveBeenCalled();
-        });
         it("does nothing when crypto is not enabled", async () => {
             mockClient!.getCrypto.mockReturnValue(undefined);
             await createAndStart();

--- a/test/unit-tests/components/structures/MatrixChat-test.tsx
+++ b/test/unit-tests/components/structures/MatrixChat-test.tsx
@@ -554,8 +554,8 @@ describe("<MatrixChat />", () => {
                     expect(defaultDispatcher.dispatch).toHaveBeenCalledWith({ action: "client_started" }),
                 );
 
-                // check we get to logged in view
-                await waitForSyncAndLoad(loginClient, true);
+                // set up keys screen is rendered
+                expect(screen.getByText("Setting up keys")).toBeInTheDocument();
             });
 
             it("should persist device language when available", async () => {
@@ -1166,6 +1166,8 @@ describe("<MatrixChat />", () => {
                     // Given force_verification is on (outer describe)
                     // And we just logged in via OIDC (inner describe)
 
+                    mocked(loginClient.getCrypto()!.userHasCrossSigningKeys).mockResolvedValue(true);
+
                     // When we load the page
                     getComponent({ realQueryParams });
 
@@ -1340,22 +1342,8 @@ describe("<MatrixChat />", () => {
                 expect(screen.getByRole("heading", { name: "Welcome Ernie" })).toBeInTheDocument();
             });
 
-            it("should go straight to logged in view when user does not have cross signing keys and server does not support cross signing", async () => {
-                loginClient.doesServerSupportUnstableFeature.mockResolvedValue(false);
-
-                await getComponentAndLogin(false);
-
-                expect(loginClient.doesServerSupportUnstableFeature).toHaveBeenCalledWith(
-                    "org.matrix.e2e_cross_signing",
-                );
-
-                // logged in
-                await screen.findByLabelText("User menu");
-            });
-
             describe("when server supports cross signing and user does not have cross signing setup", () => {
                 beforeEach(() => {
-                    loginClient.doesServerSupportUnstableFeature.mockResolvedValue(true);
                     jest.spyOn(loginClient.getCrypto()!, "userHasCrossSigningKeys").mockResolvedValue(false);
                 });
 
@@ -1400,8 +1388,6 @@ describe("<MatrixChat />", () => {
                 });
 
                 it("should go to setup e2e screen", async () => {
-                    loginClient.doesServerSupportUnstableFeature.mockResolvedValue(true);
-
                     await getComponentAndLogin();
 
                     expect(loginClient.getCrypto()!.userHasCrossSigningKeys).toHaveBeenCalled();
@@ -1424,9 +1410,7 @@ describe("<MatrixChat />", () => {
                 expect(screen.getByText("Confirm your identity")).toBeInTheDocument();
             });
 
-            it("should setup e2e when server supports cross signing", async () => {
-                loginClient.doesServerSupportUnstableFeature.mockResolvedValue(true);
-
+            it("should setup e2e", async () => {
                 await getComponentAndLogin();
 
                 expect(loginClient.getCrypto()!.userHasCrossSigningKeys).toHaveBeenCalled();
@@ -1587,8 +1571,8 @@ describe("<MatrixChat />", () => {
                     action: "will_start_client",
                 });
 
-                // logged in but waiting for sync screen
-                await screen.findByText("Logout");
+                // set up keys screen is rendered
+                expect(await screen.findByText("Setting up keys")).toBeInTheDocument();
             });
         });
     });


### PR DESCRIPTION
We already depend on an API version that includes cross-signing.

This PR takes the changes from https://github.com/element-hq/element-web/pull/31041

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
