### PR TITLE
Increase timeout of flaky wysiwyg composer test

### DIFF
--- a/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/EditWysiwygComposer-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/EditWysiwygComposer-test.tsx
@@ -55,7 +55,9 @@ describe("EditWysiwygComposer", () => {
     it("Should not render the component when not ready", async () => {
         // When
         const { rerender } = customRender(false);
-        await waitFor(() => expect(screen.getByRole("textbox")).toHaveAttribute("contentEditable", "true"));
+        await waitFor(() => expect(screen.getByRole("textbox")).toHaveAttribute("contentEditable", "true"), {
+            timeout: 2000,
+        });
 
         rerender(
             <MatrixClientContext.Provider value={mockClient}>


### PR DESCRIPTION
Closes https://github.com/element-hq/element-web/issues/31227

A timeout with the same value is used in a similar test which is not flaky:
https://github.com/element-hq/element-web/blob/5f92215ead9e10a304e95953d83f8f92fa2ccd3c/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/EditWysiwygComposer-test.tsx#L73-L85