### PR TITLE
Make `RoomList.showMessagePreview` configurable by `config.json`

### DIFF
--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -1204,7 +1204,7 @@ export const SETTINGS: Settings = {
         default: SortingAlgorithm.Recency,
     },
     "RoomList.showMessagePreview": {
-        supportedLevels: [SettingLevel.DEVICE],
+        supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG,
         default: false,
         displayName: _td("settings|show_message_previews"),
     },


### PR DESCRIPTION
RoomList.showMessagePreview is on only the device level but there is no reason to nit add the config level.