### PR TITLE
Fix Room Preview Card Layout

### DIFF
--- a/res/css/views/rooms/_RoomPreviewCard.pcss
+++ b/res/css/views/rooms/_RoomPreviewCard.pcss
@@ -92,7 +92,13 @@ Please see LICENSE files in the repository root for full details.
     }
 
     .mx_FacePile {
-        margin-top: $spacing-20;
+        display: flex;
+        align-items: center;
+        margin-top: $spacing-16;
+
+        :first-child {
+            flex-shrink: 0;
+        }
     }
 
     .mx_RoomPreviewCard_joinButtons {


### PR DESCRIPTION
Updating the room preview card to have the summary lining up with the face pile.
Also changed the margin to have equal spacing as the block above has a `$spacing-16` gap too.

| ❌ Before | ✅ After  |
|--------|--------|
| <img width="1024" height="888" alt="CleanShot 2025-12-27 at 14 54 01@2x" src="https://github.com/user-attachments/assets/515ac5e8-affe-4539-9235-51188feac363" /> | <img width="1042" height="860" alt="CleanShot 2025-12-27 at 14 53 34@2x" src="https://github.com/user-attachments/assets/bb769e6f-3b21-4eb5-8a50-c4673374a162" /> |





### 

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
