### PR TITLE
Fix i18n bootstrapping

### DIFF
--- a/apps/web/scripts/copy-res.ts
+++ b/apps/web/scripts/copy-res.ts
@@ -11,6 +11,7 @@ import { type Translations } from "matrix-web-i18n";
 
 const EW_I18N_BASE_PATH = "src/i18n/strings/";
 const SC_I18N_BASE_PATH = "../../packages/shared-components/src/i18n/strings/";
+const LANG_JSON_PATH = "webapp/i18n/languages.json";
 
 const INCLUDE_LANGS = [...new Set([...fs.readdirSync(EW_I18N_BASE_PATH)])]
     .filter((fn) => fn.endsWith(".json"))
@@ -87,7 +88,7 @@ function genLangList(langFileMap: Record<string, string>): void {
             languages[normalizedLanguage] = langFileMap[lang];
         }
     });
-    fs.writeFile("webapp/i18n/languages.json", JSON.stringify(languages, null, 4), function (err) {
+    fs.writeFile(LANG_JSON_PATH, JSON.stringify(languages, null, 4), function (err) {
         if (err) {
             console.error("Copy Error occured: " + err.message);
             throw new Error("Failed to generate languages.json");
@@ -138,7 +139,7 @@ function watchLanguage(lang: string, dest: string, langFileMap: Record<string, s
 // language resources
 const I18N_FILENAME_MAP = INCLUDE_LANGS.reduce<Record<string, string>>((m, l) => {
     const [filename, json] = prepareLangFile(l);
-    if (!watch) {
+    if (!watch || !fs.readdirSync(I18N_DEST).some(x => x === filename)) {
         genLangFile(I18N_DEST, filename, json);
     }
     m[l] = filename;
@@ -147,6 +148,8 @@ const I18N_FILENAME_MAP = INCLUDE_LANGS.reduce<Record<string, string>>((m, l) =>
 
 if (watch) {
     INCLUDE_LANGS.forEach((l) => watchLanguage(l, I18N_DEST, I18N_FILENAME_MAP));
-} else {
-    genLangList(I18N_FILENAME_MAP);
+}
+
+if (!watch || !fs.existsSync(LANG_JSON_PATH)) {
+    genLangList(I18N_FILENAME_MAP)
 }


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible). NOTE: some tests failed, but the same tests failed in a fresh environment without these changes. Looked like auto-generated class names so probably classes that weren't supposed to be in the snapshot or whatever
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass. See note above!
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)

Hello, I was working on another change and noticed that setting up the development environment as described [here](github.com/element-hq/element-web/blob/develop/developer_guide.md) results in translation keys not being replaced. This only happens in a fresh setup, which will make sense if you read on. 
<img width="671" height="399" alt="image" src="https://github.com/user-attachments/assets/27efc013-0a34-4388-9b41-707ad377074c" />

You can fix it by manually running `prebuild:i18n` but the document I linked above does not indicate this is required. I also do not see any technical reason this should be required. The root of the issue is the i18n files do not get created when running in watch mode if they do not already exist. Therefore instead of updating the docs I decided to make watch mode create the files if needed, so the extra step of running `prebuild:i18n` is not necessary. Let me know if you want me to change anything or whatever else. Thanks for all you guys do