### PR TITLE
Add Tokenizer Mode Support for Message Search

### DIFF
--- a/apps/web/src/async-components/views/dialogs/eventindex/ConfirmTokenizerChangeDialog.tsx
+++ b/apps/web/src/async-components/views/dialogs/eventindex/ConfirmTokenizerChangeDialog.tsx
@@ -1,0 +1,60 @@
+/*
+Copyright 2024 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import React from "react";
+
+import BaseDialog from "../../../../components/views/dialogs/BaseDialog";
+import Spinner from "../../../../components/views/elements/Spinner";
+import DialogButtons from "../../../../components/views/elements/DialogButtons";
+import { _t } from "../../../../languageHandler";
+import EventIndexPeg from "../../../../indexing/EventIndexPeg";
+
+interface IProps {
+    onFinished: (confirmed?: boolean) => void;
+}
+
+interface IState {
+    deleting: boolean;
+}
+
+/*
+ * Confirmation dialog for deleting the database when tokenizer mode is changed.
+ */
+export default class ConfirmTokenizerChangeDialog extends React.Component<IProps, IState> {
+    public constructor(props: IProps) {
+        super(props);
+        this.state = {
+            deleting: false,
+        };
+    }
+
+    private readonly onConfirm = async (): Promise<void> => {
+        this.setState({
+            deleting: true,
+        });
+
+        await EventIndexPeg.deleteEventIndex();
+        this.props.onFinished(true);
+    };
+
+    public render(): React.ReactNode {
+        return (
+            <BaseDialog onFinished={this.props.onFinished} title={_t("common|are_you_sure")}>
+                {_t("settings|security|tokenizer_mode_change_warning")}
+                {this.state.deleting ? <Spinner /> : <div />}
+                <DialogButtons
+                    primaryButton={_t("action|ok")}
+                    onPrimaryButtonClick={this.onConfirm}
+                    primaryButtonClass="danger"
+                    cancelButtonClass="warning"
+                    onCancel={this.props.onFinished}
+                    disabled={this.state.deleting}
+                />
+            </BaseDialog>
+        );
+    }
+}

