### PR TITLE
Avoid story with custom font size to affect room list item stories in docs page

### DIFF
--- a/packages/shared-components/src/room-list/RoomListItemView/RoomListItemView.stories.tsx
+++ b/packages/shared-components/src/room-list/RoomListItemView/RoomListItemView.stories.tsx
@@ -225,6 +225,15 @@ export const WithLargeFont: Story = {
     args: {
         isSelected: true,
     },
+    // Render the story in an iframe to avoid affecting other story
+    parameters: {
+        docs: {
+            story: {
+                inline: false,
+                iframeHeight: 170,
+            },
+        },
+    },
     decorators: [
         (Story) => {
             useEffect(() => {


### PR DESCRIPTION
Render the story in an iframe to avoid to affect the other stories in the docs summary page of room item view