### PR TITLE
Fix flaky Jest test: RoomView search results

### DIFF
--- a/test/unit-tests/components/structures/RoomView-test.tsx
+++ b/test/unit-tests/components/structures/RoomView-test.tsx
@@ -24,16 +24,7 @@ import {
 } from "matrix-js-sdk/src/matrix";
 import { type CryptoApi, CryptoEvent, UserVerificationStatus } from "matrix-js-sdk/src/crypto-api";
 import { KnownMembership } from "matrix-js-sdk/src/types";
-import {
-    act,
-    cleanup,
-    fireEvent,
-    render,
-    type RenderResult,
-    screen,
-    waitFor,
-    waitForElementToBeRemoved,
-} from "jest-matrix-react";
+import { act, cleanup, fireEvent, render, type RenderResult, screen, waitFor } from "jest-matrix-react";
 import userEvent from "@testing-library/user-event";
 
 import {
@@ -872,12 +863,13 @@ describe("RoomView", () => {
             await waitFor(() => {
                 expect(container.querySelector(".mx_RoomView_searchResultsPanel")).toBeVisible();
             });
-            const prom = waitForElementToBeRemoved(() => container.querySelector(".mx_RoomView_searchResultsPanel"));
 
             await userEvent.hover(getByText("search term"));
             await userEvent.click(await findByLabelText("Edit"));
 
-            await prom;
+            await waitFor(() => {
+                expect(container.querySelector(".mx_RoomView_searchResultsPanel")).not.toBeInTheDocument();
+            });
         });
 
         it("should switch rooms when edit is clicked on a search result for a different room", async () => {


### PR DESCRIPTION
## Problem
Flaky Jest test: "should close search results when edit is clicked" (#31778)

## Root Cause
The test called `waitForElementToBeRemoved()` before performing the click action. This starts a timeout immediately, and if the UI update was slow, it would timeout.

## Solution
- Perform user actions first (hover + click)
- Then use `waitFor()` to verify the search panel was removed
- Removed unused `waitForElementToBeRemoved` import

This follows React Testing Library best practices: perform actions, then verify state.

## Testing
Ran the test 5 times consecutively - all passed.

Fixes #31778

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)