### PR TITLE
Fix WidgetPip test having an incomplete mock

### DIFF
--- a/apps/web/test/viewmodels/room/WidgetPip-test.ts
+++ b/apps/web/test/viewmodels/room/WidgetPip-test.ts
@@ -7,7 +7,7 @@
 
 import { type MatrixClient, type Room, RoomEvent } from "matrix-js-sdk/src/matrix";
 import { type MockedObject } from "jest-mock";
-import { useRef } from "react";
+import { createRef } from "react";
 
 import { mkRoom, stubClient } from "../../test-utils";
 import { WidgetPipViewModel } from "../../../src/viewmodels/room/WidgetPipViewModel";
@@ -52,7 +52,7 @@ describe("WidgetPipViewModel", () => {
             room,
             widgetId,
             onStartMoving: () => {},
-            movePersistedElement: useRef(null),
+            movePersistedElement: createRef(),
         });
     });
 


### PR DESCRIPTION
This didn't get noticed because this seemed to be technically valid JavaScript (the tests completed) even though it wasn't valid TypeScript. We didn't catch this in https://github.com/element-hq/element-web/pull/32654 because the type linter had ~been failing~ not been running in CI, which was fixed in https://github.com/element-hq/element-web/pull/32776