### PR TITLE
Implement multipart zips for room exports

### DIFF
--- a/src/components/views/dialogs/ExportDialog.tsx
+++ b/src/components/views/dialogs/ExportDialog.tsx
@@ -388,6 +388,20 @@ const ExportDialog: React.FC<IProps> = ({ room, onFinished }) => {
                             </StyledCheckbox>
                         </>
                     )}
+
+                    {includeAttachments ? (
+                        <>
+                            <StyledCheckbox
+                                enabled={includeAttachments}
+                                className="mx_ExportDialog_attachments-checkbox"
+                                id="split-into-parts-if-needed"
+                                checked={splitIntoPartsIfNeeded}
+                                onChange={(e) => setSplitIntoPartsIfNeeded((e.target as HTMLInputElement).checked)}
+                            >
+                                {_t("export_chat|split_into_parts_if_needed")}
+                            </StyledCheckbox>
+                        </>
+                    ) : (<></>)}
                 </div>
                 {isExporting ? (
                     <div data-testid="export-progress" className="mx_ExportDialog_progress">

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1249,6 +1249,7 @@
         "html": "HTML",
         "html_title": "Exported Data",
         "include_attachments": "Include Attachments",
+        "split_into_parts_if_needed": "Split into parts if needed",
         "json": "JSON",
         "media_omitted": "Media omitted",
         "media_omitted_file_size": "Media omitted - file size limit exceeded",

--- a/src/utils/exportUtils/HtmlExport.tsx
+++ b/src/utils/exportUtils/HtmlExport.tsx
@@ -37,7 +37,6 @@ import exportJS from "!!raw-loader!./exportJS";
 export default class HTMLExporter extends Exporter {
     protected avatars: Map<string, boolean>;
     protected permalinkCreator: RoomPermalinkCreator;
-    protected totalSize: number;
     protected mediaOmitText: string;
 
     public constructor(
@@ -365,6 +364,10 @@ export default class HTMLExporter extends Exporter {
                 if (this.exportOptions.attachmentsIncluded) {
                     try {
                         const blob = await this.getMediaBlob(mxEv);
+                        if (this.totalSize + blob.size > this.exportOptions.maxSize && 
+                            this.exportOptions.splitIntoPartsIfNeeded) {
+                            await this.downloadZIP();
+                        }
                         if (this.totalSize + blob.size > this.exportOptions.maxSize) {
                             eventTile = await this.getEventTileMarkup(
                                 this.createModifiedEvent(this.mediaOmitText, mxEv),
@@ -374,7 +377,8 @@ export default class HTMLExporter extends Exporter {
                             this.totalSize += blob.size;
                             const filePath = this.getFilePath(mxEv);
                             eventTile = await this.getEventTileMarkup(mxEv, joined, filePath);
-                            if (this.totalSize == this.exportOptions.maxSize) {
+                            if (this.totalSize == this.exportOptions.maxSize && 
+                                !this.exportOptions.splitIntoPartsIfNeeded) {
                                 this.exportOptions.attachmentsIncluded = false;
                             }
                             this.addFile(filePath, blob);

--- a/src/utils/exportUtils/exportUtils.ts
+++ b/src/utils/exportUtils/exportUtils.ts
@@ -57,5 +57,6 @@ export interface IExportOptions {
     // startDate?: number;
     numberOfMessages?: number;
     attachmentsIncluded: boolean;
+    splitIntoPartsIfNeeded: boolean;
     maxSize: number;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->
Previously when a room export which includes media files passes the user specified maximum size it would stop downloading further attachments.
This PR implements the option to create multiple ZIP parts to allow exporting all attachments from the room.
When an attachment gets added to the ZIP it will first check if adding it would make the resulting file exceed the user specified maximum, if it does then the ZIP file will be downloaded before starting a new one which contains following attachments.

## Checklist

- [x] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
