### PR TITLE
Exclude binary files from Sonar analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.organization=element-hq
 sonar.sources=.
 sonar.tests=apps/web/test,apps/web/playwright,apps/desktop/playwright,packages
 sonar.test.inclusions=apps/web/test/*,apps/web/playwright/*,apps/desktop/playwright/*,packages/*/src/**/*.test.*,packages/*/src/test/**/*
-sonar.exclusions=apps/web/__mocks__,docs,apps/web/element.io,apps/web/nginx,apps/web/src/vector/modernizr.cjs
+sonar.exclusions=apps/web/__mocks__,docs,apps/web/element.io,apps/web/nginx,apps/web/src/vector/modernizr.cjs,**/*.png
 
 sonar.cpd.exclusions=**/src/i18n/strings/*.json
 sonar.javascript.lcov.reportPaths=apps/web/coverage/lcov.info,packages/shared-components/coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,23 @@ sonar.organization=element-hq
 sonar.sources=.
 sonar.tests=apps/web/test,apps/web/playwright,apps/desktop/playwright,packages
 sonar.test.inclusions=apps/web/test/*,apps/web/playwright/*,apps/desktop/playwright/*,packages/*/src/**/*.test.*,packages/*/src/test/**/*
-sonar.exclusions=apps/web/__mocks__,docs,apps/web/element.io,apps/web/nginx,apps/web/src/vector/modernizr.cjs,**/*.png
+sonar.exclusions=\
+  apps/web/__mocks__,\
+  docs,\
+  apps/web/element.io,\
+  apps/web/nginx,\
+  apps/web/src/vector/modernizr.cjs,\
+  **/*.webm,\
+  **/*.ogg,\
+  **/*.mp3,\
+  **/*.woff2,\
+  **/*.ttf,\
+  **/*.webp,\
+  **/*.jpg,\
+  **/*.apng,\
+  **/*.ico,\
+  **/*.png,\
+  **/*.gif
 
 sonar.cpd.exclusions=**/src/i18n/strings/*.json
 sonar.javascript.lcov.reportPaths=apps/web/coverage/lcov.info,packages/shared-components/coverage/lcov.info


### PR DESCRIPTION
They just cause errors

`11:39:29.466 WARN  Invalid character encountered in file /home/runner/work/element-web/element-web/apps/web/res/vector-icons/152.png at line 1 for encoding UTF-8. Please fix file content or configure the encoding to be used using property 'sonar.sourceEncoding'.`