### PR TITLE
Make links in mobile_guide configurable

### DIFF
--- a/apps/web/src/IConfigOptions.ts
+++ b/apps/web/src/IConfigOptions.ts
@@ -82,6 +82,7 @@ export interface IConfigOptions {
     };
     mobile_builds: {
         ios: string | null; // download url
+        ios_appid: string | null; // App Store App id
         android: string | null; // download url
         fdroid: string | null; // download url
     };

--- a/apps/web/src/vector/mobile_guide/index.ts
+++ b/apps/web/src/vector/mobile_guide/index.ts
@@ -55,6 +55,11 @@ async function initPage(): Promise<void> {
 
     const appVariant = (config?.["mobile_guide_app_variant"] as MobileAppVariant) ?? MobileAppVariant.X;
     const metadata = mobileApps[appVariant] ?? mobileApps[MobileAppVariant.X]; // Additional fallback in case mobile_guide_app_variant has an unexpected value.
+    metadata.name = config?.["brand"] ?? metadata.name;
+    metadata.appleAppId = config?.["mobile_builds"]?.["ios_appid"] ?? metadata.appleAppId;
+    metadata.appStoreUrl = config?.["mobile_builds"]?.["ios"] ?? metadata.appStoreUrl;
+    metadata.playStoreUrl = config?.["mobile_builds"]?.["android"] ?? metadata.playStoreUrl;
+    metadata.fDroidUrl = config?.["mobile_builds"]?.["fdroid"] ?? metadata.fDroidUrl;
 
     const incompatibleOptions = [wkConfig, serverName, defaultHsUrl].filter((i) => !!i);
     if (defaultHsUrl && (wkConfig || serverName)) {

--- a/docs/config.md
+++ b/docs/config.md
@@ -181,12 +181,13 @@ Starting with `desktop_builds`, the following sub-properties are available:
 
 When `desktop_builds` is not specified at all, the app will assume desktop downloads are available from https://element.io
 
-For `mobile_builds`, the following subproperties are available:
+For `mobile_builds`, these override any given defaults from `mobile_guide_app_variant`. The following subproperties are available:
 
 1. `ios`: The URL for where to download the iOS app, such as an App Store link. When explicitly `null`, the app will assume the
    iOS app cannot be downloaded. When not provided, the default Element app will be assumed available.
-2. `android`: The same as `ios`, except for Android instead.
-3. `fdroid`: The same as `android`, except for FDroid instead.
+2. `ios_appid`: The id of the iOS app on the App Store. Usually the last part of the App Store link, format is usually `id` and then a number.
+3. `android`: The same as `ios`, except for Android instead.
+4. `fdroid`: The same as `android`, except for FDroid instead.
 
 Together, these two options might look like the following in your config:
 
@@ -198,7 +199,8 @@ Together, these two options might look like the following in your config:
         "url": "https://example.org/not_element/download"
     },
     "mobile_builds": {
-        "ios": null,
+        "ios": "https://apps.apple.com/app/not_element/id1234567890",
+        "ios_appid": "id1234567890",
         "android": "https://example.org/not_element/android",
         "fdroid": "https://example.org/not_element/fdroid"
     }


### PR DESCRIPTION
Fixes: #25610

Up till now the /mobile_guide/ could only show the Element apps,
not custom apps configured in the mobile_builds config item.

Previously /mobile_guide/ was not parsing config.json, but does
so for other parts for some time, so also use that for the app
links.

This uses any values from mobile_builds to override the defaults
from the Element apps.

Notes: Download links in /mobile_guide/ now configurable

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [X] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [X] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
