### PR TITLE
Remodel DeviceListener ifs to be more uniform

### DIFF
--- a/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
+++ b/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
@@ -213,28 +213,30 @@ export class DeviceListenerCurrentDevice {
             } else if (!keyBackupUploadIsOk) {
                 logSpan.info("Key backup upload is unexpectedly turned off: setting state to TURN_ON_KEY_STORAGE");
                 await this.setDeviceState("turn_on_key_storage", logSpan);
-            } else if (secretStorageStatus.defaultKeyId === null) {
-                // The user just hasn't set up 4S yet: if they have key
-                // backup, prompt them to turn on recovery too. (If not, they
-                // have explicitly opted out, so don't hassle them.)
-                if (recoveryDisabled) {
-                    logSpan.info("Recovery disabled: no toast needed");
-                    await this.setDeviceState("ok", logSpan);
-                } else if (keyBackupUploadActive) {
-                    logSpan.info("No default 4S key: setting state to SET_UP_RECOVERY");
-                    await this.setDeviceState("set_up_recovery", logSpan);
-                } else {
-                    logSpan.info("No default 4S key but backup disabled: no toast needed");
-                    await this.setDeviceState("ok", logSpan);
-                }
             } else if (!recoveryIsOk) {
-                logSpan.warn("4S is missing secrets: setting state to KEY_STORAGE_OUT_OF_SYNC", {
-                    secretStorageStatus,
-                    allCrossSigningSecretsCached,
-                    isCurrentDeviceTrusted,
-                    keyBackupDownloadIsOk,
-                });
-                await this.setDeviceState("key_storage_out_of_sync", logSpan);
+                if (secretStorageStatus.defaultKeyId === null) {
+                    // The user just hasn't set up 4S yet: if they have key
+                    // backup, prompt them to turn on recovery too. (If not, they
+                    // have explicitly opted out, so don't hassle them.)
+                    if (recoveryDisabled) {
+                        logSpan.info("Recovery disabled: no toast needed");
+                        await this.setDeviceState("ok", logSpan);
+                    } else if (keyBackupUploadActive) {
+                        logSpan.info("No default 4S key: setting state to SET_UP_RECOVERY");
+                        await this.setDeviceState("set_up_recovery", logSpan);
+                    } else {
+                        logSpan.info("No default 4S key but backup disabled: no toast needed");
+                        await this.setDeviceState("ok", logSpan);
+                    }
+                } else {
+                    logSpan.warn("4S is missing secrets: setting state to KEY_STORAGE_OUT_OF_SYNC", {
+                        secretStorageStatus,
+                        allCrossSigningSecretsCached,
+                        isCurrentDeviceTrusted,
+                        keyBackupDownloadIsOk,
+                    });
+                    await this.setDeviceState("key_storage_out_of_sync", logSpan);
+                }
             } else if (!keyBackupDownloadIsOk) {
                 logSpan.warn("Backup key is not cached locally: setting state to KEY_STORAGE_OUT_OF_SYNC", {
                     secretStorageStatus,


### PR DESCRIPTION
We enter this chain of `if`s if at least one of the boolean flags is false. This change attempts to make the logic clearer by ensuring that each branch of the if matches exactly one of those booleans.
    
Justifying this change: if `secretStorageStatus.defaultKeyId === null` then `recoveryKeyIsOk` will be false, except in the strange case where recovery is disabled, in which case we should not be dealing with problems with recovery anyway, so if we previously entered this branch it would have been a bug. All existing tests pass so it looks like we didn't consider this case.

Part of https://github.com/element-hq/crypto-internal/issues/305
Depends on https://github.com/element-hq/element-web/pull/32973

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
