### PR TITLE
[wip] Preserve animated inline custom emoticons

### DIFF
--- a/apps/web/src/Linkify.tsx
+++ b/apps/web/src/Linkify.tsx
@@ -19,6 +19,16 @@ import { PERMITTED_URL_SCHEMES } from "./utils/UrlUtils";
 const COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
 const MEDIA_API_MXC_REGEX = /\/_matrix\/media\/r0\/(?:download|thumbnail)\/(.+?)\/(.+?)(?:[?/]|$)/;
 
+function sanitizeMxcImageSrc(src?: string): string | undefined {
+    if (!src) return undefined;
+    if (src.startsWith("mxc://")) return src;
+
+    const match = MEDIA_API_MXC_REGEX.exec(src);
+    if (!match) return undefined;
+
+    return `mxc://${match[1]}/${match[2]}`;
+}
+
 export const transformTags: NonNullable<IOptions["transformTags"]> = {
     // custom to matrix
     // add blank targets to all hyperlinks except vector URLs
@@ -42,22 +52,11 @@ export const transformTags: NonNullable<IOptions["transformTags"]> = {
         return { tagName, attribs };
     },
     "img": function (tagName: string, attribs: sanitizeHtml.Attributes) {
-        let src = attribs.src;
+        const src = sanitizeMxcImageSrc(attribs.src);
         // Strip out imgs that aren't `mxc` here instead of using allowedSchemesByTag
         // because transformTags is used _before_ we filter by allowedSchemesByTag and
         // we don't want to allow images with `https?` `src`s.
         if (!src) {
-            return { tagName, attribs: {} };
-        }
-
-        if (!src.startsWith("mxc://")) {
-            const match = MEDIA_API_MXC_REGEX.exec(src);
-            if (match) {
-                src = `mxc://${match[1]}/${match[2]}`;
-            }
-        }
-
-        if (!src.startsWith("mxc://")) {
             return { tagName, attribs: {} };
         }
 
@@ -74,7 +73,12 @@ export const transformTags: NonNullable<IOptions["transformTags"]> = {
         if (requestedHeight) {
             attribs.style += "height: 100%;";
         }
-        attribs.src = mediaFromMxc(src).getThumbnailOfSourceHttp(width, height)!;
+
+        const media = mediaFromMxc(src);
+        attribs.src =
+            attribs["data-mx-emoticon"] !== undefined
+                ? (media.srcHttp ?? media.getThumbnailOfSourceHttp(width, height)!)
+                : media.getThumbnailOfSourceHttp(width, height)!;
         return { tagName, attribs };
     },
     "code": function (tagName: string, attribs: sanitizeHtml.Attributes) {
@@ -179,7 +183,7 @@ export const sanitizeHtmlParams: IOptions = {
         div: ["data-mx-maths"],
         a: ["href", "name", "target", "rel"], // remote target: custom to matrix
         // img tags also accept width/height, we just map those to max-width & max-height during transformation
-        img: ["src", "alt", "title", "style"],
+        img: ["src", "alt", "title", "style", "data-mx-emoticon"],
         ol: ["start"],
         code: ["class"], // We don't actually allow all classes, we filter them in transformTags
     },

--- a/apps/web/src/Linkify.tsx
+++ b/apps/web/src/Linkify.tsx
@@ -10,10 +10,13 @@ import React, { type ReactElement } from "react";
 import sanitizeHtml, { type IOptions } from "sanitize-html";
 import { merge } from "lodash";
 import _Linkify from "linkify-react";
+import { getHttpUriForMxc } from "matrix-js-sdk/src/matrix";
 
 import { _linkifyString, _linkifyHtml, ELEMENT_URL_PATTERN, options as linkifyMatrixOptions } from "./linkify-matrix";
+import { MatrixClientPeg } from "./MatrixClientPeg";
 import { tryTransformPermalinkToLocalHref } from "./utils/permalinks/Permalinks";
 import { mediaFromMxc } from "./customisations/Media";
+import SettingsStore from "./settings/SettingsStore";
 import { PERMITTED_URL_SCHEMES } from "./utils/UrlUtils";
 
 const COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
@@ -27,6 +30,24 @@ function sanitizeMxcImageSrc(src?: string): string | undefined {
     if (!match) return undefined;
 
     return `mxc://${match[1]}/${match[2]}`;
+}
+
+function getAnimatedThumbnailHttp(src: string, width: number, height: number, animated: boolean): string | null {
+    const client = MatrixClientPeg.safeGet();
+
+    return (
+        getHttpUriForMxc(
+            client.baseUrl,
+            src,
+            Math.floor(width * window.devicePixelRatio),
+            Math.floor(height * window.devicePixelRatio),
+            "scale",
+            false,
+            true,
+            undefined,
+            animated,
+        ) || null
+    );
 }
 
 export const transformTags: NonNullable<IOptions["transformTags"]> = {
@@ -77,7 +98,8 @@ export const transformTags: NonNullable<IOptions["transformTags"]> = {
         const media = mediaFromMxc(src);
         attribs.src =
             attribs["data-mx-emoticon"] !== undefined
-                ? (media.srcHttp ?? media.getThumbnailOfSourceHttp(width, height)!)
+                ? (getAnimatedThumbnailHttp(src, width, height, SettingsStore.getValue("autoplayGifs")) ??
+                  media.getThumbnailOfSourceHttp(width, height)!)
                 : media.getThumbnailOfSourceHttp(width, height)!;
         return { tagName, attribs };
     },

--- a/apps/web/test/unit-tests/HtmlUtils-test.tsx
+++ b/apps/web/test/unit-tests/HtmlUtils-test.tsx
@@ -50,6 +50,7 @@ describe("topicToHtml", () => {
 describe("bodyToHtml", () => {
     afterEach(() => {
         jest.restoreAllMocks();
+        SettingsStore.reset();
     });
 
     it("should apply highlights to HTML messages", () => {
@@ -128,15 +129,14 @@ describe("bodyToHtml", () => {
         );
     });
 
-    it("renders inline custom emoticons from their source media URL", () => {
-        const mxcUrlToHttp = jest.fn().mockImplementation((mxc, width, height) => {
-            if (width === undefined && height === undefined) {
-                return `https://cdn.example/download/${encodeURIComponent(mxc)}`;
-            }
-
-            return `https://cdn.example/thumbnail/${encodeURIComponent(mxc)}/${width}x${height}`;
+    it("renders inline custom emoticons from animated thumbnails when GIF autoplay is enabled", () => {
+        getMockClientWithEventEmitter({ baseUrl: "https://matrix.example" });
+        const originalGetValue = SettingsStore.getValue.bind(SettingsStore);
+        const getValue = jest.spyOn(SettingsStore, "getValue");
+        getValue.mockImplementation((settingName, ...args) => {
+            if (settingName === "autoplayGifs") return true;
+            return originalGetValue(settingName, ...args);
         });
-        getMockClientWithEventEmitter({ mxcUrlToHttp });
 
         const html = bodyToHtml(
             {
@@ -149,20 +149,49 @@ describe("bodyToHtml", () => {
             [],
         );
 
-        expect(html).toContain('src="https://cdn.example/download/mxc%3A%2F%2Fexample.org%2Fparty-parrot"');
+        expect(html).toContain(
+            'src="https://matrix.example/_matrix/media/v3/thumbnail/example.org/party-parrot?width=800&amp;height=32&amp;method=scale&amp;animated=true&amp;allow_redirect=true"',
+        );
         expect(html).toContain("data-mx-emoticon");
-        expect(html).not.toContain("thumbnail");
+    });
+
+    it("renders inline custom emoticons from static thumbnails when GIF autoplay is disabled", () => {
+        getMockClientWithEventEmitter({ baseUrl: "https://matrix.example" });
+        const originalGetValue = SettingsStore.getValue.bind(SettingsStore);
+        const getValue = jest.spyOn(SettingsStore, "getValue");
+        getValue.mockImplementation((settingName, ...args) => {
+            if (settingName === "autoplayGifs") return false;
+            return originalGetValue(settingName, ...args);
+        });
+
+        const html = bodyToHtml(
+            {
+                body: ":party_parrot:",
+                msgtype: "m.text",
+                formatted_body:
+                    '<img data-mx-emoticon src="mxc://example.org/party-parrot" alt="party_parrot" title="party_parrot" height="32" />',
+                format: "org.matrix.custom.html",
+            },
+            [],
+        );
+
+        expect(html).toContain(
+            'src="https://matrix.example/_matrix/media/v3/thumbnail/example.org/party-parrot?width=800&amp;height=32&amp;method=scale&amp;animated=false&amp;allow_redirect=true"',
+        );
+        expect(html).toContain("data-mx-emoticon");
     });
 
     it("continues to thumbnail generic inline MXC images", () => {
-        const mxcUrlToHttp = jest.fn().mockImplementation((mxc, width, height) => {
-            if (width === undefined && height === undefined) {
-                return `https://cdn.example/download/${encodeURIComponent(mxc)}`;
-            }
+        getMockClientWithEventEmitter({
+            baseUrl: "https://matrix.example",
+            mxcUrlToHttp: jest.fn().mockImplementation((mxc, width, height) => {
+                if (width === undefined && height === undefined) {
+                    return `https://cdn.example/download/${encodeURIComponent(mxc)}`;
+                }
 
-            return `https://cdn.example/thumbnail/${encodeURIComponent(mxc)}/${width}x${height}`;
+                return `https://cdn.example/thumbnail/${encodeURIComponent(mxc)}/${width}x${height}`;
+            }),
         });
-        getMockClientWithEventEmitter({ mxcUrlToHttp });
 
         const html = bodyToHtml(
             {

--- a/apps/web/test/unit-tests/HtmlUtils-test.tsx
+++ b/apps/web/test/unit-tests/HtmlUtils-test.tsx
@@ -48,6 +48,10 @@ describe("topicToHtml", () => {
 });
 
 describe("bodyToHtml", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
     it("should apply highlights to HTML messages", () => {
         const html = bodyToHtml(
             {
@@ -122,6 +126,56 @@ describe("bodyToHtml", () => {
         expect(html).toMatchInlineSnapshot(
             `"foo <a href="http://link.example/test/path" target="_blank" rel="noreferrer noopener">http://link.example/<span class="mx_EventTile_searchHighlight">test</span>/path</a> bar"`,
         );
+    });
+
+    it("renders inline custom emoticons from their source media URL", () => {
+        const mxcUrlToHttp = jest.fn().mockImplementation((mxc, width, height) => {
+            if (width === undefined && height === undefined) {
+                return `https://cdn.example/download/${encodeURIComponent(mxc)}`;
+            }
+
+            return `https://cdn.example/thumbnail/${encodeURIComponent(mxc)}/${width}x${height}`;
+        });
+        getMockClientWithEventEmitter({ mxcUrlToHttp });
+
+        const html = bodyToHtml(
+            {
+                body: ":party_parrot:",
+                msgtype: "m.text",
+                formatted_body:
+                    '<img data-mx-emoticon src="mxc://example.org/party-parrot" alt="party_parrot" title="party_parrot" height="32" />',
+                format: "org.matrix.custom.html",
+            },
+            [],
+        );
+
+        expect(html).toContain('src="https://cdn.example/download/mxc%3A%2F%2Fexample.org%2Fparty-parrot"');
+        expect(html).toContain("data-mx-emoticon");
+        expect(html).not.toContain("thumbnail");
+    });
+
+    it("continues to thumbnail generic inline MXC images", () => {
+        const mxcUrlToHttp = jest.fn().mockImplementation((mxc, width, height) => {
+            if (width === undefined && height === undefined) {
+                return `https://cdn.example/download/${encodeURIComponent(mxc)}`;
+            }
+
+            return `https://cdn.example/thumbnail/${encodeURIComponent(mxc)}/${width}x${height}`;
+        });
+        getMockClientWithEventEmitter({ mxcUrlToHttp });
+
+        const html = bodyToHtml(
+            {
+                body: "inline image",
+                msgtype: "m.text",
+                formatted_body: '<img src="mxc://example.org/static-image" alt="static-image" height="32" />',
+                format: "org.matrix.custom.html",
+            },
+            [],
+        );
+
+        expect(html).toContain('src="https://cdn.example/thumbnail/mxc%3A%2F%2Fexample.org%2Fstatic-image/800x32"');
+        expect(html).not.toContain("data-mx-emoticon");
     });
 
     it("does not mistake characters in text presentation mode for emoji", () => {


### PR DESCRIPTION
## Summary

Fix inline custom emoticons sent by other Matrix clients so animated emotes stay animated in message bodies.

Element already rendered these messages, but `img` tags in formatted message bodies were treated as generic inline media and rewritten to thumbnail URLs. That made custom emoticons static even when the source media was animated. Reactions already used the original media URL, which is why the same emote could animate in reactions but not in the timeline body.

This change special-cases `img[data-mx-emoticon]` so it uses the original MXC media URL instead of a thumbnail, while keeping the existing thumbnail behaviour for normal inline images.

## Testing

- Added unit tests for:
  - inline custom emoticons using the source media URL
  - generic inline MXC images continuing to use thumbnails
- Manually verified in Element Web against a message sent from another client:
  - before: inline custom emoticon rendered but was static
  - after: inline custom emoticon renders animated
- Verified that generic inline images still follow the thumbnail path

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
