### PR TITLE
Remove release announcement labs flag

### DIFF
--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -1554,7 +1554,6 @@
         "notification_settings_beta_caption": "Introducing a simpler way to change your notification settings. Customize your %(brand)s, just the way you like.",
         "notification_settings_beta_title": "Notification Settings",
         "notifications": "Enable the notifications panel in the room header",
-        "release_announcement": "Release announcement",
         "render_reaction_images": "Render custom images in reactions",
         "render_reaction_images_description": "Sometimes referred to as \"custom emojis\".",
         "report_to_moderators": "Report to moderators",

--- a/apps/web/src/settings/Settings.tsx
+++ b/apps/web/src/settings/Settings.tsx
@@ -99,7 +99,6 @@ export enum LabGroup {
 
 export enum Features {
     NotificationSettings2 = "feature_notification_settings2",
-    ReleaseAnnouncement = "feature_release_announcement",
 }
 
 export const labGroupNames: Record<LabGroup, TranslationKey> = {
@@ -206,7 +205,6 @@ export interface Settings {
     // [settingName: `feature_${string}`]: IFeature;
     "feature_video_rooms": IFeature;
     [Features.NotificationSettings2]: IFeature;
-    [Features.ReleaseAnnouncement]: IFeature;
     "feature_msc3531_hide_messages_pending_moderation": IFeature;
     "feature_report_to_moderators": IFeature;
     "feature_latex_maths": IFeature;
@@ -1355,16 +1353,6 @@ export const SETTINGS: Settings = {
         default: [],
         // Contains room IDs
         shouldExportToRageshake: false,
-    },
-    /**
-     * Enable or disable the release announcement feature
-     */
-    [Features.ReleaseAnnouncement]: {
-        isFeature: true,
-        labsGroup: LabGroup.Ui,
-        supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG,
-        default: true,
-        displayName: _td("labs|release_announcement"),
     },
     /**
      * Managed by the {@link ReleaseAnnouncementStore}

--- a/apps/web/src/stores/ReleaseAnnouncementStore.ts
+++ b/apps/web/src/stores/ReleaseAnnouncementStore.ts
@@ -12,7 +12,6 @@ import { cloneDeep } from "lodash";
 
 import SettingsStore from "../settings/SettingsStore";
 import { SettingLevel } from "../settings/SettingLevel";
-import { Features } from "../settings/Settings";
 import ToastStore from "./ToastStore";
 
 /**
@@ -61,6 +60,12 @@ export class ReleaseAnnouncementStore extends TypedEventEmitter<ReleaseAnnouncem
     private index = 0;
 
     /**
+     * Whether the release announcement is enabled. Useful to disable it in e2e tests.
+     * @private
+     */
+    private enabled = true;
+
+    /**
      * The singleton instance of the ReleaseAnnouncementStore.
      */
     public static get instance(): ReleaseAnnouncementStore {
@@ -94,11 +99,17 @@ export class ReleaseAnnouncementStore extends TypedEventEmitter<ReleaseAnnouncem
     }
 
     /**
-     * Check if the release announcement is enabled.
-     * @private
+     * Enable the release announcement. This will allow the release announcement to be shown when calling `getReleaseAnnouncement` or `nextReleaseAnnouncement`.
      */
-    private isReleaseAnnouncementEnabled(): boolean {
-        return SettingsStore.getValue(Features.ReleaseAnnouncement);
+    public enable(): void {
+        this.enabled = true;
+    }
+
+    /**
+     * Disable the release announcement. This will prevent the release announcement from being shown when calling `getReleaseAnnouncement` or `nextReleaseAnnouncement`.
+     */
+    public disable(): void {
+        this.enabled = false;
     }
 
     /**
@@ -107,8 +118,7 @@ export class ReleaseAnnouncementStore extends TypedEventEmitter<ReleaseAnnouncem
      */
     public getReleaseAnnouncement(): Feature | null {
         // Do nothing if the release announcement is disabled
-        const isReleaseAnnouncementEnabled = this.isReleaseAnnouncementEnabled();
-        if (!isReleaseAnnouncementEnabled) return null;
+        if (!this.enabled) return null;
 
         // also don't show release announcements if any toasts are on screen
         if (ToastStore.sharedInstance().getToasts().length > 0) return null;
@@ -133,9 +143,8 @@ export class ReleaseAnnouncementStore extends TypedEventEmitter<ReleaseAnnouncem
      * @private
      */
     private async markReleaseAnnouncementAsViewed(): Promise<void> {
-        // Do nothing if the release announcement is disabled
-        const isReleaseAnnouncementEnabled = this.isReleaseAnnouncementEnabled();
-        if (!isReleaseAnnouncementEnabled) return;
+        // Do nothing if the release announcement is disabled;
+        if (!this.enabled) return;
 
         const viewedReleaseAnnouncements = this.getViewedReleaseAnnouncements();
 

--- a/apps/web/test/unit-tests/stores/ReleaseAnnouncementStore-test.tsx
+++ b/apps/web/test/unit-tests/stores/ReleaseAnnouncementStore-test.tsx
@@ -26,7 +26,6 @@ describe("ReleaseAnnouncementStore", () => {
     beforeEach(() => {
         // Default settings
         settings = {
-            feature_release_announcement: true,
             releaseAnnouncementData: {},
         };
         const watchCallbacks: Array<CallbackFn> = [];
@@ -59,13 +58,6 @@ describe("ReleaseAnnouncementStore", () => {
     });
 
     /**
-     * Disables the release announcement feature.
-     */
-    function disableReleaseAnnouncement() {
-        settings["feature_release_announcement"] = false;
-    }
-
-    /**
      * Listens to the next release announcement change event.
      */
     function listenReleaseAnnouncementChanged() {
@@ -79,8 +71,7 @@ describe("ReleaseAnnouncementStore", () => {
     });
 
     it("should return null when the release announcement is disabled", async () => {
-        disableReleaseAnnouncement();
-
+        releaseAnnouncementStore.disable();
         expect(releaseAnnouncementStore.getReleaseAnnouncement()).toBeNull();
 
         // Wait for the next release announcement change event


### PR DESCRIPTION
The release announcement labs flag was added to disable the RA in e2e tests. A cleaner option is to add an attribute to the release announcement to disable/enable.

This labs flag is undocumented in [labs.md](https://github.com/element-hq/element-web/blob/develop/docs/labs.md) and wasn't intended for an external usage.
