### PR TITLE
Exclude stories from dts generations

### DIFF
--- a/packages/shared-components/vite.config.ts
+++ b/packages/shared-components/vite.config.ts
@@ -52,7 +52,7 @@ export default defineConfig({
         dts({
             rollupTypes: true,
             include: ["src/**/*.{ts,tsx}"],
-            exclude: ["src/**/*.test.{ts,tsx}"],
+            exclude: ["src/**/*.test.{ts,tsx}", "src/**/*.stories.{ts,tsx}"],
             copyDtsFiles: true,
         }),
     ],


### PR DESCRIPTION
Exclude storybook stories from dts generation:
1. It's useless
2. Generate error like:
```sh
[vite:dts] Start generate declaration files...
src/resize/separator/SeparatorView.stories.tsx:117:37 - error TS2339: Property 'toMatchImageSnapshot' does not exist on type 'Assertion<HTMLElement>'.

117         await expect(canvasElement).toMatchImageSnapshot();
                                        ~~~~~~~~~~~~~~~~~~~~
src/resize/separator/SeparatorView.stories.tsx:150:37 - error TS2339: Property 'toMatchImageSnapshot' does not exist on type 'Assertion<HTMLElement>'.

150         await expect(canvasElement).toMatchImageSnapshot();
                                        ~~~~~~~~~~~~~~~~~~~~
```
