### PR TITLE
Do non-layered builds when running on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,13 @@ jobs:
                   cache: ${{ runner.os != 'Windows' && 'pnpm' || '' }}
                   node-version: "lts/*"
 
-            - name: Fetch layered build
+            - name: Install Dependencies (Layered)
+              if: ${{ github.ref != 'refs/heads/master' }}
               run: ./scripts/layered.sh
+
+            - name: Install Dependencies (Non layered)
+              if: ${{ github.ref == 'refs/heads/master' }}
+              run: pnpm install --frozen-lockfile
 
             - name: Copy config
               run: cp element.io/develop/config.json config.json

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -25,7 +25,7 @@ jobs:
             matrix:
                 include:
                     - name: Typescript Syntax Check
-                      install: layered
+                      install: ${{ github.ref == 'refs/heads/master' && 'normal' || 'layered' }}
                       command: "lint:types"
                     - name: ESLint
                       install: normal


### PR DESCRIPTION
Hopefully this will fix the release as it looks like we've introduced backwards incompat changes in the js-sdk between the RC and the release, which have now broken as we were incorrectly using the develop js-sdk for release builds.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
