### PR TITLE
Fix playwright tests locally

### DIFF
--- a/apps/web/playwright/e2e/chat-export/html-export.spec.ts
+++ b/apps/web/playwright/e2e/chat-export/html-export.spec.ts
@@ -122,7 +122,7 @@ test.describe("HTML Export", () => {
             await download.saveAs(zipPath);
 
             const zip = await extractZipFileToPath(zipPath, dirPath);
-            await page.goto(`file://${dirPath}/${Object.keys(zip.files)[0]}/messages.html`);
+            await page.goto(`file://${dirPath}/${Object.keys(zip.files).find((f) => f.endsWith("/messages.html"))}`);
             await expect(page).toMatchScreenshot("html-export.png", {
                 mask: [page.locator(".mx_TimelineSeparator")],
                 css: `

--- a/apps/web/src/components/structures/RoomSearchView.tsx
+++ b/apps/web/src/components/structures/RoomSearchView.tsx
@@ -40,7 +40,6 @@ interface Props {
     scope: SearchScope;
     inProgress: boolean;
     promise: Promise<ISearchResults>;
-    abortController?: AbortController;
     className: string;
     onUpdate(this: void, inProgress: boolean, results: ISearchResults | null, error: Error | null): void;
     ref?: Ref<ScrollPanel>;
@@ -48,16 +47,7 @@ interface Props {
 
 // XXX: todo: merge overlapping results somehow?
 // XXX: why doesn't searching on name work?
-export const RoomSearchView = ({
-    term,
-    scope,
-    promise,
-    abortController,
-    className,
-    onUpdate,
-    inProgress,
-    ref,
-}: Props): JSX.Element => {
+export const RoomSearchView = ({ term, scope, promise, className, onUpdate, inProgress, ref }: Props): JSX.Element => {
     const client = useContext(MatrixClientContext);
     const roomContext = useScopedRoomContext("showHiddenEvents");
     const [highlights, setHighlights] = useState<string[] | null>(null);
@@ -144,7 +134,6 @@ export const RoomSearchView = ({
         handleSearchResult(promise);
         return () => {
             aborted.current = true;
-            abortController?.abort();
         };
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/apps/web/src/components/structures/RoomView.tsx
+++ b/apps/web/src/components/structures/RoomView.tsx
@@ -2563,7 +2563,6 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                     term={this.state.search.term}
                     scope={this.state.search.scope}
                     promise={this.state.search.promise}
-                    abortController={this.state.search.abortController}
                     inProgress={!!this.state.search.inProgress}
                     className={this.messagePanelClassNames}
                     onUpdate={this.onSearchUpdate}

--- a/packages/playwright-common/playwright-screenshots.sh
+++ b/packages/playwright-common/playwright-screenshots.sh
@@ -23,7 +23,7 @@ IMAGE_NAME="ghcr.io/element-hq/element-web/playwright-server:$PW_VERSION"
 docker pull "$IMAGE_NAME" 2>/dev/null || build_image "$IMAGE_NAME"
 
 # Start the playwright-server in docker
-CONTAINER=$(docker run --network=host --rm -d -e PORT="$WS_PORT" "$IMAGE_NAME")
+CONTAINER=$(docker run --network=host -v /tmp:/tmp --rm -d -e PORT="$WS_PORT" "$IMAGE_NAME")
 # Set up an exit trap to clean up the docker container
 clean_up() {
     ARG=$?


### PR DESCRIPTION
Test like html-export rely on accessing the same `/tmp` dirs from both playwright & playwright-server, so needed a bind mount.
The issue with RoomSearchView was due to React Strict Mode double rendering causing the `/search` request to be aborted. This was an unnecessary optimisation anyway.