### PR TITLE
Add `analytics` config to nx

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -8,5 +8,6 @@
     },
     "namedInputs": {
         "src": ["{projectRoot}/src/**/*"]
-    }
+    },
+    "analytics": true
 }

--- a/nx.json
+++ b/nx.json
@@ -9,5 +9,5 @@
     "namedInputs": {
         "src": ["{projectRoot}/src/**/*"]
     },
-    "analytics": true
+    "analytics": false
 }


### PR DESCRIPTION
There doesn't seem to be any way to stop nx wanting to add this config setting,
so I think we just have to add it.