### PR TITLE
Use rejectToast in playwright tests to reject toasts

### DIFF
--- a/apps/web/playwright/e2e/accessibility/keyboard-navigation.spec.ts
+++ b/apps/web/playwright/e2e/accessibility/keyboard-navigation.spec.ts
@@ -6,6 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import { test, expect } from "../../element-web-test";
 import { Bot } from "../../pages/bot";
 
@@ -15,7 +17,7 @@ test.describe("Landmark navigation tests", () => {
     });
 
     test("without any rooms", async ({ page, homeserver, app, user }) => {
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
 
         // sometimes the space button doesn't appear right away
         await expect(page.locator(".mx_SpaceButton_active")).toBeVisible();
@@ -120,7 +122,7 @@ test.describe("Landmark navigation tests", () => {
             },
         );
 
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
         await app.viewRoomByName("Bob");
         // confirm the room was loaded
         await expect(page.getByText("Bob joined the room")).toBeVisible();

--- a/apps/web/playwright/e2e/audio-player/audio-player.spec.ts
+++ b/apps/web/playwright/e2e/audio-player/audio-player.spec.ts
@@ -7,6 +7,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import type { Locator, Page } from "@playwright/test";
 import { test, expect, type ExtendedToMatchScreenshotOptions } from "../../element-web-test";
 import { SettingLevel } from "../../../src/settings/SettingLevel";
@@ -139,7 +141,7 @@ test.describe("Audio player", { tag: ["@no-firefox", "@no-webkit"] }, () => {
     };
 
     test.beforeEach(async ({ page, app, user }) => {
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
         await app.client.createRoom({ name: "Test Room" });
         await app.viewRoomByName("Test Room");
 

--- a/apps/web/playwright/e2e/crypto/crypto.spec.ts
+++ b/apps/web/playwright/e2e/crypto/crypto.spec.ts
@@ -6,6 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../element-web-test";
 import { autoJoin, createSharedRoomWithUser, enableKeyBackup, verify } from "./utils";
@@ -172,7 +174,7 @@ test.describe("Cryptography", function () {
         "creating a DM should work, being e2e-encrypted / user verification",
         { tag: "@screenshot" },
         async ({ page, app, bot: bob, user: aliceCredentials }) => {
-            await app.closeVerifyToast();
+            await rejectToast(page, "Verify this device");
             await app.client.bootstrapCrossSigning(aliceCredentials);
             await startDMWithBob(page, bob);
             // send first message

--- a/apps/web/playwright/e2e/crypto/history-sharing.spec.ts
+++ b/apps/web/playwright/e2e/crypto/history-sharing.spec.ts
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { createNewInstance } from "@element-hq/element-web-playwright-common";
+import { createNewInstance, rejectToast } from "@element-hq/element-web-playwright-common";
 
 import { expect, test } from "../../element-web-test";
 import { ElementAppPage } from "../../pages/ElementAppPage";
@@ -37,7 +37,7 @@ test.describe("History sharing", function () {
             await bobElementApp.client.bootstrapCrossSigning(bobCredentials);
             await bobElementApp.closeKeyStorageToast();
 
-            await aliceElementApp.closeNotificationToast();
+            await rejectToast(aliceElementApp.page, "Notifications");
 
             // Create the room and send a message
             await createRoom(alicePage, "TestRoom", true);

--- a/apps/web/playwright/e2e/devtools/lowbandwidth.spec.ts
+++ b/apps/web/playwright/e2e/devtools/lowbandwidth.spec.ts
@@ -5,6 +5,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import { test, expect } from "../../element-web-test";
 import { getSampleFilePath } from "../../sample-files";
 
@@ -19,7 +21,7 @@ test.describe("Devtools", () => {
         const profileSettings = userSettings.locator(".mx_UserProfileSettings");
         await profileSettings.getByAltText("Upload").setInputFiles(getSampleFilePath("riot.png"));
         await app.closeDialog();
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
 
         // Create an initial room.
         const createRoomDialog = await app.openCreateRoomDialog();

--- a/apps/web/playwright/e2e/invite/invite-dialog.spec.ts
+++ b/apps/web/playwright/e2e/invite/invite-dialog.spec.ts
@@ -7,6 +7,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import { test, expect } from "../../element-web-test";
 
 /**
@@ -91,7 +93,7 @@ test.describe("Invite dialog", function () {
         "should support inviting a user to Direct Messages",
         { tag: "@screenshot" },
         async ({ page, app, user, bot }) => {
-            await app.closeVerifyToast();
+            await rejectToast(page, "Verify this device");
             await page
                 .getByRole("navigation", { name: "Room list" })
                 .getByRole("button", { name: "New conversation" })

--- a/apps/web/playwright/e2e/knock/create-knock-room.spec.ts
+++ b/apps/web/playwright/e2e/knock/create-knock-room.spec.ts
@@ -6,6 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import { test, expect } from "../../element-web-test";
 import { waitForRoom } from "../utils";
 import { Filter } from "../../pages/Spotlight";
@@ -19,7 +21,7 @@ test.describe("Create Knock Room", () => {
     });
 
     test("should create a knock room", async ({ page, app, user }) => {
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
 
         const dialog = await app.openCreateRoomDialog();
         await dialog.getByRole("textbox", { name: "Name" }).fill("Cybersecurity");
@@ -39,7 +41,7 @@ test.describe("Create Knock Room", () => {
     });
 
     test("should create a room and change a join rule to knock", async ({ page, app, user }) => {
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
 
         const dialog = await app.openCreateRoomDialog();
         await dialog.getByRole("textbox", { name: "Name" }).fill("Cybersecurity");
@@ -63,7 +65,7 @@ test.describe("Create Knock Room", () => {
     });
 
     test("should create a public knock room", async ({ page, app, user }) => {
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
 
         const dialog = await app.openCreateRoomDialog();
         await dialog.getByRole("textbox", { name: "Name" }).fill("Cybersecurity");

--- a/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-collapse.spec.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-collapse.spec.ts
@@ -5,6 +5,8 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import { test, expect } from "../../../element-web-test";
 import type { Locator, Page } from "playwright-core";
 
@@ -14,8 +16,8 @@ test.describe("Collapsible Room list", () => {
     });
 
     test.beforeEach(async ({ page, app, user }) => {
-        await app.closeVerifyToast();
-        await app.closeNotificationToast();
+        await rejectToast(page, "Verify this device");
+        await rejectToast(page, "Notifications");
         for (let i = 0; i < 10; i++) {
             await app.client.createRoom({ name: `room${i}` });
         }

--- a/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-custom-sections.spec.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-custom-sections.spec.ts
@@ -6,6 +6,7 @@
  */
 
 import { type Page } from "@playwright/test";
+import { rejectToast } from "@element-hq/element-web-playwright-common";
 
 import { expect, test } from "../../../element-web-test";
 import { assertRoomInSection, getRoomList, getRoomListHeader, getSectionHeader } from "./utils";
@@ -41,9 +42,9 @@ test.describe("Room list custom sections", () => {
     }
 
     test.beforeEach(async ({ page, app, user }) => {
-        // The notification toast is displayed above the search section
-        await app.closeNotificationToast();
-        await app.closeVerifyToast();
+        // The toasts are displayed above the search section
+        await rejectToast(page, "Notifications");
+        await rejectToast(page, "Verify this device");
 
         // Focus the user menu to avoid hover decoration
         await page.getByRole("button", { name: "User menu" }).focus();

--- a/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-filter-sort.spec.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-filter-sort.spec.ts
@@ -7,6 +7,7 @@
 
 import { type Visibility } from "matrix-js-sdk/src/matrix";
 import { type Page } from "@playwright/test";
+import { rejectToast } from "@element-hq/element-web-playwright-common";
 
 import { expect, test } from "../../../element-web-test";
 import { SettingLevel } from "../../../../src/settings/SettingLevel";
@@ -32,8 +33,8 @@ test.describe("Room list filters and sort", () => {
 
     test.beforeEach(async ({ page, app, bot, user }) => {
         // The toasts are displayed above the search section
-        await app.closeVerifyToast();
-        await app.closeNotificationToast();
+        await rejectToast(page, "Verify this device");
+        await rejectToast(page, "Notifications");
     });
 
     test("Tombstoned rooms are not shown even when they receive updates", async ({ page, app, bot }) => {

--- a/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-header.spec.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-header.spec.ts
@@ -5,6 +5,8 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import { test, expect } from "../../../element-web-test";
 import { getHeaderSection } from "./utils";
 
@@ -15,8 +17,8 @@ test.describe("Header section of the room list", () => {
 
     test.beforeEach(async ({ page, app, user }) => {
         // The toasts are displayed above the search section
-        await app.closeVerifyToast();
-        await app.closeNotificationToast();
+        await rejectToast(page, "Verify this device");
+        await rejectToast(page, "Notifications");
     });
 
     test("should render the header section", { tag: "@screenshot" }, async ({ page, app, user }) => {

--- a/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-panel.spec.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-panel.spec.ts
@@ -5,6 +5,8 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import { test, expect } from "../../../element-web-test";
 import { getRoomListView } from "./utils";
 
@@ -15,8 +17,8 @@ test.describe("Room list panel", () => {
 
     test.beforeEach(async ({ page, app, user }) => {
         // The toasts are displayed above the search section
-        await app.closeVerifyToast();
-        await app.closeNotificationToast();
+        await rejectToast(page, "Verify this device");
+        await rejectToast(page, "Notifications");
 
         // Populate the room list
         for (let i = 0; i < 20; i++) {

--- a/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-search.spec.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-search.spec.ts
@@ -5,6 +5,8 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import { test, expect } from "../../../element-web-test";
 import { getSearchSection } from "./utils";
 
@@ -15,8 +17,8 @@ test.describe("Search section of the room list", () => {
 
     test.beforeEach(async ({ page, app, user }) => {
         // The toasts are displayed above the search section
-        await app.closeVerifyToast();
-        await app.closeNotificationToast();
+        await rejectToast(page, "Verify this device");
+        await rejectToast(page, "Notifications");
     });
 
     test("should render the search section", { tag: "@screenshot" }, async ({ page, app, user }) => {

--- a/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-sections.spec.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-sections.spec.ts
@@ -5,6 +5,8 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import { expect, test } from "../../../element-web-test";
 import { assertRoomInSection, dragRoomToSection, getPrimaryFilters, getRoomList, getSectionHeader } from "./utils";
 
@@ -20,8 +22,8 @@ test.describe("Room list sections", () => {
 
     test.beforeEach(async ({ page, app, user }) => {
         // The toasts are displayed above the search section
-        await app.closeVerifyToast();
-        await app.closeNotificationToast();
+        await rejectToast(page, "Verify this device");
+        await rejectToast(page, "Notifications");
 
         // focus the user menu to avoid to have hover decoration
         await page.getByRole("button", { name: "User menu" }).focus();

--- a/apps/web/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
@@ -6,6 +6,7 @@
  */
 
 import { type Page } from "@playwright/test";
+import { rejectToast } from "@element-hq/element-web-playwright-common";
 
 import { expect, test } from "../../../element-web-test";
 import { type Bot } from "../../../pages/bot";
@@ -23,8 +24,8 @@ test.describe("Room list", () => {
 
     test.beforeEach(async ({ page, app, user }) => {
         // The toasts are displayed above the search section
-        await app.closeVerifyToast();
-        await app.closeNotificationToast();
+        await rejectToast(page, "Verify this device");
+        await rejectToast(page, "Notifications");
 
         // focus the user menu to avoid to have hover decoration
         await page.getByRole("button", { name: "User menu" }).focus();

--- a/apps/web/playwright/e2e/messages/messages.spec.ts
+++ b/apps/web/playwright/e2e/messages/messages.spec.ts
@@ -9,6 +9,7 @@ Please see LICENSE files in the repository root for full details.
 /* See readme.md for tips on writing these tests. */
 
 import { type Locator, type Page } from "@playwright/test";
+import { rejectToast } from "@element-hq/element-web-playwright-common";
 
 import { test, expect } from "../../element-web-test";
 import { readSampleFileSync } from "../../sample-files";
@@ -85,10 +86,10 @@ test.describe("Message rendering", () => {
         test.describe(`with ${direction} display name`, { tag: "@screenshot" }, () => {
             test.use({
                 displayName,
-                room: async ({ user, app }, use) => {
+                room: async ({ user, app, page }, use) => {
                     const roomId = await app.client.createRoom({ name: "Test room" });
                     await use({ roomId });
-                    await app.closeVerifyToast();
+                    await rejectToast(page, "Verify this device");
                 },
             });
 
@@ -216,10 +217,10 @@ test.describe("Message rendering", () => {
 test.describe("Message url previews", () => {
     test.use({
         displayName: "Alice",
-        room: async ({ user, app }, use) => {
+        room: async ({ user, app, page }, use) => {
             const roomId = await app.client.createRoom({ name: "Test room" });
             await use({ roomId });
-            await app.closeVerifyToast();
+            await rejectToast(page, "Verify this device");
         },
     });
     test("should render a basic preview", { tag: "@screenshot" }, async ({ page, user, app, room, axe }) => {

--- a/apps/web/playwright/e2e/room-directory/room-directory.spec.ts
+++ b/apps/web/playwright/e2e/room-directory/room-directory.spec.ts
@@ -6,6 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import type { Preset, Visibility } from "matrix-js-sdk/src/matrix";
 import { test, expect } from "../../element-web-test";
 
@@ -65,7 +67,7 @@ test.describe("Room Directory", () => {
                 room_alias_name: "test1234",
             });
 
-            await app.closeVerifyToast();
+            await rejectToast(page, "Verify this device");
             await page.getByRole("button", { name: "Explore rooms" }).click();
 
             const dialog = page.locator(".mx_SpotlightDialog");

--- a/apps/web/playwright/e2e/room/create-room.spec.ts
+++ b/apps/web/playwright/e2e/room/create-room.spec.ts
@@ -7,6 +7,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { type Page } from "@playwright/test";
+import { rejectToast } from "@element-hq/element-web-playwright-common";
 
 import { SettingLevel } from "../../../src/settings/SettingLevel";
 import { UIFeature } from "../../../src/settings/UIFeature";
@@ -22,7 +23,7 @@ test.describe("Create Room", () => {
         "should create a public room with name, topic & address set",
         { tag: "@screenshot" },
         async ({ page, user, app, axe }) => {
-            await app.closeVerifyToast();
+            await rejectToast(page, "Verify this device");
             const dialog = await app.openCreateRoomDialog();
             // Fill name & topic
             await dialog.getByRole("textbox", { name: "Name" }).fill(name);
@@ -51,7 +52,7 @@ test.describe("Create Room", () => {
     );
 
     test("should allow us to start a chat and show encryption state", async ({ page, user, app }) => {
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
 
         await page.getByRole("button", { name: "New conversation", exact: true }).click();
         await page.getByRole("menuitem", { name: "Start chat" }).click();
@@ -72,7 +73,7 @@ test.describe("Create Room", () => {
 
     test("should create a video room", { tag: "@screenshot" }, async ({ page, user, app }) => {
         await app.settings.setValue("feature_video_rooms", null, SettingLevel.DEVICE, true);
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
 
         const dialog = await app.openCreateRoomDialog("New video room");
         // Fill name & topic
@@ -107,7 +108,7 @@ test.describe("Create Room", () => {
         });
 
         test("should disallow creating public rooms", { tag: "@screenshot" }, async ({ page, user, app, axe }) => {
-            await app.closeVerifyToast();
+            await rejectToast(page, "Verify this device");
             const dialog = await app.openCreateRoomDialog();
             // Fill name & topic
             await dialog.getByRole("textbox", { name: "Name" }).fill(name);
@@ -134,7 +135,7 @@ test.describe("Create Room", () => {
         test.use({ labsFlags: [] });
 
         test("creates a room without encrypted state", { tag: "@screenshot" }, async ({ page, user: _user, app }) => {
-            await app.closeVerifyToast();
+            await rejectToast(page, "Verify this device");
 
             // When we start to create a room
             await page.getByRole("button", { name: "New conversation", exact: true }).click();
@@ -165,7 +166,7 @@ test.describe("Create Room", () => {
             "creates a room with encrypted state if we check the box",
             { tag: "@screenshot" },
             async ({ page, user: _user, app }) => {
-                await app.closeVerifyToast();
+                await rejectToast(page, "Verify this device");
 
                 // Given we check the Encrypted State checkbox
                 await page.getByRole("button", { name: "New conversation", exact: true }).click();
@@ -194,7 +195,7 @@ test.describe("Create Room", () => {
             "creates a room without encrypted state if we don't check the box",
             { tag: "@screenshot" },
             async ({ page, user: _user, app }) => {
-                await app.closeVerifyToast();
+                await rejectToast(page, "Verify this device");
 
                 // Given we did not check the Encrypted State checkbox
                 await page.getByRole("button", { name: "New conversation", exact: true }).click();

--- a/apps/web/playwright/e2e/room/room-status-bar.spec.ts
+++ b/apps/web/playwright/e2e/room/room-status-bar.spec.ts
@@ -4,7 +4,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { getToast } from "@element-hq/element-web-playwright-common";
+import { getToast, rejectToast } from "@element-hq/element-web-playwright-common";
 
 import { test, expect } from "../../element-web-test";
 
@@ -17,12 +17,12 @@ test.describe("Room Status Bar", () => {
             await page.setViewportSize({ width: 1400, height: 768 });
             await use(page);
         },
-        room: async ({ app, user }, use) => {
+        room: async ({ app, user, page }, use) => {
             const roomId = await app.client.createRoom({
                 name: "A room",
             });
-            await app.closeVerifyToast();
-            await app.closeNotificationToast();
+            await rejectToast(page, "Verify this device");
+            await rejectToast(page, "Notifications");
             await app.viewRoomById(roomId);
             await use({ roomId });
         },
@@ -142,7 +142,7 @@ test.describe("Room Status Bar", () => {
             "should show an error when creating a local room fails",
             { tag: "@screenshot" },
             async ({ page, app, user, bot }) => {
-                await app.closeVerifyToast();
+                await rejectToast(page, "Verify this device");
                 await page
                     .getByRole("navigation", { name: "Room list" })
                     .getByRole("button", { name: "New conversation" })

--- a/apps/web/playwright/e2e/settings/appearance-user-settings-tab/appearance-user-settings-tab.spec.ts
+++ b/apps/web/playwright/e2e/settings/appearance-user-settings-tab/appearance-user-settings-tab.spec.ts
@@ -6,6 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import { expect, test } from ".";
 
 test.describe("Appearance user settings tab", () => {
@@ -14,7 +16,7 @@ test.describe("Appearance user settings tab", () => {
     });
 
     test("should be rendered properly", { tag: "@screenshot" }, async ({ page, user, app, axe }) => {
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
         const tab = await app.settings.openUserSettings("Appearance");
 
         // Click "Show advanced" link button
@@ -32,7 +34,7 @@ test.describe("Appearance user settings tab", () => {
         "should support changing font size by using the font size dropdown",
         { tag: "@screenshot" },
         async ({ page, app, user }) => {
-            await app.closeVerifyToast();
+            await rejectToast(page, "Verify this device");
             await app.settings.openUserSettings("Appearance");
 
             const tab = page.getByTestId("mx_AppearanceUserSettingsTab");
@@ -48,7 +50,7 @@ test.describe("Appearance user settings tab", () => {
     );
 
     test("should support enabling system font", async ({ page, app, user }) => {
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
         await app.settings.openUserSettings("Appearance");
         const tab = page.getByTestId("mx_AppearanceUserSettingsTab");
 
@@ -66,7 +68,7 @@ test.describe("Appearance user settings tab", () => {
         "should keep same font and emoji when switching theme",
         { tag: "@screenshot" },
         async ({ page, app, user, util }) => {
-            await app.closeVerifyToast();
+            await rejectToast(page, "Verify this device");
 
             const roomId = await util.createAndDisplayRoom();
 

--- a/apps/web/playwright/e2e/settings/appearance-user-settings-tab/theme-choice-panel.spec.ts
+++ b/apps/web/playwright/e2e/settings/appearance-user-settings-tab/theme-choice-panel.spec.ts
@@ -6,6 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import { expect, test } from ".";
 
 test.describe("Appearance user settings tab", () => {
@@ -14,10 +16,10 @@ test.describe("Appearance user settings tab", () => {
     });
 
     test.describe("Theme Choice Panel", () => {
-        test.beforeEach(async ({ app, user, util }) => {
+        test.beforeEach(async ({ app, page, user, util }) => {
             // Disable the default theme for consistency in case ThemeWatcher automatically chooses it
             await util.disableSystemTheme();
-            await app.closeVerifyToast();
+            await rejectToast(page, "Verify this device");
 
             await util.openAppearanceTab();
         });
@@ -104,7 +106,7 @@ test.describe("Appearance user settings tab", () => {
                     await expect(page).toMatchScreenshot("window-custom-theme.png");
 
                     await page.reload();
-                    await app.closeVerifyToast();
+                    await rejectToast(page, "Verify this device");
 
                     await util.openAppearanceTab();
                     // Assert that the custom theme is still selected after reloading the page

--- a/apps/web/playwright/e2e/settings/encryption-user-tab/other-devices.spec.ts
+++ b/apps/web/playwright/e2e/settings/encryption-user-tab/other-devices.spec.ts
@@ -5,7 +5,7 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-import { createNewInstance } from "@element-hq/element-web-playwright-common";
+import { createNewInstance, rejectToast } from "@element-hq/element-web-playwright-common";
 import { type StartedHomeserverContainer } from "@element-hq/element-web-playwright-common/lib/testcontainers";
 import { type Page, type Browser, type TestInfo } from "@playwright/test";
 
@@ -99,7 +99,7 @@ test.describe("Other people's devices section in Encryption tab", () => {
 
         // Create the room and invite bob
         await inviteBobToNewRoom(alicePage, aliceElementApp, bobCredentials, bobPage);
-        await bobElementApp.closeNotificationToast();
+        await rejectToast(alicePage, "Notifications");
 
         // Perform verification.
         await verifyApp("alice", aliceElementApp, "bob", bobElementApp);

--- a/apps/web/playwright/e2e/settings/security-user-settings-tab.spec.ts
+++ b/apps/web/playwright/e2e/settings/security-user-settings-tab.spec.ts
@@ -7,6 +7,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import { test, expect } from "../../element-web-test";
 
 const IntegrationManager = "scalar.vector.im";
@@ -27,8 +29,8 @@ test.describe("Security user settings tab", () => {
 
         test.beforeEach(async ({ page, app, user }) => {
             // Dismiss toasts
-            await app.closeVerifyToast();
-            await app.closeNotificationToast();
+            await rejectToast(page, "Verify this device");
+            await rejectToast(page, "Notifications");
             await page.locator(".mx_Toast_buttons").getByRole("button", { name: "Yes" }).click(); // Allow analytics
         });
 

--- a/apps/web/playwright/e2e/sliding-sync/sliding-sync.spec.ts
+++ b/apps/web/playwright/e2e/sliding-sync/sliding-sync.spec.ts
@@ -7,6 +7,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { type Locator, type Page, type Request } from "@playwright/test";
+import { rejectToast } from "@element-hq/element-web-playwright-common";
 
 import { test as base, expect } from "../../element-web-test";
 import type { ElementAppPage } from "../../pages/ElementAppPage";
@@ -71,9 +72,9 @@ test.describe("Sliding Sync", () => {
     });
 
     // Load the user fixture for all tests
-    test.beforeEach(async ({ app, user }) => {
-        await app.closeVerifyToast();
-        await app.closeNotificationToast();
+    test.beforeEach(async ({ app, page, user }) => {
+        await rejectToast(page, "Verify this device");
+        await rejectToast(page, "Notifications");
     });
 
     test("should render the Rooms list in reverse chronological order by default and allowing sorting A-Z", async ({

--- a/apps/web/playwright/e2e/spaces/spaces.spec.ts
+++ b/apps/web/playwright/e2e/spaces/spaces.spec.ts
@@ -6,6 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import type { Locator, Page } from "@playwright/test";
 import { test, expect } from "../../element-web-test";
 import type { Preset, ICreateRoomOpts } from "matrix-js-sdk/src/matrix";
@@ -68,7 +70,7 @@ test.describe("Spaces", () => {
         "should allow user to create public space",
         { tag: ["@screenshot", "@no-webkit"] },
         async ({ page, app, user }) => {
-            await app.closeVerifyToast();
+            await rejectToast(page, "Verify this device");
             const contextMenu = await openSpaceCreateMenu(page);
             await expect(contextMenu).toMatchScreenshot("space-create-menu.png");
 
@@ -105,7 +107,7 @@ test.describe("Spaces", () => {
     );
 
     test("should allow user to create private space", { tag: "@screenshot" }, async ({ page, app, user }) => {
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
         const menu = await openSpaceCreateMenu(page);
         await menu.getByRole("button", { name: "Private" }).click();
 
@@ -152,7 +154,7 @@ test.describe("Spaces", () => {
             name: "Sample Room",
         });
 
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
         const menu = await openSpaceCreateMenu(page);
         await menu.getByRole("button", { name: "Private" }).click();
 
@@ -187,7 +189,7 @@ test.describe("Spaces", () => {
                 name: "A Room that will not be selected",
             });
 
-            await app.closeVerifyToast();
+            await rejectToast(page, "Verify this device");
             const menu = await openSpaceCreateMenu(page);
             await menu.getByRole("button", { name: "Private" }).click();
 
@@ -287,7 +289,7 @@ test.describe("Spaces", () => {
         "should render subspaces in the space panel only when expanded",
         { tag: "@screenshot" },
         async ({ page, app, user, axe }) => {
-            await app.closeVerifyToast();
+            await rejectToast(page, "Verify this device");
 
             axe.disableRules([
                 // Disable this check as it triggers on nested roving tab index elements which are in practice fine
@@ -413,7 +415,7 @@ test.describe("Spaces", () => {
         });
 
         test("should disallow creating public rooms", { tag: "@screenshot" }, async ({ page, user, app }) => {
-            await app.closeVerifyToast();
+            await rejectToast(page, "Verify this device");
             const menu = await openSpaceCreateMenu(page);
             await menu
                 .locator('.mx_SpaceBasicSettings_avatarContainer input[type="file"]')

--- a/apps/web/playwright/e2e/spaces/threads-activity-centre/threadsActivityCentre.spec.ts
+++ b/apps/web/playwright/e2e/spaces/threads-activity-centre/threadsActivityCentre.spec.ts
@@ -6,6 +6,8 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import { expect, test } from ".";
 import { CommandOrControl } from "../../utils";
 import { isDendrite } from "../../../plugins/homeserver/dendrite";
@@ -24,8 +26,8 @@ test.describe("Threads Activity Centre", { tag: "@no-firefox" }, () => {
     test(
         "should have the button correctly aligned and displayed in the space panel when expanded",
         { tag: "@screenshot" },
-        async ({ util, app }) => {
-            await app.closeVerifyToast();
+        async ({ util, page }) => {
+            await rejectToast(page, "Verify this device");
 
             // Open the space panel
             await util.expandSpacePanel();
@@ -34,26 +36,31 @@ test.describe("Threads Activity Centre", { tag: "@no-firefox" }, () => {
         },
     );
 
-    test("should not show indicator when there is no thread", { tag: "@screenshot" }, async ({ room1, util, app }) => {
-        await app.closeVerifyToast();
+    test(
+        "should not show indicator when there is no thread",
+        { tag: "@screenshot" },
+        async ({ room1, util, app, page }) => {
+            await rejectToast(page, "Verify this device");
 
-        // No indicator should be shown
-        await util.assertNoTacIndicator();
+            // No indicator should be shown
+            await util.assertNoTacIndicator();
 
-        await util.goTo(room1);
-        await util.receiveMessages(room1, ["Msg1"]);
+            await util.goTo(room1);
+            await util.receiveMessages(room1, ["Msg1"]);
 
-        // A message in the main timeline should not affect the indicator
-        await util.assertNoTacIndicator();
-    });
+            // A message in the main timeline should not affect the indicator
+            await util.assertNoTacIndicator();
+        },
+    );
 
     test("should show a notification indicator when there is a message in a thread", async ({
         room1,
         util,
         msg,
         app,
+        page,
     }) => {
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
 
         await util.goTo(room1);
         await util.receiveMessages(room1, ["Msg1", msg.threadedOff("Msg1", "Resp1")]);
@@ -68,8 +75,9 @@ test.describe("Threads Activity Centre", { tag: "@no-firefox" }, () => {
         msg,
         user,
         app,
+        page,
     }) => {
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
 
         await util.goTo(room1);
         await util.receiveMessages(room1, [
@@ -91,8 +99,8 @@ test.describe("Threads Activity Centre", { tag: "@no-firefox" }, () => {
     test(
         "should show the rooms with unread threads",
         { tag: "@screenshot" },
-        async ({ room1, room2, util, msg, user, app }) => {
-            await app.closeVerifyToast();
+        async ({ room1, room2, util, msg, user, app, page }) => {
+            await rejectToast(page, "Verify this device");
 
             await util.goTo(room2);
             await util.populateThreads(room1, room2, msg, user);
@@ -114,8 +122,8 @@ test.describe("Threads Activity Centre", { tag: "@no-firefox" }, () => {
     test(
         "should update with a thread is read",
         { tag: "@screenshot" },
-        async ({ room1, room2, util, msg, user, app }) => {
-            await app.closeVerifyToast();
+        async ({ room1, room2, util, msg, user, app, page }) => {
+            await rejectToast(page, "Verify this device");
 
             await util.goTo(room2);
             await util.populateThreads(room1, room2, msg, user);
@@ -140,8 +148,8 @@ test.describe("Threads Activity Centre", { tag: "@no-firefox" }, () => {
         },
     );
 
-    test("should order by recency after notification level", async ({ room1, room2, util, msg, user, app }) => {
-        await app.closeVerifyToast();
+    test("should order by recency after notification level", async ({ room1, room2, util, msg, user, app, page }) => {
+        await rejectToast(page, "Verify this device");
 
         await util.goTo(room2);
         await util.populateThreads(room1, room2, msg, user, false);
@@ -154,7 +162,7 @@ test.describe("Threads Activity Centre", { tag: "@no-firefox" }, () => {
     });
 
     test("should block the Spotlight to open when the TAC is opened", async ({ util, page, app }) => {
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
 
         const toggleSpotlight = () => page.keyboard.press(`${CommandOrControl}+k`);
 
@@ -171,7 +179,7 @@ test.describe("Threads Activity Centre", { tag: "@no-firefox" }, () => {
     });
 
     test("should have the correct hover state", { tag: "@screenshot" }, async ({ util, page, app }) => {
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
 
         await util.hoverTacButton();
         await expect(util.getSpacePanel()).toMatchScreenshot("tac-hovered.png");
@@ -183,7 +191,7 @@ test.describe("Threads Activity Centre", { tag: "@no-firefox" }, () => {
     });
 
     test("should mark all threads as read", { tag: "@screenshot" }, async ({ room1, room2, util, msg, page, app }) => {
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
 
         await util.receiveMessages(room1, ["Msg1", msg.threadedOff("Msg1", "Resp1")]);
 
@@ -197,8 +205,15 @@ test.describe("Threads Activity Centre", { tag: "@no-firefox" }, () => {
         await util.assertNoTacIndicator();
     });
 
-    test("should focus the thread tab when clicking an item in the TAC", async ({ room1, room2, util, msg, app }) => {
-        await app.closeVerifyToast();
+    test("should focus the thread tab when clicking an item in the TAC", async ({
+        room1,
+        room2,
+        util,
+        msg,
+        app,
+        page,
+    }) => {
+        await rejectToast(page, "Verify this device");
 
         await util.receiveMessages(room1, ["Msg1", msg.threadedOff("Msg1", "Resp1")]);
 

--- a/apps/web/playwright/e2e/timeline/media-preview-settings.spec.ts
+++ b/apps/web/playwright/e2e/timeline/media-preview-settings.spec.ts
@@ -6,6 +6,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { type EventType, type MsgType, type RoomJoinRulesEventContent } from "matrix-js-sdk/src/types";
+import { rejectToast } from "@element-hq/element-web-playwright-common";
 
 import { test, expect } from "../../element-web-test";
 import { readSampleFileSync } from "../../sample-files";
@@ -36,7 +37,7 @@ test.describe("Media preview settings", () => {
     });
 
     test("should be able to hide avatars of inviters", { tag: "@screenshot" }, async ({ page, app, room, user }) => {
-        await app.closeVerifyToast();
+        await rejectToast(page, "Verify this device");
 
         let settings = await app.settings.openUserSettings("Preferences");
         await settings.getByLabel("Hide avatars of room and inviter").click();

--- a/apps/web/playwright/e2e/timeline/timeline.spec.ts
+++ b/apps/web/playwright/e2e/timeline/timeline.spec.ts
@@ -6,6 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { rejectToast } from "@element-hq/element-web-playwright-common";
+
 import type { Locator, Page } from "@playwright/test";
 import type { ISendEventResponse, EventType, MsgType, IContent } from "matrix-js-sdk/src/matrix";
 import { test, expect } from "../../element-web-test";
@@ -783,7 +785,7 @@ test.describe("Timeline", () => {
                     await sendEvent(app.client, room.roomId);
                     await sendEvent(app.client, room.roomId, true);
                     await page.goto(`/#/room/${room.roomId}`);
-                    await app.closeVerifyToast();
+                    await rejectToast(page, "Verify this device");
 
                     await app.toggleRoomInfoPanel();
 
@@ -809,7 +811,7 @@ test.describe("Timeline", () => {
                 await sendEvent(app.client, room.roomId);
 
                 await page.goto(`/#/room/${room.roomId}`);
-                await app.closeVerifyToast();
+                await rejectToast(page, "Verify this device");
 
                 // Open a room setting dialog
                 await app.toggleRoomInfoPanel();

--- a/apps/web/playwright/pages/ElementAppPage.ts
+++ b/apps/web/playwright/pages/ElementAppPage.ts
@@ -9,6 +9,7 @@ Please see LICENSE files in the repository root for full details.
 import { type Locator, type Page, expect } from "@playwright/test";
 import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
+import { rejectToast } from "@element-hq/element-web-playwright-common";
 
 import { Settings } from "./settings";
 import { Client } from "./client";
@@ -359,25 +360,11 @@ export class ElementAppPage {
     }
 
     /**
-     * Dismiss the "Notifications" toast.
-     */
-    public async closeNotificationToast(): Promise<void> {
-        await this.closeToast("Notifications", "Dismiss");
-    }
-
-    /**
      * Dismiss the "Turn on key storage" toast.
      */
     public async closeKeyStorageToast() {
-        await this.closeToast("Turn on key storage", "Dismiss");
+        await rejectToast(this.page, "Turn on key storage");
         await this.page.getByRole("button", { name: "Yes, dismiss" }).click();
-    }
-
-    /**
-     * Dismiss the "Verify this device" toast by clicking "Later".
-     */
-    public async closeVerifyToast() {
-        await this.closeToast("Verify this device", "Later");
     }
 
     /**


### PR DESCRIPTION
Standardise on one way of rejecting toasts.

As requested in https://github.com/element-hq/element-web/pull/32891#discussion_r3021499107

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
