### PR TITLE
Keep the room creation spinner open until the new room is received from server

### DIFF
--- a/src/createRoom.ts
+++ b/src/createRoom.ts
@@ -316,9 +316,6 @@ export default async function createRoom(client: MatrixClient, opts: IOpts): Pro
                 return Promise.reject(err);
             }
         })
-        .finally(function () {
-            if (modal) modal.close();
-        })
         .then(async (res): Promise<void> => {
             roomId = res.room_id;
 
@@ -339,6 +336,9 @@ export default async function createRoom(client: MatrixClient, opts: IOpts): Pro
             });
 
             if (opts.dmUserId) await Rooms.setDMRoom(client, roomId, opts.dmUserId);
+        })
+        .finally(function () {
+            if (modal) modal.close();
         })
         .then(() => {
             if (opts.parentSpace) {


### PR DESCRIPTION
In the upcoming work for encrypted state, we need to keep the spinner until the m.room.encryption event is received. This change keeps the spinner just a little longer than before: until the room is received from the server.

I'm submitting this change partly because I think it makes sense to delay until we can confirm the room exists and partly to separate this change from other changes that will be involved in encrypted state. That way if this causes problems we can discuss or revert it separately.