### PR TITLE
Add patch for linkify to fix doctype handling

### DIFF
--- a/patches/linkify-html+4.3.2.patch
+++ b/patches/linkify-html+4.3.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/linkify-html/dist/linkify-html.mjs b/node_modules/linkify-html/dist/linkify-html.mjs
+index 63b1fe5..f61e3b7 100644
+--- a/node_modules/linkify-html/dist/linkify-html.mjs
++++ b/node_modules/linkify-html/dist/linkify-html.mjs
+@@ -201,6 +201,8 @@ var EventedTokenizer = /** @class */function () {
+           this.consume();
+           if (this.delegate.endDoctype) this.delegate.endDoctype();
+           this.transitionTo("beforeData" /* beforeData */);
++        } else {
++          throw new Error("Unexpected token");
+         }
+       },
+       doctypePublicIdentifierDoubleQuoted: function () {


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-web/issues/31269

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
