### PR TITLE
fix: prevent accidental text selection in left sidebar

### DIFF
--- a/apps/web/res/css/structures/_LeftPanel.pcss
+++ b/apps/web/res/css/structures/_LeftPanel.pcss
@@ -41,6 +41,14 @@ Please see LICENSE files in the repository root for full details.
     flex-direction: row;
     flex: 1;
     height: 100%; /* ensure space panel is still scrollable with an outer wrapper */
+    user-select: none;
+
+    input,
+    textarea,
+    select,
+    [contenteditable="true"] {
+        user-select: text;
+    }
 
     .mx_LeftPanel_wrapper--user {
         background-color: $roomlist-bg-color;


### PR DESCRIPTION
## Summary
Prevents accidental text selection when clicking and dragging in the left sidebar panel by adding `user-select: none` to the left panel wrapper.

Interactive elements (inputs, textareas, contenteditable) inside the sidebar retain normal text selection behavior.

## Changes
- Added `user-select: none` to `.mx_LeftPanel_wrapper` in `_LeftPanel.pcss`
- Added override `user-select: text` for input, textarea, select, and contenteditable elements

## Testing
- Click and drag in the left sidebar blank space — no text should be selected
- Verify that search inputs and other text fields still allow text selection

Fixes #24590

---
*Built autonomously by [islo.dev](https://islo.dev) Builder*