### PR TITLE
PoC:Support for Sign in with QR with MSC4388 including on a new device

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -85,7 +85,7 @@
         "lodash": "npm:lodash-es@^4.17.21",
         "maplibre-gl": "^5.0.0",
         "matrix-encrypt-attachment": "^1.0.3",
-        "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#develop",
+        "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#hughns/msc4108-v2025-poc",
         "matrix-widget-api": "^1.16.1",
         "memoize-one": "^6.0.0",
         "mime": "^4.0.4",

--- a/apps/web/src/Lifecycle.ts
+++ b/apps/web/src/Lifecycle.ts
@@ -297,26 +297,16 @@ async function attemptOidcNativeLogin(queryParams: QueryDict): Promise<boolean> 
         const { accessToken, refreshToken, homeserverUrl, identityServerUrl, idToken, clientId, issuer } =
             await completeOidcLogin(queryParams);
 
-        const {
-            user_id: userId,
-            device_id: deviceId,
-            is_guest: isGuest,
-        } = await getUserIdFromAccessToken(accessToken, homeserverUrl, identityServerUrl);
-
-        const credentials = {
+        await configureFromCompletedOAuthLogin({
             accessToken,
             refreshToken,
             homeserverUrl,
             identityServerUrl,
-            deviceId,
-            userId,
-            isGuest,
-        };
+            clientId,
+            issuer,
+            idToken,
+        });
 
-        logger.debug("Logged in via OIDC native flow");
-        await onSuccessfulDelegatedAuthLogin(credentials);
-        // this needs to happen after success handler which clears storages
-        persistOidcAuthenticatedSettings(clientId, issuer, idToken);
         return true;
     } catch (error) {
         logger.error("Failed to login via OIDC", error);
@@ -324,6 +314,47 @@ async function attemptOidcNativeLogin(queryParams: QueryDict): Promise<boolean> 
         onFailedDelegatedAuthLogin(getOidcErrorMessage(error as Error));
         return false;
     }
+}
+
+export async function configureFromCompletedOAuthLogin({
+    accessToken,
+    refreshToken,
+    homeserverUrl,
+    identityServerUrl,
+    clientId,
+    issuer,
+    idToken,
+}: {
+    accessToken: string;
+    refreshToken?: string;
+    homeserverUrl: string;
+    identityServerUrl?: string;
+    clientId: string;
+    issuer: string;
+    idToken: string;
+}): Promise<IMatrixClientCreds> {
+    const {
+        user_id: userId,
+        device_id: deviceId,
+        is_guest: guest,
+    } = await getUserIdFromAccessToken(accessToken, homeserverUrl, identityServerUrl);
+
+    const credentials = {
+        accessToken,
+        refreshToken,
+        homeserverUrl,
+        identityServerUrl,
+        deviceId,
+        userId,
+        guest,
+    } satisfies IMatrixClientCreds;
+
+    logger.debug("Logged in via OIDC native flow");
+    await onSuccessfulDelegatedAuthLogin(credentials);
+    // this needs to happen after success handler which clears storages
+    persistOidcAuthenticatedSettings(clientId, issuer, idToken);
+
+    return credentials;
 }
 
 /**

--- a/apps/web/src/Login.ts
+++ b/apps/web/src/Login.ts
@@ -16,6 +16,9 @@ import {
     type LoginRequest,
     type OidcClientConfig,
     type ISSOFlow,
+    type ValidatedAuthMetadata,
+    type IServerVersions,
+    OAuthGrantType,
 } from "matrix-js-sdk/src/matrix";
 import { logger } from "matrix-js-sdk/src/logger";
 
@@ -31,7 +34,12 @@ import { isUserRegistrationSupported } from "./utils/oidc/isUserRegistrationSupp
  * LoginFlow type use the client API /login endpoint
  * OidcNativeFlow is specific to this client
  */
-export type ClientLoginFlow = LoginFlow | OidcNativeFlow;
+export type ClientLoginFlow = LoginFlow | OidcNativeFlow | LoginWithQrFlow;
+
+export interface LoginWithQrFlow {
+    type: "loginWithQrFlow";
+    clientId: string;
+}
 
 interface ILoginOptions {
     defaultDeviceDisplayName?: string;
@@ -116,7 +124,17 @@ export default class Login {
                     SdkConfig.get().oidc_static_clients,
                     isRegistration,
                 );
-                return [oidcFlow];
+
+                let possibleQrFlow: LoginWithQrFlow | undefined;
+                try {
+                    const versions = await this.createTemporaryClient().getVersions();
+                    // we reuse the clientId from the oidcFlow for QR login
+                    // it might be that we later find that the homeserver is different and we initialise a new client
+                    possibleQrFlow = tryInitLoginWithQRFlow(this.delegatedAuthentication, versions, oidcFlow.clientId);
+                } catch (e) {
+                    logger.warn("Could not fetch server versions for login with QR support, assuming unsupported", e);
+                }
+                return possibleQrFlow ? [possibleQrFlow, oidcFlow] : [oidcFlow];
             } catch (error) {
                 logger.error("Failed to get oidc native flow", error);
             }
@@ -288,3 +306,24 @@ export async function sendLoginRequest(
 
     return creds;
 }
