### PR TITLE
Change 'Verify' to 'Continue' in verify this device toast

### DIFF
--- a/apps/web/src/toasts/SetupEncryptionToast.tsx
+++ b/apps/web/src/toasts/SetupEncryptionToast.tsx
@@ -84,7 +84,7 @@ const getSetupCaption = (state: DeviceStateForToast): string => {
         case "set_up_recovery":
             return _t("action|continue");
         case "verify_this_session":
-            return _t("action|verify");
+            return _t("action|continue");
         case "key_storage_out_of_sync":
             return _t("encryption|enter_recovery_key");
         case "turn_on_key_storage":

--- a/apps/web/test/unit-tests/toasts/SetupEncryptionToast-test.tsx
+++ b/apps/web/test/unit-tests/toasts/SetupEncryptionToast-test.tsx
@@ -340,7 +340,7 @@ describe("SetupEncryptionToast", () => {
 
             await expect(screen.findByText("Verify this session")).resolves.toBeInTheDocument();
             await expect(screen.findByRole("button", { name: "Later" })).resolves.toBeInTheDocument();
-            await expect(screen.findByRole("button", { name: "Verify" })).resolves.toBeInTheDocument();
+            await expect(screen.findByRole("button", { name: "Continue" })).resolves.toBeInTheDocument();
         });
 
         it("should dismiss the toast when 'Later' button clicked, and remember it", async () => {
@@ -354,14 +354,14 @@ describe("SetupEncryptionToast", () => {
             expect(DeviceListener.sharedInstance().dismissEncryptionSetup).toHaveBeenCalled();
         });
 
-        it("should open the verification dialog when 'Verify' clicked", async () => {
+        it("should open the verification dialog when 'Continue' clicked", async () => {
             jest.spyOn(Modal, "createDialog");
 
             // When we show the toast, and click Verify
             act(() => showToast("verify_this_session"));
 
             const user = userEvent.setup();
-            await user.click(await screen.findByRole("button", { name: "Verify" }));
+            await user.click(await screen.findByRole("button", { name: "Continue" }));
 
             // Then the dialog was opened
             expect(Modal.createDialog).toHaveBeenCalledWith(SetupEncryptionDialog, {}, undefined, false, true);


### PR DESCRIPTION
Wording changes for https://github.com/element-hq/crypto-internal/issues/305 . Most of the wording changes were done in localazy, but this one required a small code change: "Verify" -> "Continue".

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
