### PR TITLE
Refresh MediaProcessingError visuals and add Retry action

### DIFF
--- a/apps/web/res/css/components/views/messages/shared/_MediaProcessingError.pcss
+++ b/apps/web/res/css/components/views/messages/shared/_MediaProcessingError.pcss
@@ -6,7 +6,19 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-.mx_MediaProcessingError_Icon {
-    margin-right: $spacing-4;
-    vertical-align: text-top;
+@keyframes mx_MediaProcessingError_spinIconOnHover {
+    from {
+        transform: rotate(0deg);
+    }
+
+    to {
+        transform: rotate(-360deg);
+    }
+}
+
+@media (hover) and (prefers-reduced-motion: no-preference) {
+    .mx_MediaProcessingError_spinIconOnHover:hover > svg {
+        transform-origin: center;
+        animation: mx_MediaProcessingError_spinIconOnHover 450ms ease;
+    }
 }

--- a/apps/web/src/components/views/messages/MAudioBody.tsx
+++ b/apps/web/src/components/views/messages/MAudioBody.tsx
@@ -82,7 +82,12 @@ export default class MAudioBody extends React.PureComponent<IBodyProps, IState> 
     public render(): React.ReactNode {
         if (this.state.error) {
             return (
-                <MediaProcessingError className="mx_MAudioBody">
+                <MediaProcessingError
+                    className="mx_MAudioBody"
+                    // Compound Alert doesn't accept custom icons yet.
+                    // Replace its icon with AudioIcon if that becomes possible.
+                    title="Couldn't play audio"
+                >
                     {_t("timeline|m.audio|error_processing_audio")}
                 </MediaProcessingError>
             );

--- a/apps/web/src/components/views/messages/MImageBody.tsx
+++ b/apps/web/src/components/views/messages/MImageBody.tsx
@@ -15,7 +15,7 @@ import { logger } from "matrix-js-sdk/src/logger";
 import { ClientEvent } from "matrix-js-sdk/src/matrix";
 import { type ImageContent } from "matrix-js-sdk/src/types";
 import { Tooltip } from "@vector-im/compound-web";
-import { ImageErrorIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
+import { RestartIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
 
 import MFileBody from "./MFileBody";
 import Modal from "../../../Modal";
@@ -83,7 +83,6 @@ export class MImageBodyInner extends React.Component<IProps, IState> {
     private placeholder = createRef<HTMLDivElement>();
     private timeout?: number;
     private sizeWatcher?: string;
-
     public state: IState = {
         contentUrl: null,
         thumbUrl: null,
@@ -199,6 +198,21 @@ export class MImageBodyInner extends React.Component<IProps, IState> {
             loadedImageDimensions = { naturalWidth, naturalHeight };
         }
         this.setState({ imgLoaded: true, loadedImageDimensions });
+    };
+
+    private onRetry = (): void => {
+        this.setState(
+            {
+                contentUrl: null,
+                thumbUrl: null,
+                isAnimated: undefined,
+                error: undefined,
+                imgError: false,
+                imgLoaded: false,
+                loadedImageDimensions: undefined,
+            },
+            () => void this.downloadImage(),
+        );
     };
 
     private getContentUrl(): string | null {
@@ -361,7 +375,6 @@ export class MImageBodyInner extends React.Component<IProps, IState> {
 
     public componentDidMount(): void {
         this.unmounted = false;
-
         if (this.props.mediaVisible) {
             // noinspection JSIgnoredPromiseFromCall
             this.downloadImage();
@@ -674,9 +687,19 @@ export class MImageBodyInner extends React.Component<IProps, IState> {
             } else if (this.state.error instanceof DownloadError) {
                 errorText = _t("timeline|m.image|error_downloading");
             }
-
             return (
-                <MediaProcessingError className="mx_MImageBody" Icon={ImageErrorIcon}>
+                <MediaProcessingError
+                    className="mx_MImageBody"
+                    // Compound Alert doesn't accept custom icons yet.
+                    // Provide with ImageErrorIcon if that becomes possible.
+                    title="Couldn't show image"
+                    action={{
+                        label: "Retry",
+                        Icon: RestartIcon,
+                        onClick: this.onRetry,
+                        className: "mx_MediaProcessingError_spinIconOnHover",
+                    }}
+                >
                     {errorText}
                 </MediaProcessingError>
             );

--- a/apps/web/src/components/views/messages/MVideoBody.tsx
+++ b/apps/web/src/components/views/messages/MVideoBody.tsx
@@ -267,7 +267,12 @@ class MVideoBodyInner extends React.PureComponent<IProps, IState> {
 
         if (this.state.error !== null) {
             return (
-                <MediaProcessingError className="mx_MVideoBody">
+                <MediaProcessingError
+                    className="mx_MVideoBody"
+                    // Compound Alert doesn't accept custom icons yet.
+                    // Replace its icon with VideoCallIcon if that becomes possible.
+                    title="Couldn't show video"
+                >
                     {_t("timeline|m.video|error_decrypting")}
                 </MediaProcessingError>
             );

--- a/apps/web/src/components/views/messages/MVoiceMessageBody.tsx
+++ b/apps/web/src/components/views/messages/MVoiceMessageBody.tsx
@@ -36,7 +36,12 @@ export default class MVoiceMessageBody extends MAudioBody {
     public render(): React.ReactNode {
         if (this.state.error) {
             return (
-                <MediaProcessingError className="mx_MVoiceMessageBody">
+                <MediaProcessingError
+                    className="mx_MVoiceMessageBody"
+                    // Compound Alert doesn't accept custom icons yet.
+                    // Replace its icon with MicOnIcon if that becomes possible.
+                    title="Couldn't play voice message"
+                >
                     {_t("timeline|m.audio|error_processing_voice_message")}
                 </MediaProcessingError>
             );

--- a/apps/web/src/components/views/messages/shared/MediaProcessingError.tsx
+++ b/apps/web/src/components/views/messages/shared/MediaProcessingError.tsx
@@ -7,19 +7,50 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import React from "react";
-import { FileErrorIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
+import { Alert, Button } from "@vector-im/compound-web";
+
+import type { FileErrorIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
+
+interface Action {
+    label: string;
+    Icon?: typeof FileErrorIcon;
+    onClick: () => void;
+    className?: string;
+}
 
 interface Props {
     className?: string;
-    Icon?: typeof FileErrorIcon;
+    title?: string;
     children: React.ReactNode;
+    action?: Action;
 }
 
-const MediaProcessingError: React.FC<Props> = ({ className, children, Icon = FileErrorIcon }) => (
-    <span className={className}>
-        <Icon className="mx_MediaProcessingError_Icon" width="16" height="16" />
-        {children}
-    </span>
-);
+const MediaProcessingError: React.FC<Props> = ({ className, title, children, action }) => {
+    const resolvedTitle = title ?? (typeof children === "string" ? children : "");
+    const description = title ? children : undefined;
+
+    return (
+        <Alert
+            className={`mx_MediaProcessingError${className ? ` ${className}` : ""}`}
+            type="critical"
+            title={resolvedTitle}
+            actions={
+                action && (
+                    <Button
+                        className={action.className}
+                        kind="secondary"
+                        size="sm"
+                        Icon={action.Icon}
+                        onClick={action.onClick}
+                    >
+                        {action.label}
+                    </Button>
+                )
+            }
+        >
+            {description}
+        </Alert>
+    );
+};
 
 export default MediaProcessingError;


### PR DESCRIPTION
Replaces the bare bones ad-hoc MediaProcessingError body and styling with the standardized Compound Alert element including an operational "Retry" button.

https://github.com/user-attachments/assets/19e4871c-9229-4235-a2ae-3abd2c074c39

Caveat: Alert does not accept Icon as a prop as it currently is. If this ever changes, putting previously used media icons in there would be a good idea.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
