### PR TITLE
Do non-layered builds when running on master (second version)

### DIFF
--- a/scripts/layered.sh
+++ b/scripts/layered.sh
@@ -21,7 +21,6 @@ export PR_ORG=element-hq
 export PR_REPO=element-web
 
 js_sdk_dep=`jq -r '.dependencies["matrix-js-sdk"]' < package.json`
-analytics_events_dep=`jq -r '.dependencies["@matrix-org/analytics-events"]' < package.json`
 
 # Set up the js-sdk first (unless package.json pins a specific version)
 if [ "$js_sdk_dep" = "github:matrix-org/matrix-js-sdk#develop" ]; then


### PR DESCRIPTION
Hopefully this will fix the release as it looks like we've introduced backwards incompat changes in the js-sdk between the RC and the release, which have now broken as we were incorrectly using the develop js-sdk for release builds.

Replaces https://github.com/element-hq/element-web/pull/32623

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
