### PR TITLE
Room list: move `RecentAlgorithm` and  `Algorithm` out of old room list store

### DIFF
--- a/apps/web/src/components/views/dialogs/AddExistingToSpaceDialog.tsx
+++ b/apps/web/src/components/views/dialogs/AddExistingToSpaceDialog.tsx
@@ -27,7 +27,7 @@ import DMRoomMap from "../../../utils/DMRoomMap";
 import { calculateRoomVia } from "../../../utils/permalinks/Permalinks";
 import StyledCheckbox from "../elements/StyledCheckbox";
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
-import { sortRooms } from "../../../stores/room-list/algorithms/tag-sorting/RecentAlgorithm";
+import { sortRooms } from "../../../utils/room/sorting/RecentAlgorithm";
 import ProgressBar from "../elements/ProgressBar";
 import DecoratedRoomAvatar from "../avatars/DecoratedRoomAvatar";
 import QueryMatcher from "../../../autocomplete/QueryMatcher";

--- a/apps/web/src/components/views/dialogs/ForwardDialog.tsx
+++ b/apps/web/src/components/views/dialogs/ForwardDialog.tsx
@@ -38,7 +38,7 @@ import AutoHideScrollbar from "../../structures/AutoHideScrollbar";
 import { StaticNotificationState } from "../../../stores/notifications/StaticNotificationState";
 import NotificationBadge from "../rooms/NotificationBadge";
 import { type RoomPermalinkCreator } from "../../../utils/permalinks/Permalinks";
-import { sortRooms } from "../../../stores/room-list/algorithms/tag-sorting/RecentAlgorithm";
+import { sortRooms } from "../../../utils/room/sorting/RecentAlgorithm";
 import QueryMatcher from "../../../autocomplete/QueryMatcher";
 import TruncatedList from "../elements/TruncatedList";
 import { Action } from "../../../dispatcher/actions";

--- a/apps/web/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
+++ b/apps/web/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
@@ -70,7 +70,7 @@ import SettingsStore from "../../../../settings/SettingsStore";
 import { BreadcrumbsStore } from "../../../../stores/BreadcrumbsStore";
 import { type RoomNotificationState } from "../../../../stores/notifications/RoomNotificationState";
 import { RoomNotificationStateStore } from "../../../../stores/notifications/RoomNotificationStateStore";
-import { RecentAlgorithm } from "../../../../stores/room-list/algorithms/tag-sorting/RecentAlgorithm";
+import { RecentAlgorithm } from "../../../../utils/room/sorting/RecentAlgorithm";
 import { SdkContextClass } from "../../../../contexts/SDKContext";
 import { getMetaSpaceName, MetaSpace } from "../../../../stores/spaces";
 import SpaceStore from "../../../../stores/spaces/SpaceStore";

--- a/apps/web/src/stores/room-list/algorithms/tag-sorting/AlphabeticAlgorithm.ts
+++ b/apps/web/src/stores/room-list/algorithms/tag-sorting/AlphabeticAlgorithm.ts
@@ -9,12 +9,12 @@ Please see LICENSE files in the repository root for full details.
 import { type Room } from "matrix-js-sdk/src/matrix";
 
 import { type TagID } from "../../../room-list-v3/skip-list/tag";
-import { type IAlgorithm } from "./IAlgorithm";
+import { type Algorithm } from "../../../../utils/room/sorting/Algorithm";
 
 /**
  * Sorts rooms according to the browser's determination of alphabetic.
  */
