### PR TITLE
Revert "Add --no-tui flag to tests in GHA workflow"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,6 @@ jobs:
                   pnpm test \
                       --coverage=${{ env.ENABLE_COVERAGE }} \
                       --ci \
-                      --no-tui \
                       --max-workers ${{ steps.cpu-cores.outputs.count }} \
                       --shard ${{ matrix.runner }}/${{ strategy.job-total }} \
                       --cacheDirectory /tmp/jest_cache


### PR DESCRIPTION
Reverts element-hq/element-web#32656

It's the "summary of failing tests" that's somehow being squished, nx is presumably smart enough to turn off the tui anyway, as you'd expect.