### PR TITLE
Always check & update the users timezone on their profile on startup

### DIFF
--- a/apps/web/src/components/structures/LoggedInView.tsx
+++ b/apps/web/src/components/structures/LoggedInView.tsx
@@ -190,6 +190,9 @@ class LoggedInView extends React.Component<IProps, IState> {
             SettingsStore.watchSetting("userTimezonePublish", null, this.onTimezoneUpdate),
             SettingsStore.watchSetting("userTimezone", null, this.onTimezoneUpdate),
         ];
+        // Call this initially to ensure that we set the correct timezone, if the
+        // system time has changed between sessions.
+        void this.onTimezoneUpdate();
 
         this.loadResizer();
 


### PR DESCRIPTION
I noticed via @anoadragon453 that their timezone hadn't updated despite their system timezone updating, and they had set Element to follow the system default. We currently don't have any tools to watch the timezone change, but we can at least ensure we check and update at the start of the session.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
