### PR TITLE
Allow higher max width (16:9) and have consistent dimensions for image embeds

### DIFF
--- a/apps/web/src/settings/enums/ImageSize.ts
+++ b/apps/web/src/settings/enums/ImageSize.ts
@@ -11,8 +11,7 @@ Please see LICENSE files in the repository root for full details.
 const SIZE_LARGE = { w: 800, h: 600 };
 // For Normal the image gets drawn to never exceed SIZE_NORMAL.w, SIZE_NORMAL.h
 // constraint by: timeline width, manual height overrides
-const SIZE_NORMAL_LANDSCAPE = { w: Math.ceil(324 * (16 / 9)), h: 324 }; // for w > h
-const SIZE_NORMAL_PORTRAIT = { w: Math.ceil(324 * (9 / 16)), h: 324 }; // for h > w
+const SIZE_NORMAL = { w: Math.ceil(324 * (16 / 9)), h: 324 }; // for w > h
 
 type Dimensions = { w?: number; h?: number };
 
@@ -31,7 +30,7 @@ export function suggestedSize(size: ImageSize, contentSize: Dimensions, maxHeigh
     const aspectRatio = contentSize.w! / contentSize.h!;
     const portrait = aspectRatio < 1;
 
-    const maxSize = size === ImageSize.Large ? SIZE_LARGE : portrait ? SIZE_NORMAL_PORTRAIT : SIZE_NORMAL_LANDSCAPE;
+    const maxSize = size === ImageSize.Large ? SIZE_LARGE : SIZE_NORMAL;
     if (!contentSize.w || !contentSize.h) {
         return maxSize;
     }

--- a/apps/web/src/settings/enums/ImageSize.ts
+++ b/apps/web/src/settings/enums/ImageSize.ts
@@ -11,7 +11,7 @@ Please see LICENSE files in the repository root for full details.
 const SIZE_LARGE = { w: 800, h: 600 };
 // For Normal the image gets drawn to never exceed SIZE_NORMAL.w, SIZE_NORMAL.h
 // constraint by: timeline width, manual height overrides
-const SIZE_NORMAL_LANDSCAPE = { w: 324, h: 324 }; // for w > h
+const SIZE_NORMAL_LANDSCAPE = { w: Math.ceil(324 * (16 / 9)), h: 324 }; // for w > h
 const SIZE_NORMAL_PORTRAIT = { w: Math.ceil(324 * (9 / 16)), h: 324 }; // for h > w
 
 type Dimensions = { w?: number; h?: number };

--- a/apps/web/test/unit-tests/settings/enums/ImageSize-test.ts
+++ b/apps/web/test/unit-tests/settings/enums/ImageSize-test.ts
@@ -34,5 +34,9 @@ describe("ImageSize", () => {
             const size = suggestedSize(ImageSize.Normal, { w: 720, h: 1280 });
             expect(size).toStrictEqual({ w: 182, h: 324 });
         });
+        it("returns integer values for slightly vertical images", () => {
+            const size = suggestedSize(ImageSize.Normal, { w: 720, h: 800 });
+            expect(size).toStrictEqual({ w: 291, h: 324 });
+        });
     });
 });

--- a/apps/web/test/unit-tests/settings/enums/ImageSize-test.ts
+++ b/apps/web/test/unit-tests/settings/enums/ImageSize-test.ts
@@ -12,7 +12,7 @@ describe("ImageSize", () => {
     describe("suggestedSize", () => {
         it("constrains width", () => {
             const size = suggestedSize(ImageSize.Normal, { w: 648, h: 162 });
-            expect(size).toStrictEqual({ w: 324, h: 81 });
+            expect(size).toStrictEqual({ w: 576, h: 144 });
         });
         it("constrains height", () => {
             const size = suggestedSize(ImageSize.Normal, { w: 162, h: 648 });
@@ -24,11 +24,11 @@ describe("ImageSize", () => {
         });
         it("returns max values if content size is not specified", () => {
             const size = suggestedSize(ImageSize.Normal, {});
-            expect(size).toStrictEqual({ w: 324, h: 324 });
+            expect(size).toStrictEqual({ w: 576, h: 324 });
         });
         it("returns integer values", () => {
             const size = suggestedSize(ImageSize.Normal, { w: 642, h: 350 }); // does not divide evenly
-            expect(size).toStrictEqual({ w: 324, h: 176 });
+            expect(size).toStrictEqual({ w: 576, h: 314 });
         });
         it("returns integer values for portrait images", () => {
             const size = suggestedSize(ImageSize.Normal, { w: 720, h: 1280 });

--- a/apps/web/test/unit-tests/settings/enums/ImageSize-test.ts
+++ b/apps/web/test/unit-tests/settings/enums/ImageSize-test.ts
@@ -38,5 +38,17 @@ describe("ImageSize", () => {
             const size = suggestedSize(ImageSize.Normal, { w: 720, h: 800 });
             expect(size).toStrictEqual({ w: 291, h: 324 });
         });
+        it("constrains square image", () => {
+            const size = suggestedSize(ImageSize.Normal, { w: 1000, h: 1000 });
+            expect(size).toStrictEqual({ w: 324, h: 324 });
+        });
+        it("constrains slightly vertical square image", () => {
+            const size = suggestedSize(ImageSize.Normal, { w: 999, h: 1000 });
+            expect(size).toStrictEqual({ w: 323, h: 324 });
+        });
+        it("constrains slightly horizontal square image", () => {
+            const size = suggestedSize(ImageSize.Normal, { w: 1000, h: 999 });
+            expect(size).toStrictEqual({ w: 324, h: 323 });
+        });
     });
 });


### PR DESCRIPTION
Fixes #19869

"Landscape" images (images with width > height) are forced into a maximum width or height of 324 pixels, which can be too small on modern screens. Considering that Element is also most often used on landscape screens, and inspired by behavior in other chat clients (namely Discord as mentioned in https://github.com/element-hq/element-web/issues/19869#issuecomment-3957268684), the limit for the width is increased by a ratio of 16:9 to give a maximum width of 576 pixels. This would help with the extreme cases as mentioned in #19869.

The behavior for "portrait" images added in https://github.com/element-hq/element-web/commit/88609162250a13a1983da83cc4981d6c8a76b24c is also removed, which reduces the maximum width further to 9:16 of 324 which is 183 pixels. This happens on any image where the height is higher than the width, even by 1 pixel. Just the landscape dimensions are used instead. Images are shrunk to fit the screen anyway if the output dimensions are too big, and the maximum height is the same as before, so this effectively only makes images bigger when the screen has the available width, which it really should.

The issue 7188 mentioned in https://github.com/element-hq/element-web/commit/88609162250a13a1983da83cc4981d6c8a76b24c seems completely unrelated so I can't find the reasoning for why this was put in at all.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
