### PR TITLE
Clean shared components test log

### DIFF
--- a/packages/shared-components/src/room-list/RoomListPrimaryFilters/RoomListPrimaryFilters.test.tsx
+++ b/packages/shared-components/src/room-list/RoomListPrimaryFilters/RoomListPrimaryFilters.test.tsx
@@ -68,27 +68,33 @@ describe("<RoomListPrimaryFilters /> stories", () => {
             } as unknown as typeof ResizeObserver;
         });
 
-        function mockFiltersNotWrapping(): void {
+        async function mockFiltersNotWrapping(): Promise<void> {
             vi.spyOn(screen.getByText("People"), "offsetLeft", "get").mockReturnValue(0);
             vi.spyOn(screen.getByText("Rooms"), "offsetLeft", "get").mockReturnValue(30);
             vi.spyOn(screen.getByText("Unreads"), "offsetLeft", "get").mockReturnValue(60);
 
             const listbox = screen.getByRole("listbox", { name: "Room list filters" });
-            act(() => resizeCallback([{ target: listbox } as any], {} as ResizeObserver));
+            await act(async () => {
+                resizeCallback([{ target: listbox } as any], {} as ResizeObserver);
+                await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+            });
         }
 
-        function mockUnreadWrapping(): void {
+        async function mockUnreadWrapping(): Promise<void> {
             vi.spyOn(screen.getByText("People"), "offsetLeft", "get").mockReturnValue(0);
             vi.spyOn(screen.getByText("Rooms"), "offsetLeft", "get").mockReturnValue(30);
             vi.spyOn(screen.getByText("Unreads"), "offsetLeft", "get").mockReturnValue(0);
 
             const listbox = screen.getByRole("listbox", { name: "Room list filters" });
-            act(() => resizeCallback([{ target: listbox } as any], {} as ResizeObserver));
+            await act(async () => {
+                resizeCallback([{ target: listbox } as any], {} as ResizeObserver);
+                await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+            });
         }
 
-        it("should hide wrapping filters and show chevron", () => {
+        it("should hide wrapping filters and show chevron", async () => {
             render(<NarrowContainer />);
-            mockUnreadWrapping();
+            await mockUnreadWrapping();
 
             expect(screen.queryByRole("option", { name: "Unreads" })).toBeNull();
             expect(screen.getByRole("button", { name: "Expand filter list" })).toBeInTheDocument();
@@ -97,7 +103,7 @@ describe("<RoomListPrimaryFilters /> stories", () => {
         it("should expand and collapse filter list with chevron button", async () => {
             const user = userEvent.setup();
             render(<NarrowContainer />);
-            mockUnreadWrapping();
+            await mockUnreadWrapping();
 
             expect(screen.queryByRole("option", { name: "Unreads" })).toBeNull();
 
@@ -108,9 +114,9 @@ describe("<RoomListPrimaryFilters /> stories", () => {
             expect(screen.queryByRole("option", { name: "Unreads" })).toBeNull();
         });
 
-        it("should move active filter to front when collapsed and wrapping", () => {
+        it("should move active filter to front when collapsed and wrapping", async () => {
             render(<NarrowWithActiveWrappingFilter />);
-            mockUnreadWrapping();
+            await mockUnreadWrapping();
 
             const listbox = screen.getByRole("listbox", { name: "Room list filters" });
             expect(listbox.children[0]).toBe(screen.getByRole("option", { name: "Unreads" }));
@@ -119,7 +125,7 @@ describe("<RoomListPrimaryFilters /> stories", () => {
         it("should restore original filter order when expanded", async () => {
             const user = userEvent.setup();
             render(<NarrowWithActiveWrappingFilter />);
-            mockUnreadWrapping();
+            await mockUnreadWrapping();
 
             await user.click(screen.getByRole("button", { name: "Expand filter list" }));
 
@@ -127,13 +133,13 @@ describe("<RoomListPrimaryFilters /> stories", () => {
             expect(listbox.children[0]).toBe(screen.getByRole("option", { name: "People" }));
         });
 
-        it("should handle resize from non-wrapping to wrapping", () => {
+        it("should handle resize from non-wrapping to wrapping", async () => {
             render(<NarrowContainer />);
-            mockFiltersNotWrapping();
+            await mockFiltersNotWrapping();
 
             expect(screen.queryByRole("button", { name: "Expand filter list" })).toBeNull();
 
-            mockUnreadWrapping();
+            await mockUnreadWrapping();
             expect(screen.getByRole("button", { name: "Expand filter list" })).toBeInTheDocument();
         });
     });

--- a/packages/shared-components/src/room-list/RoomListPrimaryFilters/useCollapseFilters.ts
+++ b/packages/shared-components/src/room-list/RoomListPrimaryFilters/useCollapseFilters.ts
@@ -59,10 +59,15 @@ export function useCollapseFilters<T extends HTMLElement>(
         };
 
         hideFilters(ref.current);
-        const observer = new ResizeObserver((entries) => entries.forEach((entry) => hideFilters(entry.target)));
+        let rafId = 0;
+        const observer = new ResizeObserver((entries) => {
+            cancelAnimationFrame(rafId);
+            rafId = requestAnimationFrame(() => entries.forEach((entry) => hideFilters(entry.target)));
+        });
 
         observer.observe(ref.current);
         return () => {
+            cancelAnimationFrame(rafId);
             observer.disconnect();
         };
     }, [isExpanded, wrappingClassName]);

--- a/packages/shared-components/src/utils/i18n.tsx
+++ b/packages/shared-components/src/utils/i18n.tsx
@@ -408,7 +408,7 @@ interface ICounterpartTranslation {
 }
 
 async function getLanguage(langPath: string): Promise<ICounterpartTranslation> {
-    console.log("Loading language from", langPath);
+    if (process.env.NODE_ENV !== "test") console.log("Loading language from", langPath);
     const res = await fetch(langPath, { method: "GET" });
 
     if (!res.ok) {


### PR DESCRIPTION
This PR fixes:
- The spam `Loading language from` in shared component test
- The log `[Error: ResizeObserver loop completed with undelivered notifications.]` was appearing on room list primary filter tests