### PR TITLE
Fix docs:build workflow run on a tag

### DIFF
--- a/scripts/gen-workflow-mermaid.ts
+++ b/scripts/gen-workflow-mermaid.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs";
+import fs from "node:fs/promises";
 import path from "node:path";
 import YAML from "yaml";
 import parseArgs from "minimist";
@@ -288,16 +288,16 @@ function getTriggerNodes<K extends keyof WorkflowYaml["on"]>(key: K, workflow: W
     });
 }
 
-function readFile(...pathSegments: string[]): string {
-    return fs.readFileSync(path.join(...pathSegments), { encoding: "utf-8" });
+function readFile(...pathSegments: string[]): Promise<string> {
+    return fs.readFile(path.join(...pathSegments), { encoding: "utf-8" });
 }
 
-function readJson<T extends object>(...pathSegments: string[]): T {
-    return JSON.parse(readFile(...pathSegments));
+async function readJson<T extends object>(...pathSegments: string[]): Promise<T> {
+    return JSON.parse(await readFile(...pathSegments));
 }
 
-function readYaml<T extends object>(...pathSegments: string[]): T {
-    return YAML.parse(readFile(...pathSegments));
+async function readYaml<T extends object>(...pathSegments: string[]): Promise<T> {
+    return YAML.parse(await readFile(...pathSegments));
 }
 
 function toArray<T>(v: T | T[]): T[] {
@@ -442,8 +442,16 @@ export default async function main(dirs: string[], on?: string[], print = false,
         const {
             name,
             repository: { url },
-        } = readJson<{ name: string; repository: { url: string } }>(projectPath, "package.json");
+        } = await readJson<{ name: string; repository: { url: string } }>(projectPath, "package.json");
         const workflowsPath = path.join(projectPath, ".github", "workflows");
+
+        let files: string[];
+        try {
+            files = await fs.readdir(workflowsPath);
+        } catch (e) {
+            console.error(`Could not read ${workflowsPath}`, e);
+            continue;
+        }
 
         const project: Project = {
             name,
@@ -452,8 +460,8 @@ export default async function main(dirs: string[], on?: string[], print = false,
             workflows: new Map(),
         };
 
-        for (const file of fs.readdirSync(workflowsPath).filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))) {
-            const data = readYaml<WorkflowYaml>(workflowsPath, file);
+        for (const file of files.filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))) {
+            const data = await readYaml<WorkflowYaml>(workflowsPath, file);
             const name = data.name ?? file;
             const workflow: Workflow = {
                 id: `${project.name}/${name}`,


### PR DESCRIPTION
where js-sdk workflows are not available

```
Run pnpm --if-present run "$CMD" && pnpm -r --if-present run "$CMD"

> element-web-monorepo@0.0.0 docs:build /home/runner/work/element-web/element-web
> vitepress build docs

build error:
ENOENT: no such file or directory, scandir '/home/runner/work/element-web/element-web/node_modules/matrix-js-sdk/.github/workflows'
Error: ENOENT: no such file or directory, scandir '/home/runner/work/element-web/element-web/node_modules/matrix-js-sdk/.github/workflows'
    at Object.readdirSync (node:fs:1569:26)
    at main (file:///home/runner/work/element-web/element-web/docs/generated/%5Bid%5D.paths.ts.timestamp-1775568407362-13f9deb23a5178.mjs:293:27)
    at paths (file:///home/runner/work/element-web/element-web/docs/generated/%5Bid%5D.paths.ts.timestamp-1775568407362-13f9deb23a5178.mjs:460:24)
    at resolveRoute (file:///home/runner/work/element-web/element-web/node_modules/vitepress/dist/node/chunk-D3CUZ4fa.js:17268:60)
    at resolveDynamicRoutes (file:///home/runner/work/element-web/element-web/node_modules/vitepress/dist/node/chunk-D3CUZ4fa.js:17282:31)
    at async resolvePages (file:///home/runner/work/element-web/element-web/node_modules/vitepress/dist/node/chunk-D3CUZ4fa.js:17152:25)
    at async resolveConfig (file:///home/runner/work/element-web/element-web/node_modules/vitepress/dist/node/chunk-D3CUZ4fa.js:17449:46)
    at async build (file:///home/runner/work/element-web/element-web/node_modules/vitepress/dist/node/chunk-D3CUZ4fa.js:49562:22)
 ELIFECYCLE  Command failed with exit code 1.
Error: Process completed with exit code 1.
```

https://github.com/element-hq/element-web/actions/runs/24083811818/job/70251059450
