### PR TITLE
Custom themes now import highlights in css

### DIFF
--- a/res/themes/dark-custom/css/dark-custom.pcss
+++ b/res/themes/dark-custom/css/dark-custom.pcss
@@ -6,4 +6,5 @@
 @import "../../light-custom/css/_custom.pcss";
 @import "../../../../res/css/_components.pcss";
 @import "../../../../res/css/_compound.pcss";
+@import url("highlight.js/styles/atom-one-light.min.css");
 @import url("github-markdown-css/github-markdown-dark.css");

--- a/res/themes/light-custom/css/light-custom.pcss
+++ b/res/themes/light-custom/css/light-custom.pcss
@@ -5,4 +5,5 @@
 @import "_custom.pcss";
 @import "../../../../res/css/_components.pcss";
 @import "../../../../res/css/_compound.pcss";
+@import url("highlight.js/styles/atom-one-light.min.css");
 @import url("github-markdown-css/github-markdown-light.css");


### PR DESCRIPTION
Added import for codeblock highlights in css for custom themes

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)


Fixes #31757 

More information about the change is written there. 