### PR TITLE
Fix `.gitignore` so that newly created storybook screenshots can be commited 

### DIFF
--- a/packages/shared-components/.gitignore
+++ b/packages/shared-components/.gitignore
@@ -2,8 +2,9 @@
 /src/**/__screenshots__/
 
 # Ignore vis diffs & local baseline
-/__vis__/**
-!/__vis__/linux/__baselines__
+/__vis__/**/__diffs__
+/__vis__/**/__results__
+/__vis__/local
 
 # Ignore coverage report
 /coverage/


### PR DESCRIPTION
Since the generated screenshots are put in a directory structure that is same as the view (eg: `__vis__/linux/__baselines__/room/timeline/event-tile/call/CallStartedTile/CallStartedTileView.stories.tsx/default-auto.png`), we'd need to unignore each level of the directory.

The plugin already has a `.gitignore` suggestion: https://repobuddy.github.io/visual-testing/?path=/docs/overview--docs#ignore-snapshot-folders