--- a/apps/web/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.tsx
+++ b/apps/web/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.tsx
@@ -144,35 +144,32 @@ export default class ManageEventIndexDialog extends React.Component<IProps, ISta
         if (this.state.tokenizerMode !== this.state.initialTokenizerMode) {
             // Show confirmation dialog
             const ConfirmTokenizerChangeDialog = (await import("./ConfirmTokenizerChangeDialog")).default;
-            Modal.createDialog(
+            const { finished } = Modal.createDialog(
                 ConfirmTokenizerChangeDialog,
-                {
-                    onFinished: async (confirmed?: boolean) => {
-                        if (confirmed) {
-                            // Save the tokenizer mode setting
-                            SettingsStore.setValue(
-                                "tokenizerMode",
-                                null,
-                                SettingLevel.DEVICE,
-                                this.state.tokenizerMode,
-                            );
-                        } else {
-                            // User cancelled - revert tokenizer mode to initial value
-                            this.setState((prevState) => ({ tokenizerMode: prevState.initialTokenizerMode }));
-                            SettingsStore.setValue(
-                                "tokenizerMode",
-                                null,
-                                SettingLevel.DEVICE,
-                                this.state.initialTokenizerMode,
-                            );
-                        }
-                        this.props.onFinished();
-                    },
-                },
+                {},
                 undefined,
                 /* priority = */ false,
                 /* static = */ true,
             );
+
+            const [confirmed] = await finished;
+
+            if (confirmed) {
+                // Save the tokenizer mode setting
+                await SettingsStore.setValue("tokenizerMode", null, SettingLevel.DEVICE, this.state.tokenizerMode);
+                await EventIndexPeg.initEventIndex();
+            } else {
+                // User cancelled - revert tokenizer mode to initial value
+                this.setState((prevState) => ({ tokenizerMode: prevState.initialTokenizerMode }));
+                await SettingsStore.setValue(
+                    "tokenizerMode",
+                    null,
+                    SettingLevel.DEVICE,
+                    this.state.initialTokenizerMode,
+                );
+            }
+
+            this.props.onFinished();
         } else {
             // No change, just close the dialog
             this.props.onFinished();

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -2881,7 +2881,12 @@
             "message_search_unsupported_web": "%(brand)s can't securely cache encrypted messages locally while running in a web browser. Use <desktopLink>%(brand)s Desktop</desktopLink> for encrypted messages to appear in search results.",
             "record_session_details": "Record the client name, version, and url to recognise sessions more easily in session manager",
             "send_analytics": "Send analytics data",
-            "strict_encryption": "Only send messages to verified users"
+            "strict_encryption": "Only send messages to verified users",
+            "tokenizer_mode": "Search tokenizer mode",
+            "tokenizer_mode_change_warning": "Changing the tokenizer mode requires deleting the existing search index. The index will be rebuilt automatically. Do you want to continue?",
+            "tokenizer_mode_description": "Language-based: Single language support fixed to UI language. Only works with some languages (English, German, etc.). N-gram: Supports all languages including those without word boundaries. Works with mixed languages. Changing this setting will rebuild your search index.",
+            "tokenizer_mode_language": "Language-based (single language support based on UI settings)",
+            "tokenizer_mode_ngram": "N-gram (Multi-language support)"
         },
         "send_read_receipts": "Send read receipts",
         "send_read_receipts_unsupported": "Your server doesn't support disabling sending read receipts.",

--- a/apps/web/src/indexing/BaseEventIndexManager.ts
+++ b/apps/web/src/indexing/BaseEventIndexManager.ts
@@ -87,11 +87,16 @@ export default abstract class BaseEventIndexManager {
      *
      * @param {string} userId The event that should be added to the index.
      * @param {string} deviceId The profile of the event sender at the
+     * @param {string} tokenizerMode The tokenizer mode to use ("ngram" or "language")
      *
      * @return {Promise} A promise that will resolve when the event index is
-     * initialized.
+     * initialized. Returns { wasRecreated: true } if the database was recreated.
      */
-    public async initEventIndex(userId: string, deviceId: string): Promise<void> {
+    public async initEventIndex(
+        userId: string,
+        deviceId: string,
+        tokenizerMode?: string,
+    ): Promise<{ wasRecreated?: boolean } | void> {
         throw new Error("Unimplemented");
     }
 

--- a/apps/web/src/settings/Settings.tsx
+++ b/apps/web/src/settings/Settings.tsx
@@ -338,6 +338,7 @@ export interface Settings {
     "RightPanel.phases": IBaseSetting<IRightPanelForRoomStored | null>;
     "enableEventIndexing": IBaseSetting<boolean>;
     "crawlerSleepTime": IBaseSetting<number>;
+    "tokenizerMode": IBaseSetting<string>;
     "showCallButtonsInComposer": IBaseSetting<boolean>;
     "ircDisplayNameWidth": IBaseSetting<number>;
     "layout": IBaseSetting<Layout>;
@@ -1245,6 +1246,11 @@ export const SETTINGS: Settings = {
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS,
         displayName: _td("settings|security|message_search_sleep_time"),
         default: 3000,
+    },
+    "tokenizerMode": {
+        supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS,
+        displayName: _td("settings|security|tokenizer_mode"),
+        default: "language",
     },
     "showCallButtonsInComposer": {
         // Dev note: This is no longer "in composer" but is instead "in room header".

--- a/apps/web/src/vector/platform/SeshatIndexManager.ts
+++ b/apps/web/src/vector/platform/SeshatIndexManager.ts
@@ -28,8 +28,12 @@ export class SeshatIndexManager extends BaseEventIndexManager {
         return this.ipc.call("supportsEventIndexing");
     }
 
-    public async initEventIndex(userId: string, deviceId: string): Promise<void> {
-        return this.ipc.call("initEventIndex", userId, deviceId);
+    public async initEventIndex(
+        userId: string,
+        deviceId: string,
+        tokenizerMode?: string,
+    ): Promise<{ wasRecreated?: boolean } | void> {
+        return this.ipc.call("initEventIndex", userId, deviceId, tokenizerMode);
     }
 
     public async addEventToIndex(ev: IMatrixEvent, profile: IMatrixProfile): Promise<void> {

--- a/apps/web/test/unit-tests/async-components/dialogs/eventindex/ConfirmTokenizerChangeDialog-test.tsx
+++ b/apps/web/test/unit-tests/async-components/dialogs/eventindex/ConfirmTokenizerChangeDialog-test.tsx
@@ -1,0 +1,33 @@
+/*
+Copyright 2025 New Vector Ltd.
+Copyright 2020, 2021 The Matrix.org Foundation C.I.C.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import React from "react";
+import { fireEvent, render, screen } from "jest-matrix-react";
+
+import ConfirmTokenizerChangeDialog from "../../../../../src/async-components/views/dialogs/eventindex/ConfirmTokenizerChangeDialog";
+import EventIndexPeg from "../../../../../src/indexing/EventIndexPeg";
+import { flushPromises } from "../../../../test-utils";
+
+describe("<ConfirmTokenizerChangeDialog />", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("deletes the event index and finishes when confirmed", async () => {
+        const onFinished = jest.fn();
+        jest.spyOn(EventIndexPeg, "deleteEventIndex").mockResolvedValue(undefined);
+
+        render(<ConfirmTokenizerChangeDialog onFinished={onFinished} />);
+
+        fireEvent.click(screen.getByRole("button", { name: /ok/i }));
+        await flushPromises();
+
+        expect(EventIndexPeg.deleteEventIndex).toHaveBeenCalled();
+        expect(onFinished).toHaveBeenCalledWith(true);
+    });
+});

--- a/apps/web/test/unit-tests/async-components/dialogs/eventindex/ManageEventIndexDialog-test.tsx
+++ b/apps/web/test/unit-tests/async-components/dialogs/eventindex/ManageEventIndexDialog-test.tsx
@@ -1,0 +1,102 @@
+/*
+Copyright 2025 New Vector Ltd.
+Copyright 2020, 2021 The Matrix.org Foundation C.I.C.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import React from "react";
+import { fireEvent, render, screen } from "jest-matrix-react";
+
+import ManageEventIndexDialog from "../../../../../src/async-components/views/dialogs/eventindex/ManageEventIndexDialog";
+import Modal from "../../../../../src/Modal";
+import EventIndexPeg from "../../../../../src/indexing/EventIndexPeg";
+import SettingsStore from "../../../../../src/settings/SettingsStore";
+import { SettingLevel } from "../../../../../src/settings/SettingLevel";
+import SdkConfig from "../../../../../src/SdkConfig";
+import { flushPromises } from "../../../../test-utils";
+
+describe("<ManageEventIndexDialog />", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    const mockEventIndex = {
+        getStats: jest.fn().mockResolvedValue({ size: 1234, eventCount: 12, roomCount: 2 }),
+        crawlingRooms: jest.fn().mockReturnValue({
+            crawlingRooms: new Set(["!room1:example.org"]),
+            totalRooms: new Set(["!room1:example.org", "!room2:example.org"]),
+        }),
+        currentRoom: jest.fn().mockReturnValue({ name: "Room A" }),
+        on: jest.fn(),
+        removeListener: jest.fn(),
+    };
+
+    function setUpDefaults(tokenizerMode: "ngram" | "language" = "language"): void {
+        jest.spyOn(SdkConfig, "get").mockReturnValue({ brand: "Element" } as any);
+        jest.spyOn(EventIndexPeg, "get").mockReturnValue(mockEventIndex as any);
+        jest.spyOn(SettingsStore, "getValueAt").mockImplementation((_level, settingName): any => {
+            if (settingName === "tokenizerMode") return tokenizerMode;
+            if (settingName === "crawlerSleepTime") return 3000;
+            return undefined;
+        });
+        jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined as any);
+    }
+
+    it("closes directly when tokenizer mode is unchanged", async () => {
+        setUpDefaults("language");
+        const onFinished = jest.fn();
+        const createDialogSpy = jest.spyOn(Modal, "createDialog").mockReturnValue({} as any);
+
+        render(<ManageEventIndexDialog onFinished={onFinished} />);
+        await flushPromises();
+
+        fireEvent.click(screen.getByRole("button", { name: /done/i }));
+
+        expect(createDialogSpy).not.toHaveBeenCalled();
+        expect(onFinished).toHaveBeenCalled();
+    });
+
+    it("opens confirm dialog and saves tokenizer mode when confirmed", async () => {
+        setUpDefaults("language");
+        const onFinished = jest.fn();
+        const setValueSpy = jest.spyOn(SettingsStore, "setValue");
+
+        jest.spyOn(Modal, "createDialog").mockImplementation((_Component, props?: any) => {
+            props?.onFinished(true);
+            return {} as any;
+        });
+
+        render(<ManageEventIndexDialog onFinished={onFinished} />);
+        await flushPromises();
+
+        fireEvent.change(screen.getByRole("combobox"), { target: { value: "ngram" } });
+        fireEvent.click(screen.getByRole("button", { name: /done/i }));
+        await flushPromises();
+
+        expect(setValueSpy).toHaveBeenCalledWith("tokenizerMode", null, SettingLevel.DEVICE, "ngram");
+        expect(onFinished).toHaveBeenCalled();
+    });
+
+    it("opens confirm dialog and reverts tokenizer mode when cancelled", async () => {
+        setUpDefaults("language");
+        const onFinished = jest.fn();
+        const setValueSpy = jest.spyOn(SettingsStore, "setValue");
+
+        jest.spyOn(Modal, "createDialog").mockImplementation((_Component, props?: any) => {
+            props?.onFinished(false);
+            return {} as any;
+        });
+
+        render(<ManageEventIndexDialog onFinished={onFinished} />);
+        await flushPromises();
+
+        fireEvent.change(screen.getByRole("combobox"), { target: { value: "ngram" } });
+        fireEvent.click(screen.getByRole("button", { name: /done/i }));
+        await flushPromises();
+
+        expect(setValueSpy).toHaveBeenCalledWith("tokenizerMode", null, SettingLevel.DEVICE, "language");
+        expect(onFinished).toHaveBeenCalled();
+    });
+});

--- a/apps/web/test/unit-tests/async-components/dialogs/eventindex/ManageEventIndexDialog-test.tsx
+++ b/apps/web/test/unit-tests/async-components/dialogs/eventindex/ManageEventIndexDialog-test.tsx
@@ -62,11 +62,11 @@ describe("<ManageEventIndexDialog />", () => {
         setUpDefaults("language");
         const onFinished = jest.fn();
         const setValueSpy = jest.spyOn(SettingsStore, "setValue");
+        const initEventIndexSpy = jest.spyOn(EventIndexPeg, "initEventIndex").mockResolvedValue(true);
 
-        jest.spyOn(Modal, "createDialog").mockImplementation((_Component, props?: any) => {
-            props?.onFinished(true);
-            return {} as any;
-        });
+        jest.spyOn(Modal, "createDialog").mockReturnValue({
+            finished: Promise.resolve([true]),
+        } as any);
 
         render(<ManageEventIndexDialog onFinished={onFinished} />);
         await flushPromises();
@@ -76,6 +76,7 @@ describe("<ManageEventIndexDialog />", () => {
         await flushPromises();
 
         expect(setValueSpy).toHaveBeenCalledWith("tokenizerMode", null, SettingLevel.DEVICE, "ngram");
+        expect(initEventIndexSpy).toHaveBeenCalled();
         expect(onFinished).toHaveBeenCalled();
     });
 
@@ -84,10 +85,9 @@ describe("<ManageEventIndexDialog />", () => {
         const onFinished = jest.fn();
         const setValueSpy = jest.spyOn(SettingsStore, "setValue");
 
-        jest.spyOn(Modal, "createDialog").mockImplementation((_Component, props?: any) => {
-            props?.onFinished(false);
-            return {} as any;
-        });
+        jest.spyOn(Modal, "createDialog").mockReturnValue({
+            finished: Promise.resolve([false]),
+        } as any);
 
         render(<ManageEventIndexDialog onFinished={onFinished} />);
         await flushPromises();

--- a/apps/web/test/unit-tests/indexing/BaseEventIndexManager-test.ts
+++ b/apps/web/test/unit-tests/indexing/BaseEventIndexManager-test.ts
@@ -1,0 +1,19 @@
+/*
+Copyright 2025 New Vector Ltd.
+Copyright 2020, 2021 The Matrix.org Foundation C.I.C.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import BaseEventIndexManager from "../../../src/indexing/BaseEventIndexManager";
+
+describe("BaseEventIndexManager", () => {
+    it("initEventIndex throws unimplemented error", async () => {
+        // BaseEventIndexManager is abstract but has no abstract methods, so we can instantiate a trivial subclass.
+        class TestManager extends BaseEventIndexManager {}
+        const mgr = new TestManager();
+
+        await expect(mgr.initEventIndex("@user:example.org", "DEVICE", "ngram")).rejects.toThrow("Unimplemented");
+    });
+});

--- a/apps/web/test/unit-tests/indexing/EventIndexPeg-test.ts
+++ b/apps/web/test/unit-tests/indexing/EventIndexPeg-test.ts
@@ -1,0 +1,195 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { type Mocked } from "jest-mock";
+
+import { EventIndexPeg } from "../../../src/indexing/EventIndexPeg";
+import { mockPlatformPeg } from "../../test-utils";
+import type BaseEventIndexManager from "../../../src/indexing/BaseEventIndexManager";
+import SettingsStore from "../../../src/settings/SettingsStore";
+import { MatrixClientPeg } from "../../../src/MatrixClientPeg";
+import EventIndex from "../../../src/indexing/EventIndex";
+
+jest.mock("../../../src/indexing/EventIndex");
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
+describe("EventIndexPeg", () => {
+    describe("initEventIndex", () => {
+        it("passes tokenizerMode to initEventIndex", async () => {
+            const mockIndexingManager = {
+                initEventIndex: jest.fn().mockResolvedValue(undefined),
+                getUserVersion: jest.fn().mockResolvedValue(1),
+                isEventIndexEmpty: jest.fn().mockResolvedValue(false),
+            } as any as Mocked<BaseEventIndexManager>;
+            mockPlatformPeg({ getEventIndexingManager: () => mockIndexingManager });
+
+            jest.spyOn(MatrixClientPeg, "get").mockReturnValue({
+                getUserId: () => "@user:example.org",
+                getDeviceId: () => "DEVICE123",
+                on: jest.fn(),
+                removeListener: jest.fn(),
+            } as any);
+
+            jest.spyOn(SettingsStore, "getValueAt").mockImplementation((_level, settingName): any => {
+                if (settingName === "tokenizerMode") return "ngram";
+                if (settingName === "crawlerSleepTime") return 3000;
+                return undefined;
+            });
+
+            const peg = new EventIndexPeg();
+            await peg.initEventIndex();
+
+            expect(mockIndexingManager.initEventIndex).toHaveBeenCalledWith("@user:example.org", "DEVICE123", "ngram");
+        });
+
+        it("passes language tokenizer mode by default", async () => {
+            const mockIndexingManager = {
+                initEventIndex: jest.fn().mockResolvedValue(undefined),
+                getUserVersion: jest.fn().mockResolvedValue(1),
+                isEventIndexEmpty: jest.fn().mockResolvedValue(false),
+            } as any as Mocked<BaseEventIndexManager>;
+            mockPlatformPeg({ getEventIndexingManager: () => mockIndexingManager });
+
+            jest.spyOn(MatrixClientPeg, "get").mockReturnValue({
+                getUserId: () => "@user:example.org",
+                getDeviceId: () => "DEVICE123",
+                on: jest.fn(),
+                removeListener: jest.fn(),
+            } as any);
+
+            jest.spyOn(SettingsStore, "getValueAt").mockImplementation((_level, settingName): any => {
+                if (settingName === "tokenizerMode") return "language";
+                if (settingName === "crawlerSleepTime") return 3000;
+                return undefined;
+            });
+
+            const peg = new EventIndexPeg();
+            await peg.initEventIndex();
+
+            expect(mockIndexingManager.initEventIndex).toHaveBeenCalledWith(
+                "@user:example.org",
+                "DEVICE123",
+                "language",
+            );
+        });
+
+        it("sets forceAddInitialCheckpoints when database was recreated", async () => {
+            const mockIndex = {
+                setForceAddInitialCheckpoints: jest.fn(),
+                init: jest.fn().mockResolvedValue(undefined),
+            };
+            (EventIndex as unknown as jest.Mock).mockImplementation(() => mockIndex);
+
+            const mockIndexingManager = {
+                initEventIndex: jest.fn().mockResolvedValue({ wasRecreated: true }),
+                getUserVersion: jest.fn().mockResolvedValue(1),
+                isEventIndexEmpty: jest.fn().mockResolvedValue(false),
+            } as any as Mocked<BaseEventIndexManager>;
+            mockPlatformPeg({ getEventIndexingManager: () => mockIndexingManager });
+
+            jest.spyOn(MatrixClientPeg, "get").mockReturnValue({
+                getUserId: () => "@user:example.org",
+                getDeviceId: () => "DEVICE123",
+                on: jest.fn(),
+                removeListener: jest.fn(),
+            } as any);
+
+            jest.spyOn(SettingsStore, "getValueAt").mockImplementation((_level, settingName): any => {
+                if (settingName === "tokenizerMode") return "ngram";
+                if (settingName === "crawlerSleepTime") return 3000;
+                return undefined;
+            });
+
+            const peg = new EventIndexPeg();
+            await peg.initEventIndex();
+
+            expect(mockIndex.setForceAddInitialCheckpoints).toHaveBeenCalledWith(true);
+        });
+
+        it("sets forceAddInitialCheckpoints when index is empty", async () => {
+            const mockIndex = {
+                setForceAddInitialCheckpoints: jest.fn(),
+                init: jest.fn().mockResolvedValue(undefined),
+            };
+            (EventIndex as unknown as jest.Mock).mockImplementation(() => mockIndex);
+
+            const mockIndexingManager = {
+                initEventIndex: jest.fn().mockResolvedValue(undefined),
+                getUserVersion: jest.fn().mockResolvedValue(1),
+                isEventIndexEmpty: jest.fn().mockResolvedValue(true),
+                setUserVersion: jest.fn().mockResolvedValue(undefined),
+            } as any as Mocked<BaseEventIndexManager>;
+            mockPlatformPeg({ getEventIndexingManager: () => mockIndexingManager });
+
+            jest.spyOn(MatrixClientPeg, "get").mockReturnValue({
+                getUserId: () => "@user:example.org",
+                getDeviceId: () => "DEVICE123",
+                on: jest.fn(),
+                removeListener: jest.fn(),
+            } as any);
+
+            jest.spyOn(SettingsStore, "getValueAt").mockImplementation((_level, settingName): any => {
+                if (settingName === "tokenizerMode") return "ngram";
+                if (settingName === "crawlerSleepTime") return 3000;
+                return undefined;
+            });
+
+            const peg = new EventIndexPeg();
+            await peg.initEventIndex();
+
+            expect(mockIndexingManager.setUserVersion).toHaveBeenCalledWith(1);
+            expect(mockIndex.setForceAddInitialCheckpoints).toHaveBeenCalledWith(true);
+        });
+
+        it("reinitializes index when userVersion is 0 and index is not empty", async () => {
+            const mockIndex = {
+                setForceAddInitialCheckpoints: jest.fn(),
+                init: jest.fn().mockResolvedValue(undefined),
+            };
+            (EventIndex as unknown as jest.Mock).mockImplementation(() => mockIndex);
+
+            const mockIndexingManager = {
+                initEventIndex: jest.fn().mockResolvedValue(undefined),
+                getUserVersion: jest.fn().mockResolvedValue(0),
+                isEventIndexEmpty: jest.fn().mockResolvedValue(false),
+                closeEventIndex: jest.fn().mockResolvedValue(undefined),
+                deleteEventIndex: jest.fn().mockResolvedValue(undefined),
+                setUserVersion: jest.fn().mockResolvedValue(undefined),
+            } as any as Mocked<BaseEventIndexManager>;
+            mockPlatformPeg({ getEventIndexingManager: () => mockIndexingManager });
+
+            jest.spyOn(MatrixClientPeg, "get").mockReturnValue({
+                getUserId: () => "@user:example.org",
+                getDeviceId: () => "DEVICE123",
+                on: jest.fn(),
+                removeListener: jest.fn(),
+            } as any);
+
+            jest.spyOn(SettingsStore, "getValueAt").mockImplementation((_level, settingName): any => {
+                if (settingName === "tokenizerMode") return "ngram";
+                if (settingName === "crawlerSleepTime") return 3000;
+                return undefined;
+            });
+
+            const peg = new EventIndexPeg();
+            await peg.initEventIndex();
+
+            expect(mockIndexingManager.closeEventIndex).toHaveBeenCalled();
+            expect(mockIndexingManager.deleteEventIndex).toHaveBeenCalled();
+            expect(mockIndexingManager.initEventIndex).toHaveBeenCalledTimes(2);
+            expect(mockIndexingManager.initEventIndex).toHaveBeenNthCalledWith(
+                2,
+                "@user:example.org",
+                "DEVICE123",
+                "ngram",
+            );
+        });
+    });
+});

--- a/apps/web/test/unit-tests/vector/platform/SeshatIndexManager-test.ts
+++ b/apps/web/test/unit-tests/vector/platform/SeshatIndexManager-test.ts
@@ -1,0 +1,31 @@
+/*
+Copyright 2025 New Vector Ltd.
+Copyright 2020, 2021 The Matrix.org Foundation C.I.C.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { IPCManager } from "../../../../src/vector/platform/IPCManager";
+import { SeshatIndexManager } from "../../../../src/vector/platform/SeshatIndexManager";
+
+describe("SeshatIndexManager", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("passes tokenizerMode to initEventIndex IPC call", async () => {
+        // IPCManager requires window.electron to exist.
+        window.electron = {
+            on: jest.fn(),
+            send: jest.fn(),
+        } as unknown as Electron;
+
+        const ipcCallSpy = jest.spyOn(IPCManager.prototype, "call").mockResolvedValue(undefined);
+        const mgr = new SeshatIndexManager();
+
+        await mgr.initEventIndex("@user:example.org", "DEVICE123", "ngram");
+
+        expect(ipcCallSpy).toHaveBeenCalledWith("initEventIndex", "@user:example.org", "DEVICE123", "ngram");
+    });
+});


### PR DESCRIPTION
## Summary

This PR adds a user-facing setting to choose the tokenizer mode for local message search. N-gram tokenization is essential for languages without clear word boundaries such as Japanese, Chinese, and Korean (CJK languages).

## Changes

- Add tokenizer mode setting (Standard/Japanese) in Message Search preferences
- Pass tokenizer mode to Seshat via element-desktop IPC
- Add confirmation dialog when changing tokenizer mode (requires reindex)

## Dependencies

> ⚠️ **This PR depends on:**
> - **Seshat**: [PR #150: Add N-gram Tokenizer Mode for CJK Language Support](https://github.com/matrix-org/seshat/pull/150)
> - **element-desktop**: [PR  #2753: Add Tokenizer Mode Support for Seshat Search Index](https://github.com/element-hq/element-desktop/pull/2753)
>
> Both upstream PRs must be merged before this PR can be merged.

## Merge Order

```
1. Seshat PR #150  →  npm release (e.g., matrix-seshat@4.1.0)
2. element-desktop PR  →  update matrix-seshat dependency
3. element-web (this PR)  →  UI for tokenizer mode selection
```

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
