### PR TITLE
Update the jest option for the sonar reporter

### DIFF
--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -59,7 +59,7 @@ const config: Config = {
     moduleDirectories: ["node_modules", "test/test-utils"],
 };
 
-// if we're running under GHA, enable the GHA reporter
+// if we're running under GHA, enable relevant reporters
 if (env["GITHUB_ACTIONS"] !== undefined) {
     config.reporters ??= [];
     config.reporters.push(["github-actions", { silent: false }]);


### PR DESCRIPTION
'testResultsProcessor' is deprecated: jest-sonar-reporter supports being a regular 'reporter'.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
