### PR TITLE
Fix warning in shared components build

### DIFF
--- a/packages/shared-components/vite.config.ts
+++ b/packages/shared-components/vite.config.ts
@@ -38,6 +38,9 @@ export default defineConfig({
                 globals: {
                     "react": "react",
                     "react-dom": "ReactDom",
+                    "@vector-im/compound-design-tokens": "compoundDesignTokens",
+                    "@vector-im/compound-web": "compoundWeb",
+                    "react-virtuoso": "reactVirtuoso",
                 },
             },
         },


### PR DESCRIPTION
Add missing export in globals:

No name was provided for external module "@vector-im/compound-web" in "output.globals" – guessing "compoundWeb".
No name was provided for external module "react-virtuoso" in "output.globals" – guessing "reactVirtuoso".