### PR TITLE
Hotfix - disable autogain control on Linux

### DIFF
--- a/src/audio/VoiceRecording.ts
+++ b/src/audio/VoiceRecording.ts
@@ -103,11 +103,13 @@ export class VoiceRecording extends EventEmitter implements IDestroyable {
 
     private async makeRecorder(): Promise<void> {
         try {
+            const isLinux = navigator.userAgent.toLowerCase().includes("linux");
+
             this.recorderStream = await navigator.mediaDevices.getUserMedia({
                 audio: {
                     channelCount: CHANNELS,
                     deviceId: MediaDeviceHandler.getAudioInput(),
-                    autoGainControl: false,
+                    autoGainControl: isLinux ? false : { ideal: MediaDeviceHandler.getAudioAutoGainControl() }, // Disable on Linux,
                     echoCancellation: { ideal: MediaDeviceHandler.getAudioEchoCancellation() },
                     noiseSuppression: { ideal: MediaDeviceHandler.getAudioNoiseSuppression() },
                 },


### PR DESCRIPTION
Notes: Fix a bug (https://github.com/element-hq/element-web/issues/32469) where disabling autogain control in Element settings on Linux would not actually disable autogain control. This hotfix addresses the bug by automatically and fully disabling autogain control on Linux. A more permanent fix should follow to ensure that the setting menu functions properly on Linux.

Updated pull request to be from non-default branch.

## Checklist

- [ X] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ X] Tests written for new code (and old code if feasible).
- [ X] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [X ] Linter and other CI checks pass.
- [ X] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
