### PR TITLE
Update develop CD check-regexp to exclude Netlify

### DIFF
--- a/.github/workflows/build_develop.yml
+++ b/.github/workflows/build_develop.yml
@@ -111,7 +111,7 @@ jobs:
                   running-workflow-name: "Build & Deploy develop.element.io"
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   wait-interval: 10
-                  check-regexp: ^((?!SonarCloud|SonarQube|issue|board|label|Release|prepare|GitHub Pages|Upload).)*$
+                  check-regexp: ^((?!SonarCloud|SonarQube|issue|board|label|Release|prepare|GitHub Pages|Upload|Netlify).)*$
 
             # We keep the latest develop.tar.gz on R2 instead of relying on the github artifact uploaded earlier
             # as the expires after 24h and requires auth to download.


### PR DESCRIPTION
As the workflow_run impacts the HEAD commit so a PR triggered run may cause this to fail