### PR TITLE
README.md: fix symlink

### DIFF
--- a/apps/web/src/customisations/README.md
+++ b/apps/web/src/customisations/README.md
@@ -1,1 +1,1 @@
-../../docs/customisations.md
+../../../../docs/customisations.md


### PR DESCRIPTION
Without this fix, "docker build" fails with
`"/apps/web/src/customisations/README.md": not found`

Fixes #32763.