### PR TITLE
Strip ephemeral query params from OIDC redirect URI

### DIFF
--- a/apps/web/src/BasePlatform.ts
+++ b/apps/web/src/BasePlatform.ts
@@ -466,10 +466,9 @@ export default abstract class BasePlatform {
      * The URL to return to after a successful OIDC authentication
      */
     public getOidcCallbackUrl(): URL {
-        const url = new URL(window.location.href);
         // The redirect URL has to exactly match that registered at the OIDC server, so
-        // ensure that the fragment part of the URL is empty.
-        url.hash = "";
+        // build it from scratch to avoid leaking ephemeral query params (e.g. `updated`).
+        const url = new URL(window.location.origin + window.location.pathname);
         // Set no_universal_links=true to prevent the callback being handled by Element X installed on macOS Apple Silicon
         url.searchParams.set("no_universal_links", "true");
         return url;

--- a/apps/web/test/unit-tests/vector/platform/WebPlatform-test.ts
+++ b/apps/web/test/unit-tests/vector/platform/WebPlatform-test.ts
@@ -264,4 +264,22 @@ describe("WebPlatform", () => {
         platform.setErrorStatus(true);
         expect(spy).toHaveBeenCalledWith(expect.anything(), { bgColor: "#f00" });
     });
+
+    describe("getOidcCallbackUrl()", () => {
+        it("should not include the 'updated' query param in the redirect URI", () => {
+            Object.defineProperty(window, "location", {
+                value: {
+                    href: "https://element.example.com/?updated=1.12.12",
+                    origin: "https://element.example.com",
+                    pathname: "/",
+                },
+                writable: true,
+            });
+            const platform = new WebPlatform();
+            const url = platform.getOidcCallbackUrl();
+
+            expect(url.searchParams.has("updated")).toBe(false);
+            expect(url.searchParams.get("no_universal_links")).toEqual("true");
+        });
+    });
 });


### PR DESCRIPTION
`getOidcCallbackUrl` was building the OIDC redirect_uri from `window.location.href`, which may contain ephemeral params such as `updated` (appended on auto-update of element-web). This caused a redirect_uri mismatch on authorization servers.

Fixes https://github.com/element-hq/element-web/issues/32874

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
