### PR TITLE
Don't show the key storage out of sync toast when backup disabled

### DIFF
--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -438,7 +438,10 @@ export default class DeviceListener {
         // said we are OK with that.
         const keyBackupIsOk = keyBackupUploadActive || backupDisabled;
 
-        const backupKeyCached = (await crypto.getSessionBackupPrivateKey()) !== null;
+        // If key backup is active and not disabled: do we have the backup key
+        // cached locally?
+        const backupKeyCached =
+            !keyBackupUploadActive || backupDisabled || (await crypto.getSessionBackupPrivateKey()) !== null;
 
         const allSystemsReady =
             isCurrentDeviceTrusted && allCrossSigningSecretsCached && keyBackupIsOk && recoveryIsOk && backupKeyCached;

--- a/test/unit-tests/DeviceListener-test.ts
+++ b/test/unit-tests/DeviceListener-test.ts
@@ -367,7 +367,7 @@ describe("DeviceListener", () => {
                     expect(SetupEncryptionToast.hideToast).toHaveBeenCalled();
                 });
 
-                it("shows an out-of-sync toast when one of the secrets is missing locally", async () => {
+                it("shows an out-of-sync toast when one of the cross-signing secrets is missing locally", async () => {
                     mockCrypto!.getCrossSigningStatus.mockResolvedValue({
                         publicKeysOnDevice: true,
                         privateKeysInSecretStorage: true,
@@ -383,6 +383,30 @@ describe("DeviceListener", () => {
                     expect(SetupEncryptionToast.showToast).toHaveBeenCalledWith(
                         SetupEncryptionToast.Kind.KEY_STORAGE_OUT_OF_SYNC,
                     );
+                });
+
+                it("shows an out-of-sync toast when the backup key is missing locally", async () => {
+                    mockCrypto!.getSecretStorageStatus.mockResolvedValue(readySecretStorageStatus);
+                    mockCrypto!.getActiveSessionBackupVersion.mockResolvedValue("1");
+                    mockCrypto!.getSessionBackupPrivateKey.mockResolvedValue(null);
+
+                    await createAndStart();
+
+                    expect(SetupEncryptionToast.showToast).toHaveBeenCalledWith(
+                        SetupEncryptionToast.Kind.KEY_STORAGE_OUT_OF_SYNC,
+                    );
+                });
+
+                it("does not show an out-of-sync toast when the backup key is missing locally but backup is purposely disabled", async () => {
+                    mockCrypto!.getSecretStorageStatus.mockResolvedValue(readySecretStorageStatus);
+                    mockCrypto!.getSessionBackupPrivateKey.mockResolvedValue(null);
+                    mockClient.getAccountDataFromServer.mockImplementation((eventType) =>
+                        eventType === BACKUP_DISABLED_ACCOUNT_DATA_KEY ? ({ disabled: true } as any) : null,
+                    );
+
+                    await createAndStart();
+
+                    expect(SetupEncryptionToast.hideToast).toHaveBeenCalled();
                 });
 
                 it("hides the out-of-sync toast after we receive the missing secrets", async () => {


### PR DESCRIPTION
If key backup is purposely disabled/inactive, don't treat a missing backup key as the key storage being out of sync.

Fixes https://github.com/element-hq/element-web/issues/31494

## Checklist

- [ ] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
