### PR TITLE
Configuration for nx output under playwright

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -91,7 +91,7 @@ export default defineConfig<{}, WorkerOptions>({
         trace: "on-first-retry",
     },
     webServer: {
-        command: process.env.CI ? "npx serve -p 8080 -L ./webapp" : "pnpm start",
+        command: process.env.CI ? "npx serve -p 8080 -L ./webapp" : "nx --outputStyle stream start",
         url: `${baseURL}/config.json`,
         reuseExistingServer: true,
         timeout: (process.env.CI ? 30 : 120) * 1000,


### PR DESCRIPTION
When playwright starts the development web server, have it tell nx to use the `stream` output style, which is somewhat clearer than the default. (Specifically, it distinguishes between output from different tasks, so you can see where any errors are coming from.)