### PR TITLE
Make the feedback icon be the right color in dark theme

### DIFF
--- a/src/components/structures/UserMenu.tsx
+++ b/src/components/structures/UserMenu.tsx
@@ -9,6 +9,7 @@ Please see LICENSE files in the repository root for full details.
 import React, { type JSX, createRef, type ReactNode } from "react";
 import { type Room } from "matrix-js-sdk/src/matrix";
 import {
+    ChatSolidIcon,
     HomeSolidIcon,
     LockSolidIcon,
     QrCodeIcon,
@@ -51,7 +52,6 @@ import { SDKContext } from "../../contexts/SDKContext";
 import { shouldShowFeedback } from "../../utils/Feedback";
 import { Icon as DarkLightModeSvg } from "../../../res/img/element-icons/roomlist/dark-light-mode.svg";
 import { Icon as NotificationsIcon } from "../../../res/img/element-icons/notifications.svg";
-import { Icon as FeedbackIcon } from "../../../res/img/element-icons/feedback.svg";
 
 interface IProps {
     isPanelCollapsed: boolean;
@@ -317,7 +317,7 @@ export default class UserMenu extends React.Component<IProps, IState> {
         if (shouldShowFeedback()) {
             feedbackButton = (
                 <IconizedContextMenuOption
-                    icon={<FeedbackIcon />}
+                    icon={<ChatSolidIcon />}
                     label={_t("common|feedback")}
                     onClick={this.onProvideFeedback}
                 />


### PR DESCRIPTION
Our feedback.svg is not tintable. Rather than mess with it I think it makes sense to use the equivalent Compound icon.

Before|After
-|-
<img width="258" height="280" alt="Screenshot 2025-12-12 at 00-14-34 Element 4 Test room" src="https://github.com/user-attachments/assets/8ee4313f-a1af-4b73-ba49-3d73e4c9370c" />|<img width="258" height="280" alt="Screenshot 2025-12-12 at 00-14-26 Element 3" src="https://github.com/user-attachments/assets/2beb793c-d16a-4ac9-a7c5-b53d0cc2d872" />