### PR TITLE
rtc: use new API in tests (instead of deprecated calls)

### DIFF
--- a/test/unit-tests/Notifier-test.ts
+++ b/test/unit-tests/Notifier-test.ts
@@ -443,12 +443,16 @@ describe("Notifier", () => {
                         content: {},
                     }),
                     {
-                        call_id: "123",
-                        application: "m.call",
-                        focus_active: { type: "livekit" },
-                        foci_preferred: [],
-                        device_id: "DEVICE",
+                        kind: "session",
+                        data: {
+                            call_id: "123",
+                            application: "m.call",
+                            focus_active: { type: "livekit", focus_selection: "oldest_membership" },
+                            foci_preferred: [],
+                            device_id: "DEVICE",
+                        },
                     },
+                    "hashed_id_XXXAAAAA",
                 ),
             ];
 

--- a/test/unit-tests/models/Call-test.ts
+++ b/test/unit-tests/models/Call-test.ts
@@ -1051,7 +1051,7 @@ describe("ElementCall", () => {
             setRoomMembers(["@user:example.com", "@user2:example.com", "@user4:example.com"]);
         });
         it("don't sent notify event if there are existing room call members", async () => {
-            jest.spyOn(MatrixRTCSession, "callMembershipsForRoom").mockReturnValue([
+            jest.spyOn(MatrixRTCSession, "sessionMembershipsForSlot").mockResolvedValue([
                 { application: "m.call", callId: "" } as unknown as CallMembership,
             ]);
             const sendEventSpy = jest.spyOn(room.client, "sendEvent");


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](../docs/review.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
