### PR TITLE
Bump element-call-embedded to v0.19.1

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -126,7 +126,7 @@
         "@babel/preset-react": "^7.12.10",
         "@babel/preset-typescript": "^7.12.7",
         "@casualbot/jest-sonar-reporter": "2.5.1",
-        "@element-hq/element-call-embedded": "0.18.0",
+        "@element-hq/element-call-embedded": "0.19.1",
         "@element-hq/element-web-playwright-common": "workspace:*",
         "@fetch-mock/jest": "^0.2.20",
         "@jest/globals": "^30.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,8 +571,8 @@ importers:
         specifier: 2.5.1
         version: 2.5.1
       '@element-hq/element-call-embedded':
-        specifier: 0.18.0
-        version: 0.18.0
+        specifier: 0.19.1
+        version: 0.19.1
       '@element-hq/element-web-playwright-common':
         specifier: workspace:*
         version: link:../../packages/playwright-common
@@ -2464,8 +2464,8 @@ packages:
     engines: {node: '>=14.14'}
     hasBin: true
 
-  '@element-hq/element-call-embedded@0.18.0':
-    resolution: {integrity: sha512-Fg2VlORZWkQ9t9OJTcWFXCwVzlHVLtkaiCF0qFTCOZSYYHlA3kXDRM8TagjLkIoOVR6y+9xZldbwejgKYUS9xw==}
+  '@element-hq/element-call-embedded@0.19.1':
+    resolution: {integrity: sha512-RDZY3P3LTx10ACaGhzkwh2+boNB3x54zHF/7v/cCyoQlAVfEYMhgMEb4CRTwJFwwYFe1r++6Higa0A0G5XxZ8Q==}
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -15002,7 +15002,7 @@ snapshots:
       - supports-color
     optional: true
 
-  '@element-hq/element-call-embedded@0.18.0': {}
+  '@element-hq/element-call-embedded@0.19.1': {}
 
   '@emnapi/core@1.8.1':
     dependencies:


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Description

Bumped element-call-embedded to latest ver v0.19.1 to make use of the newly working profile pictures in calls!

<img width="1163" height="746" alt="image" src="https://github.com/user-attachments/assets/be625a6f-276f-48d1-9230-f087f9a0b891" />

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
