### PR TITLE
Pin matrix-seshat version to 4.0.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -105,7 +105,7 @@
         "typescript": "5.9.3"
     },
     "hakDependencies": {
-        "matrix-seshat": "^4.0.1"
+        "matrix-seshat": "4.0.1"
     },
     "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }


### PR DESCRIPTION
As 4.1.0 seems broken https://github.com/matrix-org/matrix-js-sdk/actions/runs/24346991243/job/71091033109
