### PR TITLE
Remove unused function to auto-rageshake when key backup is not set up

### DIFF
--- a/src/DeviceListener.ts
+++ b/src/DeviceListener.ts
@@ -493,8 +493,6 @@ export default class DeviceListener extends TypedEventEmitter<DeviceListenerEven
         if (allSystemsReady) {
             logSpan.info("No toast needed");
             await this.setDeviceState("ok", logSpan);
-
-            this.checkKeyBackupStatus();
         } else {
             // make sure our keys are finished downloading
             await crypto.getUserDeviceInfo([cli.getSafeUserId()]);
@@ -548,9 +546,6 @@ export default class DeviceListener extends TypedEventEmitter<DeviceListenerEven
                     keyBackupDownloadIsOk,
                 });
                 await this.setDeviceState("key_storage_out_of_sync", logSpan);
-            }
-            if (this.dismissedThisDeviceToast) {
-                this.checkKeyBackupStatus();
             }
         }
 
@@ -732,16 +727,6 @@ export default class DeviceListener extends TypedEventEmitter<DeviceListenerEven
             recoveryState: recoveryState,
         });
     }
-
-    /**
-     * Check if key backup is enabled, and if not, raise an `Action.ReportKeyBackupNotEnabled` event (which will
-     * trigger an auto-rageshake).
-     */
-    private checkKeyBackupStatus = async (): Promise<void> => {
-        if (!(await this.isKeyBackupUploadActive(logger))) {
-            dis.dispatch({ action: Action.ReportKeyBackupNotEnabled });
-        }
-    };
 
     /**
      * Is key backup enabled? Use a cached answer if we have one.

--- a/src/dispatcher/actions.ts
+++ b/src/dispatcher/actions.ts
@@ -230,12 +230,6 @@ export enum Action {
     PseudonymousAnalyticsReject = "pseudonymous_analytics_reject",
 
     /**
-     * Fires after crypto is setup if key backup is not enabled
-     * Used to trigger auto rageshakes when configured
-     */
-    ReportKeyBackupNotEnabled = "report_key_backup_not_enabled",
-
-    /**
      * Dispatched after leave room or space is finished
      */
     AfterLeaveRoom = "after_leave_room",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1508,7 +1508,6 @@
         "ask_to_join": "Enable ask to join",
         "automatic_debug_logs": "Automatically send debug logs on any error",
         "automatic_debug_logs_decryption": "Automatically send debug logs on decryption errors",
-        "automatic_debug_logs_key_backup": "Automatically send debug logs when key backup is not functioning",
         "beta_description": "What's next for %(brand)s? Labs are the best way to get things early, test out new features and help shape them before they actually launch.",
         "beta_feature": "This is a beta feature",
         "beta_feedback_leave_button": "To leave the beta, visit your settings.",

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -352,7 +352,6 @@ export interface Settings {
     "developerMode": IBaseSetting<boolean>;
     "automaticErrorReporting": IBaseSetting<boolean>;
     "automaticDecryptionErrorReporting": IBaseSetting<boolean>;
-    "automaticKeyBackNotEnabledReporting": IBaseSetting<boolean>;
     "debug_scroll_panel": IBaseSetting<boolean>;
     "debug_timeline_panel": IBaseSetting<boolean>;
     "debug_registration": IBaseSetting<boolean>;
@@ -1319,11 +1318,6 @@ export const SETTINGS: Settings = {
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS,
         default: false,
         controller: new ReloadOnChangeController(),
-    },
-    "automaticKeyBackNotEnabledReporting": {
-        displayName: _td("labs|automatic_debug_logs_key_backup"),
-        supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG,
-        default: false,
     },
     "debug_scroll_panel": {
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS,

--- a/src/stores/AutoRageshakeStore.ts
+++ b/src/stores/AutoRageshakeStore.ts
@@ -24,7 +24,6 @@ import defaultDispatcher from "../dispatcher/dispatcher";
 import { AsyncStoreWithClient } from "./AsyncStoreWithClient";
 import { type ActionPayload } from "../dispatcher/payloads";
 import SettingsStore from "../settings/SettingsStore";
-import { Action } from "../dispatcher/actions";
 
 // Minimum interval of 1 minute between reports
 const RAGESHAKE_INTERVAL = 60000;
@@ -66,12 +65,7 @@ export default class AutoRageshakeStore extends AsyncStoreWithClient<IState> {
         return AutoRageshakeStore.internalInstance;
     }
 
-    protected async onAction(payload: ActionPayload): Promise<void> {
-        switch (payload.action) {
-            case Action.ReportKeyBackupNotEnabled:
-                this.onReportKeyBackupNotEnabled();
-        }
-    }
+    protected async onAction(_payload: ActionPayload): Promise<void> {}
 
     protected async onReady(): Promise<void> {
         if (!SettingsStore.getValue("automaticDecryptionErrorReporting")) return;
@@ -186,16 +180,6 @@ export default class AutoRageshakeStore extends AsyncStoreWithClient<IState> {
                 `Not sending sender-side autorageshake for event ${messageContent["event_id"]}/session ${messageContent["session_id"]}: last rageshake was too recent`,
             );
         }
-    }
-
-    private async onReportKeyBackupNotEnabled(): Promise<void> {
-        if (!SettingsStore.getValue("automaticKeyBackNotEnabledReporting")) return;
-
-        await sendBugReport(SdkConfig.get().bug_report_endpoint_url, {
-            userText: `Auto-reporting key backup not enabled`,
-            sendLogs: true,
-            labels: ["web", Action.ReportKeyBackupNotEnabled],
-        });
     }
 }
 

