### PR TITLE
Simplify DeviceListener recheck logic using a failedCheck method

### DIFF
--- a/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
+++ b/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
@@ -222,18 +222,10 @@ export class DeviceListenerCurrentDevice {
                 } else {
                     await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "4S is missing secrets", {
                         secretStorageStatus,
-                        allCrossSigningSecretsCached,
-                        isCurrentDeviceTrusted,
-                        keyBackupDownloadIsOk,
                     });
                 }
             } else if (!keyBackupDownloadIsOk) {
-                await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "Backup key is not cached locally", {
-                    secretStorageStatus,
-                    allCrossSigningSecretsCached,
-                    isCurrentDeviceTrusted,
-                    keyBackupDownloadIsOk,
-                });
+                await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "Backup key is not cached locally");
             } else {
                 // We should not get here
                 logSpan.error("DeviceListenerCurrentDevice: allSystemsReady was false, but no case matched.");

--- a/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
+++ b/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
@@ -191,49 +191,49 @@ export class DeviceListenerCurrentDevice {
             logSpan.info("No toast needed");
             await this.setDeviceState("ok", logSpan);
         } else {
-            // make sure our keys are finished downloading
-            await crypto.getUserDeviceInfo([this.client.getSafeUserId()]);
-
             if (!isCurrentDeviceTrusted) {
-                // the current device is not trusted: prompt the user to verify
-                logSpan.info("Current device not verified: setting state to VERIFY_THIS_SESSION");
-                await this.setDeviceState("verify_this_session", logSpan);
+                // The current device is not trusted: prompt the user to verify
+                await this.failedCheck("verify_this_session", logSpan, "info", "Current device not verified");
             } else if (!allCrossSigningSecretsCached) {
                 // cross signing ready & device trusted, but we are missing secrets from our local cache.
                 // prompt the user to enter their recovery key.
-                logSpan.info(
-                    "Some secrets not cached: setting state to KEY_STORAGE_OUT_OF_SYNC",
+                const newState = crossSigningStatus.privateKeysInSecretStorage
+                    ? "key_storage_out_of_sync"
+                    : "identity_needs_reset";
+
+                await this.failedCheck(
+                    newState,
+                    logSpan,
+                    "info",
+                    "Some secrets not cached",
                     crossSigningStatus.privateKeysCachedLocally,
                     crossSigningStatus.privateKeysInSecretStorage,
                 );
-                await this.setDeviceState(
-                    crossSigningStatus.privateKeysInSecretStorage ? "key_storage_out_of_sync" : "identity_needs_reset",
-                    logSpan,
-                );
             } else if (!keyBackupUploadIsOk) {
-                logSpan.info("Key backup upload is unexpectedly turned off: setting state to TURN_ON_KEY_STORAGE");
-                await this.setDeviceState("turn_on_key_storage", logSpan);
+                await this.failedCheck(
+                    "turn_on_key_storage",
+                    logSpan,
+                    "info",
+                    "Key backup upload is unexpectedly turned off",
+                );
             } else if (!recoveryIsOk) {
                 if (secretStorageStatus.defaultKeyId === null) {
-                    logSpan.info("No default 4S key: setting state to SET_UP_RECOVERY");
-                    await this.setDeviceState("set_up_recovery", logSpan);
+                    await this.failedCheck("set_up_recovery", logSpan, "info", "No default 4S key");
                 } else {
-                    logSpan.warn("4S is missing secrets: setting state to KEY_STORAGE_OUT_OF_SYNC", {
+                    await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "4S is missing secrets", {
                         secretStorageStatus,
                         allCrossSigningSecretsCached,
                         isCurrentDeviceTrusted,
                         keyBackupDownloadIsOk,
                     });
-                    await this.setDeviceState("key_storage_out_of_sync", logSpan);
                 }
             } else if (!keyBackupDownloadIsOk) {
-                logSpan.warn("Backup key is not cached locally: setting state to KEY_STORAGE_OUT_OF_SYNC", {
+                await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "Backup key is not cached locally", {
                     secretStorageStatus,
                     allCrossSigningSecretsCached,
                     isCurrentDeviceTrusted,
                     keyBackupDownloadIsOk,
                 });
-                await this.setDeviceState("key_storage_out_of_sync", logSpan);
             } else {
                 // We should not get here
                 logSpan.error("DeviceListenerCurrentDevice: allSystemsReady was false, but no case matched.");
@@ -248,6 +248,30 @@ export class DeviceListenerCurrentDevice {
      */
     public getDeviceState(): DeviceState {
         return this.deviceState;
+    }
+
+    /**
+     * recheck failed - update our local device keys, log a message and set the
+     * state to display to the user.
+     */
+    private async failedCheck(
+        newState: DeviceState,
+        logSpan: LogSpan,
+        level: "info" | "warn",
+        message: string,
+        ...logItems: Array<any>
+    ): Promise<void> {
+        // Make sure our keys are finished downloading
+        await this.client.getCrypto()?.getUserDeviceInfo([this.client.getSafeUserId()]);
+
+        const fullMessage = `${message}: setting state to ${newState.toLowerCase()}`;
+        if (level === "info") {
+            logSpan.info(fullMessage, ...logItems);
+        } else {
+            logSpan.warn(fullMessage, ...logItems);
+        }
+
+        await this.setDeviceState(newState, logSpan);
     }
 
     /**

--- a/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
+++ b/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
@@ -180,56 +180,45 @@ export class DeviceListenerCurrentDevice {
         const keyBackupDownloadIsOk =
             !keyBackupUploadActive || backupDisabled || (await crypto.getSessionBackupPrivateKey()) !== null;
 
-        const allSystemsReady =
-            isCurrentDeviceTrusted &&
-            allCrossSigningSecretsCached &&
-            keyBackupUploadIsOk &&
-            recoveryIsOk &&
-            keyBackupDownloadIsOk;
+        if (!isCurrentDeviceTrusted) {
+            // The current device is not trusted: prompt the user to verify
+            await this.failedCheck("verify_this_session", logSpan, "info", "Current device not verified");
+        } else if (!allCrossSigningSecretsCached) {
+            // cross signing ready & device trusted, but we are missing secrets from our local cache.
+            // prompt the user to enter their recovery key.
+            const newState = crossSigningStatus.privateKeysInSecretStorage
+                ? "key_storage_out_of_sync"
+                : "identity_needs_reset";
 
-        if (allSystemsReady) {
+            await this.failedCheck(
+                newState,
+                logSpan,
+                "info",
+                "Some secrets not cached",
+                crossSigningStatus.privateKeysCachedLocally,
+                crossSigningStatus.privateKeysInSecretStorage,
+            );
+        } else if (!keyBackupUploadIsOk) {
+            await this.failedCheck(
+                "turn_on_key_storage",
+                logSpan,
+                "info",
+                "Key backup upload is unexpectedly turned off",
+            );
+        } else if (!recoveryIsOk) {
+            if (secretStorageStatus.defaultKeyId === null) {
+                await this.failedCheck("set_up_recovery", logSpan, "info", "No default 4S key");
+            } else {
+                await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "4S is missing secrets", {
+                    secretStorageStatus,
+                });
+            }
+        } else if (!keyBackupDownloadIsOk) {
+            await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "Backup key is not cached locally");
+        } else {
+            // Everything is OK - no need to show a toast
             logSpan.info("No toast needed");
             await this.setDeviceState("ok", logSpan);
-        } else {
-            if (!isCurrentDeviceTrusted) {
-                // The current device is not trusted: prompt the user to verify
-                await this.failedCheck("verify_this_session", logSpan, "info", "Current device not verified");
-            } else if (!allCrossSigningSecretsCached) {
-                // cross signing ready & device trusted, but we are missing secrets from our local cache.
-                // prompt the user to enter their recovery key.
-                const newState = crossSigningStatus.privateKeysInSecretStorage
-                    ? "key_storage_out_of_sync"
-                    : "identity_needs_reset";
-
-                await this.failedCheck(
-                    newState,
-                    logSpan,
-                    "info",
-                    "Some secrets not cached",
-                    crossSigningStatus.privateKeysCachedLocally,
-                    crossSigningStatus.privateKeysInSecretStorage,
-                );
-            } else if (!keyBackupUploadIsOk) {
-                await this.failedCheck(
-                    "turn_on_key_storage",
-                    logSpan,
-                    "info",
-                    "Key backup upload is unexpectedly turned off",
-                );
-            } else if (!recoveryIsOk) {
-                if (secretStorageStatus.defaultKeyId === null) {
-                    await this.failedCheck("set_up_recovery", logSpan, "info", "No default 4S key");
-                } else {
-                    await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "4S is missing secrets", {
-                        secretStorageStatus,
-                    });
-                }
-            } else if (!keyBackupDownloadIsOk) {
-                await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "Backup key is not cached locally");
-            } else {
-                // We should not get here
-                logSpan.error("DeviceListenerCurrentDevice: allSystemsReady was false, but no case matched.");
-            }
         }
     }
 


### PR DESCRIPTION
See the individual commit descriptions. This reduces the amount of boolean-wrangling we need to do to check our device is working ok.

Part of https://github.com/element-hq/crypto-internal/issues/305

Depends on https://github.com/element-hq/element-web/pull/32979

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
