### PR TITLE
Emit events from DeviceListenerCurrentDevice instead of delegating to DeviceListener

### DIFF
--- a/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.tsx
@@ -64,7 +64,7 @@ export function EncryptionUserSettingsTab({ initialState = "main" }: Readonly<Pr
     const [state, setState] = useState<State>(initialState);
 
     const deviceState = useTypedEventEmitterState(
-        DeviceListener.sharedInstance().currentDevice,
+        DeviceListener.sharedInstance().currentDeviceChangedEmitter,
         CurrentDeviceEvents.DeviceStateChanged,
         (state?: DeviceState): DeviceState => {
             return state ?? DeviceListener.sharedInstance().getDeviceState();

--- a/src/device-listener/CurrentDeviceChangedEmitter.ts
+++ b/src/device-listener/CurrentDeviceChangedEmitter.ts
@@ -1,0 +1,36 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { TypedEventEmitter } from "matrix-js-sdk/src/matrix";
+
+import { type DeviceState } from ".";
+
+/**
+ * The events emitted when the {@link DeviceState} of the current device
+ * changes.
+ */
+export const enum CurrentDeviceEvents {
+    DeviceStateChanged = "device_state",
+}
+
+/**
+ * You must provide one of these if you listen to {@link CurrentDeviceEvents}
+ * emitted by {@link DeviceListenerCurrentDevice}. It specifies how to handle
+ * each type of event.
+ */
+type EventHandlerMap = {
+    [CurrentDeviceEvents.DeviceStateChanged]: (state: DeviceState) => void;
+};
+
+/**
+ * Emits events when the current device changes state.
+ */
+export class CurrentDeviceChangedEmitter extends TypedEventEmitter<CurrentDeviceEvents, EventHandlerMap> {
+    public onStateChanged(newState: DeviceState): void {
+        this.emit(CurrentDeviceEvents.DeviceStateChanged, newState);
+    }
+}

--- a/src/device-listener/DeviceListener.ts
+++ b/src/device-listener/DeviceListener.ts
@@ -20,7 +20,12 @@ import SdkConfig from "../SdkConfig";
 import PlatformPeg from "../PlatformPeg";
 import { recordClientInformation, removeClientInformation } from "../utils/device/clientInformation";
 import SettingsStore, { type CallbackFn } from "../settings/SettingsStore";
-import { DeviceListenerOtherDevices, DeviceListenerCurrentDevice, type DeviceState } from ".";
+import {
+    DeviceListenerOtherDevices,
+    DeviceListenerCurrentDevice,
+    type DeviceState,
+    CurrentDeviceChangedEmitter,
+} from ".";
 
 const logger = baseLogger.getChild("DeviceListener:");
 
@@ -38,15 +43,18 @@ export class DeviceListener {
      *
      * Defined after {@link DeviceListener.start} has been called, before {@link
      * DeviceListener.stop} is called.
-     *
-     * When defined, emits `CurrentDeviceEvents` events when the state
+     */
+    public currentDevice?: DeviceListenerCurrentDevice;
+
+    /**
+     * Emits `CurrentDeviceEvents` events when the state
      * of the current device changes.
      *
      * @example
      * ```ts
      * const deviceState = useTypedEventEmitterState(
-     *     DeviceListener.sharedInstance().currentDevice,
-     *     CurrentDeviceEvents.DeviceState,
+     *     DeviceListener.sharedInstance().currentDeviceChangedEmitter,
+     *     CurrentDeviceEvents.DeviceStateChanged,
      *     (state?: DeviceState): DeviceState => {
      *         return state ?? DeviceListener.sharedInstance().getDeviceState();
      *     },
@@ -56,7 +64,7 @@ export class DeviceListener {
      * Now `deviceState` will reflect the state of the current device and
      * trigger an update when it changes.
      */
-    public currentDevice?: DeviceListenerCurrentDevice;
+    public currentDeviceChangedEmitter = new CurrentDeviceChangedEmitter();
 
     private running = false;
     // The client with which the instance is running. Only set if `running` is true, otherwise undefined.

--- a/src/device-listener/DeviceListenerCurrentDevice.ts
+++ b/src/device-listener/DeviceListenerCurrentDevice.ts
@@ -16,7 +16,6 @@ import {
     type SyncState,
     RoomStateEvent,
     ClientEvent,
-    TypedEventEmitter,
 } from "matrix-js-sdk/src/matrix";
 
 import { type DeviceListener, type DeviceState } from ".";
@@ -43,26 +42,9 @@ export const BACKUP_DISABLED_ACCOUNT_DATA_KEY = "m.org.matrix.custom.backup_disa
 export const RECOVERY_ACCOUNT_DATA_KEY = "io.element.recovery";
 
 /**
- * The events emitted when the {@link DeviceState} of the current device
- * changes.
- */
-export const enum CurrentDeviceEvents {
-    DeviceStateChanged = "device_state",
-}
-
-/**
- * You must provide one of these if you listen to {@link CurrentDeviceEvents}
- * emitted by {@link DeviceListenerCurrentDevice}. It specifies how to handle
- * each type of event.
- */
-type EventHandlerMap = {
-    [CurrentDeviceEvents.DeviceStateChanged]: (state: DeviceState) => void;
-};
-
-/**
  * Handles all of DeviceListener's work that relates to the current device.
  */
-export class DeviceListenerCurrentDevice extends TypedEventEmitter<CurrentDeviceEvents, EventHandlerMap> {
+export class DeviceListenerCurrentDevice {
     /**
      * The DeviceListener launching this instance.
      */
@@ -105,8 +87,6 @@ export class DeviceListenerCurrentDevice extends TypedEventEmitter<CurrentDevice
     private cachedKeyBackupUploadActive: boolean | undefined = undefined;
 
     public constructor(deviceListener: DeviceListener, client: MatrixClient, logger: Logger) {
-        super();
-
         this.deviceListener = deviceListener;
         this.client = client;
         this.logger = logger;
@@ -283,7 +263,7 @@ export class DeviceListenerCurrentDevice extends TypedEventEmitter<CurrentDevice
     private async setDeviceState(newState: DeviceState, logSpan: LogSpan): Promise<void> {
         this.deviceState = newState;
 
-        this.emit(CurrentDeviceEvents.DeviceStateChanged, newState);
+        this.deviceListener.currentDeviceChangedEmitter.onStateChanged(newState);
 
         if (newState === "ok" || this.dismissedThisDeviceToast) {
             hideSetupEncryptionToast();

--- a/src/device-listener/index.ts
+++ b/src/device-listener/index.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+export * from "./CurrentDeviceChangedEmitter";
 export * from "./DeviceListener";
 export * from "./DeviceListenerCurrentDevice";
 export * from "./DeviceListenerOtherDevices";


### PR DESCRIPTION
Emit events from CurrentDeviceChangedEmitter instead of delegating to DeviceListener, removing a potential anti-pattern of calling `emit` on a different class.

Also attempt to improve the documentation about how to make use of these events.

Part of https://github.com/element-hq/element-web/issues/31793