### PR TITLE
Support additional_creators in /upgraderoom (MSC4289)

### DIFF
--- a/src/slash-commands/upgraderoom/parseUpgradeRoomArgs.ts
+++ b/src/slash-commands/upgraderoom/parseUpgradeRoomArgs.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+export type UpgradeRoomParsedArgs = {
+    targetVersion: string;
+    additionalCreators?: string[];
+};
+
+/**
+ * Parse the supplied arguments for a room upgrade, or return null if the
+ * arguments are not valid. The arguments must be a room version followed by
+ * zero or more valid user IDs.
+ */
+export function parseUpgradeRoomArgs(args: string): UpgradeRoomParsedArgs | null {
+    const parts = args.split(/\s+/);
+    if (parts.length === 0 || parts[0] === "") {
+        return null;
+    } else {
+        const targetVersion = parts[0];
+        let additionalCreators: string[] | undefined;
+        for (let i = 1; i < parts.length; ++i) {
+            if (additionalCreators === undefined) {
+                additionalCreators = [];
+            }
+            additionalCreators.push(parts[i]);
+        }
+        return { targetVersion, additionalCreators };
+    }
+}

--- a/src/utils/RoomUpgrade.ts
+++ b/src/utils/RoomUpgrade.ts
@@ -53,6 +53,7 @@ export async function upgradeRoom(
     awaitRoom = false,
     progressCallback?: (progress: RoomUpgradeProgress) => void,
     inhibitInviteProgressDialog = false,
+    additionalCreators?: string[],
 ): Promise<string> {
     const cli = room.client;
     let spinnerModal: IHandle<any> | undefined;
@@ -91,7 +92,7 @@ export async function upgradeRoom(
 
     let newRoomId: string;
     try {
-        ({ replacement_room: newRoomId } = await cli.upgradeRoom(room.roomId, targetVersion));
+        ({ replacement_room: newRoomId } = await cli.upgradeRoom(room.roomId, targetVersion, additionalCreators));
     } catch (e) {
         if (!handleError) throw e;
         logger.error(e);

--- a/test/unit-tests/SlashCommands-test.tsx
+++ b/test/unit-tests/SlashCommands-test.tsx
@@ -22,6 +22,10 @@ import { warnSelfDemote } from "../../src/components/views/right_panel/UserInfo"
 import dispatcher from "../../src/dispatcher/dispatcher";
 import QuestionDialog from "../../src/components/views/dialogs/QuestionDialog";
 import ErrorDialog from "../../src/components/views/dialogs/ErrorDialog";
+import RoomUpgradeWarningDialog, {
+    type IFinishedOpts,
+} from "../../src/components/views/dialogs/RoomUpgradeWarningDialog";
+import { parseUpgradeRoomArgs } from "../../src/slash-commands/upgraderoom/parseUpgradeRoomArgs";
 
 jest.mock("../../src/components/views/right_panel/UserInfo");
 
@@ -127,6 +131,56 @@ describe("SlashCommands", () => {
 
         it("should be enabled by default", () => {
             expect(command.isEnabled(client, roomId)).toBe(true);
+        });
+
+        it("should return usage if given no args", () => {
+            expect(command.run(client, roomId, null, undefined).error).toBe(command.getUsage());
+            expect(command.run(client, roomId, null, "").error).toBe(command.getUsage());
+        });
+
+        it("should accept arguments of a room version with no additional creators", () => {
+            expect(parseUpgradeRoomArgs("12")).toEqual({ targetVersion: "12" });
+        });
+
+        it("should accept arguments of a room version and additional creators", () => {
+            expect(parseUpgradeRoomArgs("13 @u:s.co")).toEqual({
+                targetVersion: "13",
+                additionalCreators: ["@u:s.co"],
+            });
+
+            expect(parseUpgradeRoomArgs("14  @u:s.co @v:s.co  @w:z.uk")).toEqual({
+                targetVersion: "14",
+                additionalCreators: ["@u:s.co", "@v:s.co", "@w:z.uk"],
+            });
+        });
+
+        it("should upgrade the room when given valid arguments", async () => {
+            // Given we mock out creating dialogs and upgrading rooms
+            const createDialog = jest.spyOn(Modal, "createDialog");
+            const upgradeRoom = jest.fn().mockResolvedValue({ replacement_room: "!newroom" });
+            const resp: IFinishedOpts = { continue: true, invite: false };
+            createDialog.mockReturnValue({
+                finished: Promise.resolve([resp]),
+                close: jest.fn(),
+            });
+            client.upgradeRoom = upgradeRoom;
+
+            // When we run a room upgrade
+            const result = command.run(client, roomId, null, "12 @foo:bar.com @baz:qux.uk");
+            expect(result.promise).toBeDefined();
+            await result.promise;
+
+            // Then we warned the user
+            expect(createDialog).toHaveBeenCalledWith(
+                RoomUpgradeWarningDialog,
+                { roomId: "!room:example.com", targetVersion: "12" },
+                undefined,
+                false,
+                true,
+            );
+
+            // And when they said yes, we called into upgradeRoom
+            expect(upgradeRoom).toHaveBeenCalledWith("!room:example.com", "12", ["@foo:bar.com", "@baz:qux.uk"]);
         });
     });
 

--- a/test/unit-tests/components/views/settings/JoinRuleSettings-test.tsx
+++ b/test/unit-tests/components/views/settings/JoinRuleSettings-test.tsx
@@ -197,7 +197,7 @@ describe("<JoinRuleSettings />", () => {
 
                 fireEvent.click(within(dialog).getByText("Upgrade"));
 
-                expect(client.upgradeRoom).toHaveBeenCalledWith(roomId, preferredRoomVersion);
+                expect(client.upgradeRoom).toHaveBeenCalledWith(roomId, preferredRoomVersion, undefined);
 
                 expect(within(dialog).getByText("Upgrading room")).toBeInTheDocument();
 
@@ -245,7 +245,7 @@ describe("<JoinRuleSettings />", () => {
 
                 fireEvent.click(within(dialog).getByText("Upgrade"));
 
-                expect(client.upgradeRoom).toHaveBeenCalledWith(roomId, preferredRoomVersion);
+                expect(client.upgradeRoom).toHaveBeenCalledWith(roomId, preferredRoomVersion, undefined);
 
                 expect(within(dialog).getByText("Upgrading room")).toBeInTheDocument();
 


### PR DESCRIPTION
Allow adding the user IDs of users you want to be `additional_creators` (see MSC4289) to the `/upgraderoom` slash command.

Depends on https://github.com/matrix-org/matrix-js-sdk/pull/5173

(I work for Element but this is contributed in my spare time as an admin of the Late Night Linux matrix room, and donated to Element.)

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)

https://github.com/user-attachments/assets/2fd97b60-9789-4b79-95e3-e12a0a637fd3

