### PR TITLE
fix flaky test by waiting for chat panel before counting messages

### DIFF
--- a/playwright/e2e/voip/element-call.spec.ts
+++ b/playwright/e2e/voip/element-call.spec.ts
@@ -658,7 +658,12 @@ test.describe("Element Call", () => {
                 .getByRole("button", { name: "Send Room Message" })
                 .click();
 
-            const messageSent = await page.getByText("I sent this once!!").count();
+            const timelineLocator = page.locator(".mx_RightPanel .mx_TimelineCard");
+            // First wait for the message to appear in the timeline then
+            // check the count. This improves test stability as we know the message has been sent.
+            await expect(timelineLocator.getByText("I sent this once!!")).toBeVisible();
+
+            const messageSent = await timelineLocator.getByText("I sent this once!!").count();
 
             expect(messageSent).toBe(1);
         });


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Fixes #31603 

`element-call.spec.ts` is reported as beeing flaky.
By looking at the report/trace of playwright I can see that the expected messages are finally shown on screen
<img width="278" height="79" alt="image" src="https://github.com/user-attachments/assets/5334d684-06cb-49e4-8f75-268c851a3220" />

But when the check fails, it looks like the right panel is not yet rendered:
<img width="693" height="365" alt="image" src="https://github.com/user-attachments/assets/c0b35b6b-05b1-49a4-a931-1a858737bf15" />

In this fix I am just adding a new `expect to wait and ensure that the timeline is visible before trying to count the messages in the timeline.
Hopefuly it would fix the flakyness, but at least it will rule out the problem of the right panel chat not beeing yet rendered?


## Checklist

- [ ] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
