### PR TITLE
Fix build-and-test workflow for downstream runs

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -214,7 +214,7 @@ jobs:
             contents: read
         with:
             config: ${{ (github.event.pull_request.base.ref || github.ref_name) == 'develop' && 'element.io/nightly' || 'element.io/release' }}
-            version: ${{ (github.event.pull_request.base.ref || github.ref_name) == 'develop' && 'develop' || '' }}
+            version: ${{ case((github.event.pull_request.base.ref || github.ref_name) == 'develop' || github.event_name == 'merge_group', 'develop', '') }}
             webapp-artifact: webapp
 
     build_ed_windows:


### PR DESCRIPTION
e.g. from matrix-js-sdk

```
Run cardinalby/git-get-release-action@5172c3a026600b1d459b117738c605fabc9e4e44
Retrieving release by v1.12.13 tag...
Error: HttpError: Not Found
```

https://github.com/matrix-org/matrix-js-sdk/actions/runs/23909879285/job/69729270807
