### PR TITLE
Support downstream js-sdk changes in matrix-js-sdk#5134

### DIFF
--- a/test/unit-tests/Notifier-test.ts
+++ b/test/unit-tests/Notifier-test.ts
@@ -525,7 +525,8 @@ describe("Notifier", () => {
                         content: {},
                     }),
                     {
-                        kind: "session",
+                        // TODO: Once https://github.com/matrix-org/matrix-js-sdk/pull/5134 is merged this can be MembershipKind.Session
+                        kind: "session" as any,
                         data: {
                             call_id: "123",
                             application: "m.call",


### PR DESCRIPTION
A small change to allow https://github.com/matrix-org/matrix-js-sdk/pull/5134 downstream tests to pass. Once it's merged, the proper enum can be used.

REF https://github.com/matrix-org/matrix-js-sdk/actions/runs/22321919600/job/64582154483