--- a/test/unit-tests/DeviceListener-test.ts
+++ b/test/unit-tests/DeviceListener-test.ts
@@ -31,7 +31,6 @@ import * as SetupEncryptionToast from "../../src/toasts/SetupEncryptionToast";
 import * as UnverifiedSessionToast from "../../src/toasts/UnverifiedSessionToast";
 import * as BulkUnverifiedSessionsToast from "../../src/toasts/BulkUnverifiedSessionsToast";
 import { isSecretStorageBeingAccessed } from "../../src/SecurityManager";
-import dis from "../../src/dispatcher/dispatcher";
 import { Action } from "../../src/dispatcher/actions";
 import SettingsStore from "../../src/settings/SettingsStore";
 import { SettingLevel } from "../../src/settings/SettingLevel";
@@ -57,7 +56,6 @@ jest.mock("../../src/utils/device/snoozeBulkUnverifiedDeviceReminder", () => ({
 
 const userId = "@user:server";
 const deviceId = "my-device-id";
-const mockDispatcher = mocked(dis);
 const flushPromises = async () => await new Promise(process.nextTick);
 
 const readySecretStorageStatus: SecretStorageStatus = {
@@ -496,27 +494,6 @@ describe("DeviceListener", () => {
                 await flushPromises();
 
                 expect(mockCrypto.getActiveSessionBackupVersion).toHaveBeenCalled();
-            });
-
-            it("dispatches keybackup event when key backup is not enabled", async () => {
-                mockCrypto!.isCrossSigningReady.mockResolvedValue(true);
-
-                // current device is verified
-                mockCrypto!.getDeviceVerificationStatus.mockResolvedValue(
-                    new DeviceVerificationStatus({
-                        trustCrossSignedDevices: true,
-                        crossSigningVerified: true,
-                    }),
-                );
-
-                mockCrypto.getActiveSessionBackupVersion.mockResolvedValue(null);
-                mockClient.getAccountDataFromServer.mockImplementation((eventType) =>
-                    eventType === BACKUP_DISABLED_ACCOUNT_DATA_KEY ? ({ disabled: true } as any) : null,
-                );
-                await createAndStart();
-                expect(mockDispatcher.dispatch).toHaveBeenCalledWith({
-                    action: Action.ReportKeyBackupNotEnabled,
-                });
             });
 
             it("does not check key backup status again after check is complete", async () => {


### PR DESCRIPTION
The setting `automaticKeyBackNotEnabledReporting` defaults to `false` and we are not aware of anyone using it. If turned on, it sends a rageshake whenever we detect that key backup (key storage) is turned off. This is not helpful, since it is perfectly valid for a user to turn key backup off.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
