### PR TITLE
Fix static analysis CI gate not working

### DIFF
--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -44,6 +44,7 @@ jobs:
                       command: "rethemendex"
                       assert-diff: true
                     - name: Docs
+                      install: layered
                       command: "docs:build"
         name: ${{ matrix.name }}
         runs-on: ubuntu-24.04

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -44,8 +44,7 @@ jobs:
                       command: "rethemendex"
                       assert-diff: true
                     - name: Docs
-                      install: layered
-                      command: "docs:buildd"
+                      command: "docs:build"
         name: ${{ matrix.name }}
         runs-on: ubuntu-24.04
         steps:

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -124,7 +124,9 @@ jobs:
     # Dummy job to simplify branch protections
     ci:
         name: Static Analysis
-        needs: [lint, i18n]
+        needs: [lint, i18n, zizmor]
+        if: always()
         runs-on: ubuntu-24.04
         steps:
-            - run: echo "Ok"
+            - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+              run: exit 1

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -45,7 +45,7 @@ jobs:
                       assert-diff: true
                     - name: Docs
                       install: layered
-                      command: "docs:build"
+                      command: "docs:buildd"
         name: ${{ matrix.name }}
         runs-on: ubuntu-24.04
         steps:


### PR DESCRIPTION
The `ci` job would be skipped if one of the matrices failed, which is treated as good to merge (!)
zizmor also wasn't gated within it