### PR TITLE
Fix room list not being cleared

### DIFF
--- a/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -161,7 +161,7 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
         this.emit(LISTS_UPDATE_EVENT);
     }
 
-    protected async onNotReady(): Promise<any> {
+    protected async onNotReady(): Promise<void> {
         this.roomSkipList = undefined;
     }
 


### PR DESCRIPTION
RoomListV3 was lacking an onNotReady which meant that the room list would sometimes not be cleared between logins.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
