### PR TITLE
tweak Fira Code to be a bit smaller to pair better with Inter.

### DIFF
--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -113,7 +113,7 @@ body {
 pre,
 code {
     font-family: $monospace-font-family;
-    font-size: 100% !important;
+    font-size: 95% !important;
 }
 
 .error,


### PR DESCRIPTION
Yes, i know i'm going to typography hell for this, but while Fira Code's x-height matches Inter's, in practice it feels way bigger as the pitch is substantially larger. So, to try to make it feel more balanced, we reduce Fira Code's point size to be 95% of Inter's.