### PR TITLE
Skip bulk of CI in pull_request renovate runs

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -55,7 +55,7 @@ jobs:
             num-runners: ${{ env.NUM_RUNNERS }}
             runners-matrix: ${{ steps.runner-vars.outputs.matrix }}
             # Skip pull_request runs on renovate PRs to speed up CI time, delegating to the full run in merge queue
-            skip: ${{ inputs.skip || (startsWith(github.ref_name, 'renovate/') && github.event_name == 'pull_request') }}
+            skip: ${{ inputs.skip || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/')) }}
         steps:
             - name: Checkout code
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -54,6 +54,8 @@ jobs:
         outputs:
             num-runners: ${{ env.NUM_RUNNERS }}
             runners-matrix: ${{ steps.runner-vars.outputs.matrix }}
+            # Skip pull_request runs on renovate PRs to speed up CI time, delegating to the full run in merge queue
+            skip: ${{ inputs.skip || (startsWith(github.ref_name, 'renovate/') && github.event_name == 'pull_request') }}
         steps:
             - name: Checkout code
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -102,7 +104,7 @@ jobs:
     playwright_ew:
         name: "Run Tests [${{ matrix.project }}] ${{ matrix.runner }}/${{ needs.build_ew.outputs.num-runners }}"
         needs: build_ew
-        if: inputs.skip != true
+        if: needs.build_ew.outputs.skip != 'true'
         runs-on: ubuntu-24.04
         permissions:
             actions: read
@@ -182,7 +184,7 @@ jobs:
     downstream-modules:
         name: Downstream Playwright tests [element-modules]
         needs: build_ew
-        if: inputs.skip != true && github.event_name == 'merge_group'
+        if: needs.build_ew.outputs.skip != 'true' && github.event_name == 'merge_group'
         uses: element-hq/element-modules/.github/workflows/reusable-playwright-tests.yml@main # zizmor: ignore[unpinned-uses]
         with:
             webapp-artifact: webapp
@@ -192,7 +194,7 @@ jobs:
         name: "Prepare Element Desktop"
         uses: ./.github/workflows/build_desktop_prepare.yaml
         needs: build_ew
-        if: inputs.skip != true
+        if: needs.build_ew.outputs.skip != 'true'
         permissions:
             contents: read
         with:
@@ -204,7 +206,6 @@ jobs:
         needs: prepare_ed
         name: "Desktop Windows"
         uses: ./.github/workflows/build_desktop_windows.yaml
-        if: inputs.skip != true
         strategy:
             matrix:
                 arch: [x64, ia32, arm64]
@@ -216,7 +217,6 @@ jobs:
         needs: prepare_ed
         name: "Desktop Linux"
         uses: ./.github/workflows/build_desktop_linux.yaml
-        if: inputs.skip != true
         strategy:
             matrix:
                 sqlcipher: [system, static]
@@ -236,13 +236,13 @@ jobs:
         needs: prepare_ed
         name: "Desktop macOS"
         uses: ./.github/workflows/build_desktop_macos.yaml
-        if: inputs.skip != true
         with:
             blob_report: true
 
     complete:
         name: end-to-end-tests
         needs:
+            - build_ew
             - playwright_ew
             - downstream-modules
             - prepare_ed
@@ -253,25 +253,25 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-              if: inputs.skip != true
+              if: needs.build_ew.outputs.skip != 'true'
               with:
                   persist-credentials: false
                   repository: element-hq/element-web
 
             - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-              if: inputs.skip != true
+              if: needs.build_ew.outputs.skip != 'true'
             - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-              if: inputs.skip != true
+              if: needs.build_ew.outputs.skip != 'true'
               with:
                   cache: "pnpm"
                   node-version: "lts/*"
 
             - name: Install dependencies
-              if: inputs.skip != true
+              if: needs.build_ew.outputs.skip != 'true'
               run: pnpm install --frozen-lockfile
 
             - name: Download blob reports from GitHub Actions Artifacts
-              if: inputs.skip != true
+              if: needs.build_ew.outputs.skip != 'true'
               uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   pattern: blob-report-*
@@ -279,7 +279,7 @@ jobs:
                   merge-multiple: true
 
             - name: Merge into HTML Report
-              if: inputs.skip != true
+              if: needs.build_ew.outputs.skip != 'true'
               run: |
                   pnpm playwright merge-reports \
                       --config=playwright-merge.config.ts \
@@ -291,7 +291,7 @@ jobs:
 
             # Upload the HTML report even if one of our reporters fails, this can happen when stale screenshots are detected
             - name: Upload HTML report
-              if: always() && inputs.skip != true
+              if: always() && needs.build_ew.outputs.skip != 'true'
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: html-report


### PR DESCRIPTION
Relying instead on running the full suite in the merge queue to lower the impact of Renovate on the github actions concurrency limits in the org

