### PR TITLE
nx test:playwright:screenshots: only do snapshots for Chrome

### DIFF
--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -60,7 +60,7 @@
             "dependsOn": ["^build:playwright"]
         },
         "test:playwright:screenshots": {
-            "command": "playwright-screenshots nx test:playwright -- --update-snapshots --project=Chrome --grep @screenshot",
+            "command": "playwright-screenshots playwright test --update-snapshots --project=Chrome --grep @screenshot",
             "options": { "cwd": "apps/web" },
             "dependsOn": ["^build:playwright"]
         }

--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -60,7 +60,7 @@
             "dependsOn": ["^build:playwright"]
         },
         "test:playwright:screenshots": {
-            "command": "playwright-screenshots nx test:playwright --update-snapshots --project=Chrome --grep @screenshot",
+            "command": "playwright-screenshots nx test:playwright -- --update-snapshots --project=Chrome --grep @screenshot",
             "options": { "cwd": "apps/web" },
             "dependsOn": ["^build:playwright"]
         }


### PR DESCRIPTION
Currently, `pnpm test:playwight:screenshots` attempts to create screenshots for five (5) different browsers, which is slow.

`nx` eats the `--project` option unless we prefix with `--`.

Edit: actually, let's just remove nx altogether here. It's redundant and adds complexity.