### PR TITLE
call-widget: auto approve file download cap to get access to avatars

### DIFF
--- a/apps/web/src/stores/widgets/ElementWidgetDriver.ts
+++ b/apps/web/src/stores/widgets/ElementWidgetDriver.ts
@@ -128,6 +128,7 @@ export class ElementWidgetDriver extends WidgetDriver {
             this.allowedCapabilities.add(MatrixCapabilities.MSC4157UpdateDelayedEvent);
             this.allowedCapabilities.add(MatrixCapabilities.MSC4407SendStickyEvent);
             this.allowedCapabilities.add(MatrixCapabilities.MSC4407ReceiveStickyEvent);
+            this.allowedCapabilities.add(MatrixCapabilities.MSC4039DownloadFile);
 
             this.allowedCapabilities.add(
                 WidgetEventCapability.forStateEvent(EventDirection.Receive, EventType.RoomName).raw,

--- a/apps/web/test/unit-tests/stores/widgets/ElementWidgetDriver-test.ts
+++ b/apps/web/test/unit-tests/stores/widgets/ElementWidgetDriver-test.ts
@@ -134,6 +134,8 @@ describe("ElementWidgetDriver", () => {
             "org.matrix.msc4157.update_delayed_event",
             "org.matrix.msc4407.send.sticky_event",
             "org.matrix.msc4407.receive.sticky_event",
+            // To download avatars
+            "org.matrix.msc4039.download_file",
             // RTC decline events (send/receive, unstable/stable)
             "org.matrix.msc2762.send.event:org.matrix.msc4310.rtc.decline",
             "org.matrix.msc2762.send.event:m.rtc.decline",


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Allows Element Call widget to download files. So that it can display users avatars in the call

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
