### PR TITLE
Room list: poc dnd room list item

### DIFF
--- a/packages/shared-components/package.json
+++ b/packages/shared-components/package.json
@@ -51,6 +51,7 @@
         "lint:types": "tsc --noEmit && tsc --noEmit -p tsconfig.node.json"
     },
     "dependencies": {
+        "@dnd-kit/react": "^0.3.0",
         "@element-hq/element-web-module-api": "catalog:",
         "@matrix-org/spec": "^1.7.0",
         "@vector-im/compound-design-tokens": "catalog:",

--- a/packages/shared-components/src/room-list/RoomListItemView/RoomListItemView.module.css
+++ b/packages/shared-components/src/room-list/RoomListItemView/RoomListItemView.module.css
@@ -58,6 +58,14 @@
     }
 }
 
+.isDragging {
+    color: var(--cpd-color-text-primary);
+
+    .container {
+        background-color: var(--cpd-color-bg-action-tertiary-hovered);
+    }
+}
+
 .container {
     flex: 1;
     height: 100%;

--- a/packages/shared-components/src/room-list/RoomListItemView/RoomListItemView.tsx
+++ b/packages/shared-components/src/room-list/RoomListItemView/RoomListItemView.tsx
@@ -8,6 +8,8 @@
 import React, { type JSX, memo, useEffect, useRef, type ReactNode } from "react";
 import classNames from "classnames";
 import { Text } from "@vector-im/compound-web";
+import { useDraggable } from "@dnd-kit/react";
+import { useMergeRefs } from "react-merge-refs";
 
 import { Flex } from "../../utils/Flex";
 import { NotificationDecoration, type NotificationDecorationData } from "./NotificationDecoration";
@@ -141,14 +143,25 @@ export const RoomListItemView = memo(function RoomListItemView({
     renderAvatar,
     ...props
 }: RoomListItemViewProps): JSX.Element {
-    const ref = useRef<HTMLButtonElement>(null);
     const item = useViewModel(vm);
 
+    const ref = useRef<HTMLButtonElement>(null);
     useEffect(() => {
         if (isFocused) {
             ref.current?.focus({ preventScroll: true, focusVisible: true } as FocusOptions);
         }
     }, [isFocused]);
+
+    const {
+        ref: draggableRef,
+        handleRef,
+        isDragging,
+    } = useDraggable({
+        id: item.id,
+        feedback: "clone",
+    });
+
+    const mergedRef = useMergeRefs([draggableRef, ref]);
 
     // Generate a11y label from notification state and room name
     const a11yLabel = getA11yLabel(item.name, item.notification);
@@ -156,10 +169,11 @@ export const RoomListItemView = memo(function RoomListItemView({
     const content = (
         <Flex
             as="button"
-            ref={ref}
+            ref={mergedRef}
             className={classNames(styles.roomListItem, "mx_RoomListItemView", {
                 [styles.selected]: isSelected,
                 [styles.bold]: item.isBold,
+                [styles.isDragging]: isDragging,
                 mx_RoomListItemView_selected: isSelected,
             })}
             gap="var(--cpd-space-3x)"
@@ -175,7 +189,7 @@ export const RoomListItemView = memo(function RoomListItemView({
             tabIndex={isFocused ? 0 : -1}
             {...props}
         >
-            <Flex className={styles.container} gap="var(--cpd-space-3x)" align="center">
+            <Flex ref={handleRef} className={styles.container} gap="var(--cpd-space-3x)" align="center">
                 {renderAvatar(item.room)}
                 <Flex className={styles.content} gap="var(--cpd-space-2x)" align="center" justify="space-between">
                     {/* We truncate the room name when too long. Title here is to show the full name on hover */}

--- a/packages/shared-components/src/utils/VirtualizedList/VirtualizedList.stories.tsx
+++ b/packages/shared-components/src/utils/VirtualizedList/VirtualizedList.stories.tsx
@@ -5,7 +5,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import React from "react";
+import React, { type JSX } from "react";
+import { useDraggable, useDragOperation, useDroppable } from "@dnd-kit/react";
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { VirtualizedList, type IVirtualizedListProps, type VirtualizedListContext } from "./VirtualizedList";
@@ -20,29 +21,97 @@ const items: SimpleItem[] = Array.from({ length: 50 }, (_, i) => ({
     label: `Item ${i + 1}`,
 }));
 
+function ItemComponent({
+    item,
+    context,
+    onFocus,
+}: {
+    item: SimpleItem;
+    context: VirtualizedListContext<undefined>;
+    onFocus: (item: SimpleItem, e: React.FocusEvent) => void;
+}): JSX.Element {
+    const { ref } = useDraggable({
+        id: item.id,
+        feedback: "clone",
+    });
+
+    return (
+        <div
+            ref={ref}
+            key={item.id}
+            style={{ padding: "12px 16px", borderBottom: "1px solid #e0e0e0" }}
+            tabIndex={context.tabIndexKey === item.id ? 0 : -1}
+            onFocus={(e) => onFocus(item, e)}
+        >
+            {item.label}
+        </div>
+    );
+}
+
+function DragOverlayContent(): JSX.Element | null {
+    const { source } = useDragOperation();
+    if (!source) return null;
+
+    const item = items.find((i) => i.id === source.id);
+    if (!item) return null;
+
+    return (
+        <div style={{ padding: "12px 16px", borderBottom: "1px solid #e0e0e0", width: "100%", background: "white" }}>
+            {item.label}
+        </div>
+    );
+}
+
+const groups = [
+    {
+        group: "Group 1",
+        items: items.slice(0, 25),
+    },
+    {
+        group: "Group 2",
+        items: items.slice(25, items.length),
+    },
+];
+
+function GroupComponent({ index }: { index: number }): JSX.Element {
+    const { ref, isDropTarget } = useDroppable({ id: `group-${index}` });
+
+    return (
+        <div
+            ref={ref}
+            style={{
+                backgroundColor: isDropTarget ? "lightgreen" : "teal",
+                height: 40,
+                display: "flex",
+                alignContent: "center",
+            }}
+        >
+            Group {index}
+        </div>
+    );
+}
+
 const meta = {
     title: "Utils/VirtualizedList",
     component: VirtualizedList<SimpleItem, undefined>,
     args: {
-        items,
+        groups,
         getItemComponent: (
-            _index: number,
-            item: SimpleItem,
+            index: number,
+            groupIndex: number,
+            _item: SimpleItem,
             context: VirtualizedListContext<undefined>,
             onFocus: (item: SimpleItem, e: React.FocusEvent) => void,
-        ) => (
-            <div
-                key={item.id}
-                style={{ padding: "12px 16px", borderBottom: "1px solid #e0e0e0" }}
-                tabIndex={context.tabIndexKey === item.id ? 0 : -1}
-                onFocus={(e) => onFocus(item, e)}
-            >
-                {item.label}
-            </div>
-        ),
+        ) => {
+            const item = items[index];
+            if (!item) return <div>Item not found</div>;
+            return <ItemComponent key={item.id} item={item} context={context} onFocus={onFocus} />;
+        },
+        getGroupComponent: (index) => <GroupComponent key={index} index={index} />,
         isItemFocusable: () => true,
         getItemKey: (item) => item.id,
         style: { height: "400px" },
+        dragOverlay: <DragOverlayContent />,
     },
 } satisfies Meta<IVirtualizedListProps<SimpleItem, undefined>>;
 

--- a/packages/shared-components/src/utils/VirtualizedList/VirtualizedList.tsx
+++ b/packages/shared-components/src/utils/VirtualizedList/VirtualizedList.tsx
@@ -5,8 +5,9 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
+import { DragDropProvider, DragOverlay } from "@dnd-kit/react";
 import React, { useRef, type JSX, useCallback, useEffect, useState, useMemo } from "react";
-import { type VirtuosoHandle, type ListRange, Virtuoso, type VirtuosoProps } from "react-virtuoso";
+import { type VirtuosoHandle, type ListRange, type VirtuosoProps, GroupedVirtuoso } from "react-virtuoso";
 
 /**
  * Keyboard key codes
@@ -50,7 +51,9 @@ export interface IVirtualizedListProps<Item, Context> extends Omit<
      * The array of items to display in the virtualized list.
      * Each item will be passed to getItemComponent for rendering.
      */
-    items: Item[];
+    //items: Item[];
+
+    groups: { group: string; items: Item[] }[];
 
     /**
      * Function that renders each list item as a JSX element.
@@ -62,10 +65,13 @@ export interface IVirtualizedListProps<Item, Context> extends Omit<
      */
     getItemComponent: (
         index: number,
+        groupIndex: number,
         item: Item,
         context: VirtualizedListContext<Context>,
         onFocus: (item: Item, e: React.FocusEvent) => void,
     ) => JSX.Element;
+
+    getGroupComponent: (groupIndex: number, context: VirtualizedListContext<Context>) => JSX.Element;
 
     /**
      * Optional additional context data to pass to each rendered item.
@@ -108,6 +114,8 @@ export interface IVirtualizedListProps<Item, Context> extends Omit<
      * @param range - The new visible range with startIndex and endIndex
      */
     rangeChanged?: (range: ListRange) => void;
+
+    dragOverlay?: React.ReactNode;
 }
 
 /**
@@ -127,24 +135,33 @@ export type ScrollIntoViewOnChange<Item, Context = any> = NonNullable<
 export function VirtualizedList<Item, Context = any>(props: IVirtualizedListProps<Item, Context>): React.ReactElement {
     // Extract our custom props to avoid conflicts with Virtuoso props
     const {
-        items,
+        //       items,
+        groups,
         getItemComponent,
+        getGroupComponent,
         isItemFocusable,
         getItemKey,
         context,
         onKeyDown,
         totalCount,
         rangeChanged,
+        dragOverlay,
         ...virtuosoProps
     } = props;
+
+    const groupCounts = useMemo(() => groups.map((group) => group.items.length), [groups]);
+
+    console.log("groups", groups);
+    console.log("groups counts", groupCounts);
+
+    const items = useMemo(() => groups.flatMap((group) => group.items), [groups]);
+
     /** Reference to the Virtuoso component for programmatic scrolling */
     const virtuosoHandleRef = useRef<VirtuosoHandle>(null);
     /** Reference to the DOM element containing the virtualized list */
     const virtuosoDomRef = useRef<HTMLElement | Window>(null);
     /** Key of the item that should have tabIndex == 0 */
-    const [tabIndexKey, setTabIndexKey] = useState<string | undefined>(
-        props.items[0] ? getItemKey(props.items[0]) : undefined,
-    );
+    const [tabIndexKey, setTabIndexKey] = useState<string | undefined>(items[0] ? getItemKey(items[0]) : undefined);
     /** Range of currently visible items in the viewport */
     const [visibleRange, setVisibleRange] = useState<ListRange | undefined>(undefined);
     /** Map from item keys to their indices in the items array */
@@ -300,8 +317,9 @@ export function VirtualizedList<Item, Context = any>(props: IVirtualizedListProp
     );
 
     const getItemComponentInternal = useCallback(
-        (index: number, item: Item, context: VirtualizedListContext<Context>): JSX.Element =>
-            getItemComponent(index, item, context, onFocusForGetItemComponent),
+        (index: number, groupIndex: number, item: Item, context: VirtualizedListContext<Context>): JSX.Element => {
+            return getItemComponent(index, groupIndex, item, context, onFocusForGetItemComponent);
+        },
         [getItemComponent, onFocusForGetItemComponent],
     );
 
@@ -356,25 +374,44 @@ export function VirtualizedList<Item, Context = any>(props: IVirtualizedListProp
         [rangeChanged],
     );
 
+    // const mergedScrollerRef = useMergeRefs([scrollerRef, droppableRef]);
+
     return (
-        <Virtuoso
-            // note that either the container of direct children must be focusable to be axe
-            // compliant, so we leave tabIndex as the default so the container can be focused
-            // (virtuoso wraps the children inside another couple of elements so setting it
-            // on those doesn't seem to work, unfortunately)
-            ref={virtuosoHandleRef}
-            scrollerRef={scrollerRef}
-            onKeyDown={keyDownCallback}
-            context={listContext}
-            rangeChanged={handleRangeChanged}
-            // virtuoso errors internally if you pass undefined.
-            overscan={props.overscan || 0}
-            data={props.items}
-            totalCount={totalCount}
-            onFocus={onFocus}
-            onBlur={onBlur}
-            itemContent={getItemComponentInternal}
-            {...virtuosoProps}
-        />
+        <DragDropProvider
+            onDragOver={(event) => {
+                const { source, target } = event.operation;
+                console.log(`${source?.id} is over ${target?.id}`);
+            }}
+            onDragEnd={(event) => {
+                if (event.canceled) return;
+
+                const { target, source } = event.operation;
+                console.log(`${source?.id} was dropped on ${target?.id}`);
+            }}
+        >
+            {dragOverlay !== undefined && <DragOverlay dropAnimation={null}>{dragOverlay}</DragOverlay>}
+            <GroupedVirtuoso
+                style={{ height: "100%" }}
+                // note that either the container of direct children must be focusable to be axe
+                // compliant, so we leave tabIndex as the default so the container can be focused
+                // (virtuoso wraps the children inside another couple of elements so setting it
+                // on those doesn't seem to work, unfortunately)
+                ref={virtuosoHandleRef}
+                scrollerRef={scrollerRef}
+                // scrollerRef={mergedScrollerRef}
+                onKeyDown={keyDownCallback}
+                context={listContext}
+                rangeChanged={handleRangeChanged}
+                // virtuoso errors internally if you pass undefined.
+                overscan={props.overscan || 0}
+                groupCounts={groupCounts}
+                data={items}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                itemContent={getItemComponentInternal}
+                groupContent={getGroupComponent}
+                {...virtuosoProps}
+            />
+        </DragDropProvider>
     );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -730,6 +730,9 @@ importers:
 
   packages/shared-components:
     dependencies:
+      '@dnd-kit/react':
+        specifier: ^0.3.0
+        version: 0.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@element-hq/element-web-module-api':
         specifier: 'catalog:'
         version: 1.9.0(@matrix-org/react-sdk-module-api@2.5.0(patch_hash=016146c9cc96e6363609d2b2ac0896ccef567882eb1d73b75a77b8a30929de96)(react@19.2.4))(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(matrix-web-i18n@3.6.0)(react@19.2.4)
@@ -778,7 +781,7 @@ importers:
         version: 10.2.5(storybook@10.2.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/addon-designs':
         specifier: ^11.0.1
-        version: 11.1.1(@storybook/addon-docs@10.2.5(@types/react@19.2.10)(esbuild@0.27.2)(rollup@4.57.1(patch_hash=603340e49399c6044e41a3998891667387d5ec1acbd38d4e5862f2ba3ef58de8))(storybook@10.2.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.0(esbuild@0.27.2)(webpack-cli@6.0.1(webpack-bundle-analyzer@5.2.0)(webpack-dev-server@5.2.3)(webpack@5.105.0))))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 11.1.1(@storybook/addon-docs@10.2.5(@types/react@19.2.10)(esbuild@0.27.2)(rollup@4.57.1(patch_hash=603340e49399c6044e41a3998891667387d5ec1acbd38d4e5862f2ba3ef58de8))(storybook@10.2.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.0(esbuild@0.27.2)(webpack-cli@6.0.1)))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/addon-docs':
         specifier: ^10.0.7
         version: 10.2.5(@types/react@19.2.10)(esbuild@0.27.2)(rollup@4.57.1(patch_hash=603340e49399c6044e41a3998891667387d5ec1acbd38d4e5862f2ba3ef58de8))(storybook@10.2.5(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.105.0(esbuild@0.27.2)(webpack-cli@6.0.1(webpack-bundle-analyzer@5.2.0)(webpack-dev-server@5.2.3)(webpack@5.105.0)))
@@ -1995,6 +1998,27 @@ packages:
     resolution: {integrity: sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==}
     engines: {node: '>=14.17.0'}
 
+  '@dnd-kit/abstract@0.3.0':
+    resolution: {integrity: sha512-bHBwR8GGGwaZ/I6cjY8EUrFLEZgCcfanVjDaGcll48rLzwtzcYwMAflTdJe/9EMeQHA3cMkjLI2fbGqAgkrYOQ==}
+
+  '@dnd-kit/collision@0.3.0':
+    resolution: {integrity: sha512-CU8nkX9BwBlWfE9MOStwtHwNQzzw9oDaTUxt7o323SvxobnkT2DGDnrIZWsDfAoR/tmsP5muWC69Vij3K3fsMw==}
+
+  '@dnd-kit/dom@0.3.0':
+    resolution: {integrity: sha512-6ZuR1eliC0RjaOfSbWwTq6io6jaKi3sOiukeJdLBGSZWD/kIeCbCO897dhWRfwtj1WD+V56Uq2i58/2ImBEicQ==}
+
+  '@dnd-kit/geometry@0.3.0':
+    resolution: {integrity: sha512-3cnhDaX6ornsuz1HmLrS8JxJCCUcK/pmeGpylrlEhlnUG/3IgwNDTTuRx5MxN8GQBXUkOtDmAq7CMWKK7v6n9A==}
+
+  '@dnd-kit/react@0.3.0':
+    resolution: {integrity: sha512-vxG1gpacBFAkZj3jbRMj2+zBMu76eSwaVw42jvljgksLX744865+T8a+XkGLdcnfhat7BTXFVm+atYk8+bcE8g==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@dnd-kit/state@0.3.0':
+    resolution: {integrity: sha512-IXiEVsBIEMaBLr1JB7fLRBPOkjYSwvKXBAur3VjaDF5z2qg/dUMADsu0V7meQfTFU4JGbV19Lwi73H21a2qNpg==}
+
   '@element-hq/element-call-embedded@0.16.3':
     resolution: {integrity: sha512-OViKJonDaDNVBUW9WdV9mk78/Ruh34C7XsEgt3O8D9z+64C39elbIgllHSoH5S12IRlv9RYrrV37FZLo6QWsDQ==}
 
@@ -3024,6 +3048,9 @@ packages:
 
   '@posthog/types@1.336.4':
     resolution: {integrity: sha512-BY3cq/8segbXEvHbEXx9SWmaKJEM0AGgsOgMFH2yy13AV+rUHsGcp4Z5LDI5pU25DURN9EAZvzcoVyYy/Iokmw==}
+
+  '@preact/signals-core@1.13.0':
+    resolution: {integrity: sha512-slT6XeTCAbdql61GVLlGU4x7XHI7kCZV5Um5uhE4zLX4ApgiiXc0UYFvVOKq06xcovzp7p+61l68oPi563ARKg==}
 
   '@principalstudio/html-webpack-inject-preload@1.2.7':
     resolution: {integrity: sha512-KJKkiKG63ugBjf8U0e9jUcI9CLPTFIsxXplEDE0oi3mPpxd90X9SJovo3W2l7yh/ARKIYXhQq8fSXUN7M29TzQ==}
@@ -11878,6 +11905,45 @@ snapshots:
 
   '@discoveryjs/json-ext@0.6.3': {}
 
+  '@dnd-kit/abstract@0.3.0':
+    dependencies:
+      '@dnd-kit/geometry': 0.3.0
+      '@dnd-kit/state': 0.3.0
+      tslib: 2.8.1
+
+  '@dnd-kit/collision@0.3.0':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.0
+      '@dnd-kit/geometry': 0.3.0
+      tslib: 2.8.1
+
+  '@dnd-kit/dom@0.3.0':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.0
+      '@dnd-kit/collision': 0.3.0
+      '@dnd-kit/geometry': 0.3.0
+      '@dnd-kit/state': 0.3.0
+      tslib: 2.8.1
+
+  '@dnd-kit/geometry@0.3.0':
+    dependencies:
+      '@dnd-kit/state': 0.3.0
+      tslib: 2.8.1
+
+  '@dnd-kit/react@0.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.0
+      '@dnd-kit/dom': 0.3.0
+      '@dnd-kit/state': 0.3.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/state@0.3.0':
+    dependencies:
+      '@preact/signals-core': 1.13.0
+      tslib: 2.8.1
+
   '@element-hq/element-call-embedded@0.16.3': {}
 
   '@element-hq/element-web-module-api@1.9.0(@matrix-org/react-sdk-module-api@2.5.0(patch_hash=016146c9cc96e6363609d2b2ac0896ccef567882eb1d73b75a77b8a30929de96)(react@19.2.4))(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(matrix-web-i18n@3.6.0)(react@19.2.4)':
@@ -13080,6 +13146,8 @@ snapshots:
       cross-spawn: 7.0.6
 
   '@posthog/types@1.336.4': {}
+
+  '@preact/signals-core@1.13.0': {}
 
   '@principalstudio/html-webpack-inject-preload@1.2.7(html-webpack-plugin@5.6.6(webpack@5.105.0))(webpack@5.105.0)':
     dependencies:


### PR DESCRIPTION
https://github.com/element-hq/wat-internal/issues/381
To not merge. Will be closed when final implementation will be done

- Handle should be put on the child element of the room list item. Otherwise the content can't be dragged
- The dragged item should be rendered in [drag overlay](https://dndkit.com/react/components/drag-overlay). When the origin of the dragged item is not longer rendered (due to virtualization), the dragged item disappeared. To fix that, we can render the item in a drag overlay. For the case of the room list item, we will need to do a small refactor to be able to render only a subset of the item.
- https://github.com/element-hq/element-web/pull/32564/changes#diff-ac847055dcb6974f2c84002e0c5721ec3888c95735a79f81c3983bd61e6e8ff0R320 the given item seems to be ... incorrect in case of a grouped list. Instead, I recommend to use the index which is the index in the flat list, not in the group. Ex: `[{group1:[room1, room2], {group2: [room3, room4]}]` room3 `index=2` despite `groupIndex=1` 
    NB: It seems not be relevant anymore