### PR TITLE
Fix active room not moving in the room list after new activity

### DIFF
--- a/apps/web/src/stores/room-list-v3/skip-list/sorters/utils/getLastTimestamp.ts
+++ b/apps/web/src/stores/room-list-v3/skip-list/sorters/utils/getLastTimestamp.ts
@@ -35,13 +35,7 @@ function shouldCauseReorder(event: MatrixEvent): boolean {
 export const getLastTimestamp = (r: Room, userId: string): number => {
     const mainTimelineLastTs = ((): number => {
         const timeline = r.getLiveTimeline().getEvents();
-
-        // MSC4186: Simplified Sliding Sync sets this.
-        // If it's present, sort by it.
-        const bumpStamp = r.getBumpStamp();
-        if (bumpStamp) {
-            return bumpStamp;
-        }
+        const bumpStamp = r.getBumpStamp() ?? 0;
 
         // If the room hasn't been joined yet, it probably won't have a timeline to
         // parse. We'll still fall back to the timeline if this fails, but chances
@@ -53,7 +47,7 @@ export const getLastTimestamp = (r: Room, userId: string): number => {
                 .getState(EventTimeline.FORWARDS)
                 ?.getStateEvents(EventType.RoomMember, userId);
             if (membershipEvent && !Array.isArray(membershipEvent)) {
-                return membershipEvent.getTs();
+                return Math.max(bumpStamp, membershipEvent.getTs());
             }
         }
 
@@ -65,14 +59,14 @@ export const getLastTimestamp = (r: Room, userId: string): number => {
                 (ev.getSender() === userId && shouldCauseReorder(ev)) ||
                 Unread.eventTriggersUnreadCount(r.client, ev)
             ) {
-                return ev.getTs();
+                return Math.max(bumpStamp, ev.getTs());
             }
         }
 
         // we might only have events that don't trigger the unread indicator,
         // in which case use the oldest event even if normally it wouldn't count.
         // This is better than just assuming the last event was forever ago.
-        return timeline[0]?.getTs() ?? 0;
+        return Math.max(bumpStamp, timeline[0]?.getTs() ?? 0);
     })();
 
     const threadLastEventTimestamps = r.getThreads().map((thread) => {

--- a/apps/web/src/stores/room-list/algorithms/tag-sorting/RecentAlgorithm.ts
+++ b/apps/web/src/stores/room-list/algorithms/tag-sorting/RecentAlgorithm.ts
@@ -69,12 +69,7 @@ export const getLastTs = (r: Room, userId: string): number => {
         if (!r?.timeline) {
             return Number.MAX_SAFE_INTEGER;
         }
-        // MSC4186: Simplified Sliding Sync sets this.
-        // If it's present, sort by it.
-        const bumpStamp = r.getBumpStamp();
-        if (bumpStamp) {
-            return bumpStamp;
-        }
+        const bumpStamp = r.getBumpStamp() ?? 0;
 
         // If the room hasn't been joined yet, it probably won't have a timeline to
         // parse. We'll still fall back to the timeline if this fails, but chances
@@ -83,7 +78,7 @@ export const getLastTs = (r: Room, userId: string): number => {
         if (effectiveMembership !== EffectiveMembership.Join) {
             const membershipEvent = r.currentState.getStateEvents(EventType.RoomMember, userId);
             if (membershipEvent && !Array.isArray(membershipEvent)) {
-                return membershipEvent.getTs();
+                return Math.max(bumpStamp, membershipEvent.getTs());
             }
         }
 
@@ -95,14 +90,14 @@ export const getLastTs = (r: Room, userId: string): number => {
                 (ev.getSender() === userId && shouldCauseReorder(ev)) ||
                 Unread.eventTriggersUnreadCount(r.client, ev)
             ) {
-                return ev.getTs();
+                return Math.max(bumpStamp, ev.getTs());
             }
         }
 
         // we might only have events that don't trigger the unread indicator,
         // in which case use the oldest event even if normally it wouldn't count.
         // This is better than just assuming the last event was forever ago.
-        return r.timeline[0]?.getTs() ?? Number.MAX_SAFE_INTEGER;
+        return Math.max(bumpStamp, r.timeline[0]?.getTs() ?? Number.MAX_SAFE_INTEGER);
     })();
 
     const threadLastEventTimestamps = r.getThreads().map((thread) => {

--- a/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
+++ b/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
@@ -37,18 +37,6 @@ import { DefaultTagID } from "../../stores/room-list-v3/skip-list/tag";
 import { RoomListSectionHeaderViewModel } from "./RoomListSectionHeaderViewModel";
 import SettingsStore from "../../settings/SettingsStore";
 
-/**
- * Tracks the position of the active room within a specific section.
- * Used to implement sticky room behaviour so the selected room doesn't
- * jump around when the room list is re-sorted.
- */
-interface StickyRoomPosition {
-    /** The tag of the section the room belongs to. */
-    sectionTag: string;
-    /** The index of the room within that section. */
-    indexInSection: number;
-}
-
 interface RoomListViewModelProps {
     client: MatrixClient;
 }
@@ -80,7 +68,6 @@ export class RoomListViewModel
      * List of sections to display in the room list, derived from roomsResult and section header view model expansion state.
      */
     private sections: Section[] = [];
-    private lastActiveRoomPosition: StickyRoomPosition | undefined = undefined;
 
     // Child view model management
     private readonly roomItemViewModels = new Map<string, RoomListItemViewModel>();
@@ -418,94 +405,16 @@ export class RoomListViewModel
         return index >= 0 ? index : undefined;
     }
 
-    /**
-     * Find the position of a room within the sections list.
-     * Returns undefined if the room is not found.
-     */
-    private findRoomPosition(sections: Section[], roomId: string): StickyRoomPosition | undefined {
-        for (const section of sections) {
-            const idx = section.rooms.findIndex((room) => room.roomId === roomId);
-            if (idx !== -1) return { sectionTag: section.tag, indexInSection: idx };
-        }
-        return undefined;
-    }
-
-    /**
-     * Apply sticky room logic to keep the active room at the same position within its section.
-     * When the room list updates, this prevents the selected room from jumping around in the UI.
-     *
-     * @param isRoomChange - Whether this update is due to a room change (not a list update)
-     * @param roomId - The room ID to apply sticky logic for (can be null/undefined)
-     * @returns The modified sections array with sticky positioning applied
-     */
-    private applyStickyRoom(isRoomChange: boolean, roomId: string | null | undefined): Section[] {
-        const sections = this.roomsResult.sections;
-
-        // When opening another room, the index should obviously change
-        if (!roomId || isRoomChange) return sections;
-
-        // If there was no previously tracked position, nothing to stick to
-        const oldPosition = this.lastActiveRoomPosition;
-        if (!oldPosition) return sections;
-
-        const newPosition = this.findRoomPosition(sections, roomId);
-
-        // If the room is no longer in the list, nothing to do
-        if (!newPosition) return sections;
-
-        // If the room moved to a different section, this is an intentional structural
-        // change (e.g. favourited/unfavourited), so don't apply sticky logic
-        if (newPosition.sectionTag !== oldPosition.sectionTag) return sections;
-
-        // If the index within the section hasn't changed, nothing to do
-        if (newPosition.indexInSection === oldPosition.indexInSection) return sections;
-
-        // Find the target section and apply the sticky swap within it
-        return sections.map((section) => {
-            // Different section - no change
-            if (section.tag !== oldPosition.sectionTag) return section;
-
-            const sectionRooms = section.rooms;
-
-            // If the old index falls out of the bounds of the section
-            // (usually because rooms were removed), we can no longer place
-            // the active room in the same old position
-            if (oldPosition.indexInSection > sectionRooms.length - 1) {
-                return section;
-            }
-
-            // Making the active room sticky is as simple as removing it from
-            // its new index and placing it in the old index within the section
-            const newRooms = [...sectionRooms];
-            const [stickyRoom] = newRooms.splice(newPosition.indexInSection, 1);
-            newRooms.splice(oldPosition.indexInSection, 0, stickyRoom);
-
-            return { ...section, rooms: newRooms };
-        });
-    }
-
     private async updateRoomListData(
-        isRoomChange: boolean = false,
+        _isRoomChange: boolean = false,
         roomIdOverride: string | null = null,
     ): Promise<void> {
         // Determine the room ID to use for calculations
         // Use override if provided (e.g., during space changes), otherwise fall back to RoomViewStore
         const roomId = roomIdOverride ?? SdkContextClass.instance.roomViewStore.getRoomId();
 
-        // Apply sticky room logic to keep selected room at same position within its section
-        const stickySections = this.applyStickyRoom(isRoomChange, roomId);
-
-        // Update roomsResult with the sticky-adjusted sections
-        this.roomsResult = {
-            ...this.roomsResult,
-            sections: stickySections,
-        };
-
-        // Rebuild roomsMap with the reordered rooms
+        // Rebuild roomsMap with the latest room order from the store
         this.updateRoomsMap(this.roomsResult);
-
-        // Track the current active room position for future sticky calculations
-        this.lastActiveRoomPosition = roomId ? this.findRoomPosition(this.roomsResult.sections, roomId) : undefined;
 
         // Update section header view models with current rooms for unread state tracking
         for (const section of this.roomsResult.sections) {

--- a/apps/web/test/unit-tests/stores/room-list-v3/sorters/utils/getLastTimestamp-test.ts
+++ b/apps/web/test/unit-tests/stores/room-list-v3/sorters/utils/getLastTimestamp-test.ts
@@ -63,7 +63,32 @@ describe("getLastTimestamp", () => {
         expect(getLastTimestamp(room, "@john:matrix.org")).toBe(500);
     });
 
-    it("should return bump stamp when using sliding sync", () => {
+    it("should return the newer timestamp when live timeline is ahead of bump stamp", () => {
+        const cli = stubClient();
+        const room = new Room("room123", cli, "@john:matrix.org");
+
+        const event1 = mkMessage({
+            room: room.roomId,
+            msg: "Hello world!",
+            user: "@alice:matrix.org",
+            ts: 5,
+            event: true,
+        });
+        const event2 = mkMessage({
+            room: room.roomId,
+            msg: "Howdy!",
+            user: "@bob:matrix.org",
+            ts: 10,
+            event: true,
+        });
+
+        jest.spyOn(room, "getMyMembership").mockReturnValue(KnownMembership.Join);
+        jest.spyOn(room, "getBumpStamp").mockReturnValue(8);
+        room.addLiveEvents([event1, event2], { addToState: true });
+        expect(getLastTimestamp(room, "@john:matrix.org")).toBe(10);
+    });
+
+    it("should still use bump stamp when it is newer than the live timeline", () => {
         const cli = stubClient();
         const room = new Room("room123", cli, "@john:matrix.org");
 

--- a/apps/web/test/unit-tests/stores/room-list/algorithms/RecentAlgorithm-test.ts
+++ b/apps/web/test/unit-tests/stores/room-list/algorithms/RecentAlgorithm-test.ts
@@ -69,6 +69,56 @@ describe("RecentAlgorithm", () => {
             room.getMyMembership.mockReturnValue(KnownMembership.Invite);
             expect(algorithm.getLastTs(room, "@john:matrix.org")).toBe(Number.MAX_SAFE_INTEGER);
         });
+
+        it("prefers the newer live timeline event over a stale bump stamp", () => {
+            const room = new Room("room123", cli, "@john:matrix.org");
+
+            const event1 = mkMessage({
+                room: room.roomId,
+                msg: "Hello world!",
+                user: "@alice:matrix.org",
+                ts: 5,
+                event: true,
+            });
+            const event2 = mkMessage({
+                room: room.roomId,
+                msg: "Howdy!",
+                user: "@bob:matrix.org",
+                ts: 10,
+                event: true,
+            });
+
+            jest.spyOn(room, "getMyMembership").mockReturnValue(KnownMembership.Join);
+            jest.spyOn(room, "getBumpStamp").mockReturnValue(8);
+            room.addLiveEvents([event1, event2], { addToState: true });
+
+            expect(algorithm.getLastTs(room, "@john:matrix.org")).toBe(10);
+        });
+
+        it("still uses bump stamp when it is newer than the live timeline", () => {
+            const room = new Room("room123", cli, "@john:matrix.org");
+
+            const event1 = mkMessage({
+                room: room.roomId,
+                msg: "Hello world!",
+                user: "@alice:matrix.org",
+                ts: 5,
+                event: true,
+            });
+            const event2 = mkMessage({
+                room: room.roomId,
+                msg: "Howdy!",
+                user: "@bob:matrix.org",
+                ts: 10,
+                event: true,
+            });
+
+            jest.spyOn(room, "getMyMembership").mockReturnValue(KnownMembership.Join);
+            jest.spyOn(room, "getBumpStamp").mockReturnValue(314);
+            room.addLiveEvents([event1, event2], { addToState: true });
+
+            expect(algorithm.getLastTs(room, "@john:matrix.org")).toBe(314);
+        });
     });
 
     describe("sortRooms", () => {

--- a/apps/web/test/viewmodels/room-list/RoomListViewModel-test.tsx
+++ b/apps/web/test/viewmodels/room-list/RoomListViewModel-test.tsx
@@ -239,7 +239,7 @@ describe("RoomListViewModel", () => {
     });
 
     describe("Sticky room behavior", () => {
-        it("should keep selected room at same index when room list updates", async () => {
+        it("should move the selected room with the updated room list order", async () => {
             viewModel = new RoomListViewModel({ client: matrixClient });
 
             // Select room at index 1
@@ -260,9 +260,9 @@ describe("RoomListViewModel", () => {
 
             RoomListStoreV3.instance.emit(RoomListStoreV3Event.ListsUpdate);
 
-            // Active room should still be at index 1 (sticky behavior)
-            expect(viewModel.getSnapshot().roomListState.activeRoomIndex).toBe(1);
-            expect(viewModel.getSnapshot().sections[0].roomIds[1]).toBe("!room2:server");
+            // Active room should now be at index 0 to match the updated sort order
+            expect(viewModel.getSnapshot().roomListState.activeRoomIndex).toBe(0);
+            expect(viewModel.getSnapshot().sections[0].roomIds[0]).toBe("!room2:server");
         });
 
         it("should not apply sticky behavior when user changes rooms", async () => {
@@ -912,7 +912,7 @@ describe("RoomListViewModel", () => {
                 expect(favSection!.roomIds).toEqual(["!fav1:server"]);
             });
 
-            it("should apply sticky room within the correct section", async () => {
+            it("should keep section order in sync with the updated room list order", async () => {
                 stubClient();
                 viewModel = new RoomListViewModel({ client: matrixClient });
 
@@ -938,10 +938,11 @@ describe("RoomListViewModel", () => {
 
                 RoomListStoreV3.instance.emit(RoomListStoreV3Event.ListsUpdate);
 
-                // Sticky room should keep favRoom1 at index 0 within the favourites section
+                // The favourites section should reflect the updated order
                 const snapshot = viewModel.getSnapshot();
-                expect(snapshot.sections[0].roomIds[0]).toBe("!fav1:server");
-                expect(snapshot.roomListState.activeRoomIndex).toBe(0);
+                expect(snapshot.sections[0].roomIds[0]).toBe("!fav2:server");
+                expect(snapshot.sections[0].roomIds[1]).toBe("!fav1:server");
+                expect(snapshot.roomListState.activeRoomIndex).toBe(1);
             });
         });
     });


### PR DESCRIPTION
## Problem

When a new message arrived in the currently open room, or when I sent a message in that room myself, the room list did not immediately reorder.

In practice, the active room could stay in its previous position until I clicked into another room. That made the room list feel stale and out of sync with the actual conversation activity.

## Root cause

There were two separate issues contributing to this:

1. The room list view model kept the active room "sticky" at its previous index, which could mask legitimate reorder updates.
2. Recency sorting could prefer a stale `bumpStamp` over newer activity already present in the live timeline, so the room's effective sort timestamp was not always the freshest available signal.

## Fix

This change removes the sticky positioning behaviour for the active room in the new room list view model and updates recency sorting so that it uses the freshest timestamp available instead of blindly trusting `bumpStamp`.

As a result, when the active room receives a message or when I send one there myself, the room is reordered immediately and the room list stays in sync with actual room activity.

## Why this matters

This is a small change in code, but it fixes a very visible day-to-day UX issue.

The room list is one of the main navigation surfaces in Element. If it does not react immediately to incoming or outgoing activity, it feels laggy and forces extra clicks just to refresh the user's view of what is active right now. This change makes that behaviour feel much closer to what users expect from modern chat clients.

## Additional context

This PR includes unit test updates covering both the room list view model behaviour and the recency timestamp selection logic.

All automated and manual checks were completed before opening this PR, and the updated build was manually verified by the author.

Notes: Fix a bug where the active room could remain in its previous position in the room list until the user switched rooms, instead of moving immediately when new activity happened.
