### PR TITLE
Fix location sharing dialog screenshot flake

### DIFF
--- a/playwright/e2e/location/location.spec.ts
+++ b/playwright/e2e/location/location.spec.ts
@@ -46,12 +46,7 @@ test.describe("Location sharing", { tag: "@no-firefox" }, () => {
 
             await submitShareLocation(page);
 
-            await page.locator(".mx_RoomView_body .mx_EventTile .mx_MLocationBody").click({
-                position: {
-                    x: 225,
-                    y: 150,
-                },
-            });
+            await page.getByRole("button", { name: "Map marker" }).click();
 
             const dialog = page.getByRole("dialog");
 
@@ -65,7 +60,7 @@ test.describe("Location sharing", { tag: "@no-firefox" }, () => {
 
             await app.closeDialog();
 
-            await expect(page.locator(".mx_Marker")).toBeVisible();
+            await expect(page.getByRole("button", { name: "Map marker" })).toBeVisible();
         },
     );
 


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-web/issues/27769

<img width="300"  alt="image" src="https://github.com/user-attachments/assets/4bb6daea-e876-4b37-af9a-1889ad952a65" />

The problem appears to be that the map in the timeline and the dialog both have the name "Map". So there is a race condition for which one gets snapshotted, as evidence by the comparison.

I've changed the code to wait for the dialog to be visible before screenshotting and use the dialog locator to query for the dialogs map specifically.

Update: It was still flaked on the dialog being opened, so I think the issue might have been how weere clicking on it. I have now changed it to target the map marker which is shown after the spinner, to have more confidence in the map being loaded. Also means we don't need to use the click position api.