-export class AlphabeticAlgorithm implements IAlgorithm {
+export class AlphabeticAlgorithm implements Algorithm {
     public sortRooms(rooms: Room[], tagId: TagID): Room[] {
         const collator = new Intl.Collator();
         return rooms.sort((a, b) => {

--- a/apps/web/src/stores/room-list/algorithms/tag-sorting/ManualAlgorithm.ts
+++ b/apps/web/src/stores/room-list/algorithms/tag-sorting/ManualAlgorithm.ts
@@ -9,12 +9,12 @@ Please see LICENSE files in the repository root for full details.
 import { type Room } from "matrix-js-sdk/src/matrix";
 
 import { type TagID } from "../../../room-list-v3/skip-list/tag";
-import { type IAlgorithm } from "./IAlgorithm";
+import { type Algorithm } from "../../../../utils/room/sorting/Algorithm";
 
 /**
  * Sorts rooms according to the tag's `order` property on the room.
  */
-export class ManualAlgorithm implements IAlgorithm {
+export class ManualAlgorithm implements Algorithm {
     public sortRooms(rooms: Room[], tagId: TagID): Room[] {
         const getOrderProp = (r: Room): number => r.tags[tagId].order || 0;
         return rooms.sort((a, b) => {

--- a/apps/web/src/stores/room-list/algorithms/tag-sorting/index.ts
+++ b/apps/web/src/stores/room-list/algorithms/tag-sorting/index.ts
@@ -10,12 +10,12 @@ import { type Room } from "matrix-js-sdk/src/matrix";
 
 import { SortAlgorithm } from "../models";
 import { ManualAlgorithm } from "./ManualAlgorithm";
-import { type IAlgorithm } from "./IAlgorithm";
+import { type Algorithm } from "../../../../utils/room/sorting/Algorithm";
 import { type TagID } from "../../../room-list-v3/skip-list/tag";
-import { RecentAlgorithm } from "./RecentAlgorithm";
+import { RecentAlgorithm } from "../../../../utils/room/sorting/RecentAlgorithm";
 import { AlphabeticAlgorithm } from "./AlphabeticAlgorithm";
 
-const ALGORITHM_INSTANCES: { [algorithm in SortAlgorithm]: IAlgorithm } = {
+const ALGORITHM_INSTANCES: { [algorithm in SortAlgorithm]: Algorithm } = {
     [SortAlgorithm.Recent]: new RecentAlgorithm(),
     [SortAlgorithm.Alphabetic]: new AlphabeticAlgorithm(),
     [SortAlgorithm.Manual]: new ManualAlgorithm(),
@@ -24,9 +24,9 @@ const ALGORITHM_INSTANCES: { [algorithm in SortAlgorithm]: IAlgorithm } = {
 /**
  * Gets an instance of the defined algorithm
  * @param {SortAlgorithm} algorithm The algorithm to get an instance of.
- * @returns {IAlgorithm} The algorithm instance.
+ * @returns {Algorithm} The algorithm instance.
  */
-export function getSortingAlgorithmInstance(algorithm: SortAlgorithm): IAlgorithm {
+export function getSortingAlgorithmInstance(algorithm: SortAlgorithm): Algorithm {
     if (!ALGORITHM_INSTANCES[algorithm]) {
         throw new Error(`${algorithm} is not a known algorithm`);
     }

--- a/apps/web/src/utils/room/sorting/Algorithm.ts
+++ b/apps/web/src/utils/room/sorting/Algorithm.ts
@@ -8,12 +8,12 @@ Please see LICENSE files in the repository root for full details.
 
 import { type Room } from "matrix-js-sdk/src/matrix";
 
-import { type TagID } from "../../../room-list-v3/skip-list/tag";
+import { type TagID } from "../../../stores/room-list-v3/skip-list/tag";
 
 /**
  * Represents a tag sorting algorithm.
  */
-export interface IAlgorithm {
+export interface Algorithm {
     /**
      * Sorts the given rooms according to the sorting rules of the algorithm.
      * @param {Room[]} rooms The rooms to sort.

--- a/apps/web/src/utils/room/sorting/RecentAlgorithm.ts
+++ b/apps/web/src/utils/room/sorting/RecentAlgorithm.ts
@@ -6,15 +6,15 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { type Room, type MatrixEvent, EventType } from "matrix-js-sdk/src/matrix";
+import { type Room, EventType, type MatrixEvent } from "matrix-js-sdk/src/matrix";
 
-import { type TagID } from "../../../room-list-v3/skip-list/tag";
-import { type IAlgorithm } from "./IAlgorithm";
-import { MatrixClientPeg } from "../../../../MatrixClientPeg";
-import * as Unread from "../../../../Unread";
-import { EffectiveMembership, getEffectiveMembership } from "../../../../utils/membership";
+import { type TagID } from "../../../stores/room-list-v3/skip-list/tag";
+import { type Algorithm } from "./Algorithm";
+import { MatrixClientPeg } from "../../../MatrixClientPeg";
+import * as Unread from "../../../Unread";
+import { EffectiveMembership, getEffectiveMembership } from "../../membership";
 
-export function shouldCauseReorder(event: MatrixEvent): boolean {
+function shouldCauseReorder(event: MatrixEvent): boolean {
     const type = event.getType();
     const content = event.getContent();
     const prevContent = event.getPrevContent();
@@ -117,7 +117,7 @@ export const getLastTs = (r: Room, userId: string): number => {
  * Sorts rooms according to the last event's timestamp in each room that seems
  * useful to the user.
  */
-export class RecentAlgorithm implements IAlgorithm {
+export class RecentAlgorithm implements Algorithm {
     public sortRooms(rooms: Room[], tagId: TagID): Room[] {
         return sortRooms(rooms);
     }

--- a/apps/web/test/unit-tests/stores/room-list/algorithms/list-ordering/ImportanceAlgorithm-test.ts
+++ b/apps/web/test/unit-tests/stores/room-list/algorithms/list-ordering/ImportanceAlgorithm-test.ts
@@ -18,7 +18,7 @@ import { RoomUpdateCause } from "../../../../../../src/stores/room-list/models";
 import { NotificationLevel } from "../../../../../../src/stores/notifications/NotificationLevel";
 import { AlphabeticAlgorithm } from "../../../../../../src/stores/room-list/algorithms/tag-sorting/AlphabeticAlgorithm";
 import { getMockClientWithEventEmitter, mockClientMethodsUser } from "../../../../../test-utils";
-import { RecentAlgorithm } from "../../../../../../src/stores/room-list/algorithms/tag-sorting/RecentAlgorithm";
+import { RecentAlgorithm } from "../../../../../../src/utils/room/sorting/RecentAlgorithm";
 import { DEFAULT_PUSH_RULES, makePushRule } from "../../../../../test-utils/pushRules";
 
 describe("ImportanceAlgorithm", () => {

--- a/apps/web/test/unit-tests/stores/room-list/algorithms/list-ordering/NaturalAlgorithm-test.ts
+++ b/apps/web/test/unit-tests/stores/room-list/algorithms/list-ordering/NaturalAlgorithm-test.ts
@@ -14,7 +14,7 @@ import { SortAlgorithm } from "../../../../../../src/stores/room-list/algorithms
 import { DefaultTagID } from "../../../../../../src/stores/room-list-v3/skip-list/tag";
 import { RoomUpdateCause } from "../../../../../../src/stores/room-list/models";
 import { AlphabeticAlgorithm } from "../../../../../../src/stores/room-list/algorithms/tag-sorting/AlphabeticAlgorithm";
-import { RecentAlgorithm } from "../../../../../../src/stores/room-list/algorithms/tag-sorting/RecentAlgorithm";
+import { RecentAlgorithm } from "../../../../../../src/utils/room/sorting/RecentAlgorithm";
 import { RoomNotificationStateStore } from "../../../../../../src/stores/notifications/RoomNotificationStateStore";
 import * as RoomNotifs from "../../../../../../src/RoomNotifs";
 import { getMockClientWithEventEmitter, mockClientMethodsUser } from "../../../../../test-utils";

--- a/apps/web/test/unit-tests/utils/room/sorting/RecentAlgorithm-test.ts
+++ b/apps/web/test/unit-tests/utils/room/sorting/RecentAlgorithm-test.ts
@@ -12,7 +12,7 @@ import { KnownMembership } from "matrix-js-sdk/src/types";
 import { mkMessage, mkRoom, stubClient } from "../../../../test-utils";
 import { MatrixClientPeg } from "../../../../../src/MatrixClientPeg";
 import "../../../../../src/stores/room-list/RoomListStore";
-import { RecentAlgorithm } from "../../../../../src/stores/room-list/algorithms/tag-sorting/RecentAlgorithm";
+import { RecentAlgorithm } from "../../../../../src/utils/room/sorting/RecentAlgorithm";
 import { makeThreadEvent, mkThread } from "../../../../test-utils/threads";
 import { DefaultTagID } from "../../../../../src/stores/room-list-v3/skip-list/tag";
 

--- a/apps/web/test/unit-tests/utils/room/sorting/RecentAlgorithm-test.ts
+++ b/apps/web/test/unit-tests/utils/room/sorting/RecentAlgorithm-test.ts
@@ -9,9 +9,8 @@ Please see LICENSE files in the repository root for full details.
 import { Room, type MatrixClient } from "matrix-js-sdk/src/matrix";
 import { KnownMembership } from "matrix-js-sdk/src/types";
 
-import { mkMessage, mkRoom, stubClient } from "../../../../test-utils";
+import { mkMembership, mkMessage, mkRoom, stubClient } from "../../../../test-utils";
 import { MatrixClientPeg } from "../../../../../src/MatrixClientPeg";
-import "../../../../../src/stores/room-list/RoomListStore";
 import { RecentAlgorithm } from "../../../../../src/utils/room/sorting/RecentAlgorithm";
 import { makeThreadEvent, mkThread } from "../../../../test-utils/threads";
 import { DefaultTagID } from "../../../../../src/stores/room-list-v3/skip-list/tag";
@@ -68,6 +67,31 @@ describe("RecentAlgorithm", () => {
             const room = mkRoom(cli, "!new:example.org");
             room.getMyMembership.mockReturnValue(KnownMembership.Invite);
             expect(algorithm.getLastTs(room, "@john:matrix.org")).toBe(Number.MAX_SAFE_INTEGER);
+        });
+
+        describe("shouldCauseReorder", () => {
+            const userId = "@john:matrix.org";
+
+            it.each([KnownMembership.Join, KnownMembership.Invite, KnownMembership.Leave, KnownMembership.Ban])(
+                "counts a membership change from the current user (join → %s)",
+                (membership) => {
+                    const room = new Room("room123", cli, userId);
+                    room.getMyMembership = () => KnownMembership.Join;
+
+                    const membershipEvent = mkMembership({
+                        room: room.roomId,
+                        user: userId,
+                        mship: membership,
+                        prevMship: KnownMembership.Join,
+                        ts: 99,
+                        event: true,
+                        skey: userId,
+                    });
+
+                    room.addLiveEvents([membershipEvent], { addToState: true });
+                    expect(algorithm.getLastTs(room, userId)).toBe(99);
+                },
+            );
         });
     });
 


### PR DESCRIPTION
Task https://github.com/element-hq/element-web/issues/32691

Move `RecentAlgorithm` and  `Algorithm`  to `utils/room-sorting`. They are used in some place of the code to do a manual sorting of the rooms.

In a near future, we want to be able to use the a new room list store for that.