### PR TITLE
Fix flaky OIDC "verifiy dialog" test

### DIFF
--- a/apps/web/playwright/e2e/oidc/oidc-native.spec.ts
+++ b/apps/web/playwright/e2e/oidc/oidc-native.spec.ts
@@ -148,7 +148,8 @@ test.describe("OIDC Native", { tag: ["@no-firefox", "@no-webkit"] }, () => {
 
             const userId = `alice_${testInfo.testId}`;
             await registerAccountMas(page, mailpitClient, userId, `${userId}@email.com`, "Pa$sW0rD!");
-            await expect(page.getByText("Welcome")).toBeVisible();
+            // richvdh: This takes several seconds to happen on a dev instance
+            await expect(page.getByText("Welcome")).toBeVisible({ timeout: 10000 });
 
             // Log out
             await page.getByRole("button", { name: "User menu" }).click();
@@ -162,11 +163,14 @@ test.describe("OIDC Native", { tag: ["@no-firefox", "@no-webkit"] }, () => {
 
             // Log in again
             await page.goto("/#/login");
+            await expect(page.getByText("Sign in")).toBeVisible();
             await page.getByRole("button", { name: "Continue" }).click();
+            await expect(page.getByText("Continue to Element?")).toBeVisible();
             await page.getByRole("button", { name: "Continue" }).click();
 
             // We should be being warned that we need to verify (but we can't)
-            await expect(page.getByText("Confirm your digital identity")).toBeVisible();
+            // richvdh: Again, Element takes several seconds to load on a dev instance
+            await expect(page.getByText("Confirm your digital identity")).toBeVisible({ timeout: 10000 });
 
             // And there should be no way to close this prompt
             await expect(page.getByRole("button", { name: "Skip verification for now" })).not.toBeVisible();


### PR DESCRIPTION
This test was flaking. The problem appears to have been that we were clicking "Continue" twice in succession; the intention was that we click on two *different* "Continue" buttons, but sometimes we ended up clicking in the same one twice.

Fix it by waiting for the content to change after the first click.

Fixes: #31316