### PR TITLE
Consolidate element-modules playwright run into the main html report

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -188,6 +188,7 @@ jobs:
         uses: element-hq/element-modules/.github/workflows/reusable-playwright-tests.yml@main # zizmor: ignore[unpinned-uses]
         with:
             webapp-artifact: webapp
+            reporter: blob
 
     prepare_ed:
         name: "Prepare Element Desktop"


### PR DESCRIPTION
Requires https://github.com/element-hq/element-modules/pull/249

This also enables tracking flaky tests for modules tests