### PR TITLE
Fix the logic and comments surrounding the e2e test: "should open the notification options menu"

### DIFF
--- a/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
+++ b/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
@@ -137,7 +137,7 @@ test.describe("Room list", () => {
 
             roomItemMenu = roomItem.getByRole("button", { name: "Notification options" });
             await roomItemMenu.click();
-            
+
             // The Mute room option should be selected
             await expect(page.getByRole("menuitem", { name: "Mute room" })).toHaveAttribute("aria-selected", "true");
             await expect(page).toMatchScreenshot("room-list-item-open-notification-options-selection.png");


### PR DESCRIPTION
I think there was a misunderstanding of the test [here](https://github.com/element-hq/element-web/pull/30205/changes/4870bed86a5e9014a5b6213104fd5e48bf261370).

I believe the intent of it was to test that when hovered and not hovered the silent notification icon is displayed(bell with a line).