### PR TITLE
CodeStyle: Add a note about SettingsStore mocks

### DIFF
--- a/code_style.md
+++ b/code_style.md
@@ -364,6 +364,19 @@ Note: We use PostCSS + some plugins to process our styles. It looks like SCSS, b
         });
     });
     ```
+3. When you need to test a feature that relies on SettingsStore values, be sure to tighly scope your mock:
+   ```typescript
+   // BAD - Obscures other settings, not clear which setting is required for test.
+   jest.spyOn(SettingsStore, "getValue").mockReturnValue(false);
+   // GOOD - Passes through other settings to SettingsStore, clear which settings are in use.
+   const realGetValue = SettingsStore.getValue;
+   jest.spyOn(SettingsStore, "getValue").mockImplementation((settingName, ...params) => {
+       if (settingName === "feature_cool_stuff") {
+           return true;
+       }
+       realGetValue(settingName, ...params);
+   });
+   ```
 
 ## Comments
 


### PR DESCRIPTION
This has bitten me a number of times, and a bunch of the existing unit tests do this incorrectly.