### PR TITLE
Unset buttons does not include color inherit

### DIFF
--- a/res/css/views/rooms/RoomListPanel/_RoomListItemView.pcss
+++ b/res/css/views/rooms/RoomListPanel/_RoomListItemView.pcss
@@ -16,6 +16,7 @@
  */
 .mx_RoomListItemView {
     /* Remove button default style */
+    color: inherit;
     background: unset;
     border: none;
     padding: 0;

--- a/res/css/views/rooms/_PinnedMessageBanner.pcss
+++ b/res/css/views/rooms/_PinnedMessageBanner.pcss
@@ -22,6 +22,7 @@
     box-shadow: 0 var(--cpd-space-2x) var(--cpd-space-6x) calc(var(--cpd-space-2x) * -1) rgb(27, 29, 34, 0.1);
 
     .mx_PinnedMessageBanner_main {
+        color: inherit;
         background: transparent;
         border: none;
         text-align: start;

--- a/res/css/views/rooms/_RoomHeader.pcss
+++ b/res/css/views/rooms/_RoomHeader.pcss
@@ -21,6 +21,7 @@ Please see LICENSE files in the repository root for full details.
 
 .mx_RoomHeader_infoWrapper {
     /* unset button styles */
+    color: inherit;
     background: unset;
     border: unset;
     flex: 1;


### PR DESCRIPTION
This PR fixes a display error of text fields when changing colors in custom themes. Room list and room header was always white or black depending on root custom theme. Now it is switched to inherit color instead. I dont know if this is desired from the client developments side but it is nice if it could follow suit with the rest.

It now inherits this from body: 
color: var(--timeline-text-color);

Fixed button color to inherit in following scenarios:
 * RoomList now rooms follow room text compound color
 * PinnedMessageBanner follow room text compound color
 * RoomHeader follow room text compound color

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
