### PR TITLE
Fix 'occured' -> 'occurred' typos including user-visible i18n string

### DIFF
--- a/apps/web/src/PosthogAnalytics.ts
+++ b/apps/web/src/PosthogAnalytics.ts
@@ -434,7 +434,7 @@ export class PosthogAnalytics {
     }
 
     private trackNewUserEvent(): void {
-        // This is the only event that could have occured before analytics opt-in
+        // This is the only event that could have occurred before analytics opt-in
         // that we want to accumulate before the user has given consent
         // All other scenarios should not track a user before they have given
         // explicit consent that they are ok with their analytics data being collected

--- a/apps/web/src/Searching.ts
+++ b/apps/web/src/Searching.ts
@@ -739,7 +739,7 @@ export interface SearchInfo {
      */
     count?: number;
     /**
-     * Describe the error if any occured.
+     * Describe the error if any occurred.
      */
     error?: Error;
 }

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -1994,7 +1994,7 @@
         "error_join_incompatible_version_1": "Sorry, your homeserver is too old to participate here.",
         "error_join_incompatible_version_2": "Please contact your homeserver administrator.",
         "error_join_title": "Failed to join",
-        "error_join_unknown": "An unknown error occured.",
+        "error_join_unknown": "An unknown error occurred.",
         "error_jump_to_date": "Server returned %(statusCode)s with error code %(errorCode)s",
         "error_jump_to_date_connection": "A network error occurred while trying to find and jump to the given date. Your homeserver might be down or there was just a temporary problem with your internet connection. Please try again. If this continues, please contact your homeserver administrator.",
         "error_jump_to_date_details": "Error details",

--- a/apps/web/src/viewmodels/room/timeline/DateSeparatorViewModel.tsx
+++ b/apps/web/src/viewmodels/room/timeline/DateSeparatorViewModel.tsx
@@ -175,7 +175,7 @@ export class DateSeparatorViewModel
             }
         } catch (err) {
             logger.error(
-                `Error occured while trying to find event in ${roomIdForJumpRequest} ` +
+                `Error occurred while trying to find event in ${roomIdForJumpRequest} ` +
                     `at timestamp=${unixTimestamp}:`,
                 err,
             );
@@ -186,7 +186,7 @@ export class DateSeparatorViewModel
             // room.
             const currentRoomId = SdkContextClass.instance.roomViewStore.getRoomId();
             if (currentRoomId === roomIdForJumpRequest) {
-                let friendlyErrorMessage = "An error occured while trying to find and jump to the given date.";
+                let friendlyErrorMessage = "An error occurred while trying to find and jump to the given date.";
                 let submitDebugLogsContent: React.ReactElement = <></>;
 
                 if (err instanceof ConnectionError) {
@@ -251,7 +251,7 @@ export class DateSeparatorViewModel
     public onBugReport = (err?: Error): void => {
         Modal.createDialog(BugReportDialog, {
             error: err,
-            initialText: "Error occured while using jump to date #jump-to-date",
+            initialText: "Error occurred while using jump to date #jump-to-date",
         });
     };
 


### PR DESCRIPTION
Fix 7 instances of \`occured\` → \`occurred\` across 4 files in element-web.

## Files

| File | Instances | Kind |
|------|-----------|------|
| \`apps/web/src/viewmodels/room/timeline/DateSeparatorViewModel.tsx\` | 3 | Error messages and log strings |
| \`apps/web/src/i18n/strings/en_EN.json\` | 1 | **User-visible i18n string** (\`error_join_unknown\`) |
| \`apps/web/src/Searching.ts\` | 1 | Comment |
| \`apps/web/src/PosthogAnalytics.ts\` | 1 | Comment |

The i18n change is user-visible in the UI when \`error_join_unknown\` is shown. Translation files for other locales are not touched — the i18n pipeline regenerates from the source \`en_EN.json\`.