### PR TITLE
Fix calls sometimes not knowing that they're presented

### DIFF
--- a/test/unit-tests/components/structures/PipContainer-test.tsx
+++ b/test/unit-tests/components/structures/PipContainer-test.tsx
@@ -133,6 +133,7 @@ describe("PipContainer", () => {
             {
                 action: Action.ViewRoom,
                 room_id: roomId,
+                view_call: false, // We're testing PiP functionality, so view the timeline
                 metricsTrigger: undefined,
             },
             true,


### PR DESCRIPTION
Just a little edge case I found while working on https://github.com/element-hq/element-web/issues/30838. Because RoomViewStore used two slightly different conditions, the `Call.presented` flag could get out of sync with the `viewingCall` flag. But these should effectively be the same thing.

This was causing some subtle bugs if you would join a call, switch to another room, and then click back into the call room via the room list. The call would be visible but not know that it's presented, causing:

1. The hangup sound to get cut off at the end of the call
2. The widget to disappear immediately without offering a 'reconnect' button if you lose connectivity