### PR TITLE
Move vm hooks into view model folder

### DIFF
--- a/packages/shared-components/src/audio/AudioPlayerView/AudioPlayerView.stories.tsx
+++ b/packages/shared-components/src/audio/AudioPlayerView/AudioPlayerView.stories.tsx
@@ -10,7 +10,7 @@ import { fn } from "storybook/test";
 
 import type { Meta, StoryFn } from "@storybook/react-vite";
 import { AudioPlayerView, type AudioPlayerViewActions, type AudioPlayerViewSnapshot } from "./AudioPlayerView";
-import { useMockedViewModel } from "../../useMockedViewModel";
+import { useMockedViewModel } from "../../viewmodel";
 
 type AudioPlayerProps = AudioPlayerViewSnapshot & AudioPlayerViewActions;
 const AudioPlayerViewWrapper = ({ togglePlay, onKeyDown, onSeekbarChange, ...rest }: AudioPlayerProps): JSX.Element => {

--- a/packages/shared-components/src/audio/AudioPlayerView/AudioPlayerView.tsx
+++ b/packages/shared-components/src/audio/AudioPlayerView/AudioPlayerView.tsx
@@ -7,8 +7,7 @@
 
 import React, { type ChangeEventHandler, type JSX, type KeyboardEventHandler, type MouseEventHandler } from "react";
 
-import { type ViewModel } from "../../viewmodel/ViewModel";
-import { useViewModel } from "../../useViewModel";
+import { type ViewModel, useViewModel } from "../../viewmodel";
 import { MediaBody } from "../../message-body/MediaBody";
 import { Flex } from "../../utils/Flex";
 import styles from "./AudioPlayerView.module.css";

--- a/packages/shared-components/src/composer/HistoryVisibleBannerView/HistoryVisibleBannerView.stories.tsx
+++ b/packages/shared-components/src/composer/HistoryVisibleBannerView/HistoryVisibleBannerView.stories.tsx
@@ -8,7 +8,7 @@ import { type Meta, type StoryFn } from "@storybook/react-vite";
 import React, { type JSX } from "react";
 import { fn } from "storybook/test";
 
-import { useMockedViewModel } from "../../useMockedViewModel";
+import { useMockedViewModel } from "../../viewmodel";
 import {
     HistoryVisibleBannerView,
     type HistoryVisibleBannerViewActions,

--- a/packages/shared-components/src/composer/HistoryVisibleBannerView/HistoryVisibleBannerView.tsx
+++ b/packages/shared-components/src/composer/HistoryVisibleBannerView/HistoryVisibleBannerView.tsx
@@ -8,9 +8,8 @@
 import { Link } from "@vector-im/compound-web";
 import React, { type JSX } from "react";
 
-import { useViewModel } from "../../useViewModel";
 import { _t } from "../../utils/i18n";
-import { type ViewModel } from "../../viewmodel";
+import { type ViewModel, useViewModel } from "../../viewmodel";
 import { Banner } from "../Banner";
 
 export interface HistoryVisibleBannerViewActions {

--- a/packages/shared-components/src/event-tiles/TextualEventView/TextualEventView.tsx
+++ b/packages/shared-components/src/event-tiles/TextualEventView/TextualEventView.tsx
@@ -7,8 +7,7 @@ Please see LICENSE files in the repository root for full details.
 
 import React, { type ReactNode, type JSX } from "react";
 
-import { type ViewModel } from "../../viewmodel/ViewModel";
-import { useViewModel } from "../../useViewModel";
+import { type ViewModel, useViewModel } from "../../viewmodel";
 
 export type TextualEventViewSnapshot = {
     content: string | ReactNode;

--- a/packages/shared-components/src/index.ts
+++ b/packages/shared-components/src/index.ts
@@ -36,5 +36,3 @@ export * from "./utils/I18nApi";
 
 // MVVM
 export * from "./viewmodel";
-export * from "./useMockedViewModel";
-export * from "./useViewModel";

--- a/packages/shared-components/src/room-list/RoomListHeaderView/RoomListHeaderView.stories.tsx
+++ b/packages/shared-components/src/room-list/RoomListHeaderView/RoomListHeaderView.stories.tsx
@@ -14,7 +14,7 @@ import {
     type RoomListHeaderViewActions,
     type RoomListHeaderViewSnapshot,
 } from "./RoomListHeaderView";
-import { useMockedViewModel } from "../../useMockedViewModel";
+import { useMockedViewModel } from "../../viewmodel";
 import { defaultSnapshot } from "./default-snapshot";
 
 type RoomListHeaderProps = RoomListHeaderViewSnapshot & RoomListHeaderViewActions;

--- a/packages/shared-components/src/room-list/RoomListHeaderView/RoomListHeaderView.tsx
+++ b/packages/shared-components/src/room-list/RoomListHeaderView/RoomListHeaderView.tsx
@@ -9,8 +9,7 @@ import React, { type JSX } from "react";
 import { IconButton, H1 } from "@vector-im/compound-web";
 import ComposeIcon from "@vector-im/compound-design-tokens/assets/web/icons/compose";
 
-import { type ViewModel } from "../../viewmodel/ViewModel";
-import { useViewModel } from "../../useViewModel";
+import { type ViewModel, useViewModel } from "../../viewmodel";
 import { Flex } from "../../utils/Flex";
 import { useI18n } from "../../utils/i18nContext";
 import { ComposeMenuView, OptionMenuView, SpaceMenuView } from "./menu";

--- a/packages/shared-components/src/room-list/RoomListHeaderView/menu/ComposeMenuView.tsx
+++ b/packages/shared-components/src/room-list/RoomListHeaderView/menu/ComposeMenuView.tsx
@@ -14,7 +14,7 @@ import RoomIcon from "@vector-im/compound-design-tokens/assets/web/icons/room";
 
 import { type RoomListHeaderViewModel } from "../RoomListHeaderView";
 import { useI18n } from "../../../utils/i18nContext";
-import { useViewModel } from "../../../useViewModel";
+import { useViewModel } from "../../../viewmodel";
 
 interface ComposeMenuViewProps {
     /**

--- a/packages/shared-components/src/room-list/RoomListHeaderView/menu/OptionMenuView.tsx
+++ b/packages/shared-components/src/room-list/RoomListHeaderView/menu/OptionMenuView.tsx
@@ -10,7 +10,7 @@ import React, { type JSX, useState } from "react";
 import OverflowHorizontalIcon from "@vector-im/compound-design-tokens/assets/web/icons/overflow-horizontal";
 
 import { type RoomListHeaderViewModel } from "../RoomListHeaderView";
-import { useViewModel } from "../../../useViewModel";
+import { useViewModel } from "../../../viewmodel";
 import { useI18n } from "../../../utils/i18nContext";
 import styles from "./OptionMenuView.module.css";
 

--- a/packages/shared-components/src/room-list/RoomListHeaderView/menu/SpaceMenuView.tsx
+++ b/packages/shared-components/src/room-list/RoomListHeaderView/menu/SpaceMenuView.tsx
@@ -14,7 +14,7 @@ import PreferencesIcon from "@vector-im/compound-design-tokens/assets/web/icons/
 import UserAddIcon from "@vector-im/compound-design-tokens/assets/web/icons/user-add";
 
 import styles from "./SpaceMenuView.module.css";
-import { useViewModel } from "../../../useViewModel";
+import { useViewModel } from "../../../viewmodel";
 import { useI18n } from "../../../utils/i18nContext";
 import { type RoomListHeaderViewModel } from "../RoomListHeaderView";
 

--- a/packages/shared-components/src/room-list/RoomListSearchView/RoomListSearchView.stories.tsx
+++ b/packages/shared-components/src/room-list/RoomListSearchView/RoomListSearchView.stories.tsx
@@ -14,7 +14,7 @@ import {
     type RoomListSearchViewActions,
     type RoomListSearchViewSnapshot,
 } from "./RoomListSearchView";
-import { useMockedViewModel } from "../../useMockedViewModel";
+import { useMockedViewModel } from "../../viewmodel";
 
 type RoomListSearchProps = RoomListSearchViewSnapshot & RoomListSearchViewActions;
 

--- a/packages/shared-components/src/room-list/RoomListSearchView/RoomListSearchView.tsx
+++ b/packages/shared-components/src/room-list/RoomListSearchView/RoomListSearchView.tsx
@@ -12,8 +12,7 @@ import SearchIcon from "@vector-im/compound-design-tokens/assets/web/icons/searc
 import DialPadIcon from "@vector-im/compound-design-tokens/assets/web/icons/dial-pad";
 
 import styles from "./RoomListSearchView.module.css";
-import { type ViewModel } from "../../viewmodel/ViewModel";
-import { useViewModel } from "../../useViewModel";
+import { type ViewModel, useViewModel } from "../../viewmodel";
 import { Flex } from "../../utils/Flex";
 import { useI18n } from "../../utils/i18nContext";
 

--- a/packages/shared-components/src/room/RoomStatusBar/RoomStatusBarView.stories.tsx
+++ b/packages/shared-components/src/room/RoomStatusBar/RoomStatusBarView.stories.tsx
@@ -8,7 +8,7 @@ import { type Meta, type StoryFn } from "@storybook/react-vite";
 import React, { type JSX } from "react";
 import { fn } from "storybook/test";
 
-import { useMockedViewModel } from "../../useMockedViewModel";
+import { useMockedViewModel } from "../../viewmodel";
 import {
     RoomStatusBarState,
     RoomStatusBarView,

--- a/packages/shared-components/src/room/RoomStatusBar/RoomStatusBarView.tsx
+++ b/packages/shared-components/src/room/RoomStatusBar/RoomStatusBarView.tsx
@@ -10,8 +10,7 @@ import { RestartIcon, DeleteIcon } from "@vector-im/compound-design-tokens/asset
 import { Button, InlineSpinner, Text } from "@vector-im/compound-web";
 
 import styles from "./RoomStatusBarView.module.css";
-import { useViewModel } from "../../useViewModel";
-import { type ViewModel } from "../../viewmodel";
+import { type ViewModel, useViewModel } from "../../viewmodel";
 import { useI18n } from "../../utils/i18nContext";
 import { Banner } from "../../composer/Banner";
 export interface RoomStatusBarViewActions {

--- a/packages/shared-components/src/viewmodel/index.ts
+++ b/packages/shared-components/src/viewmodel/index.ts
@@ -12,3 +12,5 @@ export * from "./ViewModelSubscriptions";
 export type * from "./ViewModel";
 export * from "./MockViewModel";
 export * from "./useCreateAutoDisposedViewModel";
+export * from "./useViewModel";
+export * from "./useMockedViewModel";

--- a/packages/shared-components/src/viewmodel/useMockedViewModel.ts
+++ b/packages/shared-components/src/viewmodel/useMockedViewModel.ts
@@ -7,7 +7,8 @@
 
 import { useMemo } from "react";
 
-import { MockViewModel, type ViewModel } from "./viewmodel";
+import { MockViewModel } from "./MockViewModel";
+import { type ViewModel } from "./ViewModel";
 
 /**
  * Hook helper to return a mocked view model created with the given snapshot and actions.

--- a/packages/shared-components/src/viewmodel/useViewModel.ts
+++ b/packages/shared-components/src/viewmodel/useViewModel.ts
@@ -7,7 +7,7 @@ Please see LICENSE files in the repository root for full details.
 
 import { useSyncExternalStore } from "react";
 
-import { type ViewModel } from "./viewmodel/ViewModel";
+import { type ViewModel } from "./ViewModel";
 
 /**
  * A small wrapper around useSyncExternalStore to use a view model in a shared component view


### PR DESCRIPTION
Move vm hooks into view model folder to keep all the vm stuff into the view model folder
