### PR TITLE
Fix date separator trigger ref forwarding for jump-to-date menu

### DIFF
--- a/packages/shared-components/src/room/timeline/DateSeparatorView/DateSeparatorButton.tsx
+++ b/packages/shared-components/src/room/timeline/DateSeparatorView/DateSeparatorButton.tsx
@@ -6,7 +6,6 @@
  */
 
 import React, { forwardRef } from "react";
-import { mergeRefs } from "react-merge-refs";
 import { Heading, Tooltip } from "@vector-im/compound-web";
 import ChevronDownIcon from "@vector-im/compound-design-tokens/assets/web/icons/chevron-down";
 
@@ -21,8 +20,6 @@ export interface DateSeparatorButtonProps {
     tooltipOpen?: boolean;
     /** Extra CSS classes to apply to the component. */
     className?: string;
-    /** Optional ref for the button container element. */
-    buttonRef?: React.Ref<HTMLDivElement>;
     /** Called when the pointer enters the button trigger. */
     onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
     /** Called when the pointer leaves the button trigger. */
@@ -35,7 +32,7 @@ export interface DateSeparatorButtonProps {
 
 /** Interactive date separator button that opens the jump-to-date menu. */
 export const DateSeparatorButton = forwardRef<HTMLDivElement, DateSeparatorButtonProps>(function DateSeparatorButton(
-    { label, tooltipOpen, className, buttonRef, ...props },
+    { label, tooltipOpen, className, ...props },
     forwardedRef,
 ): React.ReactNode {
     const { translate: _t } = useI18n();
@@ -43,7 +40,7 @@ export const DateSeparatorButton = forwardRef<HTMLDivElement, DateSeparatorButto
     return (
         <Tooltip description={_t("room|jump_to_date")} placement="right" open={tooltipOpen}>
             <Flex
-                ref={mergeRefs([buttonRef, forwardedRef])}
+                ref={forwardedRef}
                 data-testid="jump-to-date-separator-button"
                 className={className}
                 aria-live="off"

--- a/packages/shared-components/src/room/timeline/DateSeparatorView/DateSeparatorButton.tsx
+++ b/packages/shared-components/src/room/timeline/DateSeparatorView/DateSeparatorButton.tsx
@@ -5,7 +5,8 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-import React from "react";
+import React, { forwardRef } from "react";
+import { mergeRefs } from "react-merge-refs";
 import { Heading, Tooltip } from "@vector-im/compound-web";
 import ChevronDownIcon from "@vector-im/compound-design-tokens/assets/web/icons/chevron-down";
 
@@ -33,18 +34,16 @@ export interface DateSeparatorButtonProps {
 }
 
 /** Interactive date separator button that opens the jump-to-date menu. */
-export function DateSeparatorButton({
-    label,
-    tooltipOpen,
-    className,
-    buttonRef,
-    ...props
-}: DateSeparatorButtonProps): React.ReactNode {
+export const DateSeparatorButton = forwardRef<HTMLDivElement, DateSeparatorButtonProps>(function DateSeparatorButton(
+    { label, tooltipOpen, className, buttonRef, ...props },
+    forwardedRef,
+): React.ReactNode {
     const { translate: _t } = useI18n();
+
     return (
         <Tooltip description={_t("room|jump_to_date")} placement="right" open={tooltipOpen}>
             <Flex
-                ref={buttonRef}
+                ref={mergeRefs([buttonRef, forwardedRef])}
                 data-testid="jump-to-date-separator-button"
                 className={className}
                 aria-live="off"
@@ -60,4 +59,4 @@ export function DateSeparatorButton({
             </Flex>
         </Tooltip>
     );
-}
+});

--- a/packages/shared-components/src/room/timeline/DateSeparatorView/DateSeparatorButton.tsx
+++ b/packages/shared-components/src/room/timeline/DateSeparatorView/DateSeparatorButton.tsx
@@ -30,7 +30,7 @@ export interface DateSeparatorButtonProps {
     onBlur?: React.FocusEventHandler<HTMLDivElement>;
 }
 
-/** Interactive date separator button that opens the jump-to-date menu. */
+/** Interactive date separator button that forwards its ref to the underlying trigger element used by Compound Menu. */
 export const DateSeparatorButton = forwardRef<HTMLDivElement, DateSeparatorButtonProps>(function DateSeparatorButton(
     { label, tooltipOpen, className, ...props },
     forwardedRef,

--- a/packages/shared-components/src/room/timeline/DateSeparatorView/DateSeparatorView.test.tsx
+++ b/packages/shared-components/src/room/timeline/DateSeparatorView/DateSeparatorView.test.tsx
@@ -7,12 +7,13 @@
 
 import { render, screen } from "@test-utils";
 import { composeStories } from "@storybook/react-vite";
-import React from "react";
+import React, { createRef } from "react";
 import { describe, it, expect } from "vitest";
 import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { BaseViewModel } from "../../../core/viewmodel/BaseViewModel";
+import { DateSeparatorButton } from "./DateSeparatorButton";
 import { DateSeparatorView, type DateSeparatorViewModel, type DateSeparatorViewSnapshot } from "./DateSeparatorView";
 import * as stories from "./DateSeparatorView.stories";
 
@@ -72,5 +73,13 @@ describe("DateSeparatorView", () => {
         expect(screen.getByText("Today", { selector: "h2" })).toBeInTheDocument();
         vm.setSnapshot({ label: "Yesterday" });
         await waitFor(() => expect(screen.getByText("Yesterday", { selector: "h2" })).toBeInTheDocument());
+    });
+
+    it("forwards refs to the trigger element", () => {
+        const ref = createRef<HTMLDivElement>();
+
+        render(<DateSeparatorButton ref={ref} label="Today" />);
+
+        expect(ref.current).toBe(screen.getByTestId("jump-to-date-separator-button"));
     });
 });


### PR DESCRIPTION
DateSeparatorView used DateSeparatorButton as the trigger for the jump-to-date menu, but that trigger did not forward the ref required by Radix/compound Menu when using asChild. Because the same element was also wrapped in a tooltip, the floating/menu anchor became unstable under repeated remounts while scrolling the timeline, which could lead to runaway update loops and the React "Maximum update depth exceeded" error.

Fixes: https://github.com/element-hq/element-web/issues/33101
