### PR TITLE
Fix vite-dts throwing type error on build

### DIFF
--- a/packages/shared-components/tsconfig.json
+++ b/packages/shared-components/tsconfig.json
@@ -14,7 +14,7 @@
         "declaration": true,
         "jsx": "react",
         "lib": ["es2022", "es2024.promise", "dom", "dom.iterable"],
-        "types": [],
+        "types": ["storybook-addon-vis/matcher"],
         "strict": true,
         "paths": {
             "@test-utils": ["./src/test/utils/index"]


### PR DESCRIPTION
Fixes the following error that is thrown on build:
`src/resize/separator/SeparatorView.stories.tsx:117:37 - error TS2339: Property 'toMatchImageSnapshot' does not exist on type 'Assertion<HTMLElement>'.`

Based on https://www.npmjs.com/package/@lewiswright/storybook-addon-vis#typescript-configuration