### PR TITLE
Prevent right panel from breaking the chat timeline layout

### DIFF
--- a/apps/web/res/css/structures/_MainSplit.pcss
+++ b/apps/web/res/css/structures/_MainSplit.pcss
@@ -11,6 +11,42 @@ Please see LICENSE files in the repository root for full details.
     min-width: 0;
     min-height: 0;
     height: 100%;
+    --mx-target-content-width: var(--mx-min-timeline-width);
+
+    > .mx_MainSplit_timeline > * {
+        min-width: var(--mx-target-content-width);
+    }
+
+    > .mx_MainSplit_timeline:has(+ div > .mx_RightPanel) {
+        --mx-target-content-width: clamp(
+            100%,
+            calc(100% + (var(--mx-preferred-timeline-width) - 100%) * 9999),
+            var(--mx-main-split-width)
+        );
+        --mx-overlap-width: max(
+            0px,
+            calc(
+                max(
+                    var(--mx-min-timeline-width),
+                    min(var(--mx-preferred-timeline-width), var(--mx-main-split-width))
+                ) - 100%
+            )
+        );
+
+        position: relative;
+        overflow-x: clip;
+
+        &::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            /* A bit of a hack, but very reliable. Expand the painted background to full width once overlap is non-zero. */
+            background-image: linear-gradient($overlay-background, $overlay-background);
+            background-repeat: no-repeat;
+            background-size: calc(var(--mx-overlap-width) * 100000) 100%;
+            pointer-events: none;
+        }
+    }
 }
 
 .mx_MainSplit > .mx_RightPanel_ResizeWrapper {

--- a/apps/web/src/components/structures/MainSplit.tsx
+++ b/apps/web/src/components/structures/MainSplit.tsx
@@ -7,13 +7,16 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import React, { type JSX, type ReactNode } from "react";
+import React, { createRef, type JSX, type ReactNode } from "react";
 import { type NumberSize, Resizable } from "re-resizable";
 import { type Direction } from "re-resizable/lib/resizer";
 import { type WebPanelResize } from "@matrix-org/analytics-events/types/typescript/WebPanelResize";
 
 import { PosthogAnalytics } from "../../PosthogAnalytics.ts";
 import { SDKContext } from "../../contexts/SDKContext.ts";
+
+const MIN_TIMELINE_WIDTH = 360;
+const PREFERRED_TIMELINE_WIDTH = 500;
 
 interface IProps {
     collapsedRhs?: boolean;
@@ -42,8 +45,24 @@ export default class MainSplit extends React.Component<IProps> {
         defaultSize: 320,
     };
 
+    private readonly mainSplitRef = createRef<HTMLDivElement>();
+    private readonly resizeObserver: ResizeObserver;
+
     public constructor(props: IProps, context: React.ContextType<typeof SDKContext>) {
         super(props, context);
+
+        this.resizeObserver = new ResizeObserver(this.onMainSplitResize);
+    }
+
+    public componentDidMount(): void {
+        if (!this.mainSplitRef.current) return;
+
+        this.resizeObserver.observe(this.mainSplitRef.current);
+        this.setMainSplitWidth(this.mainSplitRef.current.getBoundingClientRect().width);
+    }
+
+    public componentWillUnmount(): void {
+        this.resizeObserver.disconnect();
     }
 
     private onResizeStart = (): void => {
@@ -93,6 +112,18 @@ export default class MainSplit extends React.Component<IProps> {
         };
     }
 
+    private onMainSplitResize = (entries: ResizeObserverEntry[]): void => {
+        if (!entries[0]) return;
+
+        this.setMainSplitWidth(entries[0].contentRect.width);
+    };
+
+    private setMainSplitWidth(width: number): void {
+        this.mainSplitRef.current?.style.setProperty("--mx-main-split-width", `${Math.round(width)}px`);
+        this.mainSplitRef.current?.style.setProperty("--mx-min-timeline-width", `${MIN_TIMELINE_WIDTH}px`);
+        this.mainSplitRef.current?.style.setProperty("--mx-preferred-timeline-width", `${PREFERRED_TIMELINE_WIDTH}px`);
+    }
+
     public render(): React.ReactNode {
         const bodyView = React.Children.only(this.props.children);
         const panelView = this.props.panel;
@@ -129,7 +160,7 @@ export default class MainSplit extends React.Component<IProps> {
         }
 
         return (
-            <div className="mx_MainSplit">
+            <div className="mx_MainSplit" ref={this.mainSplitRef}>
                 {bodyView}
                 {children}
             </div>


### PR DESCRIPTION
Prevents chat timeline layout from breaking when compressed by the right panel or in small viewports.

<table>
<tr>
<td>
<img width="1040" height="720" alt="squeeze1" src="https://github.com/user-attachments/assets/cf2d6709-9294-4af9-95bd-0751c81c2476" />
</td>
<td>
<img width="1040" height="720" alt="squeeze2" src="https://github.com/user-attachments/assets/4427d2c8-82e4-43b2-9886-f68ac7149f28" />
</td>
</tr>
</table>

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
