### PR TITLE
Remove useless `disabled=` on RoomStatusBarView

### DIFF
--- a/packages/shared-components/src/room/RoomStatusBar/RoomStatusBarView.tsx
+++ b/packages/shared-components/src/room/RoomStatusBar/RoomStatusBarView.tsx
@@ -270,7 +270,6 @@ export function RoomStatusBarView({ vm }: Readonly<RoomStatusBarViewProps>): JSX
                                         size="sm"
                                         kind="secondary"
                                         Icon={DeleteIcon}
-                                        disabled={snapshot.isResending}
                                         className={styles.secondaryAction}
                                         onClick={deleteAllClick}
                                     >
@@ -282,7 +281,6 @@ export function RoomStatusBarView({ vm }: Readonly<RoomStatusBarViewProps>): JSX
                                         size="sm"
                                         kind="primary"
                                         Icon={RestartIcon}
-                                        disabled={snapshot.isResending}
                                         onClick={resendClick}
                                         className={styles.primaryAction}
                                     >

--- a/packages/shared-components/src/room/RoomStatusBar/__snapshots__/RoomStatusBarView.test.tsx.snap
+++ b/packages/shared-components/src/room/RoomStatusBar/__snapshots__/RoomStatusBarView.test.tsx.snap
@@ -281,7 +281,6 @@ exports[`RoomStatusBarView > renders unsent messages 1`] = `
       class="actions"
     >
       <button
-        aria-disabled="false"
         class="_button_13vu4_8 secondaryAction _has-icon_13vu4_60"
         data-kind="secondary"
         data-size="sm"
@@ -303,7 +302,6 @@ exports[`RoomStatusBarView > renders unsent messages 1`] = `
         Delete all
       </button>
       <button
-        aria-disabled="false"
         class="_button_13vu4_8 primaryAction _has-icon_13vu4_60"
         data-kind="primary"
         data-size="sm"
@@ -376,7 +374,6 @@ exports[`RoomStatusBarView > renders unsent messages and deletes all 1`] = `
       class="actions"
     >
       <button
-        aria-disabled="false"
         class="_button_13vu4_8 secondaryAction _has-icon_13vu4_60"
         data-kind="secondary"
         data-size="sm"
@@ -398,7 +395,6 @@ exports[`RoomStatusBarView > renders unsent messages and deletes all 1`] = `
         Delete all
       </button>
       <button
-        aria-disabled="false"
         class="_button_13vu4_8 primaryAction _has-icon_13vu4_60"
         data-kind="primary"
         data-size="sm"
@@ -471,7 +467,6 @@ exports[`RoomStatusBarView > renders unsent messages and resends all 1`] = `
       class="actions"
     >
       <button
-        aria-disabled="false"
         class="_button_13vu4_8 secondaryAction _has-icon_13vu4_60"
         data-kind="secondary"
         data-size="sm"
@@ -493,7 +488,6 @@ exports[`RoomStatusBarView > renders unsent messages and resends all 1`] = `
         Delete all
       </button>
       <button
-        aria-disabled="false"
         class="_button_13vu4_8 primaryAction _has-icon_13vu4_60"
         data-kind="primary"
         data-size="sm"


### PR DESCRIPTION
We don't need a `disabled=` because we actually hide both buttons anyway with a spinner (as per design :stuck_out_tongue: ). This should have no impact to end users but makes our code make more sense

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
