### PR TITLE
Update font format from 'ttf' to 'truetype'

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -39,7 +39,7 @@ e.g. in config.json:
                     "faces": [
                         {
                             "font-family": "Inter",
-                            "src": [{"url": "/fonts/Inter.ttf", "format": "ttf"}]
+                            "src": [{"url": "/fonts/Inter.ttf", "format": "truetype"}]
                         }
                     ],
                     "general": "Inter, sans",


### PR DESCRIPTION
Following the docs to add a custom font to a theme won't work, as it uses an incorrect format specifier for fonts. This caused me a bit of confusion until I saw the generated css code and looked up @font-family syntax.
As per css docs `ttf` isn't a valid format specifier. Instead, for '.ttf' fonts you need to use `truetype`. https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@supports#font-format



## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
