### PR TITLE
Add message explaining history visibility settings do not work on encrypted rooms

### DIFF
--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2431,7 +2431,7 @@
             "history_visibility_joined": "Members only (since they joined)",
             "history_visibility_legend": "Who can read history?",
             "history_visibility_shared": "Members only (since the point in time of selecting this option)",
-            "history_visibility_warning": "The visibility of existing history will not be changed.",
+            "history_visibility_warning": "The visibility of existing history will not be changed. Note: these settings currently do not work in encrypted rooms.",
             "history_visibility_world_readable": "Anyone",
             "join_rule_description": "Decide who can join %(roomName)s.",
             "join_rule_invite": "Private (invite only)",

--- a/test/unit-tests/components/views/settings/tabs/room/__snapshots__/SecurityRoomSettingsTab-test.tsx.snap
+++ b/test/unit-tests/components/views/settings/tabs/room/__snapshots__/SecurityRoomSettingsTab-test.tsx.snap
@@ -15,7 +15,7 @@ exports[`<SecurityRoomSettingsTab /> history visibility uses shared as default h
     <div
       class="mx_SettingsSubsection_text"
     >
-      The visibility of existing history will not be changed.
+      The visibility of existing history will not be changed. Note: these settings currently do not work in encrypted rooms.
     </div>
   </div>
   <div


### PR DESCRIPTION
This relates to messages by @jtrees in https://github.com/element-hq/element-meta/issues/2829. It's unknown how long the bug will remain, but at present users face a situation where settings do not do what they expect, with nothing explaining the problem. This PR doesn't fix the underlying issue, but does tell users that there *is* a bug.

@andybalaam said in that thread "we may get around to actually providing the feature before we get around to removing the option", but with a simple text fix, that doesn't need to be the case.

Feedback on the exact wording of the message, and translations to other languages, would be greatly appreciated.