### PR TITLE
Generalise npm publishing workflow to work for more than just shared-components

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -1,6 +1,15 @@
-name: Publish shared component npm package
+name: Publish npm package
+run-name: Publish ${{ inputs.package }}
 on:
-    workflow_dispatch: {}
+    workflow_dispatch:
+        inputs:
+            package:
+                description: Which package to release
+                required: true
+                type: choice
+                options:
+                    - playwright-common
+                    - shared-components
 
 concurrency: release
 jobs:
@@ -29,10 +38,9 @@ jobs:
             - name: Update npm
               run: npm install -g npm@latest
 
-            # Need to setup element web too as it needs the translations
-            - name: 🛠️ Setup EW
+            - name: 🛠️ Install dependencies
               run: pnpm install --frozen-lockfile
 
             - name: 🚀 Publish to npm
-              working-directory: packages/shared-components
+              working-directory: packages/${{ inputs.package }}
               run: npm publish --access public --provenance

--- a/packages/shared-components/README.md
+++ b/packages/shared-components/README.md
@@ -365,4 +365,4 @@ pnpm i18n
 Two steps are required to publish a new version of this package:
 
 1. Bump the version in `package.json` following semver rules and open a PR.
-2. Once merged run the [github workflow](https://github.com/element-hq/element-web/actions/workflows/shared-component-publish.yaml)
+2. Once merged run the [github workflow](https://github.com/element-hq/element-web/actions/workflows/npm-publish.yaml)


### PR DESCRIPTION
To enable shipping more npm packages from the monorepo