### PR TITLE
Fix layered.sh linking js-sdk incorrectly

### DIFF
--- a/scripts/fetchdep.sh
+++ b/scripts/fetchdep.sh
@@ -27,7 +27,10 @@ clone() {
     then
         echo "Trying to use $org/$repo#$branch"
         # Disable auth prompts: https://serverfault.com/a/665959
-        GIT_TERMINAL_PROMPT=0 git clone https://github.com/$org/$repo.git $repo --branch "$branch" --depth 1 && exit 0
+        if GIT_TERMINAL_PROMPT=0 git clone "https://github.com/$org/$repo.git" "$repo" --branch "$branch" --depth 1; then
+            git -C "$repo" log -1
+            exit 0
+        fi
     fi
 }
 
@@ -39,7 +42,7 @@ getPRInfo() {
 
         apiEndpoint="https://api.github.com/repos/$PR_ORG/$PR_REPO/pulls/$number"
 
-        head=$(curl $apiEndpoint | jq -r '.head.label')
+        head=$(curl "$apiEndpoint" | jq -r '.head.label')
     fi
 }
 
@@ -47,16 +50,17 @@ getPRInfo() {
 # GH API for more info - "fork:branch". Some give us this directly.
 if [ -n "$PR_NUMBER" ]; then
     # GitHub
-    getPRInfo $PR_NUMBER
+    getPRInfo "$PR_NUMBER"
 elif [ -n "$REVIEW_ID" ]; then
     # Netlify
-    getPRInfo $REVIEW_ID
+    getPRInfo "$REVIEW_ID"
 fi
 
 # for forks, $head will be in the format "fork:branch", so we split it by ":"
 # into an array. On non-forks, this has the effect of splitting into a single
 # element array given ":" shouldn't appear in the head - it'll just be the
 # branch name. Based on the results, we clone.
+# shellcheck disable=SC2206
 BRANCH_ARRAY=(${head//:/ })
 TRY_ORG=$deforg
 TRY_BRANCH=${BRANCH_ARRAY[0]}
@@ -67,13 +71,13 @@ if [[ "$head" == *":"* ]]; then
     fi
     TRY_BRANCH=${BRANCH_ARRAY[1]}
 fi
-clone ${TRY_ORG} $defrepo ${TRY_BRANCH}
+clone "$TRY_ORG" "$defrepo" "$TRY_BRANCH"
 
 # For merge queue runs we need to extract the temporary branch name
 # the ref_name will look like `gh-readonly-queue/<branch>/pr-<number>-<sha>`
 if [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
     withoutPrefix=${GITHUB_REF_NAME#gh-readonly-queue/}
-    clone $deforg $defrepo ${withoutPrefix%%/pr-*}
+    clone "$deforg" "$defrepo" "${withoutPrefix%%/pr-*}"
 fi
 
 # Try the target branch of the push or PR, or the branch that was pushed to
@@ -83,10 +87,10 @@ if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
     base_or_branch=${GITHUB_REF}
 fi
 if [ -n "$base_or_branch" ]; then
-    clone $deforg $defrepo $base_or_branch
+    clone "$deforg" "$defrepo" "$base_or_branch"
 fi
 
 # Try HEAD which is the branch name in Netlify (not BRANCH which is pull/xxxx/head for PR builds)
-clone $deforg $defrepo $HEAD
+clone "$deforg" "$defrepo" "$HEAD"
 # Use the default branch as the last resort.
-clone $deforg $defrepo $defbranch
+clone "$deforg" "$defrepo" "$defbranch"

--- a/scripts/layered.sh
+++ b/scripts/layered.sh
@@ -25,14 +25,14 @@ js_sdk_dep=$(jq -r '.dependencies["matrix-js-sdk"]' < $(pnpm -w root)/../apps/we
 # Set up the js-sdk first (unless package.json pins a specific version)
 if [ "$js_sdk_dep" = "github:matrix-org/matrix-js-sdk#develop" ]; then
     scripts/fetchdep.sh matrix-org matrix-js-sdk develop
-    pushd matrix-js-sdk
-    [ -n "$JS_SDK_GITHUB_BASE_REF" ] && git fetch --depth 1 origin $JS_SDK_GITHUB_BASE_REF && git checkout $JS_SDK_GITHUB_BASE_REF
-    pnpm link
-    pnpm install --frozen-lockfile
-    popd
+
+    if [ -n "$JS_SDK_GITHUB_BASE_REF" ]; then
+        git -C matrix-js-sdk fetch --depth 1 origin $JS_SDK_GITHUB_BASE_REF
+        git -C matrix-js-sdk checkout $JS_SDK_GITHUB_BASE_REF
+    fi
 
     # Link into into element-web
-    pnpm link matrix-js-sdk
+    pnpm link ./matrix-js-sdk
 else
     echo "Skipping matrix-js-sdk fetch and link as package.json pins $js_sdk_dep"
 fi

--- a/scripts/layered.sh
+++ b/scripts/layered.sh
@@ -14,7 +14,7 @@ set -ex
 # for the primary repo (element-web in this case).
 
 # Install dependencies
-pnpm install --frozen-lockfile
+pnpm install --frozen-lockfile $@
 
 # Pass appropriate repo to fetchdep.sh
 export PR_ORG=element-hq
@@ -30,11 +30,11 @@ if [ "$js_sdk_dep" = "github:matrix-org/matrix-js-sdk#develop" ]; then
         git -C matrix-js-sdk fetch --depth 1 origin $JS_SDK_GITHUB_BASE_REF
         git -C matrix-js-sdk checkout $JS_SDK_GITHUB_BASE_REF
     fi
+    pnpm -C matrix-js-sdk install --frozen-lockfile --ignore-scripts
 
-    # Link into into element-web
+    # Link into into element-web & the monorepo
+    pnpm -C apps/web link ./matrix-js-sdk
     pnpm link ./matrix-js-sdk
 else
     echo "Skipping matrix-js-sdk fetch and link as package.json pins $js_sdk_dep"
 fi
-
-pnpm install --frozen-lockfile $@


### PR DESCRIPTION
It was linking into the root which ended up just moving the hoisted matrix-js-sdk into apps/web so it wasn't getting picked up correctly

pnpm link already installs dependencies, this was causing the prepare script to run twice

Review commit-by-commit