### PR TITLE
Actually run the type linter

### DIFF
--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -34,9 +34,9 @@
             "executor": "nx:run-commands",
             "options": {
                 "commands": [
-                    "pnpm tsc --noEmit --project ./tsconfig.module_system.json",
-                    "pnpm tsc --noEmit",
-                    "pnpm tsc --noEmit -p playwright"
+                    "pnpm exec tsc --noEmit --project ./tsconfig.module_system.json",
+                    "pnpm exec tsc --noEmit",
+                    "pnpm exec tsc --noEmit -p playwright"
                 ],
                 "parallel": false,
                 "cwd": "apps/web"


### PR DESCRIPTION
For reasons that currently reamin a mystery, pnpm was doing... well, I don't know what, but it definitely wasn't running the right tsc command as it exited alomst instantly. Adding the 'exec' rather than using the short form seems to make it do the right thing.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
