### PR TITLE
Separate cases in DeviceListener

### DIFF
--- a/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
+++ b/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
@@ -246,7 +246,7 @@ export class DeviceListenerCurrentDevice {
                 await this.setDeviceState("key_storage_out_of_sync", logSpan);
             } else {
                 // We should not get here
-                throw new Error("DeviceListenerCurrentDevice is in an unexpected state");
+                logSpan.error("DeviceListenerCurrentDevice: allSystemsReady was false, but no case matched.");
             }
         }
     }


### PR DESCRIPTION
According to the comment in `else` there were two ways to end up there. Split these into separate cases and provide a different log message in each case. If we somehow get there another way, throw an error.

Part of https://github.com/element-hq/crypto-internal/issues/305

Depends on https://github.com/element-hq/element-web/pull/32971

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