+
+const tryInitLoginWithQRFlow = (
+    authMetadata: ValidatedAuthMetadata,
+    versions: IServerVersions,
+    clientId: string,
+): LoginWithQrFlow | undefined => {
+    const msc4388Supported = !!versions?.unstable_features?.["io.element.msc4388"];
+
+    const deviceAuthorizationGrantSupported = authMetadata?.grant_types_supported.includes(
+        OAuthGrantType.DeviceAuthorization,
+    );
+
+    if (!msc4388Supported || !deviceAuthorizationGrantSupported) return undefined;
+
+    const flow = {
+        type: "loginWithQrFlow",
+        clientId
+    } satisfies LoginWithQrFlow;
+
+    return flow;
+};

--- a/apps/web/src/Login.ts
+++ b/apps/web/src/Login.ts
@@ -16,10 +16,8 @@ import {
     type LoginRequest,
     type OidcClientConfig,
     type ISSOFlow,
-    type ValidatedAuthMetadata,
-    type IServerVersions,
-    OAuthGrantType,
 } from "matrix-js-sdk/src/matrix";
+import { isSignInWithQRAvailable } from "matrix-js-sdk/src/rendezvous";
 import { logger } from "matrix-js-sdk/src/logger";
 
 import { type IMatrixClientCreds } from "./MatrixClientPeg";
