### PR TITLE
Fix flaky MemberListView tests

### DIFF
--- a/test/unit-tests/components/views/rooms/memberlist/MemberListHeaderView-test.tsx
+++ b/test/unit-tests/components/views/rooms/memberlist/MemberListHeaderView-test.tsx
@@ -71,7 +71,7 @@ describe("MemberListHeaderView", () => {
             memberListRoom.currentState.members[newMember.userId] = newMember;
         }
         await reRender();
-        expect(screen.queryByPlaceholderText("Search room members")).toBeVisible();
+        await waitFor(() => expect(screen.queryByPlaceholderText("Search room members")).toBeVisible());
     });
 
     describe("Invite button functionality", () => {
@@ -84,7 +84,9 @@ describe("MemberListHeaderView", () => {
             jest.spyOn(memberListRoom, "getMyMembership").mockReturnValue(KnownMembership.Join);
             jest.spyOn(memberListRoom, "canInvite").mockReturnValue(false);
             await reRender();
-            expect(screen.getByRole("button", { name: "Invite" })).toHaveAttribute("aria-disabled", "true");
+            await waitFor(() =>
+                expect(screen.getByRole("button", { name: "Invite" })).toHaveAttribute("aria-disabled", "true"),
+            );
         });
 
         it("Renders enabled invite button when current user is a member and has rights to invite", async () => {
@@ -92,7 +94,9 @@ describe("MemberListHeaderView", () => {
             jest.spyOn(memberListRoom, "getMyMembership").mockReturnValue(KnownMembership.Join);
             jest.spyOn(memberListRoom, "canInvite").mockReturnValue(true);
             await reRender();
-            expect(screen.getByRole("button", { name: "Invite" })).not.toHaveAttribute("aria-disabled", "true");
+            await waitFor(() =>
+                expect(screen.getByRole("button", { name: "Invite" })).not.toHaveAttribute("aria-disabled", "true"),
+            );
         });
 
         it("Opens room inviter on button click", async () => {
@@ -101,6 +105,7 @@ describe("MemberListHeaderView", () => {
             jest.spyOn(memberListRoom, "canInvite").mockReturnValue(true);
             await reRender();
 
+            await waitFor(() => expect(screen.getByRole("button", { name: "Invite" })).not.toBeDisabled());
             fireEvent.click(screen.getByRole("button", { name: "Invite" }));
             expect(defaultDispatcher.dispatch).toHaveBeenCalledWith({
                 action: "view_invite",

--- a/test/unit-tests/components/views/rooms/memberlist/MemberListView-test.tsx
+++ b/test/unit-tests/components/views/rooms/memberlist/MemberListView-test.tsx
@@ -191,20 +191,24 @@ describe("MemberListView and MemberlistHeaderView", () => {
                     u.user!.presence = "offline";
                 });
 
-                await act(reRender);
+                await reRender();
 
-                const tiles = root.container.querySelectorAll(".mx_MemberTileView");
-                expectOrderedByPresenceAndPowerLevel(memberListRoom, tiles, enablePresence);
+                await waitFor(() => {
+                    const tiles = root.container.querySelectorAll(".mx_MemberTileView");
+                    expectOrderedByPresenceAndPowerLevel(memberListRoom, tiles, enablePresence);
+                });
             });
 
             it("by power level", async () => {
                 const { reRender, root, memberListRoom } = rendered;
                 // We already have admin, moderator, and default users so leave them alone
 
-                await act(reRender);
+                await reRender();
 
-                const tiles = root.container.querySelectorAll(".mx_EntityTile");
-                expectOrderedByPresenceAndPowerLevel(memberListRoom, tiles, enablePresence);
+                await waitFor(() => {
+                    const tiles = root.container.querySelectorAll(".mx_EntityTile");
+                    expectOrderedByPresenceAndPowerLevel(memberListRoom, tiles, enablePresence);
+                });
             });
 
             it("by last active timestamp", async () => {
@@ -229,10 +233,12 @@ describe("MemberListView and MemberlistHeaderView", () => {
                     u.user!.lastActiveAgo = 100;
                 });
 
-                await act(reRender);
+                await reRender();
 
-                const tiles = root.container.querySelectorAll(".mx_EntityTile");
-                expectOrderedByPresenceAndPowerLevel(memberListRoom, tiles, enablePresence);
+                await waitFor(() => {
+                    const tiles = root.container.querySelectorAll(".mx_EntityTile");
+                    expectOrderedByPresenceAndPowerLevel(memberListRoom, tiles, enablePresence);
+                });
             });
 
             it("by name", async () => {
@@ -247,10 +253,12 @@ describe("MemberListView and MemberlistHeaderView", () => {
                     u.powerLevel = 100;
                 });
 
-                await act(reRender);
+                await reRender();
 
-                const tiles = root.container.querySelectorAll(".mx_EntityTile");
-                expectOrderedByPresenceAndPowerLevel(memberListRoom, tiles, enablePresence);
+                await waitFor(() => {
+                    const tiles = root.container.querySelectorAll(".mx_EntityTile");
+                    expectOrderedByPresenceAndPowerLevel(memberListRoom, tiles, enablePresence);
+                });
             });
         });
     });

--- a/test/unit-tests/components/views/rooms/memberlist/common.tsx
+++ b/test/unit-tests/components/views/rooms/memberlist/common.tsx
@@ -163,6 +163,5 @@ function createReRenderFunction(client: MatrixClient, memberListRoom: Room): Ren
                 getRoomId: () => memberListRoom.roomId,
             });
         });
-        await new Promise((r) => setTimeout(r, 1000));
     };
 }


### PR DESCRIPTION
## Problem
The MemberListView tests were flaky (#31251, #31582) due to timing issues with async rendering.

## Root Cause
The `reRender()` function in [common.tsx](cci:7://file:///c:/Users/bh/Desktop/open%20source/element-web/test/unit-tests/components/views/rooms/memberlist/common.tsx:0:0-0:0) used `setTimeout(r, 1000)` - a hard 1-second sleep that's unreliable on slow CI machines.

## Solution
- Removed the `setTimeout(1000)` from `reRender()` in [common.tsx](https://github.com/aditya-cherukuru/element-web/blob/fix/flaky-memberlist-view-tests/test/unit-tests/components/views/rooms/memberlist/common.tsx)
- Replaced [act(reRender)](cci:1://file:///c:/Users/bh/Desktop/open%20source/matrix-js-sdk/src/models/room-state.ts:861:4-882:5) with `await reRender()` followed by `waitFor()` in [MemberListView-test.tsx](https://github.com/aditya-cherukuru/element-web/blob/fix/flaky-memberlist-view-tests/test/unit-tests/components/views/rooms/memberlist/MemberListView-test.tsx) and [MemberListHeaderView-test.tsx](https://github.com/aditya-cherukuru/element-web/blob/fix/flaky-memberlist-view-tests/test/unit-tests/components/views/rooms/memberlist/MemberListHeaderView-test.tsx)


## Testing
Ran tests for both files 5 times consecutively - all passed consistently.

Fixes #31251
Fixes #31582

## Checklist

- [x] I have read through review guidelines and CONTRIBUTING.md.
- [x] Tests written for new code (and old code if feasible).
- [ ] New or updated public/exported symbols have accurate TSDoc documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the CLA.