### PR TITLE
call: Pass the echo cancellation and noise suppression settings to EC

### DIFF
--- a/src/models/Call.ts
+++ b/src/models/Call.ts
@@ -744,6 +744,17 @@ export class ElementCall extends Call {
             params.append("allowIceFallback", "true");
         }
 
+        const echoCancellation = SettingsStore.getValue("webrtc_audio_echoCancellation");
+        if (!echoCancellation) {
+            // the default is true, so only set if false
+            params.append("echoCancellation", "false");
+        }
+        const noiseSuppression = SettingsStore.getValue("webrtc_audio_noiseSuppression");
+        if (!noiseSuppression) {
+            // the default is true, so only set if false
+            params.append("noiseSuppression", "false");
+        }
+
         // Set custom fonts
         if (SettingsStore.getValue("useSystemFont")) {
             SettingsStore.getValue("systemFont")

--- a/test/unit-tests/models/Call-test.ts
+++ b/test/unit-tests/models/Call-test.ts
@@ -567,6 +567,96 @@ describe("ElementCall", () => {
             SettingsStore.getValue = originalGetValue;
         });
 
+        describe("Echo cancellation & Noise Suppression", () => {
+            it("passes echo cancellation settings through widget URL if needed", async () => {
+                const originalGetValue = SettingsStore.getValue;
+                SettingsStore.getValue = (
+                    name: SettingKey,
+                    roomId: string | null = null,
+                    excludeDefault = false,
+                ): any => {
+                    switch (name) {
+                        case "webrtc_audio_echoCancellation":
+                            return false;
+                    }
+                };
+                ElementCall.create(room);
+                const call = Call.get(room);
+                if (!(call instanceof ElementCall)) throw new Error("Failed to create call");
+
+                const urlParams = new URLSearchParams(new URL(call.widget.url).hash.slice(1));
+                expect(urlParams.get("echoCancellation")).toBe("false");
+
+                SettingsStore.getValue = originalGetValue;
+            });
+
+            it("does not pass echo cancellation settings through widget URL if not needed", async () => {
+                const originalGetValue = SettingsStore.getValue;
+                SettingsStore.getValue = (
+                    name: SettingKey,
+                    roomId: string | null = null,
+                    excludeDefault = false,
+                ): any => {
+                    switch (name) {
+                        case "webrtc_audio_echoCancellation":
+                            return true;
+                    }
+                };
+                ElementCall.create(room);
+                const call = Call.get(room);
+                if (!(call instanceof ElementCall)) throw new Error("Failed to create call");
+
+                const urlParams = new URLSearchParams(new URL(call.widget.url).hash.slice(1));
+                expect(urlParams.get("echoCancellation")).toBeNull();
+
+                SettingsStore.getValue = originalGetValue;
+            });
+
+            it("passes noise suppression settings through widget URL if needed", async () => {
+                const originalGetValue = SettingsStore.getValue;
+                SettingsStore.getValue = (
+                    name: SettingKey,
+                    roomId: string | null = null,
+                    excludeDefault = false,
+                ): any => {
+                    switch (name) {
+                        case "webrtc_audio_noiseSuppression":
+                            return false;
+                    }
+                };
+                ElementCall.create(room);
+                const call = Call.get(room);
+                if (!(call instanceof ElementCall)) throw new Error("Failed to create call");
+
+                const urlParams = new URLSearchParams(new URL(call.widget.url).hash.slice(1));
+                expect(urlParams.get("noiseSuppression")).toBe("false");
+
+                SettingsStore.getValue = originalGetValue;
+            });
+
+            it("does not pass noise suppression settings through widget URL if not needed", async () => {
+                const originalGetValue = SettingsStore.getValue;
+                SettingsStore.getValue = (
+                    name: SettingKey,
+                    roomId: string | null = null,
+                    excludeDefault = false,
+                ): any => {
+                    switch (name) {
+                        case "webrtc_audio_noiseSuppression":
+                            return true;
+                    }
+                };
+                ElementCall.create(room);
+                const call = Call.get(room);
+                if (!(call instanceof ElementCall)) throw new Error("Failed to create call");
+
+                const urlParams = new URLSearchParams(new URL(call.widget.url).hash.slice(1));
+                expect(urlParams.get("noiseSuppression")).toBeNull();
+
+                SettingsStore.getValue = originalGetValue;
+            });
+        });
+
         it("passes ICE fallback preference through widget URL", async () => {
             // Test with the preference set to false
             ElementCall.create(room);


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Uses the existing voice processing settings and pass them to ElementCall via widget URL
<img width="681" height="197" alt="image" src="https://github.com/user-attachments/assets/0c3a4cd4-674d-49f7-8807-8330c53848b5" />

Depends on https://github.com/element-hq/element-call/pull/3590 to support reading the new url params
## Checklist

- [ ] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