@@ -127,10 +125,11 @@ export default class Login {
 
                 let possibleQrFlow: LoginWithQrFlow | undefined;
                 try {
-                    const versions = await this.createTemporaryClient().getVersions();
+                    // TODO: this seems wasteful
+                    const tempClient = this.createTemporaryClient();
                     // we reuse the clientId from the oidcFlow for QR login
                     // it might be that we later find that the homeserver is different and we initialise a new client
-                    possibleQrFlow = tryInitLoginWithQRFlow(this.delegatedAuthentication, versions, oidcFlow.clientId);
+                    possibleQrFlow = await tryInitLoginWithQRFlow(tempClient,oidcFlow.clientId);
                 } catch (e) {
                     logger.warn("Could not fetch server versions for login with QR support, assuming unsupported", e);
                 }
@@ -307,18 +306,14 @@ export async function sendLoginRequest(
     return creds;
 }
 
-const tryInitLoginWithQRFlow = (
-    authMetadata: ValidatedAuthMetadata,
-    versions: IServerVersions,
+const tryInitLoginWithQRFlow = async (
+    tempClient: MatrixClient,
     clientId: string,
-): LoginWithQrFlow | undefined => {
-    const msc4388Supported = !!versions?.unstable_features?.["io.element.msc4388"];
+): Promise<LoginWithQrFlow | undefined> => {
+    // This could fail because the server doesn't support the API or it requires authentication
+    const canUseServer = await isSignInWithQRAvailable(tempClient);
 
-    const deviceAuthorizationGrantSupported = authMetadata?.grant_types_supported.includes(
-        OAuthGrantType.DeviceAuthorization,
-    );
-
-    if (!msc4388Supported || !deviceAuthorizationGrantSupported) return undefined;
+    if (!canUseServer) return undefined;
 
     const flow = {
         type: "loginWithQrFlow",

--- a/apps/web/src/Login.ts
+++ b/apps/web/src/Login.ts
@@ -129,7 +129,7 @@ export default class Login {
                     const tempClient = this.createTemporaryClient();
                     // we reuse the clientId from the oidcFlow for QR login
                     // it might be that we later find that the homeserver is different and we initialise a new client
-                    possibleQrFlow = await tryInitLoginWithQRFlow(tempClient,oidcFlow.clientId);
+                    possibleQrFlow = await tryInitLoginWithQRFlow(tempClient, oidcFlow.clientId);
                 } catch (e) {
                     logger.warn("Could not fetch server versions for login with QR support, assuming unsupported", e);
                 }
@@ -317,7 +317,7 @@ const tryInitLoginWithQRFlow = async (
 
     const flow = {
         type: "loginWithQrFlow",
-        clientId
+        clientId,
     } satisfies LoginWithQrFlow;
 
     return flow;

--- a/apps/web/src/components/structures/MatrixChat.tsx
+++ b/apps/web/src/components/structures/MatrixChat.tsx
@@ -2131,9 +2131,14 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
      * Note: SSO users (and any others using token login) currently do not pass through
      * this, as they instead jump straight into the app after `attemptTokenLogin`.
      */
-    private onUserCompletedLoginFlow = async (credentials: IMatrixClientCreds): Promise<void> => {
+    private onUserCompletedLoginFlow = async (
+        credentials: IMatrixClientCreds,
+        alreadySignedIn = false,
+    ): Promise<void> => {
         // Create and start the client
-        await Lifecycle.setLoggedIn(credentials);
+        if (!alreadySignedIn) {
+            await Lifecycle.setLoggedIn(credentials);
+        }
         await this.postLoginSetup();
 
         PerformanceMonitor.instance.stop(PerformanceEntryNames.LOGIN);

--- a/apps/web/src/components/structures/auth/Login.tsx
+++ b/apps/web/src/components/structures/auth/Login.tsx
@@ -15,7 +15,7 @@ import { QrCodeIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
 import { secureRandomString } from "matrix-js-sdk/src/randomstring";
 
 import { _t, UserFriendlyError } from "../../../languageHandler";
-import Login, { LoginWithQrFlow, type ClientLoginFlow, type OidcNativeFlow } from "../../../Login";
+import Login, { type LoginWithQrFlow, type ClientLoginFlow, type OidcNativeFlow } from "../../../Login";
 import { messageForConnectionError, messageForLoginError } from "../../../utils/ErrorUtils";
 import AutoDiscoveryUtils from "../../../utils/AutoDiscoveryUtils";
 import AuthPage from "../../views/auth/AuthPage";
@@ -37,7 +37,6 @@ import { startOidcLogin } from "../../../utils/oidc/authorize";
 import { ModuleApi } from "../../../modules/Api.ts";
 import LoginWithQR from "../../views/auth/LoginWithQR.tsx";
 import { Mode } from "../../views/auth/LoginWithQR-types.ts";
-import type LoginWithQRFlow from "../../views/auth/LoginWithQRFlow.tsx";
 import createMatrixClient from "../../../utils/createMatrixClient.ts";
 
 interface IProps {
@@ -464,7 +463,7 @@ class LoginComponent extends React.PureComponent<IProps, IState> {
                     );
                 }}
             >
-                {_t("action|continue")}
+                {_t("Sign in manually")}
             </Button>
         );
     };
@@ -500,11 +499,10 @@ class LoginComponent extends React.PureComponent<IProps, IState> {
     private renderLoginWithQRStep = (): JSX.Element => {
         return (
             <>
-                <p className="mx_Login_withQR_or">or</p>
-                <AccessibleButton className="mx_Login_withQR" kind="primary_outline" onClick={this.startLoginWithQR}>
+                <Button className="mx_Login_fullWidthButton" kind="primary" size="sm" onClick={this.startLoginWithQR}>
                     <QrCodeIcon />
                     {_t("Sign in with QR code")}
-                </AccessibleButton>
+                </Button>
             </>
         );
     };

--- a/apps/web/src/components/structures/auth/Login.tsx
+++ b/apps/web/src/components/structures/auth/Login.tsx
@@ -9,11 +9,13 @@ Please see LICENSE files in the repository root for full details.
 import React, { type JSX, memo, type ReactNode } from "react";
 import classNames from "classnames";
 import { logger } from "matrix-js-sdk/src/logger";
-import { type SSOFlow, SSOAction } from "matrix-js-sdk/src/matrix";
+import { type SSOFlow, type MatrixClient, SSOAction } from "matrix-js-sdk/src/matrix";
 import { Button } from "@vector-im/compound-web";
+import { QrCodeIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
+import { secureRandomString } from "matrix-js-sdk/src/randomstring";
 
 import { _t, UserFriendlyError } from "../../../languageHandler";
-import Login, { type ClientLoginFlow, type OidcNativeFlow } from "../../../Login";
+import Login, { LoginWithQrFlow, type ClientLoginFlow, type OidcNativeFlow } from "../../../Login";
 import { messageForConnectionError, messageForLoginError } from "../../../utils/ErrorUtils";
 import AutoDiscoveryUtils from "../../../utils/AutoDiscoveryUtils";
 import AuthPage from "../../views/auth/AuthPage";
@@ -33,6 +35,10 @@ import { type ValidatedServerConfig } from "../../../utils/ValidatedServerConfig
 import { filterBoolean } from "../../../utils/arrays";
 import { startOidcLogin } from "../../../utils/oidc/authorize";
 import { ModuleApi } from "../../../modules/Api.ts";
+import LoginWithQR from "../../views/auth/LoginWithQR.tsx";
+import { Mode } from "../../views/auth/LoginWithQR-types.ts";
+import type LoginWithQRFlow from "../../views/auth/LoginWithQRFlow.tsx";
+import createMatrixClient from "../../../utils/createMatrixClient.ts";
 
 interface IProps {
     serverConfig: ValidatedServerConfig;
@@ -51,7 +57,8 @@ interface IProps {
 
     // Called when the user has logged in. Params:
     // - The object returned by the login API
-    onLoggedIn(data: IMatrixClientCreds): void;
+    // - alreadySignedIn: true if the user was already signed in (e.g. QR login) and only the post login setup is needed
+    onLoggedIn(data: IMatrixClientCreds, alreadySignedIn?: boolean): void;
 
     // login shouldn't know or care how registration, password recovery, etc is done.
     onRegisterClick?(): void;
@@ -79,6 +86,9 @@ interface IState {
     serverIsAlive: boolean;
     serverErrorIsFatal: boolean;
     serverDeadError?: ReactNode;
+
+    loginWithQrInProgress: boolean;
+    loginWithQrClient?: MatrixClient;
 }
 
 type OnPasswordLogin = {
@@ -110,6 +120,8 @@ class LoginComponent extends React.PureComponent<IProps, IState> {
             serverIsAlive: true,
             serverErrorIsFatal: false,
             serverDeadError: "",
+
+            loginWithQrInProgress: false,
         };
 
         // map from login step type to a function which will render a control
@@ -123,6 +135,7 @@ class LoginComponent extends React.PureComponent<IProps, IState> {
             // eslint-disable-next-line @typescript-eslint/naming-convention
             "m.login.sso": () => this.renderSsoStep("sso"),
             "oidcNativeFlow": () => this.renderOidcNativeStep(),
+            "loginWithQrFlow": () => this.renderLoginWithQRStep(),
         };
     }
 
@@ -402,7 +415,7 @@ class LoginComponent extends React.PureComponent<IProps, IState> {
         if (!this.state.flows) return null;
 
         // this is the ideal order we want to show the flows in
-        const order = ["oidcNativeFlow", "m.login.password", "m.login.sso"];
+        const order = ["loginWithQrFlow", "oidcNativeFlow", "m.login.password", "m.login.sso"];
 
         const flows = filterBoolean(order.map((type) => this.state.flows?.find((flow) => flow.type === type)));
         return (
@@ -472,6 +485,43 @@ class LoginComponent extends React.PureComponent<IProps, IState> {
         );
     };
 
+    private startLoginWithQR = (): void => {
+        if (this.state.loginWithQrInProgress) return;
+        // pick our device ID
+        const deviceId = secureRandomString(10);
+        const loginWithQrClient = createMatrixClient({
+            baseUrl: this.loginLogic.getHomeserverUrl(),
+            idBaseUrl: this.loginLogic.getIdentityServerUrl(),
+            deviceId,
+        });
+        this.setState({ loginWithQrInProgress: true, loginWithQrClient });
+    };
+
+    private renderLoginWithQRStep = (): JSX.Element => {
+        return (
+            <>
+                <p className="mx_Login_withQR_or">or</p>
+                <AccessibleButton className="mx_Login_withQR" kind="primary_outline" onClick={this.startLoginWithQR}>
+                    <QrCodeIcon />
+                    {_t("Sign in with QR code")}
+                </AccessibleButton>
+            </>
+        );
+    };
+
+    private onLoginWithQRFinished = (success: boolean, credentials?: IMatrixClientCreds): void => {
+        if (credentials) {
+            this.props.onLoggedIn(credentials, true);
+        } else if (!success) {
+            this.state.loginWithQrClient?.stopClient();
+            this.setState({ loginWithQrInProgress: false, loginWithQrClient: undefined });
+        }
+    };
+
+    private get qrClientId(): string {
+        return (this.state.flows?.find((flow) => flow.type === "loginWithQrFlow") as LoginWithQrFlow).clientId ?? "";
+    }
+
     public render(): React.ReactNode {
         const loader =
             this.isBusy() && !this.state.busyLoggingIn ? (
@@ -532,20 +582,34 @@ class LoginComponent extends React.PureComponent<IProps, IState> {
             <AuthPage>
                 <AuthHeader disableLanguageSelector={this.props.isSyncing || this.state.busyLoggingIn} />
                 <AuthBody>
-                    <h1>
-                        {_t("action|sign_in")}
-                        {loader}
-                    </h1>
-                    {errorTextSection}
-                    {serverDeadSection}
-                    <ServerPicker
-                        serverConfig={this.props.serverConfig}
-                        onServerConfigChange={this.props.onServerConfigChange}
-                        disabled={this.isBusy()}
-                    />
-                    {this.renderLoginComponentForFlows()}
-                    {this.props.children}
-                    {footer}
+                    {this.state.loginWithQrInProgress ? (
+                        <>
+                            <LoginWithQR
+                                onFinished={this.onLoginWithQRFinished}
+                                mode={Mode.Show}
+                                client={this.state.loginWithQrClient!}
+                                clientId={this.qrClientId}
+                            />
+                        </>
+                    ) : (
+                        <>
+                            {" "}
+                            <h1>
+                                {_t("action|sign_in")}
+                                {loader}
+                            </h1>
+                            {errorTextSection}
+                            {serverDeadSection}
+                            <ServerPicker
+                                serverConfig={this.props.serverConfig}
+                                onServerConfigChange={this.props.onServerConfigChange}
+                                disabled={this.isBusy()}
+                            />
+                            {this.renderLoginComponentForFlows()}
+                            {this.props.children}
+                            {footer}
+                        </>
+                    )}
                 </AuthBody>
             </AuthPage>
         );

--- a/apps/web/src/components/views/auth/LoginWithQR.tsx
+++ b/apps/web/src/components/views/auth/LoginWithQR.tsx
@@ -73,7 +73,9 @@ export default class LoginWithQR extends React.Component<IProps, IState> {
     }
 
     private get ourIntent(): RendezvousIntent {
-        return this.props.client.getUserId() ? RendezvousIntent.RECIPROCATE_LOGIN_ON_EXISTING_DEVICE : RendezvousIntent.LOGIN_ON_NEW_DEVICE;
+        return this.props.client.getUserId()
+            ? RendezvousIntent.RECIPROCATE_LOGIN_ON_EXISTING_DEVICE
+            : RendezvousIntent.LOGIN_ON_NEW_DEVICE;
     }
 
     public componentDidMount(): void {
@@ -119,7 +121,10 @@ export default class LoginWithQR extends React.Component<IProps, IState> {
 
             if (msc4388) {
                 // use helper methods for 2025 version
-                rendezvous = this.ourIntent === RendezvousIntent.LOGIN_ON_NEW_DEVICE ? await signInByGeneratingQR(this.props.client, this.onFailure) : await linkNewDeviceByGeneratingQR(this.props.client, this.onFailure);
+                rendezvous =
+                    this.ourIntent === RendezvousIntent.LOGIN_ON_NEW_DEVICE
+                        ? await signInByGeneratingQR(this.props.client, this.onFailure)
+                        : await linkNewDeviceByGeneratingQR(this.props.client, this.onFailure);
             } else {
                 // old way for 2024 version
                 const transport = new MSC4108RendezvousSession({
@@ -161,7 +166,6 @@ export default class LoginWithQR extends React.Component<IProps, IState> {
                     phase: Phase.OutOfBandConfirmation,
                     homeserverBaseUrl: baseUrl,
                 });
-
             }
 
             // we ask the user to confirm that the channel is secure
@@ -210,10 +214,14 @@ export default class LoginWithQR extends React.Component<IProps, IState> {
                     throw new Error("Homeserver base URL not found in state");
                 }
 
-                if (new URL(this.props.client.baseUrl).toString() !== new URL(this.state.homeserverBaseUrl).toString()) {
+                if (
+                    new URL(this.props.client.baseUrl).toString() !== new URL(this.state.homeserverBaseUrl).toString()
+                ) {
                     // would need to switch homeservers
                     this.setState({ phase: Phase.Error, failureReason: ClientRendezvousFailureReason.Unknown });
-                    logger.info(`Changing homeservers during new device login not yet supported: ${this.props.client.baseUrl} -> ${this.state.homeserverBaseUrl}`);
+                    logger.info(
+                        `Changing homeservers during new device login not yet supported: ${this.props.client.baseUrl} -> ${this.state.homeserverBaseUrl}`,
+                    );
                     throw new Error("Changing homeservers during new device login not yet supported");
                 }
 
@@ -239,7 +247,7 @@ export default class LoginWithQR extends React.Component<IProps, IState> {
                         refreshToken: datr.refresh_token,
                         homeserverUrl: this.state.homeserverBaseUrl,
                         clientId: this.props.clientId,
-                        idToken: datr.id_token ?? '', // I'm not sure the idToken is actually required
+                        idToken: datr.id_token ?? "", // I'm not sure the idToken is actually required
                         issuer: metadata!.issuer,
                         identityServerUrl: undefined, // PROTOTYPE: we should have stored this from before
                     });

--- a/apps/web/src/components/views/auth/LoginWithQR.tsx
+++ b/apps/web/src/components/views/auth/LoginWithQR.tsx
@@ -13,30 +13,38 @@ import {
     MSC4108RendezvousSession,
     MSC4108SecureChannel,
     MSC4108SignInWithQR,
+    MSC4108v2025SignInWithQR,
     RendezvousError,
     type RendezvousFailureReason,
     RendezvousIntent,
+    signInByGeneratingQR,
+    linkNewDeviceByGeneratingQR,
 } from "matrix-js-sdk/src/rendezvous";
 import { logger } from "matrix-js-sdk/src/logger";
 import { type MatrixClient } from "matrix-js-sdk/src/matrix";
 
 import { Click, Mode, Phase } from "./LoginWithQR-types";
 import LoginWithQRFlow from "./LoginWithQRFlow";
+import { MatrixClientPeg, type IMatrixClientCreds } from "../../../MatrixClientPeg";
+import { configureFromCompletedOAuthLogin, restoreSessionFromStorage } from "../../../Lifecycle";
 
 interface IProps {
     client: MatrixClient;
+    clientId: string;
     mode: Mode;
-    onFinished(...args: any): void;
+    onFinished(success: boolean, credentials?: IMatrixClientCreds): void;
 }
 
 interface IState {
     phase: Phase;
-    rendezvous?: MSC4108SignInWithQR;
+    rendezvous?: MSC4108SignInWithQR | MSC4108v2025SignInWithQR;
     mediaPermissionError?: boolean;
     verificationUri?: string;
     userCode?: string;
     checkCode?: string;
     failureReason?: FailureReason;
+    homeserverBaseUrl?: string;
+    newClient?: MatrixClient;
 }
 
 export enum LoginWithQRFailureReason {
@@ -65,7 +73,7 @@ export default class LoginWithQR extends React.Component<IProps, IState> {
     }
 
     private get ourIntent(): RendezvousIntent {
-        return RendezvousIntent.RECIPROCATE_LOGIN_ON_EXISTING_DEVICE;
+        return this.props.client.getUserId() ? RendezvousIntent.RECIPROCATE_LOGIN_ON_EXISTING_DEVICE : RendezvousIntent.LOGIN_ON_NEW_DEVICE;
     }
 
     public componentDidMount(): void {
@@ -99,23 +107,31 @@ export default class LoginWithQR extends React.Component<IProps, IState> {
         }
     }
 
-    private onFinished(success: boolean): void {
+    private onFinished(success: boolean, credentials?: IMatrixClientCreds): void {
         this.finished = true;
-        this.props.onFinished(success);
+        this.props.onFinished(success, credentials);
     }
 
     private generateAndShowCode = async (): Promise<void> => {
-        let rendezvous: MSC4108SignInWithQR;
+        let rendezvous: MSC4108SignInWithQR | MSC4108v2025SignInWithQR;
         try {
-            const transport = new MSC4108RendezvousSession({
-                onFailure: this.onFailure,
-                client: this.props.client,
-            });
-            await transport.send("");
-            const channel = new MSC4108SecureChannel(transport, undefined, this.onFailure);
-            rendezvous = new MSC4108SignInWithQR(channel, false, this.props.client, this.onFailure);
+            const msc4388 = true;
 
-            await rendezvous.generateCode();
+            if (msc4388) {
+                // use helper methods for 2025 version
+                rendezvous = this.ourIntent === RendezvousIntent.LOGIN_ON_NEW_DEVICE ? await signInByGeneratingQR(this.props.client, this.onFailure) : await linkNewDeviceByGeneratingQR(this.props.client, this.onFailure);
+            } else {
+                // old way for 2024 version
+                const transport = new MSC4108RendezvousSession({
+                    onFailure: this.onFailure,
+                    client: this.props.client,
+                });
+                await transport.send("");
+                const channel = new MSC4108SecureChannel(transport, undefined, this.onFailure);
+                rendezvous = new MSC4108SignInWithQR(channel, false, this.props.client, this.onFailure);
+
+                await rendezvous.generateCode();
+            }
             this.setState({
                 phase: Phase.ShowingQR,
                 rendezvous,
@@ -136,6 +152,16 @@ export default class LoginWithQR extends React.Component<IProps, IState> {
                     phase: Phase.OutOfBandConfirmation,
                     verificationUri,
                 });
+            } else {
+                if (!(rendezvous instanceof MSC4108v2025SignInWithQR)) {
+                    throw new Error("Sign in on new device using QR is not implemented for 2024 version of MSC4108");
+                }
+                const { baseUrl } = await rendezvous.negotiateProtocols();
+                this.setState({
+                    phase: Phase.OutOfBandConfirmation,
+                    homeserverBaseUrl: baseUrl,
+                });
+
             }
 
             // we ask the user to confirm that the channel is secure
@@ -148,7 +174,7 @@ export default class LoginWithQR extends React.Component<IProps, IState> {
     };
 
     private approveLogin = async (checkCode: string | undefined): Promise<void> => {
-        if (!(this.state.rendezvous instanceof MSC4108SignInWithQR)) {
+        if (!this.state.rendezvous) {
             this.setState({ phase: Phase.Error, failureReason: ClientRendezvousFailureReason.Unknown });
             throw new Error("Rendezvous not found");
         }
@@ -175,8 +201,73 @@ export default class LoginWithQR extends React.Component<IProps, IState> {
                 // done
                 this.onFinished(true);
             } else {
-                this.setState({ phase: Phase.Error, failureReason: ClientRendezvousFailureReason.Unknown });
-                throw new Error("New device flows around OIDC are not yet implemented");
+                if (!(this.state.rendezvous instanceof MSC4108v2025SignInWithQR)) {
+                    throw new Error("Sign in on new device using QR is not implemented for 2024 version of MSC4108");
+                }
+
+                if (!this.state.homeserverBaseUrl) {
+                    this.setState({ phase: Phase.Error, failureReason: ClientRendezvousFailureReason.Unknown });
+                    throw new Error("Homeserver base URL not found in state");
+                }
+
+                if (new URL(this.props.client.baseUrl).toString() !== new URL(this.state.homeserverBaseUrl).toString()) {
+                    // would need to switch homeservers
+                    this.setState({ phase: Phase.Error, failureReason: ClientRendezvousFailureReason.Unknown });
+                    logger.info(`Changing homeservers during new device login not yet supported: ${this.props.client.baseUrl} -> ${this.state.homeserverBaseUrl}`);
+                    throw new Error("Changing homeservers during new device login not yet supported");
+                }
+
+                const metadata = await this.props.client.getAuthMetadata();
+                const deviceId = this.props.client.getDeviceId()!;
+                const { userCode } = await this.state.rendezvous.deviceAuthorizationGrant({
+                    metadata,
+                    clientId: this.props.clientId,
+                    deviceId,
+                });
+                this.setState({ phase: Phase.WaitingForDevice, userCode });
+
+                const datr = await this.state.rendezvous.completeLoginOnNewDevice({
+                    clientId: this.props.clientId,
+                });
+
+                if (datr) {
+                    // TODO: this is not the right way to do this
+
+                    // store and use the new credentials
+                    const credentials = await configureFromCompletedOAuthLogin({
+                        accessToken: datr.access_token,
+                        refreshToken: datr.refresh_token,
+                        homeserverUrl: this.state.homeserverBaseUrl,
+                        clientId: this.props.clientId,
+                        idToken: datr.id_token ?? '', // I'm not sure the idToken is actually required
+                        issuer: metadata!.issuer,
+                        identityServerUrl: undefined, // PROTOTYPE: we should have stored this from before
+                    });
+
+                    const { secrets } = await this.state.rendezvous.shareSecrets();
+
+                    await restoreSessionFromStorage();
+
+                    if (secrets) {
+                        const crypto = MatrixClientPeg.safeGet().getCrypto();
+                        if (crypto) {
+                            await crypto.importSecretsBundle?.(secrets);
+                            // it should be sufficient to just upload the device keys with the signature
+                            // but this seems to do the job for now
+                            await crypto.crossSignDevice(deviceId);
+                        } else {
+                            logger.warn("Crypto not initialised");
+                        }
+                    } else {
+                        logger.warn("No secrets received from QR login");
+                    }
+
+                    // PROTOTYPE: fudge to try and allow the self verification to complete before we change screen
+                    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+                    // done
+                    this.onFinished(true, credentials);
+                }
             }
         } catch (e: RendezvousError | unknown) {
             logger.error("Error whilst approving sign in", e);

--- a/apps/web/src/components/views/auth/LoginWithQR.tsx
+++ b/apps/web/src/components/views/auth/LoginWithQR.tsx
@@ -258,20 +258,20 @@ export default class LoginWithQR extends React.Component<IProps, IState> {
 
                     if (secrets) {
                         const crypto = MatrixClientPeg.safeGet().getCrypto();
-                        if (crypto) {
-                            await crypto.importSecretsBundle?.(secrets);
+                        if (crypto?.importSecretsBundle) {
+                            await crypto.importSecretsBundle(secrets);
                             // it should be sufficient to just upload the device keys with the signature
                             // but this seems to do the job for now
                             await crypto.crossSignDevice(deviceId);
+
+                            // PROTOTYPE: this is a fudge to bypass the complete security step
+                            window.location.reload();
                         } else {
-                            logger.warn("Crypto not initialised");
+                            logger.warn("Crypto not initialised or no importSecretsBundle() method, cannot import secrets from QR login");
                         }
                     } else {
                         logger.warn("No secrets received from QR login");
                     }
-
-                    // PROTOTYPE: fudge to try and allow the self verification to complete before we change screen
-                    await new Promise((resolve) => setTimeout(resolve, 1000));
 
                     // done
                     this.onFinished(true, credentials);

--- a/apps/web/src/components/views/settings/devices/LoginWithQRSection.tsx
+++ b/apps/web/src/components/views/settings/devices/LoginWithQRSection.tsx
@@ -11,7 +11,7 @@ import {
     type IServerVersions,
     type OidcClientConfig,
     type MatrixClient,
-    DEVICE_CODE_SCOPE,
+    OAuthGrantType,
 } from "matrix-js-sdk/src/matrix";
 import QrCodeIcon from "@vector-im/compound-design-tokens/assets/web/icons/qr-code";
 import { Text } from "@vector-im/compound-web";
@@ -28,19 +28,24 @@ interface IProps {
     isCrossSigningReady?: boolean;
 }
 
-export function shouldShowQr(
+export function shouldShowQrForLinkNewDevice(
     cli: MatrixClient,
     isCrossSigningReady: boolean,
     oidcClientConfig?: OidcClientConfig,
     versions?: IServerVersions,
 ): boolean {
+    // support MSC4108 v2024
     const msc4108Supported = !!versions?.unstable_features?.["org.matrix.msc4108"];
+    // and MSC4108 v2025 which uses MSC4388
+    const msc4388Supported = !!versions?.unstable_features?.["io.element.msc4388"];
 
-    const deviceAuthorizationGrantSupported = oidcClientConfig?.grant_types_supported.includes(DEVICE_CODE_SCOPE);
+    const deviceAuthorizationGrantSupported = oidcClientConfig?.grant_types_supported.includes(
+        OAuthGrantType.DeviceAuthorization,
+    );
 
     return (
         !!deviceAuthorizationGrantSupported &&
-        msc4108Supported &&
+        (msc4388Supported || msc4108Supported) &&
         !!cli.getCrypto()?.exportSecretsBundle &&
         isCrossSigningReady
     );
@@ -48,7 +53,7 @@ export function shouldShowQr(
 
 const LoginWithQRSection: React.FC<IProps> = ({ onShowQr, versions, oidcClientConfig, isCrossSigningReady }) => {
     const cli = useMatrixClientContext();
-    const offerShowQr = shouldShowQr(cli, !!isCrossSigningReady, oidcClientConfig, versions);
+    const offerShowQr = shouldShowQrForLinkNewDevice(cli, !!isCrossSigningReady, oidcClientConfig, versions);
 
     return (
         <SettingsSubsection heading={_t("settings|sessions|sign_in_with_qr")}>

--- a/apps/web/src/components/views/settings/devices/LoginWithQRSection.tsx
+++ b/apps/web/src/components/views/settings/devices/LoginWithQRSection.tsx
@@ -13,6 +13,7 @@ import {
     type MatrixClient,
     OAuthGrantType,
 } from "matrix-js-sdk/src/matrix";
+import { isSignInWithQRAvailable } from "matrix-js-sdk/src/rendezvous";
 import QrCodeIcon from "@vector-im/compound-design-tokens/assets/web/icons/qr-code";
 import { Text } from "@vector-im/compound-web";
 
@@ -20,6 +21,7 @@ import { _t } from "../../../../languageHandler";
 import AccessibleButton from "../../elements/AccessibleButton";
 import { SettingsSubsection } from "../shared/SettingsSubsection";
 import { useMatrixClientContext } from "../../../../contexts/MatrixClientContext";
+import { useAsyncMemo } from "../../../../hooks/useAsyncMemo";
 
 interface IProps {
     onShowQr: () => void;
@@ -28,16 +30,17 @@ interface IProps {
     isCrossSigningReady?: boolean;
 }
 
-export function shouldShowQrForLinkNewDevice(
+export async function shouldShowQrForLinkNewDevice(
     cli: MatrixClient,
     isCrossSigningReady: boolean,
     oidcClientConfig?: OidcClientConfig,
     versions?: IServerVersions,
-): boolean {
+): Promise<boolean> {
+    // support MSC4108 v2025 which uses MSC4388
+    const msc4108v2025Available = await isSignInWithQRAvailable(cli);
+
     // support MSC4108 v2024
     const msc4108Supported = !!versions?.unstable_features?.["org.matrix.msc4108"];
-    // and MSC4108 v2025 which uses MSC4388
-    const msc4388Supported = !!versions?.unstable_features?.["io.element.msc4388"];
 
     const deviceAuthorizationGrantSupported = oidcClientConfig?.grant_types_supported.includes(
         OAuthGrantType.DeviceAuthorization,
@@ -45,7 +48,7 @@ export function shouldShowQrForLinkNewDevice(
 
     return (
         !!deviceAuthorizationGrantSupported &&
-        (msc4388Supported || msc4108Supported) &&
+        (msc4108Supported || msc4108v2025Available) &&
         !!cli.getCrypto()?.exportSecretsBundle &&
         isCrossSigningReady
     );
@@ -53,7 +56,11 @@ export function shouldShowQrForLinkNewDevice(
 
 const LoginWithQRSection: React.FC<IProps> = ({ onShowQr, versions, oidcClientConfig, isCrossSigningReady }) => {
     const cli = useMatrixClientContext();
-    const offerShowQr = shouldShowQrForLinkNewDevice(cli, !!isCrossSigningReady, oidcClientConfig, versions);
+    const offerShowQr = useAsyncMemo(
+        () => shouldShowQrForLinkNewDevice(cli, !!isCrossSigningReady, oidcClientConfig, versions),
+        [cli, isCrossSigningReady, oidcClientConfig, versions],
+        false,
+    );
 
     return (
         <SettingsSubsection heading={_t("settings|sessions|sign_in_with_qr")}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,8 +289,8 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       matrix-js-sdk:
-        specifier: github:matrix-org/matrix-js-sdk#develop
-        version: https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/219eb617dc6d5f48c9424eae38b9863fd177f99c
+        specifier: github:matrix-org/matrix-js-sdk#hughns/msc4108-v2025-poc
+        version: https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/572c5de5b2d2da9798b2a765a0ad9170928e9d8b
       matrix-widget-api:
         specifier: ^1.17.0
         version: 1.17.0
@@ -2669,8 +2669,9 @@ packages:
   '@matrix-org/emojibase-bindings@1.5.0':
     resolution: {integrity: sha512-+W9/ow2Z3iQa7ZOF698PBhwNcgGkn36B5Sr8VDPx8N8CH7+Uw+7TrtbtKPZVdgf4m/THmgmfX40jS5YDBsLaYg==}
 
-  '@matrix-org/matrix-sdk-crypto-wasm@17.1.0':
-    resolution: {integrity: sha512-yKPqBvKlHSqkt/UJh+Z+zLKQP8bd19OxokXYXh3VkKbW0+C44nPHsidSwd3SH+RxT+Ck2PDRwVcVXEnUft+/2g==}
+  '@matrix-org/matrix-sdk-crypto-wasm@https://codeload.github.com/matrix-org/matrix-sdk-crypto-wasm/tar.gz/04d0abc6f89982612bd87b36b5efba178478dd72':
+    resolution: {tarball: https://codeload.github.com/matrix-org/matrix-sdk-crypto-wasm/tar.gz/04d0abc6f89982612bd87b36b5efba178478dd72}
+    version: 18.0.0
     engines: {node: '>= 18'}
 
   '@matrix-org/react-sdk-module-api@2.5.0':
@@ -7819,8 +7820,8 @@ packages:
   matrix-events-sdk@0.0.1:
     resolution: {integrity: sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==}
 
-  matrix-js-sdk@https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/219eb617dc6d5f48c9424eae38b9863fd177f99c:
-    resolution: {tarball: https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/219eb617dc6d5f48c9424eae38b9863fd177f99c}
+  matrix-js-sdk@https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/572c5de5b2d2da9798b2a765a0ad9170928e9d8b:
+    resolution: {tarball: https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/572c5de5b2d2da9798b2a765a0ad9170928e9d8b}
     version: 41.1.0
     engines: {node: '>=22.0.0'}
 
@@ -12712,7 +12713,7 @@ snapshots:
       emojibase: 17.0.0
       emojibase-data: 17.0.0(emojibase@17.0.0)
 
-  '@matrix-org/matrix-sdk-crypto-wasm@17.1.0': {}
+  '@matrix-org/matrix-sdk-crypto-wasm@https://codeload.github.com/matrix-org/matrix-sdk-crypto-wasm/tar.gz/04d0abc6f89982612bd87b36b5efba178478dd72': {}
 
   '@matrix-org/react-sdk-module-api@2.5.0(patch_hash=016146c9cc96e6363609d2b2ac0896ccef567882eb1d73b75a77b8a30929de96)(react@19.2.4)':
     dependencies:
@@ -18712,10 +18713,10 @@ snapshots:
 
   matrix-events-sdk@0.0.1: {}
 
-  matrix-js-sdk@https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/219eb617dc6d5f48c9424eae38b9863fd177f99c:
+  matrix-js-sdk@https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/572c5de5b2d2da9798b2a765a0ad9170928e9d8b:
     dependencies:
       '@babel/runtime': 7.28.6
-      '@matrix-org/matrix-sdk-crypto-wasm': 17.1.0
+      '@matrix-org/matrix-sdk-crypto-wasm': https://codeload.github.com/matrix-org/matrix-sdk-crypto-wasm/tar.gz/04d0abc6f89982612bd87b36b5efba178478dd72
       another-json: 0.2.0
       bs58: 6.0.0
       content-type: 1.0.5


### PR DESCRIPTION
Uses https://github.com/matrix-org/matrix-js-sdk/pull/5219

This is a implementation of the 2025 version of MSC4108 to support the MSC.

Features:

- it supports generating and showing a QR on an existing Element Web
- it supports generating and showing a QR to sign in on a new Element Web

Notes for when implementing production code:

- the lifecycle changes are probably not sensible
- the crypto integration is messy
- no tests

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
