### PR TITLE
Improve output of playwright-screenshots script

### DIFF
--- a/packages/playwright-common/playwright-screenshots.sh
+++ b/packages/playwright-common/playwright-screenshots.sh
@@ -19,14 +19,11 @@ WS_PORT=3000
 PW_VERSION=$(pnpm --silent -- playwright --version | awk '{print $2}')
 IMAGE_NAME="ghcr.io/element-hq/element-web/playwright-server:$PW_VERSION"
 
-# If we don't already have the image, and it exists in the repository, pull it;
-# failing that build it.
+# If the image exists in the repository, pull it; otherwise, build it.
 #
-# (This series of explicit tests gives the user clearer progress info than just
+# (This explicit test gives the user clearer progress info than just
 # `docker pull 2>/dev/null || build_image`.)
-if docker image inspect "$IMAGE_NAME" &>/dev/null; then
-    echo "Using local copy of image $IMAGE_NAME"
-elif docker manifest inspect "$IMAGE_NAME" &>/dev/null; then
+if docker manifest inspect "$IMAGE_NAME" &>/dev/null; then
     docker pull "$IMAGE_NAME"
 else
     build_image "$IMAGE_NAME"

--- a/packages/playwright-common/playwright-screenshots.sh
+++ b/packages/playwright-common/playwright-screenshots.sh
@@ -19,8 +19,18 @@ WS_PORT=3000
 PW_VERSION=$(pnpm --silent -- playwright --version | awk '{print $2}')
 IMAGE_NAME="ghcr.io/element-hq/element-web/playwright-server:$PW_VERSION"
 
-# Pull the image, failing that build the image
-docker pull "$IMAGE_NAME" 2>/dev/null || build_image "$IMAGE_NAME"
+# If we don't already have the image, and it exists in the repository, pull it;
+# failing that build it.
+#
+# (This series of explicit tests gives the user clearer progress info than just
+# `docker pull 2>/dev/null || build_image`.)
+if docker image inspect "$IMAGE_NAME" &>/dev/null; then
+    echo "Using local copy of image $IMAGE_NAME"
+elif docker manifest inspect "$IMAGE_NAME" &>/dev/null; then
+    docker pull "$IMAGE_NAME"
+else
+    build_image "$IMAGE_NAME"
+fi
 
 # Start the playwright-server in docker
 CONTAINER=$(docker run --network=host -v /tmp:/tmp --rm -d -e PORT="$WS_PORT" "$IMAGE_NAME")


### PR DESCRIPTION
Currently, when you run the playwright-screenshots script, it sits silently for 2 minutes 30 seconds (yes, I timed it) and looks like it's crashed. It's actually pulling a GB of images from the docker repo, but the user has no way to know that.

Update the script to actually give the user some feedback.