### PR TITLE
Moved typing indicator to Composer

### DIFF
--- a/res/css/structures/_RoomView.pcss
+++ b/res/css/structures/_RoomView.pcss
@@ -32,6 +32,7 @@ Please see LICENSE files in the repository root for full details.
     }
 
     .mx_MessageComposer {
+        position: relative;
         width: 100%;
         flex: 0 0 auto;
         margin-right: 2px;
@@ -156,9 +157,6 @@ Please see LICENSE files in the repository root for full details.
     list-style-type: none;
     padding: var(--RoomView_MessageList-padding); /* mx_ProfileResizer depends on this value */
     margin: 0;
-    /* needed as min-height is set to clientHeight in ScrollPanel
-    to prevent shrinking when WhoIsTypingTile is hidden */
-    box-sizing: border-box;
 
     li {
         clear: both;

--- a/res/css/views/right_panel/_TimelineCard.pcss
+++ b/res/css/views/right_panel/_TimelineCard.pcss
@@ -158,14 +158,6 @@ Please see LICENSE files in the repository root for full details.
         }
     }
 
-    .mx_WhoIsTypingTile {
-        margin-left: -12px; /* undo padding on the message list */
-    }
-
-    .mx_WhoIsTypingTile_avatars {
-        flex-basis: 48px; /* 12 (padding on message list) + 36 (padding on event lines) */
-    }
-
     .mx_GenericEventListSummary_unstyledList, /* RR next to a message on the event list summary */
     .mx_RoomView_MessageList {
         /* RR next to a message on the messsge list */

--- a/res/css/views/rooms/_WhoIsTypingTile.pcss
+++ b/res/css/views/rooms/_WhoIsTypingTile.pcss
@@ -6,8 +6,14 @@ Please see LICENSE files in the repository root for full details.
 */
 
 .mx_WhoIsTypingTile {
-    margin-left: -18px; /* offset padding from mx_RoomView_MessageList to center avatars */
-    padding-top: 18px;
+    --padding-top: 9px;
+    position: absolute;
+    background: linear-gradient(to top, var(--cpd-color-bg-canvas-default) var(--padding-top), transparent);
+    left: 0;
+    right: 0;
+    top: calc((1lh + var(--padding-top)) * -1);
+    margin-left: 0;
+    padding-top: var(--padding-top);
     display: flex;
     align-items: center;
 }
@@ -25,6 +31,7 @@ Please see LICENSE files in the repository root for full details.
 .mx_WhoIsTypingTile_avatars .mx_BaseAvatar {
     border: 1px solid $background;
     border-radius: 40px;
+    vertical-align: middle;
 }
 
 .mx_WhoIsTypingTile_remainingAvatarPlaceholder {
@@ -45,6 +52,7 @@ Please see LICENSE files in the repository root for full details.
 .mx_WhoIsTypingTile_label {
     flex: 1;
     font: var(--cpd-font-body-md-semibold);
+    font-size: var(--cpd-font-size-body-sm);
     color: $roomtopic-color;
 }
 

--- a/src/components/structures/TimelinePanel.tsx
+++ b/src/components/structures/TimelinePanel.tsx
@@ -740,7 +740,6 @@ class TimelinePanel extends React.Component<IProps, IState> {
             }
 
             this.setState(updatedState as IState, () => {
-                this.messagePanel.current?.updateTimelineMinHeight();
                 if (callRMUpdated) {
                     this.props.onReadMarkerUpdated?.();
                 }
@@ -1447,8 +1446,6 @@ class TimelinePanel extends React.Component<IProps, IState> {
         const onLoaded = (): void => {
             if (this.unmounted) return;
 
-            // clear the timeline min-height when (re)loading the timeline
-            this.messagePanel.current?.onTimelineReset();
             this.reloadEvents();
 
             // If we switched away from the room while there were pending

--- a/src/components/views/rooms/WhoIsTypingTile.tsx
+++ b/src/components/views/rooms/WhoIsTypingTile.tsx
@@ -167,7 +167,7 @@ export default class WhoIsTypingTile extends React.Component<IProps, IState> {
                 <MemberAvatar
                     key={u.userId}
                     member={u}
-                    size="24px"
+                    size="14px"
                     resizeMethod="crop"
                     viewUserOnClick={true}
                     aria-live="off"
@@ -207,12 +207,12 @@ export default class WhoIsTypingTile extends React.Component<IProps, IState> {
         }
 
         return (
-            <li className="mx_WhoIsTypingTile" aria-atomic="true">
+            <div className="mx_WhoIsTypingTile" aria-atomic="true">
                 <div className="mx_WhoIsTypingTile_avatars">
                     {this.renderTypingIndicatorAvatars(usersTyping, this.props.whoIsTypingLimit)}
                 </div>
                 <div className="mx_WhoIsTypingTile_label">{typingString}</div>
-            </li>
+            </div>
         );
     }
 }


### PR DESCRIPTION
Fixes #19855 and #16304

This is mostly a proposal as I know there have been previous design discussions apparently that didn't reach a conclusion.

This moves the typing indicator to above the composer input without changing any of the functionality. The design eliminates the need for any extra spacing to be maintained in the timeline which simplifies a lot of other aspects of the code.

Attached is a short demo where I toggle the typing indicator on and off manually to show how it leaves the timeline unaffected and the new style for it.

https://github.com/user-attachments/assets/4b100c0c-3c7d-48e8-9973-da6e38c4ac69


