### PR TITLE
Fix "key storage out of sync" appearing when key storage is actually fine

### DIFF
--- a/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
+++ b/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
@@ -94,6 +94,7 @@ export class DeviceListenerCurrentDevice {
         this.client.on(CryptoEvent.UserTrustStatusChanged, this.onUserTrustStatusChanged);
         this.client.on(CryptoEvent.KeysChanged, this.onCrossSigningKeysChanged);
         this.client.on(CryptoEvent.KeyBackupStatus, this.onKeyBackupStatusChanged);
+        this.client.on(CryptoEvent.KeyBackupDecryptionKeyCached, this.onKeyBackupDecryptionKeyCached);
         this.client.on(ClientEvent.AccountData, this.onAccountData);
         this.client.on(ClientEvent.Sync, this.onSync);
         this.client.on(RoomStateEvent.Events, this.onRoomStateEvents);
@@ -112,6 +113,7 @@ export class DeviceListenerCurrentDevice {
         this.client.removeListener(CryptoEvent.UserTrustStatusChanged, this.onUserTrustStatusChanged);
         this.client.removeListener(CryptoEvent.KeysChanged, this.onCrossSigningKeysChanged);
         this.client.removeListener(CryptoEvent.KeyBackupStatus, this.onKeyBackupStatusChanged);
+        this.client.removeListener(CryptoEvent.KeyBackupDecryptionKeyCached, this.onKeyBackupDecryptionKeyCached);
         this.client.removeListener(ClientEvent.AccountData, this.onAccountData);
         this.client.removeListener(ClientEvent.Sync, this.onSync);
         this.client.removeListener(RoomStateEvent.Events, this.onRoomStateEvents);
@@ -305,6 +307,12 @@ export class DeviceListenerCurrentDevice {
 
     private onKeyBackupStatusChanged = (): void => {
         this.logger.info("Backup status changed");
+        this.cachedKeyBackupUploadActive = undefined;
+        this.deviceListener.recheck();
+    };
+
+    private onKeyBackupDecryptionKeyCached = (): void => {
+        this.logger.info("Backup decryption key cached");
         this.cachedKeyBackupUploadActive = undefined;
         this.deviceListener.recheck();
     };

--- a/apps/web/test/unit-tests/DeviceListener-test.ts
+++ b/apps/web/test/unit-tests/DeviceListener-test.ts
@@ -161,6 +161,28 @@ describe("DeviceListener", () => {
             expect(unwatchSettingSpy).toHaveBeenCalled();
         });
 
+        it("responds to KeyBackupDecryptionKeyCached events", async () => {
+            // Given a Device Listener
+            const recheck = jest.fn();
+            const deviceListener = await createAndStart();
+            deviceListener.recheck = recheck;
+
+            // When a KeyBackupDecryptionKeyCached event happens
+            mockClient.emit(CryptoEvent.KeyBackupDecryptionKeyCached, "3");
+
+            // Then we rechecked the device information
+            expect(recheck).toHaveBeenCalled();
+
+            // And when we stop our device listener
+            const removeListener = jest.fn(() => {});
+            // @ts-ignore overwriting with a mock
+            mockClient.removeListener = removeListener;
+            deviceListener.stop();
+
+            // Then it should stop listening
+            expect(removeListener).toHaveBeenCalledWith(CryptoEvent.KeyBackupDecryptionKeyCached, expect.any(Function));
+        });
+
         describe("when device client information feature is enabled", () => {
             beforeEach(() => {
                 jest.spyOn(SettingsStore, "getValue").mockImplementation(


### PR DESCRIPTION
Make the DeviceListener listen to KeyBackupDecryptionKeyCached events.

Fixes #31916

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
