### PR TITLE
Add ol override CSS for markdown-body

### DIFF
--- a/res/css/views/rooms/_EventTile.pcss
+++ b/res/css/views/rooms/_EventTile.pcss
@@ -759,6 +759,12 @@ $left-gutter: 64px;
         }
         */
 
+        /* Support arbitrarily large marker numbers */
+        ol {
+            list-style-position: inside;
+            padding-inline-start: 0.5em;
+        }
+
         /* Override nested lists being lower-roman */
         ol ol,
         ul ol {


### PR DESCRIPTION
Fixes #14621

This small CSS change affects the marker numbers on ordered lists.

Before this change:

<img width="464" height="380" alt="Screenshot 2025-12-31 at 01 05 56" src="https://github.com/user-attachments/assets/cb676753-456d-4c36-aa7b-84f7548fb9f9" />

After this change:

<img width="425" height="377" alt="Screenshot 2025-12-31 at 01 07 11" src="https://github.com/user-attachments/assets/18a141f4-96c6-4e11-a74e-4590a8cac575" />

---

As you can see this visually changes the marker numbers to be positioned inside with the content which has the trade-off of not being visually aligned vertically.

Despite this downside I feel it still likely represents one of the cleanest fixes possible to the problem as it doesn't affect HTML structure and will remain unaffected by other upstream changes in how rendering for these lists works. Additionally, it avoids any fragile JavaScript calculations trying to determine how much leading padding is required for a given list of numbers given complex structures such as this valid HTML where it isn't always going to be programatically obvious what the largest marker number value will be:

```HTML
<ol>
    <li>new style</li>
    <li>new style</li>
    <li>new style</li>
    <li>new style</li>
    <li value="500">new style</li>
    <li value="6">new style</li>
    <li>new style</li>
    <li>new style</li>
    <li>new style</li>
    <li>new style</li>
</ol>
```