### PR TITLE
Fix playwright-server docker image not exiting

### DIFF
--- a/packages/playwright-common/Dockerfile
+++ b/packages/playwright-common/Dockerfile
@@ -21,4 +21,4 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 # The easiest solution is to use docker-init, which is in fact `tini` (https://github.com/krallin/tini).
 #
 # See https://github.com/krallin/tini/issues/8#issuecomment-146135930 for a good explanation of all this.)
-ENTRYPOINT ["/usr/bin/docker-init" "/docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/docker-init", "/docker-entrypoint.sh"]

--- a/packages/playwright-common/Dockerfile
+++ b/packages/playwright-common/Dockerfile
@@ -12,4 +12,13 @@ RUN npm i -g playwright@${PLAYWRIGHT_VERSION}
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
+# We use `docker-init` as PID 1, which means that the container shuts down correctly on SIGTERM.
+#
+# (The problem is that PID 1 doesn't get default signal handlers, and
+# playwright server doesn't register a SIGTERM handler, so if that ends up as
+# PID 1, then it ignores SIGTERM. Likewise bash doesn't retstart a SIGTERM handler by default.
+#
+# The easiest solution is to use docker-init, which is in fact `tini` (https://github.com/krallin/tini).
+#
+# See https://github.com/krallin/tini/issues/8#issuecomment-146135930 for a good explanation of all this.)
+ENTRYPOINT ["/usr/bin/docker-init" "/docker-entrypoint.sh"]

--- a/packages/playwright-common/Dockerfile
+++ b/packages/playwright-common/Dockerfile
@@ -16,7 +16,7 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 #
 # (The problem is that PID 1 doesn't get default signal handlers, and
 # playwright server doesn't register a SIGTERM handler, so if that ends up as
-# PID 1, then it ignores SIGTERM. Likewise bash doesn't retstart a SIGTERM handler by default.
+# PID 1, then it ignores SIGTERM. Likewise bash doesn't set a SIGTERM handler by default.
 #
 # The easiest solution is to use docker-init, which is in fact `tini` (https://github.com/krallin/tini).
 #

--- a/packages/playwright-common/docker-entrypoint.sh
+++ b/packages/playwright-common/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # We use npm here as we used `npm i -g` to install playwright in the Dockerfile
-npm exec -- playwright run-server --port "$PORT" --host 0.0.0.0
+exec npm exec -- /usr/bin/playwright run-server --port "$PORT" --host 0.0.0.0

--- a/packages/playwright-common/docker-entrypoint.sh
+++ b/packages/playwright-common/docker-entrypoint.sh
@@ -1,4 +1,2 @@
 #!/bin/bash
-
-# We use npm here as we used `npm i -g` to install playwright in the Dockerfile
-exec npm exec -- /usr/bin/playwright run-server --port "$PORT" --host 0.0.0.0
+exec /usr/bin/playwright run-server --port "$PORT" --host 0.0.0.0


### PR DESCRIPTION
... by wrapping with tini.

Currently, when you `docker stop` the playwright-server docker container, nothing happens for 10 seconds, because the container ignores the SIGTERM signal.

Per the comment, wrapping with tini instead of bash fixes the problem, because tini will forward the signal to the playwright server.