### PR TITLE
Simplify DeviceListener logic: consider recovery disabled if backup is disabled

### DIFF
--- a/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
+++ b/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
@@ -161,8 +161,6 @@ export class DeviceListenerCurrentDevice {
 
         const recoveryDisabled = await this.recheckRecoveryDisabled(this.client);
 
-        const recoveryIsOk = secretStorageStatus.ready || recoveryDisabled;
-
         const isCurrentDeviceTrusted = Boolean(
             (await crypto.getDeviceVerificationStatus(this.client.getSafeUserId(), this.client.deviceId!))
                 ?.crossSigningVerified,
@@ -170,6 +168,8 @@ export class DeviceListenerCurrentDevice {
 
         const keyBackupUploadActive = await this.isKeyBackupUploadActive(logSpan);
         const backupDisabled = await this.recheckBackupDisabled();
+
+        const recoveryIsOk = secretStorageStatus.ready || recoveryDisabled || backupDisabled;
 
         // We warn if key backup upload is turned off and we have not explicitly
         // said we are OK with that.
@@ -215,16 +215,8 @@ export class DeviceListenerCurrentDevice {
                 await this.setDeviceState("turn_on_key_storage", logSpan);
             } else if (!recoveryIsOk) {
                 if (secretStorageStatus.defaultKeyId === null) {
-                    // The user just hasn't set up 4S yet: if they have key
-                    // backup, prompt them to turn on recovery too. (If not, they
-                    // have explicitly opted out, so don't hassle them.)
-                    if (keyBackupUploadActive) {
-                        logSpan.info("No default 4S key: setting state to SET_UP_RECOVERY");
-                        await this.setDeviceState("set_up_recovery", logSpan);
-                    } else {
-                        logSpan.info("No default 4S key but backup disabled: no toast needed");
-                        await this.setDeviceState("ok", logSpan);
-                    }
+                    logSpan.info("No default 4S key: setting state to SET_UP_RECOVERY");
+                    await this.setDeviceState("set_up_recovery", logSpan);
                 } else {
                     logSpan.warn("4S is missing secrets: setting state to KEY_STORAGE_OUT_OF_SYNC", {
                         secretStorageStatus,


### PR DESCRIPTION
If backup is disabled, recovery is implicitly disabled too, so there is no need to warn about recovery being broken.

Part of https://github.com/element-hq/crypto-internal/issues/305
Depends on https://github.com/element-hq/element-web/pull/32977

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
