### PR TITLE
Fix nx configuration to actually run type linter

### DIFF
--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -34,9 +34,12 @@
             "executor": "nx:run-commands",
             "options": {
                 "commands": [
-                    "tsc --noEmit --project ./tsconfig.module_system.json",
-                    "tsc --noEmit",
-                    "tsc --noEmit -p playwright"
+                    // We indirect via `pnpm exec` to stop knip interpreting the
+                    // commandline and declaring `playwright` and `./tsconfig.module_system.json`
+                    // as unlisted dependencies.
+                    "pnpm exec tsc --noEmit --project ./tsconfig.module_system.json",
+                    "pnpm exec tsc --noEmit",
+                    "pnpm exec tsc --noEmit --project playwright"
                 ],
                 "parallel": false,
                 "cwd": "apps/web"


### PR DESCRIPTION
The current configuration for `nx lint:types` indirects its `tsc` incantations via pnpm, but that means they don't actually work due to a pnpm reentrancy bug (https://github.com/pnpm/pnpm/issues/5291) which causes pnpm not to run those commands at all if the top level pnpm has `--if-present`.

Turns out that adding an explicit `exec` to the pnpm commandline works around the bug.

Also I've taken the opportunity to document the reason the indirection is there in the first place, to save anyone else losing a day on it. (It seems to be some sort of `knip` bug, but reproducing it outside element-web was more effort than I can spare.)