### PR TITLE
Remove an extra paragraph in advanced room settings

### DIFF
--- a/src/components/views/dialogs/CreateRoomDialog.tsx
+++ b/src/components/views/dialogs/CreateRoomDialog.tsx
@@ -456,7 +456,6 @@ export default class CreateRoomDialog extends React.Component<IProps, IState> {
                                     checked={this.state.noFederate}
                                     helpMessage={federateLabel}
                                 />
-                                z<p>{federateLabel}</p>
                             </details>
                         )}
                     </Form.Root>

--- a/test/unit-tests/components/views/dialogs/__snapshots__/CreateRoomDialog-test.tsx.snap
+++ b/test/unit-tests/components/views/dialogs/__snapshots__/CreateRoomDialog-test.tsx.snap
@@ -187,10 +187,6 @@ exports[`<CreateRoomDialog /> for a private room should create a private room 1`
               </span>
             </div>
           </div>
-          z
-          <p>
-            You might enable this if the room will only be used for collaborating with internal teams on your homeserver. This cannot be changed later.
-          </p>
         </details>
       </form>
     </div>


### PR DESCRIPTION
This was introduced (presumably accidentally) in
[#30169](https://github.com/element-hq/element-web/pull/30169/files#diff-89268874351e08a327e47b0a7e1d4e916e1ad8dc4be8b4a3f1ef67f3f83a5bc9R459)

Before:
<img width="505" height="600" alt="image" src="https://github.com/user-attachments/assets/e90050f4-2af2-4562-9ce8-a40271454db9" />

After:
<img width="505" height="513" alt="image" src="https://github.com/user-attachments/assets/fdc4ddc1-808d-48cb-9fab-ea542bd15738" />
