### PR TITLE
Give a global variable name for react-resizable-panels

### DIFF
--- a/packages/shared-components/vite.config.ts
+++ b/packages/shared-components/vite.config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
                     "@vector-im/compound-design-tokens": "compoundDesignTokens",
                     "@vector-im/compound-web": "compoundWeb",
                     "react-virtuoso": "reactVirtuoso",
+                    "react-resizable-panels": "reactResizablePanels",
                 },
             },
         },


### PR DESCRIPTION
To get rid of:
`
[MISSING_GLOBAL_NAME] Warning: No name was provided for external module "react-resizable-panels" in "output.globals" – guessing "react_resizable_panels".`