### PR TITLE
Introduce module API to allow overriding "supportedLevels" on settings.

### DIFF
--- a/apps/web/playwright/e2e/audio-player/audio-player.spec.ts
+++ b/apps/web/playwright/e2e/audio-player/audio-player.spec.ts
@@ -7,9 +7,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import type { Locator, Page } from "@playwright/test";
 import { test, expect } from "../../element-web-test";
-import { SettingLevel } from "../../../src/settings/SettingLevel";
 import { Layout } from "../../../src/settings/enums/Layout";
 import { type ElementAppPage } from "../../pages/ElementAppPage";
 import { getSampleFilePath } from "../../sample-files";

--- a/apps/web/playwright/e2e/composer/CIDER.spec.ts
+++ b/apps/web/playwright/e2e/composer/CIDER.spec.ts
@@ -6,8 +6,9 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import { test, expect } from "../../element-web-test";
-import { SettingLevel } from "../../../src/settings/SettingLevel";
 
 const CtrlOrMeta = process.platform === "darwin" ? "Meta" : "Control";
 

--- a/apps/web/playwright/e2e/composer/RTE.spec.ts
+++ b/apps/web/playwright/e2e/composer/RTE.spec.ts
@@ -6,8 +6,9 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import { test, expect } from "../../element-web-test";
-import { SettingLevel } from "../../../src/settings/SettingLevel";
 
 const CtrlOrMeta = process.platform === "darwin" ? "Meta" : "Control";
 

--- a/apps/web/playwright/e2e/devtools/upgraderoom.spec.ts
+++ b/apps/web/playwright/e2e/devtools/upgraderoom.spec.ts
@@ -5,7 +5,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { SettingLevel } from "../../../src/settings/SettingLevel";
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import { test, expect } from "../../element-web-test";
 
 test.describe("Room upgrade dialog", () => {

--- a/apps/web/playwright/e2e/editing/editing.spec.ts
+++ b/apps/web/playwright/e2e/editing/editing.spec.ts
@@ -7,11 +7,11 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { type Locator, type Page } from "@playwright/test";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import type { EventType, IContent, ISendEventResponse, MsgType, Visibility } from "matrix-js-sdk/src/matrix";
 import { expect, test } from "../../element-web-test";
 import { type ElementAppPage } from "../../pages/ElementAppPage";
-import { SettingLevel } from "../../../src/settings/SettingLevel";
 import { isDendrite } from "../../plugins/homeserver/dendrite";
 
 async function sendEvent(app: ElementAppPage, roomId: string): Promise<ISendEventResponse> {

--- a/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-filter-sort.spec.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-filter-sort.spec.ts
@@ -7,9 +7,9 @@
 
 import { type Visibility } from "matrix-js-sdk/src/matrix";
 import { type Page } from "@playwright/test";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { expect, test } from "../../../element-web-test";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import { getFilterCollapseButton, getFilterExpandButton, getPrimaryFilters, getRoomOptionsMenu } from "./utils";
 
 test.describe("Room list filters and sort", () => {

--- a/apps/web/playwright/e2e/polls/polls.spec.ts
+++ b/apps/web/playwright/e2e/polls/polls.spec.ts
@@ -6,9 +6,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import { test, expect } from "../../element-web-test";
 import { Bot } from "../../pages/bot";
-import { SettingLevel } from "../../../src/settings/SettingLevel";
 import { Layout } from "../../../src/settings/enums/Layout";
 import type { Locator, Page } from "@playwright/test";
 import { isDendrite } from "../../plugins/homeserver/dendrite";

--- a/apps/web/playwright/e2e/room/create-room.spec.ts
+++ b/apps/web/playwright/e2e/room/create-room.spec.ts
@@ -7,8 +7,8 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { type Page } from "@playwright/test";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
-import { SettingLevel } from "../../../src/settings/SettingLevel";
 import { UIFeature } from "../../../src/settings/UIFeature";
 import { test, expect } from "../../element-web-test";
 

--- a/apps/web/playwright/e2e/settings/appearance-user-settings-tab/index.ts
+++ b/apps/web/playwright/e2e/settings/appearance-user-settings-tab/index.ts
@@ -7,10 +7,10 @@
  */
 
 import { type Locator, type Page } from "@playwright/test";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { type ElementAppPage } from "../../../pages/ElementAppPage";
 import { test as base, expect } from "../../../element-web-test";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import { Layout } from "../../../../src/settings/enums/Layout";
 
 export { expect };

--- a/apps/web/playwright/e2e/settings/notifications/notifications-settings-2-tab.spec.ts
+++ b/apps/web/playwright/e2e/settings/notifications/notifications-settings-2-tab.spec.ts
@@ -5,8 +5,9 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import { test, expect } from "../../../element-web-test";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 
 test.describe("Notifications 2 tab", () => {
     test.use({

--- a/apps/web/playwright/e2e/settings/room-settings/room-video-tab.spec.ts
+++ b/apps/web/playwright/e2e/settings/room-settings/room-video-tab.spec.ts
@@ -6,9 +6,9 @@
  */
 
 import { type Locator } from "@playwright/test";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { test, expect } from "../../../element-web-test";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 
 test.describe("Voice & Video room settings tab", () => {
     const roomName = "Test room";

--- a/apps/web/playwright/e2e/threads/threads.spec.ts
+++ b/apps/web/playwright/e2e/threads/threads.spec.ts
@@ -5,7 +5,8 @@ Copyright 2023 The Matrix.org Foundation C.I.C.
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.
 */
-import { SettingLevel } from "../../../src/settings/SettingLevel";
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import { Layout } from "../../../src/settings/enums/Layout";
 import { test, expect } from "../../element-web-test";
 import { isDendrite } from "../../plugins/homeserver/dendrite";

--- a/apps/web/playwright/e2e/timeline/timeline.spec.ts
+++ b/apps/web/playwright/e2e/timeline/timeline.spec.ts
@@ -6,10 +6,11 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import type { Locator, Page } from "@playwright/test";
 import type { ISendEventResponse, EventType, MsgType } from "matrix-js-sdk/src/matrix";
 import { test, expect } from "../../element-web-test";
-import { SettingLevel } from "../../../src/settings/SettingLevel";
 import { Layout } from "../../../src/settings/enums/Layout";
 import { type Client } from "../../pages/client";
 import { type ElementAppPage } from "../../pages/ElementAppPage";

--- a/apps/web/playwright/e2e/voip/element-call.spec.ts
+++ b/apps/web/playwright/e2e/voip/element-call.spec.ts
@@ -8,9 +8,9 @@ Please see LICENSE files in the repository root for full details.
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { type Page } from "@playwright/test";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import type { EventType, Preset } from "matrix-js-sdk/src/matrix";
-import { SettingLevel } from "../../../src/settings/SettingLevel";
 import { test, expect } from "../../element-web-test";
 import type { Credentials } from "../../plugins/homeserver";
 import { Bot } from "../../pages/bot";

--- a/apps/web/playwright/global.d.ts
+++ b/apps/web/playwright/global.d.ts
@@ -6,8 +6,9 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { type SettingLevel } from "@element-hq/element-web-module-api";
+
 import type * as Matrix from "matrix-js-sdk/src/matrix";
-import { type SettingLevel } from "../src/settings/SettingLevel";
 
 declare global {
     interface Window {

--- a/apps/web/playwright/pages/settings.ts
+++ b/apps/web/playwright/pages/settings.ts
@@ -8,7 +8,7 @@ Please see LICENSE files in the repository root for full details.
 
 import { type Locator, type Page } from "@playwright/test";
 
-import type { SettingLevel } from "../../src/settings/SettingLevel";
+import type { SettingLevel } from "@element-hq/element-web-module-api";
 
 export class Settings {
     public constructor(private readonly page: Page) {}

--- a/apps/web/src/LegacyCallHandler.tsx
+++ b/apps/web/src/LegacyCallHandler.tsx
@@ -23,6 +23,7 @@ import {
 } from "matrix-js-sdk/src/webrtc/call";
 import { logger } from "matrix-js-sdk/src/logger";
 import { CallEventHandlerEvent } from "matrix-js-sdk/src/webrtc/callEventHandler";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { MatrixClientPeg } from "./MatrixClientPeg";
 import Modal from "./Modal";
@@ -31,7 +32,6 @@ import dis from "./dispatcher/dispatcher";
 import WidgetUtils from "./utils/WidgetUtils";
 import SettingsStore from "./settings/SettingsStore";
 import { WidgetType } from "./widgets/WidgetType";
-import { SettingLevel } from "./settings/SettingLevel";
 import QuestionDialog from "./components/views/dialogs/QuestionDialog";
 import ErrorDialog from "./components/views/dialogs/ErrorDialog";
 import WidgetStore from "./stores/WidgetStore";

--- a/apps/web/src/Lifecycle.ts
+++ b/apps/web/src/Lifecycle.ts
@@ -19,6 +19,7 @@ import {
 } from "matrix-js-sdk/src/matrix";
 import { type AESEncryptedSecretStoragePayload } from "matrix-js-sdk/src/types";
 import { logger } from "matrix-js-sdk/src/logger";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { type IMatrixClientCreds, MatrixClientPeg, type MatrixClientPegAssignOpts } from "./MatrixClientPeg";
 import { ModuleRunner } from "./modules/ModuleRunner";
@@ -36,7 +37,6 @@ import { sendLoginRequest } from "./Login";
 import * as StorageManager from "./utils/StorageManager";
 import * as StorageAccess from "./utils/StorageAccess";
 import SettingsStore from "./settings/SettingsStore";
-import { SettingLevel } from "./settings/SettingLevel";
 import ToastStore from "./stores/ToastStore";
 import { IntegrationManagers } from "./integrations/IntegrationManagers";
 import { Mjolnir } from "./mjolnir/Mjolnir";

--- a/apps/web/src/MediaDeviceHandler.ts
+++ b/apps/web/src/MediaDeviceHandler.ts
@@ -9,9 +9,9 @@ Please see LICENSE files in the repository root for full details.
 
 import EventEmitter from "events";
 import { logger } from "matrix-js-sdk/src/logger";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore from "./settings/SettingsStore";
-import { SettingLevel } from "./settings/SettingLevel";
 import { MatrixClientPeg } from "./MatrixClientPeg";
 import { _t } from "./languageHandler";
 

--- a/apps/web/src/Notifier.ts
+++ b/apps/web/src/Notifier.ts
@@ -26,6 +26,7 @@ import {
 import { logger } from "matrix-js-sdk/src/logger";
 import { type PermissionChanged as PermissionChangedEvent } from "@matrix-org/analytics-events/types/typescript/PermissionChanged";
 import { type SessionMembershipData, type IRTCNotificationContent } from "matrix-js-sdk/src/matrixrtc";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { MatrixClientPeg } from "./MatrixClientPeg";
 import { PosthogAnalytics } from "./PosthogAnalytics";
@@ -38,7 +39,6 @@ import { _t } from "./languageHandler";
 import Modal from "./Modal";
 import SettingsStore from "./settings/SettingsStore";
 import { hideToast as hideNotificationsToast } from "./toasts/DesktopNotificationsToast";
-import { SettingLevel } from "./settings/SettingLevel";
 import { isPushNotifyDisabled } from "./settings/controllers/NotificationControllers";
 import UserActivity from "./UserActivity";
 import { mediaFromMxc } from "./customisations/Media";

--- a/apps/web/src/TimezoneHandler.ts
+++ b/apps/web/src/TimezoneHandler.ts
@@ -6,7 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { SettingLevel } from "./settings/SettingLevel";
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import SettingsStore from "./settings/SettingsStore";
 
 export const USER_TIMEZONE_KEY = "userTimezone";

--- a/apps/web/src/async-components/views/dialogs/eventindex/DisableEventIndexDialog.tsx
+++ b/apps/web/src/async-components/views/dialogs/eventindex/DisableEventIndexDialog.tsx
@@ -7,6 +7,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import React from "react";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import BaseDialog from "../../../../components/views/dialogs/BaseDialog";
 import Spinner from "../../../../components/views/elements/Spinner";
@@ -16,7 +17,6 @@ import { _t } from "../../../../languageHandler";
 import SettingsStore from "../../../../settings/SettingsStore";
 import EventIndexPeg from "../../../../indexing/EventIndexPeg";
 import { Action } from "../../../../dispatcher/actions";
-import { SettingLevel } from "../../../../settings/SettingLevel";
 
 interface IProps {
     onFinished: (success?: boolean) => void;

--- a/apps/web/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.tsx
+++ b/apps/web/src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.tsx
@@ -8,6 +8,7 @@ Please see LICENSE files in the repository root for full details.
 
 import React, { type ChangeEvent } from "react";
 import { type Room } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../../languageHandler";
 import SdkConfig from "../../../../SdkConfig";
@@ -15,7 +16,6 @@ import SettingsStore from "../../../../settings/SettingsStore";
 import Modal from "../../../../Modal";
 import { formatBytes, formatCountLong } from "../../../../utils/FormattingUtils";
 import EventIndexPeg from "../../../../indexing/EventIndexPeg";
-import { SettingLevel } from "../../../../settings/SettingLevel";
 import Field from "../../../../components/views/elements/Field";
 import BaseDialog from "../../../../components/views/dialogs/BaseDialog";
 import DialogButtons from "../../../../components/views/elements/DialogButtons";

--- a/apps/web/src/components/structures/LoggedInView.tsx
+++ b/apps/web/src/components/structures/LoggedInView.tsx
@@ -23,6 +23,7 @@ import {
 import { type MatrixCall } from "matrix-js-sdk/src/webrtc/call";
 import classNames from "classnames";
 import { GroupView, SeparatorView, Panel, LeftResizablePanelView } from "@element-hq/web-shared-components";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { isOnlyCtrlOrCmdKeyEvent, Key } from "../../Keyboard";
 import PageTypes from "../../PageTypes";
@@ -30,7 +31,6 @@ import MediaDeviceHandler from "../../MediaDeviceHandler";
 import dis from "../../dispatcher/dispatcher";
 import { type IMatrixClientCreds } from "../../MatrixClientPeg";
 import SettingsStore from "../../settings/SettingsStore";
-import { SettingLevel } from "../../settings/SettingLevel";
 import ResizeHandle from "../views/elements/ResizeHandle";
 import { CollapseDistributor, Resizer } from "../../resizer";
 import PlatformPeg from "../../PlatformPeg";

--- a/apps/web/src/components/structures/MatrixChat.tsx
+++ b/apps/web/src/components/structures/MatrixChat.tsx
@@ -29,6 +29,7 @@ import "what-input";
 import sanitizeHtml from "sanitize-html";
 import { I18nContext, LinkedTextContext, LinkedText } from "@element-hq/web-shared-components";
 import { LockSolidIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import PosthogTrackers from "../../PosthogTrackers";
 import { DecryptionFailureTracker } from "../../DecryptionFailureTracker";
@@ -66,7 +67,6 @@ import {
     RoomNotificationStateStore,
     UPDATE_STATUS_INDICATOR,
 } from "../../stores/notifications/RoomNotificationStateStore";
-import { SettingLevel } from "../../settings/SettingLevel";
 import ThreepidInviteStore, {
     type IThreepidInvite,
     type IThreepidInviteWireFormat,

--- a/apps/web/src/components/structures/UserMenu.tsx
+++ b/apps/web/src/components/structures/UserMenu.tsx
@@ -19,6 +19,7 @@ import {
     ThemeIcon,
 } from "@vector-im/compound-design-tokens/assets/web/icons";
 import { IconButton } from "@vector-im/compound-web";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { MatrixClientPeg } from "../../MatrixClientPeg";
 import defaultDispatcher from "../../dispatcher/dispatcher";
@@ -40,7 +41,6 @@ import { getHomePageUrl } from "../../utils/pages";
 import { OwnProfileStore } from "../../stores/OwnProfileStore";
 import { UPDATE_EVENT } from "../../stores/AsyncStore";
 import BaseAvatar from "../views/avatars/BaseAvatar";
-import { SettingLevel } from "../../settings/SettingLevel";
 import IconizedContextMenu, {
     IconizedContextMenuOption,
     IconizedContextMenuOptionList,

--- a/apps/web/src/components/views/auth/LanguageSelector.tsx
+++ b/apps/web/src/components/views/auth/LanguageSelector.tsx
@@ -6,12 +6,12 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import React, { type JSX } from "react";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SdkConfig from "../../../SdkConfig";
 import { getCurrentLanguage } from "../../../languageHandler";
 import SettingsStore from "../../../settings/SettingsStore";
 import PlatformPeg from "../../../PlatformPeg";
-import { SettingLevel } from "../../../settings/SettingLevel";
 import LanguageDropdown from "../elements/LanguageDropdown";
 
 function onChange(newLang: string): void {

--- a/apps/web/src/components/views/beta/BetaCard.tsx
+++ b/apps/web/src/components/views/beta/BetaCard.tsx
@@ -8,11 +8,11 @@ Please see LICENSE files in the repository root for full details.
 
 import React, { type ReactNode, useState } from "react";
 import { sleep } from "matrix-js-sdk/src/utils";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../languageHandler";
 import AccessibleButton from "../elements/AccessibleButton";
 import SettingsStore from "../../../settings/SettingsStore";
-import { SettingLevel } from "../../../settings/SettingLevel";
 import Modal from "../../../Modal";
 import BetaFeedbackDialog from "../dialogs/BetaFeedbackDialog";
 import SdkConfig from "../../../SdkConfig";

--- a/apps/web/src/components/views/dialogs/AskInviteAnywayDialog.tsx
+++ b/apps/web/src/components/views/dialogs/AskInviteAnywayDialog.tsx
@@ -8,10 +8,10 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import React, { type JSX, useCallback } from "react";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../languageHandler";
 import SettingsStore from "../../../settings/SettingsStore";
-import { SettingLevel } from "../../../settings/SettingLevel";
 import BaseDialog from "./BaseDialog";
 
 export interface UnknownProfile {

--- a/apps/web/src/components/views/dialogs/DevtoolsDialog.tsx
+++ b/apps/web/src/components/views/dialogs/DevtoolsDialog.tsx
@@ -9,6 +9,7 @@ Please see LICENSE files in the repository root for full details.
 
 import React, { type JSX, useState } from "react";
 import { Form } from "@vector-im/compound-web";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t, _td } from "../../../languageHandler";
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
@@ -22,7 +23,6 @@ import WidgetExplorer from "./devtools/WidgetExplorer";
 import { UserList } from "./devtools/Users";
 import { AccountDataExplorer, RoomAccountDataExplorer } from "./devtools/AccountData";
 import SettingsFlag from "../elements/SettingsFlag";
-import { SettingLevel } from "../../../settings/SettingLevel";
 import ServerInfo from "./devtools/ServerInfo";
 import CopyableText from "../elements/CopyableText";
 import RoomNotifications from "./devtools/RoomNotifications";

--- a/apps/web/src/components/views/dialogs/SpacePreferencesDialog.tsx
+++ b/apps/web/src/components/views/dialogs/SpacePreferencesDialog.tsx
@@ -9,6 +9,7 @@ Please see LICENSE files in the repository root for full details.
 import React, { type ChangeEvent } from "react";
 import { type Room } from "matrix-js-sdk/src/matrix";
 import { VisibilityOnIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t, _td } from "../../../languageHandler";
 import BaseDialog from "../dialogs/BaseDialog";
@@ -16,7 +17,6 @@ import TabbedView, { Tab } from "../../structures/TabbedView";
 import StyledCheckbox from "../elements/StyledCheckbox";
 import { useSettingValue } from "../../../hooks/useSettings";
 import SettingsStore from "../../../settings/SettingsStore";
-import { SettingLevel } from "../../../settings/SettingLevel";
 import { SpacePreferenceTab } from "../../../dispatcher/payloads/OpenSpacePreferencesPayload";
 import { type NonEmptyArray } from "../../../@types/common";
 import SettingsTab from "../settings/tabs/SettingsTab";

--- a/apps/web/src/components/views/dialogs/devtools/SettingExplorer.tsx
+++ b/apps/web/src/components/views/dialogs/devtools/SettingExplorer.tsx
@@ -9,12 +9,12 @@ Please see LICENSE files in the repository root for full details.
 
 import React, { type ChangeEvent, useContext, useMemo, useState } from "react";
 import { logger } from "matrix-js-sdk/src/logger";
+import { type SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t, _td } from "../../../../languageHandler";
 import BaseTool, { DevtoolsContext, type IDevtoolsProps } from "./BaseTool";
 import AccessibleButton from "../../elements/AccessibleButton";
 import SettingsStore, { LEVEL_ORDER } from "../../../../settings/SettingsStore";
-import { type SettingLevel } from "../../../../settings/SettingLevel";
 import { type SettingKey, SETTINGS, type SettingValueType } from "../../../../settings/Settings";
 import Field from "../../elements/Field";
 

--- a/apps/web/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
+++ b/apps/web/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
@@ -41,6 +41,7 @@ import {
     CloseIcon,
     LinkIcon,
 } from "@vector-im/compound-design-tokens/assets/web/icons";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { KeyBindingAction } from "../../../../accessibility/KeyboardShortcuts";
 import {
@@ -65,7 +66,6 @@ import { MatrixClientPeg } from "../../../../MatrixClientPeg";
 import { PosthogAnalytics } from "../../../../PosthogAnalytics";
 import { getCachedRoomIdForAlias } from "../../../../RoomAliasCache";
 import { showStartChatInviteDialog } from "../../../../RoomInvite";
-import { SettingLevel } from "../../../../settings/SettingLevel";
 import SettingsStore from "../../../../settings/SettingsStore";
 import { BreadcrumbsStore } from "../../../../stores/BreadcrumbsStore";
 import { type RoomNotificationState } from "../../../../stores/notifications/RoomNotificationState";

--- a/apps/web/src/components/views/directory/NetworkDropdown.tsx
+++ b/apps/web/src/components/views/directory/NetworkDropdown.tsx
@@ -10,12 +10,12 @@ import { without } from "lodash";
 import React, { useCallback, useEffect, useState } from "react";
 import { MatrixError } from "matrix-js-sdk/src/matrix";
 import { CloseIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../languageHandler";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
 import Modal from "../../../Modal";
 import SdkConfig from "../../../SdkConfig";
-import { SettingLevel } from "../../../settings/SettingLevel";
 import SettingsStore from "../../../settings/SettingsStore";
 import { type Protocols } from "../../../utils/DirectoryUtils";
 import {

--- a/apps/web/src/components/views/elements/IRCTimelineProfileResizer.tsx
+++ b/apps/web/src/components/views/elements/IRCTimelineProfileResizer.tsx
@@ -7,10 +7,10 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import React from "react";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore from "../../../settings/SettingsStore";
 import Draggable, { type ILocationState } from "./Draggable";
-import { SettingLevel } from "../../../settings/SettingLevel";
 
 interface IProps {
     // Current room

--- a/apps/web/src/components/views/elements/SettingsDropdown.tsx
+++ b/apps/web/src/components/views/elements/SettingsDropdown.tsx
@@ -7,9 +7,9 @@ Please see LICENSE files in the repository root for full details.
 
 import React, { type JSX, useCallback, useId, useState } from "react";
 import { _t } from "@element-hq/web-shared-components";
+import { type SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore from "../../../settings/SettingsStore";
-import { type SettingLevel } from "../../../settings/SettingLevel";
 import { SETTINGS, type StringSettingKey } from "../../../settings/Settings";
 import { useSettingValueAt } from "../../../hooks/useSettings.ts";
 import Dropdown, { type DropdownProps } from "./Dropdown.tsx";

--- a/apps/web/src/components/views/elements/SettingsField.tsx
+++ b/apps/web/src/components/views/elements/SettingsField.tsx
@@ -7,10 +7,10 @@ Please see LICENSE files in the repository root for full details.
 
 import React, { type ChangeEvent, type JSX, useCallback, useState } from "react";
 import { EditInPlace } from "@vector-im/compound-web";
+import { type SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore from "../../../settings/SettingsStore";
 import { _t } from "../../../languageHandler";
-import { type SettingLevel } from "../../../settings/SettingLevel";
 import { type StringSettingKey } from "../../../settings/Settings";
 
 interface Props {

--- a/apps/web/src/components/views/elements/SettingsFlag.tsx
+++ b/apps/web/src/components/views/elements/SettingsFlag.tsx
@@ -11,10 +11,10 @@ import React, { type ChangeEvent } from "react";
 import { secureRandomString } from "matrix-js-sdk/src/randomstring";
 import { SettingsToggleInput } from "@vector-im/compound-web";
 import { logger } from "matrix-js-sdk/src/logger";
+import { type SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore from "../../../settings/SettingsStore";
 import { _t } from "../../../languageHandler";
-import { type SettingLevel } from "../../../settings/SettingLevel";
 import { type BooleanSettingKey, defaultWatchManager } from "../../../settings/Settings";
 
 interface IProps {

--- a/apps/web/src/components/views/location/LocationShareMenu.tsx
+++ b/apps/web/src/components/views/location/LocationShareMenu.tsx
@@ -8,6 +8,7 @@ Please see LICENSE files in the repository root for full details.
 
 import React, { type SyntheticEvent, useContext, useState } from "react";
 import { type Room, type IEventRelation } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import ContextMenu, { type MenuProps } from "../../structures/ContextMenu";
@@ -19,7 +20,6 @@ import ShareType from "./ShareType";
 import { OwnProfileStore } from "../../../stores/OwnProfileStore";
 import { EnableLiveShare } from "./EnableLiveShare";
 import { useFeatureEnabled } from "../../../hooks/useSettings";
-import { SettingLevel } from "../../../settings/SettingLevel";
 
 type Props = Omit<ILocationPickerProps, "onChoose" | "shareType"> & {
     onFinished: (ev?: SyntheticEvent) => void;

--- a/apps/web/src/components/views/settings/EventIndexPanel.tsx
+++ b/apps/web/src/components/views/settings/EventIndexPanel.tsx
@@ -8,6 +8,7 @@ Please see LICENSE files in the repository root for full details.
 
 import React, { type JSX, lazy } from "react";
 import { type EmptyObject } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../languageHandler";
 import SdkConfig from "../../../SdkConfig";
@@ -16,7 +17,6 @@ import SettingsStore from "../../../settings/SettingsStore";
 import AccessibleButton from "../elements/AccessibleButton";
 import { formatBytes, formatCountLong } from "../../../utils/FormattingUtils";
 import EventIndexPeg from "../../../indexing/EventIndexPeg";
-import { SettingLevel } from "../../../settings/SettingLevel";
 import SeshatResetDialog from "../dialogs/SeshatResetDialog";
 import InlineSpinner from "../elements/InlineSpinner";
 import ExternalLink from "../elements/ExternalLink";

--- a/apps/web/src/components/views/settings/FontScalingPanel.tsx
+++ b/apps/web/src/components/views/settings/FontScalingPanel.tsx
@@ -8,12 +8,12 @@ Please see LICENSE files in the repository root for full details.
 
 import React from "react";
 import { type EmptyObject } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import EventTilePreview from "../elements/EventTilePreview";
 import SettingsStore from "../../../settings/SettingsStore";
 import { type Layout } from "../../../settings/enums/Layout";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
-import { SettingLevel } from "../../../settings/SettingLevel";
 import { _t } from "../../../languageHandler";
 import { SettingsSubsection } from "./shared/SettingsSubsection";
 import Field from "../elements/Field";

--- a/apps/web/src/components/views/settings/ImageSizePanel.tsx
+++ b/apps/web/src/components/views/settings/ImageSizePanel.tsx
@@ -8,11 +8,11 @@ Please see LICENSE files in the repository root for full details.
 
 import React from "react";
 import { type EmptyObject } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore from "../../../settings/SettingsStore";
 import StyledRadioButton from "../elements/StyledRadioButton";
 import { _t } from "../../../languageHandler";
-import { SettingLevel } from "../../../settings/SettingLevel";
 import { ImageSize } from "../../../settings/enums/ImageSize";
 import { SettingsSubsection } from "./shared/SettingsSubsection";
 import { Icon as ImgSizeNormalIcon } from "../../../../res/img/element-icons/settings/img-size-normal.svg";

--- a/apps/web/src/components/views/settings/LayoutSwitcher.tsx
+++ b/apps/web/src/components/views/settings/LayoutSwitcher.tsx
@@ -8,11 +8,11 @@
 
 import React, { type JSX, useEffect, useState } from "react";
 import { Field, HelpMessage, InlineField, Label, RadioControl, Root, ToggleControl } from "@vector-im/compound-web";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { SettingsSubsection } from "./shared/SettingsSubsection";
 import { _t } from "../../../languageHandler";
 import SettingsStore from "../../../settings/SettingsStore";
-import { SettingLevel } from "../../../settings/SettingLevel";
 import { useSettingValue } from "../../../hooks/useSettings";
 import { Layout } from "../../../settings/enums/Layout";
 import EventTilePreview from "../elements/EventTilePreview";

--- a/apps/web/src/components/views/settings/Notifications.tsx
+++ b/apps/web/src/components/views/settings/Notifications.tsx
@@ -20,6 +20,7 @@ import {
 } from "matrix-js-sdk/src/matrix";
 import { logger } from "matrix-js-sdk/src/logger";
 import { Form, SettingsToggleInput } from "@vector-im/compound-web";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import Spinner from "../elements/Spinner";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
@@ -34,7 +35,6 @@ import {
 import { _t, type TranslatedString } from "../../../languageHandler";
 import SettingsStore from "../../../settings/SettingsStore";
 import StyledRadioButton from "../elements/StyledRadioButton";
-import { SettingLevel } from "../../../settings/SettingLevel";
 import Modal from "../../../Modal";
 import ErrorDialog from "../dialogs/ErrorDialog";
 import SdkConfig from "../../../SdkConfig";

--- a/apps/web/src/components/views/settings/SetIntegrationManager.tsx
+++ b/apps/web/src/components/views/settings/SetIntegrationManager.tsx
@@ -10,12 +10,12 @@ import React from "react";
 import { logger } from "matrix-js-sdk/src/logger";
 import { type EmptyObject } from "matrix-js-sdk/src/matrix";
 import { Form, SettingsToggleInput } from "@vector-im/compound-web";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../languageHandler";
 import { IntegrationManagers } from "../../../integrations/IntegrationManagers";
 import { type IntegrationManagerInstance } from "../../../integrations/IntegrationManagerInstance";
 import SettingsStore from "../../../settings/SettingsStore";
-import { SettingLevel } from "../../../settings/SettingLevel";
 import Heading from "../typography/Heading";
 import { SettingsSubsectionText } from "./shared/SettingsSubsection";
 import { UIFeature } from "../../../settings/UIFeature";

--- a/apps/web/src/components/views/settings/ThemeChoicePanel.tsx
+++ b/apps/web/src/components/views/settings/ThemeChoicePanel.tsx
@@ -21,12 +21,12 @@ import {
 import DeleteIcon from "@vector-im/compound-design-tokens/assets/web/icons/delete";
 import classNames from "classnames";
 import { logger } from "matrix-js-sdk/src/logger";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../languageHandler";
 import { SettingsSubsection } from "./shared/SettingsSubsection";
 import ThemeWatcher from "../../../settings/watchers/ThemeWatcher";
 import SettingsStore from "../../../settings/SettingsStore";
-import { SettingLevel } from "../../../settings/SettingLevel";
 import dis from "../../../dispatcher/dispatcher";
 import { type RecheckThemePayload } from "../../../dispatcher/payloads/RecheckThemePayload";
 import { Action } from "../../../dispatcher/actions";

--- a/apps/web/src/components/views/settings/encryption/AdvancedPanel.tsx
+++ b/apps/web/src/components/views/settings/encryption/AdvancedPanel.tsx
@@ -9,13 +9,13 @@ import React, { type JSX, lazy, type MouseEventHandler } from "react";
 import { Button, HelpMessage, InlineField, InlineSpinner, Label, Root, ToggleControl } from "@vector-im/compound-web";
 import DownloadIcon from "@vector-im/compound-design-tokens/assets/web/icons/download";
 import ShareIcon from "@vector-im/compound-design-tokens/assets/web/icons/share";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../../languageHandler";
 import { SettingsSection } from "../shared/SettingsSection";
 import { useMatrixClientContext } from "../../../../contexts/MatrixClientContext";
 import { useAsyncMemo } from "../../../../hooks/useAsyncMemo";
 import Modal from "../../../../Modal";
-import { SettingLevel } from "../../../../settings/SettingLevel";
 import { useSettingValueAt } from "../../../../hooks/useSettings";
 import SettingsStore from "../../../../settings/SettingsStore";
 

--- a/apps/web/src/components/views/settings/notifications/NotificationSettings2.tsx
+++ b/apps/web/src/components/views/settings/notifications/NotificationSettings2.tsx
@@ -8,6 +8,7 @@ Please see LICENSE files in the repository root for full details.
 
 import React, { type JSX, useState } from "react";
 import { Form, SettingsToggleInput } from "@vector-im/compound-web";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import NewAndImprovedIcon from "../../../../../res/img/element-icons/new-and-improved.svg";
 import { useMatrixClientContext } from "../../../../contexts/MatrixClientContext";
@@ -18,7 +19,6 @@ import {
     type NotificationSettings,
 } from "../../../../models/notificationsettings/NotificationSettings";
 import { RoomNotifState } from "../../../../RoomNotifs";
-import { SettingLevel } from "../../../../settings/SettingLevel";
 import { NotificationLevel } from "../../../../stores/notifications/NotificationLevel";
 import { clearAllNotifications } from "../../../../utils/notifications";
 import AccessibleButton from "../../elements/AccessibleButton";

--- a/apps/web/src/components/views/settings/tabs/room/NotificationSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/room/NotificationSettingsTab.tsx
@@ -8,12 +8,12 @@ Please see LICENSE files in the repository root for full details.
 
 import React, { type JSX, createRef } from "react";
 import { logger } from "matrix-js-sdk/src/logger";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../../../languageHandler";
 import AccessibleButton, { type ButtonEvent } from "../../../elements/AccessibleButton";
 import Notifier from "../../../../../Notifier";
 import SettingsStore from "../../../../../settings/SettingsStore";
-import { SettingLevel } from "../../../../../settings/SettingLevel";
 import { type RoomEchoChamber } from "../../../../../stores/local-echo/RoomEchoChamber";
 import { EchoChamber } from "../../../../../stores/local-echo/EchoChamber";
 import MatrixClientContext from "../../../../../contexts/MatrixClientContext";

--- a/apps/web/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
@@ -19,12 +19,12 @@ import {
 import { logger } from "matrix-js-sdk/src/logger";
 import { Form, InlineSpinner, SettingsToggleInput } from "@vector-im/compound-web";
 import { WarningIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../../../languageHandler";
 import Modal from "../../../../../Modal";
 import QuestionDialog from "../../../dialogs/QuestionDialog";
 import StyledRadioGroup from "../../../elements/StyledRadioGroup";
-import { SettingLevel } from "../../../../../settings/SettingLevel";
 import SettingsStore from "../../../../../settings/SettingsStore";
 import { UIFeature } from "../../../../../settings/UIFeature";
 import AccessibleButton from "../../../elements/AccessibleButton";

--- a/apps/web/src/components/views/settings/tabs/user/AppearanceUserSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/AppearanceUserSettingsTab.tsx
@@ -10,13 +10,13 @@ Please see LICENSE files in the repository root for full details.
 import React, { type ChangeEvent, type ReactNode } from "react";
 import { type EmptyObject } from "matrix-js-sdk/src/matrix";
 import { Form } from "@vector-im/compound-web";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../../../languageHandler";
 import SettingsStore from "../../../../../settings/SettingsStore";
 import SettingsFlag from "../../../elements/SettingsFlag";
 import Field from "../../../elements/Field";
 import AccessibleButton from "../../../elements/AccessibleButton";
-import { SettingLevel } from "../../../../../settings/SettingLevel";
 import { UIFeature } from "../../../../../settings/UIFeature";
 import { LayoutSwitcher } from "../../LayoutSwitcher";
 import FontScalingPanel from "../../FontScalingPanel";

--- a/apps/web/src/components/views/settings/tabs/user/InviteRulesAccountSettings.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/InviteRulesAccountSettings.tsx
@@ -8,11 +8,11 @@ Please see LICENSE files in the repository root for full details.
 import React, { type ChangeEvent, type FC, useCallback, useState } from "react";
 import { Form, SettingsToggleInput } from "@vector-im/compound-web";
 import { logger } from "matrix-js-sdk/src/logger";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../../../languageHandler";
 import { useSettingValue } from "../../../../../hooks/useSettings";
 import SettingsStore from "../../../../../settings/SettingsStore";
-import { SettingLevel } from "../../../../../settings/SettingLevel";
 
 /**
  * A settings component which allows the user to enable/disable invite blocking.

--- a/apps/web/src/components/views/settings/tabs/user/LabsUserSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/LabsUserSettingsTab.tsx
@@ -9,10 +9,10 @@ import React, { type JSX } from "react";
 import { sortBy } from "lodash";
 import { type EmptyObject } from "matrix-js-sdk/src/matrix";
 import { Form } from "@vector-im/compound-web";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../../../languageHandler";
 import SettingsStore from "../../../../../settings/SettingsStore";
-import { SettingLevel } from "../../../../../settings/SettingLevel";
 import SdkConfig from "../../../../../SdkConfig";
 import BetaCard from "../../../beta/BetaCard";
 import SettingsFlag from "../../../elements/SettingsFlag";

--- a/apps/web/src/components/views/settings/tabs/user/MediaPreviewAccountSettings.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/MediaPreviewAccountSettings.tsx
@@ -7,12 +7,12 @@ Please see LICENSE files in the repository root for full details.
 
 import React, { type ChangeEventHandler, useCallback } from "react";
 import { Field, HelpMessage, InlineField, Label, RadioInput, Root, SettingsToggleInput } from "@vector-im/compound-web";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { type MediaPreviewConfig, MediaPreviewValue } from "../../../../../@types/media_preview";
 import { _t } from "../../../../../languageHandler";
 import { useSettingValue } from "../../../../../hooks/useSettings";
 import SettingsStore from "../../../../../settings/SettingsStore";
-import { SettingLevel } from "../../../../../settings/SettingLevel";
 
 export const MediaPreviewAccountSettings: React.FC<{ roomId?: string }> = ({ roomId }) => {
     const currentMediaPreview = useSettingValue("mediaPreviewConfig", roomId);

--- a/apps/web/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -9,13 +9,13 @@ Please see LICENSE files in the repository root for full details.
 
 import React, { type ChangeEvent, type JSX, type ReactElement, useCallback, useEffect, useState } from "react";
 import { SettingsToggleInput } from "@vector-im/compound-web";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { type NonEmptyArray } from "../../../../../@types/common";
 import { _t, getCurrentLanguage } from "../../../../../languageHandler";
 import SettingsStore from "../../../../../settings/SettingsStore";
 import Field from "../../../elements/Field";
 import Dropdown from "../../../elements/Dropdown";
-import { SettingLevel } from "../../../../../settings/SettingLevel";
 import SettingsFlag from "../../../elements/SettingsFlag";
 import AccessibleButton from "../../../elements/AccessibleButton";
 import dis from "../../../../../dispatcher/dispatcher";

--- a/apps/web/src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx
@@ -13,12 +13,12 @@ import { KnownMembership, type Membership } from "matrix-js-sdk/src/types";
 import { logger } from "matrix-js-sdk/src/logger";
 import { WarningIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
 import { Form } from "@vector-im/compound-web";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../../../languageHandler";
 import { MatrixClientPeg } from "../../../../../MatrixClientPeg";
 import AccessibleButton from "../../../elements/AccessibleButton";
 import dis from "../../../../../dispatcher/dispatcher";
-import { SettingLevel } from "../../../../../settings/SettingLevel";
 import SettingsStore from "../../../../../settings/SettingsStore";
 import { UIFeature } from "../../../../../settings/UIFeature";
 import { type ActionPayload } from "../../../../../dispatcher/payloads";

--- a/apps/web/src/components/views/settings/tabs/user/SidebarUserSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/SidebarUserSettingsTab.tsx
@@ -13,10 +13,10 @@ import {
     UserProfileSolidIcon,
     FavouriteSolidIcon,
 } from "@vector-im/compound-design-tokens/assets/web/icons";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../../../languageHandler";
 import SettingsStore from "../../../../../settings/SettingsStore";
-import { SettingLevel } from "../../../../../settings/SettingLevel";
 import StyledCheckbox from "../../../elements/StyledCheckbox";
 import { useSettingValue } from "../../../../../hooks/useSettings";
 import { MetaSpace } from "../../../../../stores/spaces";

--- a/apps/web/src/components/views/settings/tabs/user/VoiceUserSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/VoiceUserSettingsTab.tsx
@@ -12,12 +12,12 @@ import { logger } from "matrix-js-sdk/src/logger";
 import { FALLBACK_ICE_SERVER } from "matrix-js-sdk/src/webrtc/call";
 import { type EmptyObject } from "matrix-js-sdk/src/matrix";
 import { Form, SettingsToggleInput } from "@vector-im/compound-web";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../../../languageHandler";
 import MediaDeviceHandler, { type IMediaDevices, MediaDeviceKindEnum } from "../../../../../MediaDeviceHandler";
 import Field from "../../../elements/Field";
 import AccessibleButton from "../../../elements/AccessibleButton";
-import { SettingLevel } from "../../../../../settings/SettingLevel";
 import SettingsFlag from "../../../elements/SettingsFlag";
 import { requestMediaPermissions } from "../../../../../utils/media/requestMediaPermissions";
 import SettingsTab from "../SettingsTab";

--- a/apps/web/src/components/views/spaces/QuickThemeSwitcher.tsx
+++ b/apps/web/src/components/views/spaces/QuickThemeSwitcher.tsx
@@ -7,13 +7,13 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import React, { type ReactElement, useMemo } from "react";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../languageHandler";
 import { Action } from "../../../dispatcher/actions";
 import { findNonHighContrastTheme, getOrderedThemes } from "../../../theme";
 import Dropdown from "../elements/Dropdown";
 import SettingsStore from "../../../settings/SettingsStore";
-import { SettingLevel } from "../../../settings/SettingLevel";
 import dis from "../../../dispatcher/dispatcher";
 import { type RecheckThemePayload } from "../../../dispatcher/payloads/RecheckThemePayload";
 import PosthogTrackers from "../../../PosthogTrackers";

--- a/apps/web/src/components/views/spaces/SpacePanel.tsx
+++ b/apps/web/src/components/views/spaces/SpacePanel.tsx
@@ -31,6 +31,7 @@ import {
     PlusIcon,
     ChevronRightIcon,
 } from "@vector-im/compound-design-tokens/assets/web/icons";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { _t } from "../../../languageHandler";
 import { useContextMenu } from "../../structures/ContextMenu";
@@ -58,7 +59,6 @@ import IconizedContextMenu, {
     IconizedContextMenuOptionList,
 } from "../context_menus/IconizedContextMenu";
 import SettingsStore from "../../../settings/SettingsStore";
-import { SettingLevel } from "../../../settings/SettingLevel";
 import UIStore from "../../../stores/UIStore";
 import QuickSettingsButton from "./QuickSettingsButton";
 import { useSettingValue } from "../../../hooks/useSettings";

--- a/apps/web/src/dispatcher/payloads/SettingUpdatedPayload.ts
+++ b/apps/web/src/dispatcher/payloads/SettingUpdatedPayload.ts
@@ -6,9 +6,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { type SettingLevel } from "@element-hq/element-web-module-api";
+
 import { type ActionPayload } from "../payloads";
 import { type Action } from "../actions";
-import { type SettingLevel } from "../../settings/SettingLevel";
 import { type SettingValueType } from "../../settings/Settings";
 
 export interface SettingUpdatedPayload extends ActionPayload {

--- a/apps/web/src/emojipicker/recent.ts
+++ b/apps/web/src/emojipicker/recent.ts
@@ -8,9 +8,9 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { orderBy } from "lodash";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore from "../settings/SettingsStore";
-import { SettingLevel } from "../settings/SettingLevel";
 
 interface ILegacyFormat {
     [emoji: string]: [number, number]; // [count, date]

--- a/apps/web/src/hooks/spotlight/useRecentSearches.ts
+++ b/apps/web/src/hooks/spotlight/useRecentSearches.ts
@@ -8,9 +8,9 @@ Please see LICENSE files in the repository root for full details.
 
 import { useState } from "react";
 import { type Room } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { MatrixClientPeg } from "../../MatrixClientPeg";
-import { SettingLevel } from "../../settings/SettingLevel";
 import SettingsStore from "../../settings/SettingsStore";
 import { filterBoolean } from "../../utils/arrays";
 

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -7,9 +7,9 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { useEffect, useState } from "react";
+import { type SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore from "../settings/SettingsStore";
-import { type SettingLevel } from "../settings/SettingLevel";
 import { type FeatureSettingKey, type SettingKey, type Settings } from "../settings/Settings.tsx";
 
 // Hook to fetch the value of a setting and dynamically update when it changes

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -6,7 +6,8 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-import { SettingLevel } from "../settings/SettingLevel";
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import { useSettingValue, useSettingValueAt } from "./useSettings";
 
 /**

--- a/apps/web/src/indexing/EventIndex.ts
+++ b/apps/web/src/indexing/EventIndex.ts
@@ -33,11 +33,11 @@ import {
 import { KnownMembership } from "matrix-js-sdk/src/types";
 import { sleep } from "matrix-js-sdk/src/utils";
 import { logger } from "matrix-js-sdk/src/logger";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import PlatformPeg from "../PlatformPeg";
 import { MatrixClientPeg } from "../MatrixClientPeg";
 import SettingsStore from "../settings/SettingsStore";
-import { SettingLevel } from "../settings/SettingLevel";
 import {
     type ICrawlerCheckpoint,
     type IEventAndProfile,

--- a/apps/web/src/indexing/EventIndexPeg.ts
+++ b/apps/web/src/indexing/EventIndexPeg.ts
@@ -12,12 +12,12 @@ Please see LICENSE files in the repository root for full details.
  */
 
 import { logger } from "matrix-js-sdk/src/logger";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import PlatformPeg from "../PlatformPeg";
 import EventIndex from "../indexing/EventIndex";
 import { MatrixClientPeg } from "../MatrixClientPeg";
 import SettingsStore from "../settings/SettingsStore";
-import { SettingLevel } from "../settings/SettingLevel";
 
 const INDEX_VERSION = 1;
 

--- a/apps/web/src/languageHandler.tsx
+++ b/apps/web/src/languageHandler.tsx
@@ -20,10 +20,10 @@ import {
     getLocale,
     setMissingEntryGenerator as setMissingEntryGeneratorSharedComponents,
 } from "@element-hq/web-shared-components";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore from "./settings/SettingsStore";
 import PlatformPeg from "./PlatformPeg";
-import { SettingLevel } from "./settings/SettingLevel";
 import { retry } from "./utils/promise";
 import SdkConfig from "./SdkConfig";
 import { ModuleRunner } from "./modules/ModuleRunner";

--- a/apps/web/src/mjolnir/Mjolnir.ts
+++ b/apps/web/src/mjolnir/Mjolnir.ts
@@ -8,13 +8,13 @@ Please see LICENSE files in the repository root for full details.
 
 import { type MatrixEvent, RoomStateEvent, Preset } from "matrix-js-sdk/src/matrix";
 import { logger } from "matrix-js-sdk/src/logger";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { MatrixClientPeg } from "../MatrixClientPeg";
 import { ALL_RULE_TYPES, BanList } from "./BanList";
 import SettingsStore from "../settings/SettingsStore";
 import { _t } from "../languageHandler";
 import dis from "../dispatcher/dispatcher";
-import { SettingLevel } from "../settings/SettingLevel";
 import { type ActionPayload } from "../dispatcher/payloads";
 import { type DoAfterSyncPreparedPayload } from "../dispatcher/payloads/DoAfterSyncPreparedPayload";
 import { Action } from "../dispatcher/actions";

--- a/apps/web/src/modules/StoresApi.ts
+++ b/apps/web/src/modules/StoresApi.ts
@@ -7,12 +7,14 @@ Please see LICENSE files in the repository root for full details.
 import {
     type StoresApi as IStoresApi,
     type RoomListStoreApi as IRoomListStore,
+    type SettingsStoreApi as ISettingsStoreApi,
     type Room,
     Watchable,
 } from "@element-hq/element-web-module-api";
 
 import type { RoomListStoreV3Class, RoomListStoreV3Event } from "../stores/room-list-v3/RoomListStoreV3";
 import { Room as ModuleRoom } from "./models/Room";
+import { ModuleSettingsStore } from "./stores/SettingsStore";
 
 interface RlsEvents {
     LISTS_LOADED_EVENT: RoomListStoreV3Event.ListsLoaded;
@@ -96,11 +98,19 @@ class RoomsWatchable extends Watchable<Room[]> {
 
 export class StoresApi implements IStoresApi {
     private roomListStoreApi?: IRoomListStore;
+    private settingsStoresApi?: ISettingsStoreApi;
 
     public get roomListStore(): IRoomListStore {
         if (!this.roomListStoreApi) {
             this.roomListStoreApi = new RoomListStoreApi();
         }
         return this.roomListStoreApi;
+    }
+
+    public get settingsStore(): ISettingsStoreApi {
+        if (!this.settingsStoresApi) {
+            this.settingsStoresApi = new ModuleSettingsStore();
+        }
+        return this.settingsStoresApi;
     }
 }

--- a/apps/web/src/modules/stores/SettingsStore.ts
+++ b/apps/web/src/modules/stores/SettingsStore.ts
@@ -1,0 +1,19 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import type { SettingLevel, SettingsStoreApi } from "@element-hq/element-web-module-api";
+import SettingsStore from "../../settings/SettingsStore";
+import type { SettingKey } from "../../settings/Settings";
+
+export class ModuleSettingsStore implements SettingsStoreApi {
+    public overrideSettingsSupportedLevels(settingName: string, supportedLevels: SettingLevel[]): void {
+        const key = settingName as SettingKey;
+        // Validate that the setting is real.
+        SettingsStore.getSettingWithOverrides(key);
+        SettingsStore.setSettingOverride(key, { supportedLevels });
+    }
+}

--- a/apps/web/src/settings/SettingLevel.ts
+++ b/apps/web/src/settings/SettingLevel.ts
@@ -5,18 +5,3 @@ Copyright 2020 The Matrix.org Foundation C.I.C.
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.
 */
-
-/**
- * Represents the various setting levels supported by the SettingsStore.
- */
-export enum SettingLevel {
-    // TODO: [TS] Follow naming convention
-    DEVICE = "device",
-    ROOM_DEVICE = "room-device",
-    ROOM_ACCOUNT = "room-account",
-    ACCOUNT = "account",
-    ROOM = "room",
-    PLATFORM = "platform",
-    CONFIG = "config",
-    DEFAULT = "default",
-}

--- a/apps/web/src/settings/Settings.tsx
+++ b/apps/web/src/settings/Settings.tsx
@@ -11,6 +11,7 @@ import React, { type ReactNode } from "react";
 import { STABLE_MSC4133_EXTENDED_PROFILES, UNSTABLE_MSC4133_EXTENDED_PROFILES } from "matrix-js-sdk/src/matrix";
 // Import these directly from shared-components to avoid circular deps
 import { _t, _td } from "@element-hq/web-shared-components";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { type MediaPreviewConfig } from "../@types/media_preview.ts";
 import DeviceIsolationModeController from "./controllers/DeviceIsolationModeController.ts";
@@ -22,7 +23,6 @@ import ThemeController from "./controllers/ThemeController";
 import ReloadOnChangeController from "./controllers/ReloadOnChangeController";
 import FontSizeController from "./controllers/FontSizeController";
 import SystemFontController from "./controllers/SystemFontController";
-import { SettingLevel } from "./SettingLevel";
 import type SettingController from "./controllers/SettingController";
 import { IS_MAC } from "../Keyboard";
 import UIFeatureController from "./controllers/UIFeatureController";

--- a/apps/web/src/settings/SettingsStore.ts
+++ b/apps/web/src/settings/SettingsStore.ts
@@ -10,6 +10,7 @@ Please see LICENSE files in the repository root for full details.
 import { logger } from "matrix-js-sdk/src/logger";
 import { type ReactNode } from "react";
 import { ClientEvent } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import DeviceSettingsHandler from "./handlers/DeviceSettingsHandler";
 import RoomDeviceSettingsHandler from "./handlers/RoomDeviceSettingsHandler";
@@ -31,7 +32,6 @@ import {
 } from "./Settings";
 import LocalEchoWrapper from "./handlers/LocalEchoWrapper";
 import { type CallbackFn as WatchCallbackFn } from "./WatchManager";
-import { SettingLevel } from "./SettingLevel";
 import type SettingsHandler from "./handlers/SettingsHandler";
 import { type SettingUpdatedPayload } from "../dispatcher/payloads/SettingUpdatedPayload";
 import { Action } from "../dispatcher/actions";
@@ -134,6 +134,11 @@ export default class SettingsStore {
     private static watchers = new Map<string, WatchCallbackFn>();
     private static monitors = new Map<string, Map<string | null, string>>(); // { settingName => { roomId => callbackRef } }
 
+    /**
+     * Overrides that may be placed upon the `SETTINGS` defined at build time.
+     */
+    private static overrides = new Map<SettingKey, Partial<ISetting>>();
+
     // Counter used for generation of watcher IDs
     private static watcherCount = 1;
 
@@ -149,6 +154,22 @@ export default class SettingsStore {
      */
     public static getFeatureSettingNames(): SettingKey[] {
         return (Object.keys(SETTINGS) as SettingKey[]).filter((n) => SettingsStore.isFeature(n));
+    }
+
+    public static setSettingOverride<K extends SettingKey>(key: K, partial: Partial<Settings[K]>): Settings[K] {
+        this.overrides.set(key, partial);
+    }
+
+    public static getSettingWithOverrides<K extends SettingKey>(key: K): Settings[K] {
+        const initial = SETTINGS[key];
+        if (!initial) {
+            throw new Error(`Setting '${key}' does not appear to be a setting.`);
+        }
+        const overrides = this.overrides.get(key);
+        return {
+            ...initial,
+            ...overrides,
+        };
     }
 
     /**
@@ -168,7 +189,7 @@ export default class SettingsStore {
      * @returns {string} A reference to the watcher that was employed.
      */
     public static watchSetting(settingName: SettingKey, roomId: string | null, callbackFn: CallbackFn): string {
-        const setting = SETTINGS[settingName];
+        const setting = this.getSettingWithOverrides(settingName);
         if (!setting) throw new Error(`${settingName} is not a setting`);
 
         const finalSettingName: string = setting.invertedSettingName ?? settingName;
@@ -269,9 +290,10 @@ export default class SettingsStore {
      * @return {String} The display name for the setting, or null if not found.
      */
     public static getDisplayName(settingName: SettingKey, atLevel = SettingLevel.DEFAULT): string | null {
-        if (!SETTINGS[settingName] || !SETTINGS[settingName].displayName) return null;
+        const setting = this.getSettingWithOverrides(settingName);
+        if (!setting || !setting.displayName) return null;
 
-        const displayName = SETTINGS[settingName].displayName;
+        const displayName = setting.displayName;
 
         if (typeof displayName === "string") {
             return _t(displayName);
@@ -292,7 +314,8 @@ export default class SettingsStore {
      * @return {String} The description for the setting, or null if not found.
      */
     public static getDescription(settingName: SettingKey): string | ReactNode {
-        const description = SETTINGS[settingName]?.description;
+        const setting = this.getSettingWithOverrides(settingName);
+        const description = setting?.description;
         if (!description) return null;
         if (typeof description !== "string") return description();
         return _t(description);
@@ -304,8 +327,9 @@ export default class SettingsStore {
      * @return {boolean} True if the setting is a feature.
      */
     public static isFeature(settingName: SettingKey): boolean {
-        if (!SETTINGS[settingName]) return false;
-        return !!SETTINGS[settingName].isFeature;
+        const setting = this.getSettingWithOverrides(settingName);
+        if (!setting) return false;
+        return !!setting.isFeature;
     }
 
     /**
@@ -314,8 +338,9 @@ export default class SettingsStore {
      * @return {boolean} True if the setting should have a warning sign.
      */
     public static shouldHaveWarning(settingName: SettingKey): boolean {
-        if (!SETTINGS[settingName]) return false;
-        return SETTINGS[settingName].shouldWarn ?? false;
+        const setting = this.getSettingWithOverrides(settingName);
+        if (!setting) return false;
+        return setting.shouldWarn ?? false;
     }
 
     public static getBetaInfo(settingName: SettingKey): ISetting["betaInfo"] {
@@ -324,10 +349,11 @@ export default class SettingsStore {
             SettingsStore.isFeature(settingName) &&
             SettingsStore.getValueAt(SettingLevel.CONFIG, settingName, null, true, true) !== false
         ) {
-            const betaInfo = SETTINGS[settingName]!.betaInfo;
+            const setting = this.getSettingWithOverrides(settingName);
+            const betaInfo = setting!.betaInfo;
             if (betaInfo) {
                 betaInfo.requiresRefresh =
-                    betaInfo.requiresRefresh ?? SETTINGS[settingName]!.controller instanceof ReloadOnChangeController;
+                    betaInfo.requiresRefresh ?? setting!.controller instanceof ReloadOnChangeController;
             }
             return betaInfo;
         }
@@ -335,7 +361,8 @@ export default class SettingsStore {
 
     public static getLabGroup(settingName: SettingKey): LabGroup | undefined {
         if (SettingsStore.isFeature(settingName)) {
-            return (<IFeature>SETTINGS[settingName]).labsGroup;
+            const setting = this.getSettingWithOverrides(settingName);
+            return (<IFeature>setting).labsGroup;
         }
     }
 
@@ -347,7 +374,8 @@ export default class SettingsStore {
      * @return {string} The reason the setting is disabled.
      */
     public static disabledMessage(settingName: SettingKey): string | undefined {
-        const disabled = SETTINGS[settingName].controller?.settingDisabled;
+        const setting = this.getSettingWithOverrides(settingName);
+        const disabled = setting.controller?.settingDisabled;
         return typeof disabled === "string" ? disabled : undefined;
     }
 
@@ -374,12 +402,8 @@ export default class SettingsStore {
         roomId: string | null = null,
         excludeDefault = false,
     ): Settings[S]["default"] | undefined {
-        // Verify that the setting is actually a setting
-        if (!SETTINGS[settingName]) {
-            throw new Error("Setting '" + settingName + "' does not appear to be a setting.");
-        }
+        const setting = this.getSettingWithOverrides(settingName);
 
-        const setting = SETTINGS[settingName];
         const levelOrder = getLevelOrder(setting);
 
         return SettingsStore.getValueAt(levelOrder[0], settingName, roomId, false, excludeDefault);
@@ -403,12 +427,7 @@ export default class SettingsStore {
         explicit = false,
         excludeDefault = false,
     ): Settings[S]["default"] {
-        // Verify that the setting is actually a setting
-        const setting = SETTINGS[settingName];
-        if (!setting) {
-            throw new Error("Setting '" + settingName + "' does not appear to be a setting.");
-        }
-
+        const setting = this.getSettingWithOverrides(settingName);
         const levelOrder = getLevelOrder(setting);
         if (!levelOrder.includes(SettingLevel.DEFAULT)) levelOrder.push(SettingLevel.DEFAULT); // always include default
 
@@ -449,17 +468,11 @@ export default class SettingsStore {
 
     /**
      * Gets the default value of a setting.
-     * @param {string} settingName The name of the setting to read the value of.
-     * @param {String} roomId The room ID to read the setting value in, may be null.
-     * @return {*} The default value
+     * @param settingName The name of the setting to read the value of.
+     * @return The default value
      */
-    public static getDefaultValue(settingName: SettingKey): any {
-        // Verify that the setting is actually a setting
-        if (!SETTINGS[settingName]) {
-            throw new Error("Setting '" + settingName + "' does not appear to be a setting.");
-        }
-
-        return SETTINGS[settingName].default;
+    public static getDefaultValue<K extends SettingKey>(settingName: K): Settings[K]["default"] {
+        return this.getSettingWithOverrides(settingName).default;
     }
 
     private static getFinalValue(
@@ -500,11 +513,7 @@ export default class SettingsStore {
         level: SettingLevel,
         value: any,
     ): Promise<void> {
-        // Verify that the setting is actually a setting
-        const setting = SETTINGS[settingName];
-        if (!setting) {
-            throw new Error("Setting '" + settingName + "' does not appear to be a setting.");
-        }
+        const setting = this.getSettingWithOverrides(settingName);
 
         const handler = SettingsStore.getHandler(settingName, level);
         if (!handler) {
@@ -553,11 +562,7 @@ export default class SettingsStore {
      * @return {boolean} True if the user may set the setting, false otherwise.
      */
     public static canSetValue(settingName: SettingKey, roomId: string | null, level: SettingLevel): boolean {
-        const setting = SETTINGS[settingName];
-        // Verify that the setting is actually a setting
-        if (!setting) {
-            throw new Error("Setting '" + settingName + "' does not appear to be a setting.");
-        }
+        const setting = this.getSettingWithOverrides(settingName);
 
         if (setting.controller?.settingDisabled) {
             return false;
@@ -589,7 +594,7 @@ export default class SettingsStore {
         roomId: string | null,
         level: SettingLevel,
     ): boolean {
-        const setting = SETTINGS[settingName];
+        const setting = this.getSettingWithOverrides(settingName);
         const levelOrders = getLevelOrder(setting);
         const configIndex = levelOrders.indexOf(SettingLevel.CONFIG);
         const levelIndex = levelOrders.indexOf(level);
@@ -620,11 +625,7 @@ export default class SettingsStore {
      * on your own).
      */
     public static doesSettingSupportLevel(settingName: SettingKey, level: SettingLevel): boolean {
-        const setting = SETTINGS[settingName];
-        if (!setting) {
-            throw new Error("Setting '" + settingName + "' does not appear to be a setting.");
-        }
-
+        const setting = this.getSettingWithOverrides(settingName);
         return level === SettingLevel.DEFAULT || !!setting.supportedLevels?.includes(level);
     }
 
@@ -635,11 +636,7 @@ export default class SettingsStore {
      * @return {SettingLevel}
      */
     public static firstSupportedLevel(settingName: SettingKey): SettingLevel | null {
-        // Verify that the setting is actually a setting
-        const setting = SETTINGS[settingName];
-        if (!setting) {
-            throw new Error("Setting '" + settingName + "' does not appear to be a setting.");
-        }
+        const setting = this.getSettingWithOverrides(settingName);
 
         const levelOrder = getLevelOrder(setting);
         if (!levelOrder.includes(SettingLevel.DEFAULT)) levelOrder.push(SettingLevel.DEFAULT); // always include default
@@ -737,7 +734,7 @@ export default class SettingsStore {
         // problem if there's a type representation issue. Also, this way it is guaranteed
         // to show up in a rageshake if required.
 
-        const def = SETTINGS[realSettingName];
+        const def = this.getSettingWithOverrides(realSettingName);
         logger.log(`--- definition: ${def ? JSON.stringify(def) : "<NOT_FOUND>"}`);
         logger.log(`--- default level order: ${JSON.stringify(LEVEL_ORDER)}`);
         logger.log(`--- registered handlers: ${JSON.stringify(Object.keys(LEVEL_HANDLERS))}`);
@@ -847,9 +844,10 @@ export default class SettingsStore {
      */
     public static exportForRageshake(): string {
         const settingMap: Record<string, unknown> = {};
-        for (const settingKey of (Object.keys(SETTINGS) as SettingKey[]).filter(
-            (s) => SETTINGS[s].shouldExportToRageshake !== false,
-        )) {
+        for (const settingKey of Object.keys(SETTINGS) as SettingKey[]) {
+            if (this.getSettingWithOverrides(settingKey).shouldExportToRageshake === false) {
+                continue;
+            }
             try {
                 settingMap[settingKey] = SettingsStore.getValue(settingKey);
             } catch (e) {
@@ -866,11 +864,16 @@ export default class SettingsStore {
         return handlers[level]!;
     }
 
-    private static getHandlers(settingName: SettingKey): HandlerMap {
-        if (!SETTINGS[settingName]) return {};
+    private static getHandlers<K extends SettingKey>(settingName: K): HandlerMap {
+        let setting: Settings[K];
+        try {
+            setting = this.getSettingWithOverrides(settingName);
+        } catch {
+            return {};
+        }
 
         const handlers: Partial<Record<SettingLevel, SettingsHandler>> = {};
-        for (const level of SETTINGS[settingName].supportedLevels) {
+        for (const level of setting.supportedLevels) {
             if (!LEVEL_HANDLERS[level]) throw new Error("Unexpected level " + level);
             if (SettingsStore.isLevelSupported(level)) handlers[level] = LEVEL_HANDLERS[level];
         }

--- a/apps/web/src/settings/WatchManager.ts
+++ b/apps/web/src/settings/WatchManager.ts
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { type SettingLevel } from "./SettingLevel";
+import { type SettingLevel } from "@element-hq/element-web-module-api";
 
 export type CallbackFn = (changedInRoomId: string | null, atLevel: SettingLevel, newValAtLevel: any) => void;
 

--- a/apps/web/src/settings/controllers/AnalyticsController.ts
+++ b/apps/web/src/settings/controllers/AnalyticsController.ts
@@ -6,8 +6,9 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { type SettingLevel } from "@element-hq/element-web-module-api";
+
 import SettingController from "./SettingController";
-import { type SettingLevel } from "../SettingLevel";
 import PosthogTrackers, { type InteractionName } from "../../PosthogTrackers";
 
 /**

--- a/apps/web/src/settings/controllers/DeviceIsolationModeController.ts
+++ b/apps/web/src/settings/controllers/DeviceIsolationModeController.ts
@@ -7,10 +7,10 @@ Please see LICENSE files in the repository root for full details.
 
 import { AllDevicesIsolationMode, OnlySignedDevicesIsolationMode } from "matrix-js-sdk/src/crypto-api";
 import { type MatrixClient } from "matrix-js-sdk/src/matrix";
+import { type SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingController from "./SettingController";
 import { MatrixClientPeg } from "../../MatrixClientPeg";
-import { type SettingLevel } from "../SettingLevel";
 
 /**
  * A controller for the "exclude_insecure_devices" setting, which will

--- a/apps/web/src/settings/controllers/FallbackIceServerController.ts
+++ b/apps/web/src/settings/controllers/FallbackIceServerController.ts
@@ -6,8 +6,8 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { ClientEvent, type IClientWellKnown, type MatrixClient } from "matrix-js-sdk/src/matrix";
+import { type SettingLevel } from "@element-hq/element-web-module-api";
 
-import { type SettingLevel } from "../SettingLevel";
 import SettingsStore from "../SettingsStore.ts";
 import MatrixClientBackedController from "./MatrixClientBackedController.ts";
 

--- a/apps/web/src/settings/controllers/FontSizeController.ts
+++ b/apps/web/src/settings/controllers/FontSizeController.ts
@@ -6,11 +6,12 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import SettingController from "./SettingController";
 import dis from "../../dispatcher/dispatcher";
 import { type UpdateFontSizeDeltaPayload } from "../../dispatcher/payloads/UpdateFontSizeDeltaPayload";
 import { Action } from "../../dispatcher/actions";
-import { SettingLevel } from "../SettingLevel";
 
 export default class FontSizeController extends SettingController {
     public constructor() {

--- a/apps/web/src/settings/controllers/IncompatibleController.ts
+++ b/apps/web/src/settings/controllers/IncompatibleController.ts
@@ -6,8 +6,9 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { type SettingLevel } from "@element-hq/element-web-module-api";
+
 import SettingController from "./SettingController";
-import { type SettingLevel } from "../SettingLevel";
 import SettingsStore from "../SettingsStore";
 import { type BooleanSettingKey } from "../Settings.tsx";
 

--- a/apps/web/src/settings/controllers/NotificationControllers.ts
+++ b/apps/web/src/settings/controllers/NotificationControllers.ts
@@ -9,10 +9,10 @@ Please see LICENSE files in the repository root for full details.
 
 import { logger } from "matrix-js-sdk/src/logger";
 import { PushRuleActionName } from "matrix-js-sdk/src/matrix";
+import { type SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingController from "./SettingController";
 import { MatrixClientPeg } from "../../MatrixClientPeg";
-import { type SettingLevel } from "../SettingLevel";
 
 // .m.rule.master being enabled means all events match that push rule
 // default action on this rule is dont_notify, but it could be something else

--- a/apps/web/src/settings/controllers/ReducedMotionController.ts
+++ b/apps/web/src/settings/controllers/ReducedMotionController.ts
@@ -6,8 +6,9 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { type SettingLevel } from "@element-hq/element-web-module-api";
+
 import SettingController from "./SettingController";
-import { type SettingLevel } from "../SettingLevel";
 
 /**
  * For animation-like settings, this controller checks whether the user has

--- a/apps/web/src/settings/controllers/ReloadOnChangeController.ts
+++ b/apps/web/src/settings/controllers/ReloadOnChangeController.ts
@@ -6,9 +6,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { type SettingLevel } from "@element-hq/element-web-module-api";
+
 import SettingController from "./SettingController";
 import PlatformPeg from "../../PlatformPeg";
-import { type SettingLevel } from "../SettingLevel";
 
 export default class ReloadOnChangeController extends SettingController {
     public onChange(level: SettingLevel, roomId: string, newValue: any): void {

--- a/apps/web/src/settings/controllers/ServerSupportUnstableFeatureController.ts
+++ b/apps/web/src/settings/controllers/ServerSupportUnstableFeatureController.ts
@@ -6,7 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { type SettingLevel } from "../SettingLevel";
+import { type SettingLevel } from "@element-hq/element-web-module-api";
+
 import MatrixClientBackedController from "./MatrixClientBackedController";
 import { type WatchManager } from "../WatchManager";
 import SettingsStore from "../SettingsStore";

--- a/apps/web/src/settings/controllers/SettingController.ts
+++ b/apps/web/src/settings/controllers/SettingController.ts
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { type SettingLevel } from "../SettingLevel";
+import { type SettingLevel } from "@element-hq/element-web-module-api";
 
 /**
  * Represents a controller for individual settings to alter the reading behaviour

--- a/apps/web/src/settings/controllers/ThemeController.ts
+++ b/apps/web/src/settings/controllers/ThemeController.ts
@@ -7,9 +7,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { type SettingLevel } from "@element-hq/element-web-module-api";
+
 import SettingController from "./SettingController";
 import { DEFAULT_THEME, enumerateThemes } from "../../theme";
-import { type SettingLevel } from "../SettingLevel";
 
 export default class ThemeController extends SettingController {
     public getValueOverride(

--- a/apps/web/src/settings/controllers/UIFeatureController.ts
+++ b/apps/web/src/settings/controllers/UIFeatureController.ts
@@ -6,8 +6,9 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { type SettingLevel } from "@element-hq/element-web-module-api";
+
 import SettingController from "./SettingController";
-import { type SettingLevel } from "../SettingLevel";
 import SettingsStore from "../SettingsStore";
 import { type SettingKey } from "../Settings.tsx";
 

--- a/apps/web/src/settings/handlers/AccountSettingsHandler.ts
+++ b/apps/web/src/settings/handlers/AccountSettingsHandler.ts
@@ -9,10 +9,10 @@ Please see LICENSE files in the repository root for full details.
 
 import { type AccountDataEvents, ClientEvent, type MatrixClient, type MatrixEvent } from "matrix-js-sdk/src/matrix";
 import { isEqual } from "lodash";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import MatrixClientBackedSettingsHandler from "./MatrixClientBackedSettingsHandler";
 import { objectClone, objectKeyChanges } from "../../utils/objects";
-import { SettingLevel } from "../SettingLevel";
 import { type WatchManager } from "../WatchManager";
 import { MEDIA_PREVIEW_ACCOUNT_DATA_TYPE } from "../../@types/media_preview";
 

--- a/apps/web/src/settings/handlers/DeviceSettingsHandler.ts
+++ b/apps/web/src/settings/handlers/DeviceSettingsHandler.ts
@@ -8,7 +8,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { SettingLevel } from "../SettingLevel";
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import { type CallbackFn, type WatchManager } from "../WatchManager";
 import AbstractLocalStorageSettingsHandler from "./AbstractLocalStorageSettingsHandler";
 

--- a/apps/web/src/settings/handlers/LocalEchoWrapper.ts
+++ b/apps/web/src/settings/handlers/LocalEchoWrapper.ts
@@ -7,8 +7,9 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { type SettingLevel } from "@element-hq/element-web-module-api";
+
 import SettingsHandler from "./SettingsHandler";
-import { type SettingLevel } from "../SettingLevel";
 
 /**
  * A wrapper for a SettingsHandler that performs local echo on

--- a/apps/web/src/settings/handlers/PlatformSettingsHandler.ts
+++ b/apps/web/src/settings/handlers/PlatformSettingsHandler.ts
@@ -6,10 +6,11 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import SettingsHandler from "./SettingsHandler";
 import PlatformPeg from "../../PlatformPeg";
 import { SETTINGS } from "../Settings";
-import { SettingLevel } from "../SettingLevel";
 
 /**
  * Gets and sets settings at the "platform" level for the current device.

--- a/apps/web/src/settings/handlers/RoomAccountSettingsHandler.ts
+++ b/apps/web/src/settings/handlers/RoomAccountSettingsHandler.ts
@@ -14,10 +14,10 @@ import {
     type Room,
     RoomEvent,
 } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import MatrixClientBackedSettingsHandler from "./MatrixClientBackedSettingsHandler";
 import { objectClone, objectKeyChanges } from "../../utils/objects";
-import { SettingLevel } from "../SettingLevel";
 import { type WatchManager } from "../WatchManager";
 import { MEDIA_PREVIEW_ACCOUNT_DATA_TYPE } from "../../@types/media_preview";
 

--- a/apps/web/src/settings/handlers/RoomDeviceSettingsHandler.ts
+++ b/apps/web/src/settings/handlers/RoomDeviceSettingsHandler.ts
@@ -8,8 +8,8 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { safeSet } from "matrix-js-sdk/src/utils";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
-import { SettingLevel } from "../SettingLevel";
 import { type WatchManager } from "../WatchManager";
 import AbstractLocalStorageSettingsHandler from "./AbstractLocalStorageSettingsHandler";
 

--- a/apps/web/src/settings/handlers/RoomSettingsHandler.ts
+++ b/apps/web/src/settings/handlers/RoomSettingsHandler.ts
@@ -14,10 +14,10 @@ import {
     RoomStateEvent,
     type StateEvents,
 } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import MatrixClientBackedSettingsHandler from "./MatrixClientBackedSettingsHandler";
 import { objectClone, objectKeyChanges } from "../../utils/objects";
-import { SettingLevel } from "../SettingLevel";
 import { type WatchManager } from "../WatchManager";
 
 const DEFAULT_SETTINGS_EVENT_TYPE = "im.vector.web.settings";

--- a/apps/web/src/settings/watchers/FontWatcher.ts
+++ b/apps/web/src/settings/watchers/FontWatcher.ts
@@ -6,12 +6,13 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import dis from "../../dispatcher/dispatcher";
 import SettingsStore from "../SettingsStore";
 import type IWatcher from "./Watcher";
 import { toPx } from "../../utils/units";
 import { Action } from "../../dispatcher/actions";
-import { SettingLevel } from "../SettingLevel";
 import { type UpdateSystemFontPayload } from "../../dispatcher/payloads/UpdateSystemFontPayload";
 import { type ActionPayload } from "../../dispatcher/payloads";
 

--- a/apps/web/src/settings/watchers/ThemeWatcher.ts
+++ b/apps/web/src/settings/watchers/ThemeWatcher.ts
@@ -9,13 +9,13 @@ Please see LICENSE files in the repository root for full details.
 
 import { logger } from "matrix-js-sdk/src/logger";
 import { TypedEventEmitter } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore from "../SettingsStore";
 import dis from "../../dispatcher/dispatcher";
 import { Action } from "../../dispatcher/actions";
 import { findHighContrastTheme, getCustomTheme } from "../../theme";
 import { type ActionPayload } from "../../dispatcher/payloads";
-import { SettingLevel } from "../SettingLevel";
 
 export enum ThemeWatcherEvent {
     Change = "change",

--- a/apps/web/src/stores/BreadcrumbsStore.ts
+++ b/apps/web/src/stores/BreadcrumbsStore.ts
@@ -9,12 +9,12 @@ Please see LICENSE files in the repository root for full details.
 import { type Room, RoomEvent, ClientEvent } from "matrix-js-sdk/src/matrix";
 import { KnownMembership } from "matrix-js-sdk/src/types";
 import { isNullOrUndefined } from "matrix-js-sdk/src/utils";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore from "../settings/SettingsStore";
 import { AsyncStoreWithClient } from "./AsyncStoreWithClient";
 import defaultDispatcher from "../dispatcher/dispatcher";
 import { arrayHasDiff, filterBoolean } from "../utils/arrays";
-import { SettingLevel } from "../settings/SettingLevel";
 import { Action } from "../dispatcher/actions";
 import { type SettingUpdatedPayload } from "../dispatcher/payloads/SettingUpdatedPayload";
 import { type ViewRoomPayload } from "../dispatcher/payloads/ViewRoomPayload";

--- a/apps/web/src/stores/CallStore.ts
+++ b/apps/web/src/stores/CallStore.ts
@@ -9,13 +9,13 @@ Please see LICENSE files in the repository root for full details.
 import { logger } from "matrix-js-sdk/src/logger";
 import { type MatrixRTCSession, MatrixRTCSessionManagerEvents, type Transport } from "matrix-js-sdk/src/matrixrtc";
 import { MatrixError, type EmptyObject, type Room } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import defaultDispatcher from "../dispatcher/dispatcher";
 import { UPDATE_EVENT } from "./AsyncStore";
 import { AsyncStoreWithClient } from "./AsyncStoreWithClient";
 import WidgetStore from "./WidgetStore";
 import SettingsStore from "../settings/SettingsStore";
-import { SettingLevel } from "../settings/SettingLevel";
 import { Call, CallEvent, ConnectionState } from "../models/Call";
 
 export enum CallStoreEvent {

--- a/apps/web/src/stores/ReleaseAnnouncementStore.ts
+++ b/apps/web/src/stores/ReleaseAnnouncementStore.ts
@@ -9,9 +9,9 @@
 import { TypedEventEmitter } from "matrix-js-sdk/src/matrix";
 import { logger } from "matrix-js-sdk/src/logger";
 import { cloneDeep } from "lodash";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore from "../settings/SettingsStore";
-import { SettingLevel } from "../settings/SettingLevel";
 import ToastStore from "./ToastStore";
 
 /**

--- a/apps/web/src/stores/right-panel/RightPanelStore.ts
+++ b/apps/web/src/stores/right-panel/RightPanelStore.ts
@@ -8,12 +8,12 @@ Please see LICENSE files in the repository root for full details.
 
 import { logger } from "matrix-js-sdk/src/logger";
 import { CryptoEvent } from "matrix-js-sdk/src/crypto-api";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import defaultDispatcher from "../../dispatcher/dispatcher";
 import { pendingVerificationRequestForUser } from "../../verification";
 import SettingsStore from "../../settings/SettingsStore";
 import { RightPanelPhases } from "./RightPanelStorePhases";
-import { SettingLevel } from "../../settings/SettingLevel";
 import { UPDATE_EVENT } from "../AsyncStore";
 import { ReadyWatchingStore } from "../ReadyWatchingStore";
 import {

--- a/apps/web/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/apps/web/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -7,6 +7,7 @@ Please see LICENSE files in the repository root for full details.
 
 import { logger } from "matrix-js-sdk/src/logger";
 import { EventType } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import type { EmptyObject, Room } from "matrix-js-sdk/src/matrix";
 import type { MatrixDispatcher } from "../../dispatcher/dispatcher";
@@ -29,7 +30,6 @@ import { InvitesFilter } from "./skip-list/filters/InvitesFilter";
 import { MentionsFilter } from "./skip-list/filters/MentionsFilter";
 import { LowPriorityFilter } from "./skip-list/filters/LowPriorityFilter";
 import { type Sorter, SortingAlgorithm } from "./skip-list/sorters";
-import { SettingLevel } from "../../settings/SettingLevel";
 import { MARKED_UNREAD_TYPE_STABLE, MARKED_UNREAD_TYPE_UNSTABLE } from "../../utils/notifications";
 import { Action } from "../../dispatcher/actions";
 import { UnreadSorter } from "./skip-list/sorters/UnreadSorter";

--- a/apps/web/src/stores/room-list-v3/section.ts
+++ b/apps/web/src/stores/room-list-v3/section.ts
@@ -6,8 +6,8 @@
  */
 
 import { v4 as uuidv4 } from "uuid";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
-import { SettingLevel } from "../../settings/SettingLevel";
 import SettingsStore from "../../settings/SettingsStore";
 import Modal from "../../Modal";
 import { CreateSectionDialog } from "../../components/views/dialogs/CreateSectionDialog";

--- a/apps/web/src/stores/widgets/WidgetLayoutStore.ts
+++ b/apps/web/src/stores/widgets/WidgetLayoutStore.ts
@@ -11,13 +11,13 @@ import { MapWithDefault, recursiveMapToObject } from "matrix-js-sdk/src/utils";
 import { type IWidget } from "matrix-widget-api";
 import { clamp, defaultNumber, sum } from "@element-hq/web-shared-components";
 import { type Container } from "@element-hq/element-web-module-api";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore from "../../settings/SettingsStore";
 import WidgetStore, { type IApp } from "../WidgetStore";
 import { WidgetType } from "../../widgets/WidgetType";
 import defaultDispatcher from "../../dispatcher/dispatcher";
 import { ReadyWatchingStore } from "../ReadyWatchingStore";
-import { SettingLevel } from "../../settings/SettingLevel";
 import { arrayFastClone } from "../../utils/arrays";
 import { UPDATE_EVENT } from "../AsyncStore";
 import { type IStoredLayout, type ILayoutStateEvent, WIDGET_LAYOUT_EVENT_TYPE, type IWidgetLayouts } from "./types";

--- a/apps/web/src/stores/widgets/WidgetPermissionStore.ts
+++ b/apps/web/src/stores/widgets/WidgetPermissionStore.ts
@@ -7,9 +7,9 @@
  */
 
 import { type Widget, WidgetKind } from "matrix-widget-api";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore from "../../settings/SettingsStore";
-import { SettingLevel } from "../../settings/SettingLevel";
 import { type SdkContextClass } from "../../contexts/SDKContext";
 
 export enum OIDCState {

--- a/apps/web/src/toasts/DesktopNotificationsToast.ts
+++ b/apps/web/src/toasts/DesktopNotificationsToast.ts
@@ -6,6 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import { _t } from "../languageHandler";
 import Notifier from "../Notifier";
 import GenericToast from "../components/views/toasts/GenericToast";
@@ -13,7 +15,6 @@ import ToastStore from "../stores/ToastStore";
 import { MatrixClientPeg } from "../MatrixClientPeg";
 import { getLocalNotificationAccountDataEventType } from "../utils/notifications";
 import SettingsStore from "../settings/SettingsStore";
-import { SettingLevel } from "../settings/SettingLevel";
 
 const onAccept = async (): Promise<void> => {
     await SettingsStore.setValue("notificationsEnabled", null, SettingLevel.DEVICE, true);

--- a/apps/web/src/utils/media/mediaVisibility.ts
+++ b/apps/web/src/utils/media/mediaVisibility.ts
@@ -6,9 +6,9 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { JoinRule, type MatrixClient, type MatrixEvent } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { type MediaPreviewConfig, MediaPreviewValue } from "../../@types/media_preview";
-import { SettingLevel } from "../../settings/SettingLevel";
 import SettingsStore from "../../settings/SettingsStore";
 
 /**

--- a/apps/web/src/viewmodels/room-list/RoomListHeaderViewModel.ts
+++ b/apps/web/src/viewmodels/room-list/RoomListHeaderViewModel.ts
@@ -12,6 +12,7 @@ import {
     type RoomListHeaderViewModel as RoomListHeaderViewModelInterface,
     type SortOption,
 } from "@element-hq/web-shared-components";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import defaultDispatcher from "../../dispatcher/dispatcher";
 import PosthogTrackers from "../../PosthogTrackers";
@@ -29,7 +30,6 @@ import type { ViewRoomPayload } from "../../dispatcher/payloads/ViewRoomPayload"
 import SettingsStore from "../../settings/SettingsStore";
 import RoomListStoreV3 from "../../stores/room-list-v3/RoomListStoreV3";
 import { SortingAlgorithm } from "../../stores/room-list-v3/skip-list/sorters";
-import { SettingLevel } from "../../settings/SettingLevel";
 import { createRoom, hasCreateRoomRights } from "./utils";
 
 export interface Props {

--- a/apps/web/src/viewmodels/structures/ResizerViewModel.ts
+++ b/apps/web/src/viewmodels/structures/ResizerViewModel.ts
@@ -16,9 +16,9 @@ import {
 } from "@element-hq/web-shared-components";
 import { debounce } from "lodash";
 import whatInput from "what-input";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore from "../../settings/SettingsStore";
-import { SettingLevel } from "../../settings/SettingLevel";
 
 function getInitialState(): ResizerViewSnapshot {
     if (SettingsStore.getValue("RoomList.isPanelCollapsed")) {

--- a/apps/web/test/unit-tests/DeviceListener-test.ts
+++ b/apps/web/test/unit-tests/DeviceListener-test.ts
@@ -24,6 +24,7 @@ import {
     type SecretStorageStatus,
 } from "matrix-js-sdk/src/crypto-api";
 import { type CryptoSessionStateChange } from "@matrix-org/analytics-events/types/typescript/CryptoSessionStateChange";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { DeviceListener, BACKUP_DISABLED_ACCOUNT_DATA_KEY } from "../../src/device-listener";
 import { MatrixClientPeg } from "../../src/MatrixClientPeg";
@@ -33,7 +34,6 @@ import * as BulkUnverifiedSessionsToast from "../../src/toasts/BulkUnverifiedSes
 import { isSecretStorageBeingAccessed } from "../../src/SecurityManager";
 import { Action } from "../../src/dispatcher/actions";
 import SettingsStore from "../../src/settings/SettingsStore";
-import { SettingLevel } from "../../src/settings/SettingLevel";
 import { getMockClientWithEventEmitter, mockPlatformPeg } from "../test-utils";
 import { isBulkUnverifiedDeviceReminderSnoozed } from "../../src/utils/device/snoozeBulkUnverifiedDeviceReminder";
 import { PosthogAnalytics } from "../../src/PosthogAnalytics";

--- a/apps/web/test/unit-tests/HtmlUtils-test.tsx
+++ b/apps/web/test/unit-tests/HtmlUtils-test.tsx
@@ -9,11 +9,11 @@ Please see LICENSE files in the repository root for full details.
 import React from "react";
 import { render, screen } from "jest-matrix-react";
 import parse from "html-react-parser";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { bodyToHtml, bodyToNode, formatEmojis, topicToHtml } from "../../src/HtmlUtils";
 import SettingsStore from "../../src/settings/SettingsStore";
 import { getMockClientWithEventEmitter } from "../test-utils";
-import { SettingLevel } from "../../src/settings/SettingLevel";
 import SdkConfig from "../../src/SdkConfig";
 
 describe("topicToHtml", () => {

--- a/apps/web/test/unit-tests/MediaDeviceHandler-test.ts
+++ b/apps/web/test/unit-tests/MediaDeviceHandler-test.ts
@@ -7,8 +7,8 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { mocked } from "jest-mock";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
-import { SettingLevel } from "../../src/settings/SettingLevel";
 import { MatrixClientPeg } from "../../src/MatrixClientPeg";
 import { stubClient } from "../test-utils";
 import MediaDeviceHandler from "../../src/MediaDeviceHandler";

--- a/apps/web/test/unit-tests/PosthogAnalytics-test.ts
+++ b/apps/web/test/unit-tests/PosthogAnalytics-test.ts
@@ -11,6 +11,7 @@ import { mocked } from "jest-mock";
 import { type PostHog } from "posthog-js";
 import { type MatrixClient } from "matrix-js-sdk/src/matrix";
 import { type CryptoApi } from "matrix-js-sdk/src/crypto-api";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import {
     Anonymity,
@@ -24,7 +25,6 @@ import SettingsStore from "../../src/settings/SettingsStore";
 import { Layout } from "../../src/settings/enums/Layout";
 import defaultDispatcher from "../../src/dispatcher/dispatcher";
 import { Action } from "../../src/dispatcher/actions";
-import { SettingLevel } from "../../src/settings/SettingLevel";
 
 const getFakePosthog = (): PostHog =>
     ({

--- a/apps/web/test/unit-tests/components/structures/LoggedInView-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/LoggedInView-test.tsx
@@ -24,6 +24,7 @@ import { MediaHandler } from "matrix-js-sdk/src/webrtc/mediaHandler";
 import { logger } from "matrix-js-sdk/src/logger";
 import userEvent from "@testing-library/user-event";
 import { PushProcessor } from "matrix-js-sdk/src/pushprocessor";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import LoggedInView from "../../../../src/components/structures/LoggedInView";
 import { SDKContext } from "../../../../src/contexts/SDKContext";
@@ -33,7 +34,6 @@ import { flushPromises, getMockClientWithEventEmitter, mockClientMethodsUser } f
 import { TestSdkContext } from "../../TestSdkContext";
 import defaultDispatcher from "../../../../src/dispatcher/dispatcher";
 import SettingsStore from "../../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import { Action } from "../../../../src/dispatcher/actions";
 import Modal from "../../../../src/Modal";
 import { SETTINGS } from "../../../../src/settings/Settings";

--- a/apps/web/test/unit-tests/components/structures/MatrixChat-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/MatrixChat-test.tsx
@@ -25,6 +25,7 @@ import {
     UserVerificationStatus,
     type CryptoApi,
 } from "matrix-js-sdk/src/crypto-api";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import MatrixChat from "../../../../src/components/structures/MatrixChat";
 import * as StorageAccess from "../../../../src/utils/StorageAccess";
@@ -55,7 +56,6 @@ import EventIndexPeg from "../../../../src/indexing/EventIndexPeg";
 import * as Lifecycle from "../../../../src/Lifecycle";
 import { SSO_HOMESERVER_URL_KEY, SSO_ID_SERVER_URL_KEY } from "../../../../src/BasePlatform";
 import SettingsStore from "../../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import { MatrixClientPeg } from "../../../../src/MatrixClientPeg";
 import DMRoomMap from "../../../../src/utils/DMRoomMap";
 import { ReleaseAnnouncementStore } from "../../../../src/stores/ReleaseAnnouncementStore";

--- a/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
@@ -26,6 +26,7 @@ import { type CryptoApi, CryptoEvent, UserVerificationStatus } from "matrix-js-s
 import { KnownMembership } from "matrix-js-sdk/src/types";
 import { act, cleanup, fireEvent, render, type RenderResult, screen, waitFor, findByRole } from "jest-matrix-react";
 import userEvent from "@testing-library/user-event";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import {
     createTestClient,
@@ -47,7 +48,6 @@ import defaultDispatcher from "../../../../src/dispatcher/dispatcher";
 import { type ViewRoomPayload } from "../../../../src/dispatcher/payloads/ViewRoomPayload";
 import { RoomView } from "../../../../src/components/structures/RoomView";
 import SettingsStore from "../../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import DMRoomMap from "../../../../src/utils/DMRoomMap";
 import { NotificationState } from "../../../../src/stores/notifications/NotificationState";
 import { RightPanelPhases } from "../../../../src/stores/right-panel/RightPanelStorePhases";

--- a/apps/web/test/unit-tests/components/structures/TimelinePanel-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/TimelinePanel-test.tsx
@@ -31,6 +31,7 @@ import { KnownMembership } from "matrix-js-sdk/src/types";
 import React from "react";
 import { type Mocked, mocked } from "jest-mock";
 import { forEachRight } from "lodash";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import TimelinePanel from "../../../../src/components/structures/TimelinePanel";
 import { MatrixClientPeg } from "../../../../src/MatrixClientPeg";
@@ -48,7 +49,6 @@ import SettingsStore from "../../../../src/settings/SettingsStore";
 import ScrollPanel from "../../../../src/components/structures/ScrollPanel";
 import defaultDispatcher from "../../../../src/dispatcher/dispatcher";
 import { Action } from "../../../../src/dispatcher/actions";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import MatrixClientBackedController from "../../../../src/settings/controllers/MatrixClientBackedController";
 import { SdkContextClass } from "../../../../src/contexts/SDKContext";
 import type Timer from "../../../../src/utils/Timer";

--- a/apps/web/test/unit-tests/components/views/avatars/RoomAvatar-test.tsx
+++ b/apps/web/test/unit-tests/components/views/avatars/RoomAvatar-test.tsx
@@ -10,6 +10,7 @@ import React from "react";
 import { render } from "jest-matrix-react";
 import { EventType, type MatrixClient, MatrixEvent, Room, RoomMember } from "matrix-js-sdk/src/matrix";
 import { mocked } from "jest-mock";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import RoomAvatar from "../../../../../src/components/views/avatars/RoomAvatar";
 import { filterConsole, stubClient } from "../../../../test-utils";
@@ -19,7 +20,6 @@ import * as AvatarModule from "../../../../../src/Avatar";
 import { DirectoryMember } from "../../../../../src/utils/direct-messages";
 import { MediaPreviewValue } from "../../../../../src/@types/media_preview";
 import SettingsStore from "../../../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../../../src/settings/SettingLevel";
 
 describe("RoomAvatar", () => {
     let client: MatrixClient;

--- a/apps/web/test/unit-tests/components/views/dialogs/SpotlightDialog-test.tsx
+++ b/apps/web/test/unit-tests/components/views/dialogs/SpotlightDialog-test.tsx
@@ -20,6 +20,7 @@ import {
 import { KnownMembership } from "matrix-js-sdk/src/types";
 import sanitizeHtml from "sanitize-html";
 import { fireEvent, render, screen, waitFor } from "jest-matrix-react";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SpotlightDialog from "../../../../../src/components/views/dialogs/spotlight/SpotlightDialog";
 import { Filter } from "../../../../../src/components/views/dialogs/spotlight/Filter";
@@ -29,7 +30,6 @@ import { DirectoryMember, startDmOnFirstMessage } from "../../../../../src/utils
 import DMRoomMap from "../../../../../src/utils/DMRoomMap";
 import { flushPromisesWithFakeTimers, mkRoom, stubClient } from "../../../../test-utils";
 import SettingsStore from "../../../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../../../src/settings/SettingLevel";
 import defaultDispatcher from "../../../../../src/dispatcher/dispatcher";
 import SdkConfig from "../../../../../src/SdkConfig";
 import { Action } from "../../../../../src/dispatcher/actions";

--- a/apps/web/test/unit-tests/components/views/dialogs/UserSettingsDialog-test.tsx
+++ b/apps/web/test/unit-tests/components/views/dialogs/UserSettingsDialog-test.tsx
@@ -10,6 +10,7 @@ import React, { type ReactElement } from "react";
 import { render, screen, waitFor } from "jest-matrix-react";
 import { mocked, type MockedObject } from "jest-mock";
 import { ClientEvent, MatrixEvent, type MatrixClient } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore, { type CallbackFn } from "../../../../../src/settings/SettingsStore";
 import SdkConfig from "../../../../../src/SdkConfig";
@@ -25,7 +26,6 @@ import {
     useMockMediaDevices,
 } from "../../../../test-utils";
 import { UIFeature } from "../../../../../src/settings/UIFeature";
-import { SettingLevel } from "../../../../../src/settings/SettingLevel";
 import { SdkContextClass } from "../../../../../src/contexts/SDKContext";
 import { type FeatureSettingKey } from "../../../../../src/settings/Settings.tsx";
 

--- a/apps/web/test/unit-tests/components/views/location/LocationShareMenu-test.tsx
+++ b/apps/web/test/unit-tests/components/views/location/LocationShareMenu-test.tsx
@@ -12,6 +12,7 @@ import { RoomMember, RelationType, type MatrixClient, M_ASSET, LocationAssetType
 import { logger } from "matrix-js-sdk/src/logger";
 import { act, fireEvent, render, type RenderResult } from "jest-matrix-react";
 import * as maplibregl from "maplibre-gl";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import LocationShareMenu from "../../../../../src/components/views/location/LocationShareMenu";
 import MatrixClientContext from "../../../../../src/contexts/MatrixClientContext";
@@ -28,7 +29,6 @@ import {
 import Modal from "../../../../../src/Modal";
 import { DEFAULT_DURATION_MS } from "../../../../../src/components/views/location/LiveDurationDropdown";
 import { OwnBeaconStore } from "../../../../../src/stores/OwnBeaconStore";
-import { SettingLevel } from "../../../../../src/settings/SettingLevel";
 import QuestionDialog from "../../../../../src/components/views/dialogs/QuestionDialog";
 
 jest.useFakeTimers();

--- a/apps/web/test/unit-tests/components/views/rooms/MessageComposer-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/MessageComposer-test.tsx
@@ -11,6 +11,7 @@ import { EventType, type MatrixEvent, RoomMember, THREAD_RELATION_TYPE } from "m
 import { act, fireEvent, render, screen, waitFor } from "jest-matrix-react";
 import userEvent from "@testing-library/user-event";
 import { initOnce } from "@vector-im/matrix-wysiwyg";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import {
     clearAllModals,
@@ -28,7 +29,6 @@ import ResizeNotifier from "../../../../../src/utils/ResizeNotifier";
 import { RoomPermalinkCreator } from "../../../../../src/utils/permalinks/Permalinks";
 import { LocalRoom } from "../../../../../src/models/LocalRoom";
 import SettingsStore from "../../../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../../../src/settings/SettingLevel";
 import dis from "../../../../../src/dispatcher/dispatcher";
 import { E2EStatus } from "../../../../../src/utils/ShieldUtils";
 import { addTextToComposerRTL } from "../../../../test-utils/composer";

--- a/apps/web/test/unit-tests/components/views/rooms/RoomHeader/RoomHeader-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/RoomHeader/RoomHeader-test.tsx
@@ -37,6 +37,7 @@ import {
 import { type ViewRoomOpts } from "@matrix-org/react-sdk-module-api/lib/lifecycles/RoomViewLifecycle";
 import { mocked } from "jest-mock";
 import userEvent from "@testing-library/user-event";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { filterConsole, setupAsyncStoreWithClient, stubClient } from "../../../../../test-utils";
 import RoomHeader from "../../../../../../src/components/views/rooms/RoomHeader/RoomHeader";
@@ -58,7 +59,6 @@ import MatrixClientContext from "../../../../../../src/contexts/MatrixClientCont
 import { _t } from "../../../../../../src/languageHandler";
 import WidgetStore, { type IApp } from "../../../../../../src/stores/WidgetStore";
 import { UIFeature } from "../../../../../../src/settings/UIFeature";
-import { SettingLevel } from "../../../../../../src/settings/SettingLevel";
 import { ElementCallMemberEventType } from "../../../../../../src/call-types";
 import { defaultWatchManager } from "../../../../../../src/settings/Settings.tsx";
 

--- a/apps/web/test/unit-tests/components/views/rooms/RoomListHeader-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/RoomListHeader-test.tsx
@@ -10,6 +10,7 @@ import React from "react";
 import { type MatrixClient, type Room, EventType } from "matrix-js-sdk/src/matrix";
 import { mocked } from "jest-mock";
 import { act, render, screen, fireEvent, type RenderResult } from "jest-matrix-react";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SpaceStore from "../../../../../src/stores/spaces/SpaceStore";
 import { MetaSpace } from "../../../../../src/stores/spaces";
@@ -19,7 +20,6 @@ import { stubClient, mkSpace } from "../../../../test-utils";
 import DMRoomMap from "../../../../../src/utils/DMRoomMap";
 import { MatrixClientPeg } from "../../../../../src/MatrixClientPeg";
 import SettingsStore from "../../../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../../../src/settings/SettingLevel";
 import { shouldShowComponent } from "../../../../../src/customisations/helpers/UIComponents";
 import { UIComponent } from "../../../../../src/settings/UIFeature";
 

--- a/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/utils/message-test.ts
+++ b/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/utils/message-test.ts
@@ -7,6 +7,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { EventStatus, type IEventRelation, MsgType } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { type IRoomState } from "../../../../../../../src/components/structures/RoomView";
 import {
@@ -16,7 +17,6 @@ import {
 import { createTestClient, getRoomContext, mkEvent, mkStubRoom } from "../../../../../../test-utils";
 import defaultDispatcher from "../../../../../../../src/dispatcher/dispatcher";
 import SettingsStore from "../../../../../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../../../../../src/settings/SettingLevel";
 import EditorStateTransfer from "../../../../../../../src/utils/EditorStateTransfer";
 import * as ConfirmRedactDialog from "../../../../../../../src/components/views/dialogs/ConfirmRedactDialog";
 import * as SlashCommands from "../../../../../../../src/slash-commands/SlashCommands";

--- a/apps/web/test/unit-tests/components/views/settings/EventIndexPanel-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/EventIndexPanel-test.tsx
@@ -8,13 +8,13 @@ Please see LICENSE files in the repository root for full details.
 
 import React from "react";
 import { fireEvent, render, screen, within } from "jest-matrix-react";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import EventIndexPanel from "../../../../../src/components/views/settings/EventIndexPanel";
 import EventIndexPeg from "../../../../../src/indexing/EventIndexPeg";
 import EventIndex from "../../../../../src/indexing/EventIndex";
 import { clearAllModals, flushPromises, getMockClientWithEventEmitter } from "../../../../test-utils";
 import SettingsStore from "../../../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../../../src/settings/SettingLevel";
 
 describe("<EventIndexPanel />", () => {
     getMockClientWithEventEmitter({

--- a/apps/web/test/unit-tests/components/views/settings/LayoutSwitcher-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/LayoutSwitcher-test.tsx
@@ -9,12 +9,12 @@
 import React from "react";
 import { act, render, screen, waitFor } from "jest-matrix-react";
 import { mocked } from "jest-mock";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { LayoutSwitcher } from "../../../../../src/components/views/settings/LayoutSwitcher";
 import MatrixClientContext from "../../../../../src/contexts/MatrixClientContext";
 import { stubClient } from "../../../../test-utils";
 import SettingsStore from "../../../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../../../src/settings/SettingLevel";
 import { Layout } from "../../../../../src/settings/enums/Layout";
 
 describe("<LayoutSwitcher />", () => {

--- a/apps/web/test/unit-tests/components/views/settings/SetIntegrationManager-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/SetIntegrationManager-test.tsx
@@ -9,6 +9,7 @@ Please see LICENSE files in the repository root for full details.
 import React from "react";
 import { fireEvent, render, screen, waitFor, within } from "jest-matrix-react";
 import { logger } from "matrix-js-sdk/src/logger";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import MatrixClientContext from "../../../../../src/contexts/MatrixClientContext";
 import SettingsStore from "../../../../../src/settings/SettingsStore";
@@ -20,7 +21,6 @@ import {
     flushPromises,
 } from "../../../../test-utils";
 import SetIntegrationManager from "../../../../../src/components/views/settings/SetIntegrationManager";
-import { SettingLevel } from "../../../../../src/settings/SettingLevel";
 
 describe("SetIntegrationManager", () => {
     const userId = "@alice:server.org";

--- a/apps/web/test/unit-tests/components/views/settings/ThemeChoicePanel-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/ThemeChoicePanel-test.tsx
@@ -11,11 +11,11 @@ import { act, render, screen, waitFor } from "jest-matrix-react";
 import { mocked, type MockedObject } from "jest-mock";
 import userEvent from "@testing-library/user-event";
 import fetchMock from "@fetch-mock/jest";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { ThemeChoicePanel } from "../../../../../src/components/views/settings/ThemeChoicePanel";
 import SettingsStore from "../../../../../src/settings/SettingsStore";
 import ThemeWatcher from "../../../../../src/settings/watchers/ThemeWatcher";
-import { SettingLevel } from "../../../../../src/settings/SettingLevel";
 
 jest.mock("../../../../../src/settings/watchers/ThemeWatcher");
 

--- a/apps/web/test/unit-tests/components/views/settings/encryption/AdvancedPanel-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/encryption/AdvancedPanel-test.tsx
@@ -9,11 +9,11 @@ import React from "react";
 import { type MatrixClient } from "matrix-js-sdk/src/matrix";
 import { render, screen, waitFor } from "jest-matrix-react";
 import userEvent from "@testing-library/user-event";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { createTestClient, withClientContextRenderOptions } from "../../../../../test-utils";
 import { AdvancedPanel } from "../../../../../../src/components/views/settings/encryption/AdvancedPanel";
 import SettingsStore from "../../../../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../../../../src/settings/SettingLevel";
 
 describe("<AdvancedPanel />", () => {
     let matrixClient: MatrixClient;

--- a/apps/web/test/unit-tests/components/views/settings/tabs/room/NotificationSettingsTab-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/tabs/room/NotificationSettingsTab-test.tsx
@@ -10,6 +10,7 @@ import React from "react";
 import { render, type RenderResult, screen, within } from "jest-matrix-react";
 import { type MatrixClient } from "matrix-js-sdk/src/matrix";
 import userEvent from "@testing-library/user-event";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import NotificationSettingsTab from "../../../../../../../src/components/views/settings/tabs/room/NotificationSettingsTab";
 import { mkStubRoom, stubClient } from "../../../../../../test-utils";
@@ -17,7 +18,6 @@ import { MatrixClientPeg } from "../../../../../../../src/MatrixClientPeg";
 import { EchoChamber } from "../../../../../../../src/stores/local-echo/EchoChamber";
 import { type RoomEchoChamber } from "../../../../../../../src/stores/local-echo/RoomEchoChamber";
 import SettingsStore from "../../../../../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../../../../../src/settings/SettingLevel";
 
 describe("NotificationSettingsTab", () => {
     const roomId = "!room:example.com";

--- a/apps/web/test/unit-tests/components/views/settings/tabs/user/InviteRulesAccountSetting-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/tabs/user/InviteRulesAccountSetting-test.tsx
@@ -7,11 +7,11 @@ Please see LICENSE files in the repository root for full details.
 import React from "react";
 import { render } from "jest-matrix-react";
 import userEvent from "@testing-library/user-event";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { InviteRulesAccountSetting } from "../../../../../../../src/components/views/settings/tabs/user/InviteRulesAccountSettings";
 import SettingsStore from "../../../../../../../src/settings/SettingsStore";
 import { type ComputedInviteConfig } from "../../../../../../../src/@types/invite-rules";
-import { SettingLevel } from "../../../../../../../src/settings/SettingLevel";
 
 function mockSetting(inviteRules: ComputedInviteConfig, blockInvites: boolean) {
     jest.spyOn(SettingsStore, "getValue").mockImplementation((settingName) => {

--- a/apps/web/test/unit-tests/components/views/settings/tabs/user/PreferencesUserSettingsTab-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/tabs/user/PreferencesUserSettingsTab-test.tsx
@@ -9,12 +9,12 @@ Please see LICENSE files in the repository root for full details.
 import React from "react";
 import { fireEvent, render, type RenderResult, screen, waitFor } from "jest-matrix-react";
 import userEvent from "@testing-library/user-event";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import PreferencesUserSettingsTab from "../../../../../../../src/components/views/settings/tabs/user/PreferencesUserSettingsTab";
 import { MatrixClientPeg } from "../../../../../../../src/MatrixClientPeg";
 import { mockPlatformPeg, stubClient } from "../../../../../../test-utils";
 import SettingsStore from "../../../../../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../../../../../src/settings/SettingLevel";
 import MatrixClientBackedController from "../../../../../../../src/settings/controllers/MatrixClientBackedController";
 import PlatformPeg from "../../../../../../../src/PlatformPeg";
 import { type SettingKey } from "../../../../../../../src/settings/Settings.tsx";

--- a/apps/web/test/unit-tests/components/views/settings/tabs/user/SidebarUserSettingsTab-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/tabs/user/SidebarUserSettingsTab-test.tsx
@@ -8,12 +8,12 @@ Please see LICENSE files in the repository root for full details.
 
 import React from "react";
 import { fireEvent, render, screen } from "jest-matrix-react";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SidebarUserSettingsTab from "../../../../../../../src/components/views/settings/tabs/user/SidebarUserSettingsTab";
 import PosthogTrackers from "../../../../../../../src/PosthogTrackers";
 import SettingsStore from "../../../../../../../src/settings/SettingsStore";
 import { MetaSpace } from "../../../../../../../src/stores/spaces";
-import { SettingLevel } from "../../../../../../../src/settings/SettingLevel";
 import { flushPromises } from "../../../../../../test-utils";
 import SdkConfig from "../../../../../../../src/SdkConfig";
 

--- a/apps/web/test/unit-tests/components/views/spaces/QuickThemeSwitcher-test.tsx
+++ b/apps/web/test/unit-tests/components/views/spaces/QuickThemeSwitcher-test.tsx
@@ -10,11 +10,11 @@ import React from "react";
 import { render, screen, waitFor } from "jest-matrix-react";
 import userEvent from "@testing-library/user-event";
 import { mocked } from "jest-mock";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import QuickThemeSwitcher from "../../../../../src/components/views/spaces/QuickThemeSwitcher";
 import { getOrderedThemes } from "../../../../../src/theme";
 import SettingsStore from "../../../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../../../src/settings/SettingLevel";
 import dis from "../../../../../src/dispatcher/dispatcher";
 import { Action } from "../../../../../src/dispatcher/actions";
 import { mockPlatformPeg } from "../../../../test-utils/platform";

--- a/apps/web/test/unit-tests/settings/SettingsStore-test.ts
+++ b/apps/web/test/unit-tests/settings/SettingsStore-test.ts
@@ -8,10 +8,10 @@ Please see LICENSE files in the repository root for full details.
 
 import { ClientEvent, type MatrixClient, type Room, SyncState } from "matrix-js-sdk/src/matrix";
 import { waitFor } from "jest-matrix-react";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import type BasePlatform from "../../../src/BasePlatform";
 import SdkConfig from "../../../src/SdkConfig";
-import { SettingLevel } from "../../../src/settings/SettingLevel";
 import SettingsStore from "../../../src/settings/SettingsStore";
 import { mkStubRoom, mockPlatformPeg, stubClient } from "../../test-utils";
 import { SETTINGS, type SettingKey } from "../../../src/settings/Settings.tsx";

--- a/apps/web/test/unit-tests/settings/controllers/AnalyticsController-test.ts
+++ b/apps/web/test/unit-tests/settings/controllers/AnalyticsController-test.ts
@@ -6,9 +6,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import PosthogTrackers from "../../../../src/PosthogTrackers";
 import AnalyticsController from "../../../../src/settings/controllers/AnalyticsController";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 
 describe("AnalyticsController", () => {
     afterEach(() => {

--- a/apps/web/test/unit-tests/settings/controllers/DeviceIsolationModeController-test.ts
+++ b/apps/web/test/unit-tests/settings/controllers/DeviceIsolationModeController-test.ts
@@ -6,10 +6,10 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { AllDevicesIsolationMode, OnlySignedDevicesIsolationMode } from "matrix-js-sdk/src/crypto-api";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { stubClient } from "../../../test-utils";
 import DeviceIsolationModeController from "../../../../src/settings/controllers/DeviceIsolationModeController.ts";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 
 describe("DeviceIsolationModeController", () => {
     afterEach(() => {

--- a/apps/web/test/unit-tests/settings/controllers/FallbackIceServerController-test.ts
+++ b/apps/web/test/unit-tests/settings/controllers/FallbackIceServerController-test.ts
@@ -7,8 +7,8 @@ Please see LICENSE files in the repository root for full details.
 
 import fetchMock from "@fetch-mock/jest";
 import { ClientEvent, MatrixClient } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import FallbackIceServerController from "../../../../src/settings/controllers/FallbackIceServerController.ts";
 import MatrixClientBackedController from "../../../../src/settings/controllers/MatrixClientBackedController.ts";
 import SettingsStore from "../../../../src/settings/SettingsStore.ts";

--- a/apps/web/test/unit-tests/settings/controllers/FontSizeController-test.ts
+++ b/apps/web/test/unit-tests/settings/controllers/FontSizeController-test.ts
@@ -6,10 +6,11 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import { Action } from "../../../../src/dispatcher/actions";
 import dis from "../../../../src/dispatcher/dispatcher";
 import FontSizeController from "../../../../src/settings/controllers/FontSizeController";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 
 const dispatchSpy = jest.spyOn(dis, "fire");
 

--- a/apps/web/test/unit-tests/settings/controllers/IncompatibleController-test.ts
+++ b/apps/web/test/unit-tests/settings/controllers/IncompatibleController-test.ts
@@ -6,8 +6,9 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import IncompatibleController from "../../../../src/settings/controllers/IncompatibleController";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import SettingsStore from "../../../../src/settings/SettingsStore";
 import { type FeatureSettingKey } from "../../../../src/settings/Settings.tsx";
 

--- a/apps/web/test/unit-tests/settings/controllers/InviteRulesConfigController-test.ts
+++ b/apps/web/test/unit-tests/settings/controllers/InviteRulesConfigController-test.ts
@@ -6,10 +6,10 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { MatrixEvent } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import MatrixClientBackedController from "../../../../src/settings/controllers/MatrixClientBackedController";
 import InviteRulesConfigController from "../../../../src/settings/controllers/InviteRulesConfigController";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import { getMockClientWithEventEmitter, mockClientMethodsServer } from "../../../test-utils";
 import { INVITE_RULES_ACCOUNT_DATA_TYPE, type InviteConfigAccountData } from "../../../../src/@types/invite-rules";
 

--- a/apps/web/test/unit-tests/settings/controllers/MediaPreviewConfigController-test.ts
+++ b/apps/web/test/unit-tests/settings/controllers/MediaPreviewConfigController-test.ts
@@ -6,10 +6,10 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { MatrixEvent } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import MatrixClientBackedController from "../../../../src/settings/controllers/MatrixClientBackedController";
 import MediaPreviewConfigController from "../../../../src/settings/controllers/MediaPreviewConfigController";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import { getMockClientWithEventEmitter, mockClientMethodsServer } from "../../../test-utils";
 import { MEDIA_PREVIEW_ACCOUNT_DATA_TYPE, MediaPreviewValue } from "../../../../src/@types/media_preview";
 

--- a/apps/web/test/unit-tests/settings/controllers/RequiresSettingsController-test.ts
+++ b/apps/web/test/unit-tests/settings/controllers/RequiresSettingsController-test.ts
@@ -5,8 +5,9 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import RequiresSettingsController from "../../../../src/settings/controllers/RequiresSettingsController";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import SettingsStore from "../../../../src/settings/SettingsStore";
 
 describe("RequiresSettingsController", () => {

--- a/apps/web/test/unit-tests/settings/controllers/ServerSupportUnstableFeatureController-test.ts
+++ b/apps/web/test/unit-tests/settings/controllers/ServerSupportUnstableFeatureController-test.ts
@@ -7,9 +7,9 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { type MatrixClient } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import ServerSupportUnstableFeatureController from "../../../../src/settings/controllers/ServerSupportUnstableFeatureController";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import { type FeatureSettingKey, LabGroup, SETTINGS } from "../../../../src/settings/Settings";
 import { stubClient } from "../../../test-utils";
 import { WatchManager } from "../../../../src/settings/WatchManager";

--- a/apps/web/test/unit-tests/settings/controllers/ThemeController-test.ts
+++ b/apps/web/test/unit-tests/settings/controllers/ThemeController-test.ts
@@ -6,8 +6,9 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import ThemeController from "../../../../src/settings/controllers/ThemeController";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import SettingsStore from "../../../../src/settings/SettingsStore";
 import { DEFAULT_THEME } from "../../../../src/theme";
 

--- a/apps/web/test/unit-tests/settings/handlers/RoomDeviceSettingsHandler-test.ts
+++ b/apps/web/test/unit-tests/settings/handlers/RoomDeviceSettingsHandler-test.ts
@@ -6,8 +6,9 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { SettingLevel } from "@element-hq/element-web-module-api";
+
 import RoomDeviceSettingsHandler from "../../../../src/settings/handlers/RoomDeviceSettingsHandler";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import { type CallbackFn, WatchManager } from "../../../../src/settings/WatchManager";
 
 describe("RoomDeviceSettingsHandler", () => {

--- a/apps/web/test/unit-tests/settings/watchers/FontWatcher-test.tsx
+++ b/apps/web/test/unit-tests/settings/watchers/FontWatcher-test.tsx
@@ -9,9 +9,9 @@ Please see LICENSE files in the repository root for full details.
 
 import { sleep } from "matrix-js-sdk/src/utils";
 import { waitFor } from "jest-matrix-react";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore from "../../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import { FontWatcher } from "../../../../src/settings/watchers/FontWatcher";
 import { Action } from "../../../../src/dispatcher/actions";
 import { untilDispatch } from "../../../test-utils";

--- a/apps/web/test/unit-tests/settings/watchers/ThemeWatcher-test.tsx
+++ b/apps/web/test/unit-tests/settings/watchers/ThemeWatcher-test.tsx
@@ -6,9 +6,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { type SettingLevel } from "@element-hq/element-web-module-api";
+
 import SettingsStore from "../../../../src/settings/SettingsStore";
 import ThemeWatcher from "../../../../src/settings/watchers/ThemeWatcher";
-import { type SettingLevel } from "../../../../src/settings/SettingLevel";
 import { type SettingKey, type Settings } from "../../../../src/settings/Settings.tsx";
 
 function makeMatchMedia(values: any) {

--- a/apps/web/test/unit-tests/stores/ReleaseAnnouncementStore-test.tsx
+++ b/apps/web/test/unit-tests/stores/ReleaseAnnouncementStore-test.tsx
@@ -7,10 +7,10 @@
  */
 
 import { mocked } from "jest-mock";
+import { type SettingLevel } from "@element-hq/element-web-module-api";
 
 import SettingsStore, { type CallbackFn } from "../../../src/settings/SettingsStore";
 import { type Feature, ReleaseAnnouncementStore } from "../../../src/stores/ReleaseAnnouncementStore";
-import { type SettingLevel } from "../../../src/settings/SettingLevel";
 import ToastStore from "../../../src/stores/ToastStore";
 
 jest.mock("../../../src/settings/SettingsStore");

--- a/apps/web/test/unit-tests/stores/SpaceStore-test.ts
+++ b/apps/web/test/unit-tests/stores/SpaceStore-test.ts
@@ -20,6 +20,7 @@ import {
     type RoomState,
 } from "matrix-js-sdk/src/matrix";
 import { KnownMembership } from "matrix-js-sdk/src/types";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import SpaceStore from "../../../src/stores/spaces/SpaceStore";
 import {
@@ -34,7 +35,6 @@ import { mkEvent, stubClient } from "../../test-utils";
 import DMRoomMap from "../../../src/utils/DMRoomMap";
 import defaultDispatcher from "../../../src/dispatcher/dispatcher";
 import SettingsStore from "../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../src/settings/SettingLevel";
 import { Action } from "../../../src/dispatcher/actions";
 import { MatrixClientPeg } from "../../../src/MatrixClientPeg";
 import RoomListStore from "../../../src/stores/room-list/RoomListStore";

--- a/apps/web/test/unit-tests/stores/room-list/RoomListStore-test.ts
+++ b/apps/web/test/unit-tests/stores/room-list/RoomListStore-test.ts
@@ -17,9 +17,9 @@ import {
 } from "matrix-js-sdk/src/matrix";
 import { KnownMembership } from "matrix-js-sdk/src/types";
 import { mocked } from "jest-mock";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import defaultDispatcher, { type MatrixDispatcher } from "../../../../src/dispatcher/dispatcher";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import SettingsStore, { type CallbackFn } from "../../../../src/settings/SettingsStore";
 import { ListAlgorithm, SortAlgorithm } from "../../../../src/stores/room-list/algorithms/models";
 import { OrderedDefaultTagIDs, RoomUpdateCause } from "../../../../src/stores/room-list/models";

--- a/apps/web/test/unit-tests/stores/room-list/SpaceWatcher-test.ts
+++ b/apps/web/test/unit-tests/stores/room-list/SpaceWatcher-test.ts
@@ -8,6 +8,7 @@ Please see LICENSE files in the repository root for full details.
 
 import { mocked } from "jest-mock";
 import { type Room } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { SpaceWatcher } from "../../../../src/stores/room-list/SpaceWatcher";
 import type { RoomListStoreClass } from "../../../../src/stores/room-list/RoomListStore";
@@ -15,7 +16,6 @@ import SettingsStore from "../../../../src/settings/SettingsStore";
 import SpaceStore from "../../../../src/stores/spaces/SpaceStore";
 import { MetaSpace, UPDATE_HOME_BEHAVIOUR } from "../../../../src/stores/spaces";
 import { stubClient, mkSpace, emitPromise, setupAsyncStoreWithClient } from "../../../test-utils";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import { MatrixClientPeg } from "../../../../src/MatrixClientPeg";
 import { SpaceFilterCondition } from "../../../../src/stores/room-list/filters/SpaceFilterCondition";
 import DMRoomMap from "../../../../src/utils/DMRoomMap";

--- a/apps/web/test/unit-tests/stores/widgets/WidgetPermissionStore-test.ts
+++ b/apps/web/test/unit-tests/stores/widgets/WidgetPermissionStore-test.ts
@@ -9,11 +9,11 @@ Please see LICENSE files in the repository root for full details.
 import { mocked } from "jest-mock";
 import { type MatrixClient } from "matrix-js-sdk/src/matrix";
 import { Widget, WidgetKind } from "matrix-widget-api";
+import { type SettingLevel } from "@element-hq/element-web-module-api";
 
 import { OIDCState, WidgetPermissionStore } from "../../../../src/stores/widgets/WidgetPermissionStore";
 import SettingsStore from "../../../../src/settings/SettingsStore";
 import { TestSdkContext } from "../../TestSdkContext";
-import { type SettingLevel } from "../../../../src/settings/SettingLevel";
 import { SdkContextClass } from "../../../../src/contexts/SDKContext";
 import { stubClient } from "../../../test-utils";
 import { ElementWidgetDriver } from "../../../../src/stores/widgets/ElementWidgetDriver";

--- a/apps/web/test/unit-tests/utils/notifications-test.ts
+++ b/apps/web/test/unit-tests/utils/notifications-test.ts
@@ -15,6 +15,7 @@ import {
     type AccountDataEvents,
 } from "matrix-js-sdk/src/matrix";
 import { type Mocked, mocked } from "jest-mock";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import {
     localNotificationsAreSilenced,
@@ -32,7 +33,6 @@ import { getMockClientWithEventEmitter, mockClientMethodsServer } from "../../te
 import { mkMessage, stubClient } from "../../test-utils/test-utils";
 import { MatrixClientPeg } from "../../../src/MatrixClientPeg";
 import { NotificationLevel } from "../../../src/stores/notifications/NotificationLevel";
-import { SettingLevel } from "../../../src/settings/SettingLevel";
 import MatrixClientBackedController from "../../../src/settings/controllers/MatrixClientBackedController";
 import SettingsStore from "../../../src/settings/SettingsStore";
 

--- a/apps/web/test/viewmodels/room/right-panel/WidgetContextMenuViewModel-test.tsx
+++ b/apps/web/test/viewmodels/room/right-panel/WidgetContextMenuViewModel-test.tsx
@@ -8,6 +8,7 @@
 import React from "react";
 import { MatrixWidgetType } from "matrix-widget-api";
 import { type MatrixClient, Room } from "matrix-js-sdk/src/matrix";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import {
     WidgetContextMenuViewModel,
@@ -20,7 +21,6 @@ import { WidgetLayoutStore } from "../../../../src/stores/widgets/WidgetLayoutSt
 import * as livestream from "../../../../src/Livestream";
 import Modal from "../../../../src/Modal";
 import SettingsStore from "../../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../../src/settings/SettingLevel";
 import * as widgetStore from "../../../../src/stores/WidgetStore";
 import { WidgetMessagingStore } from "../../../../src/stores/widgets/WidgetMessagingStore";
 import { type WidgetMessaging } from "../../../../src/stores/widgets/WidgetMessaging";

--- a/apps/web/test/viewmodels/structures/ResizerViewModel-test.ts
+++ b/apps/web/test/viewmodels/structures/ResizerViewModel-test.ts
@@ -8,10 +8,10 @@
 import { waitFor } from "jest-matrix-react";
 import { type PanelImperativeHandle } from "@element-hq/web-shared-components";
 import whatInput from "what-input";
+import { SettingLevel } from "@element-hq/element-web-module-api";
 
 import { ResizerViewModel } from "../../../src/viewmodels/structures/ResizerViewModel";
 import SettingsStore from "../../../src/settings/SettingsStore";
-import { SettingLevel } from "../../../src/settings/SettingLevel";
 
 jest.mock("what-input");
 

--- a/packages/module-api/element-web-module-api.api.md
+++ b/packages/module-api/element-web-module-api.api.md
@@ -425,6 +425,32 @@ export interface RoomViewProps {
 // @alpha @deprecated (undocumented)
 export type RuntimeModuleConstructor = new (api: ModuleApi) => RuntimeModule;
 
+// @public
+export enum SettingLevel {
+    // (undocumented)
+    ACCOUNT = "account",
+    // (undocumented)
+    CONFIG = "config",
+    // (undocumented)
+    DEFAULT = "default",
+    // (undocumented)
+    DEVICE = "device",
+    // (undocumented)
+    PLATFORM = "platform",
+    // (undocumented)
+    ROOM = "room",
+    // (undocumented)
+    ROOM_ACCOUNT = "room-account",
+    // (undocumented)
+    ROOM_DEVICE = "room-device"
+}
+
+// @alpha
+export interface SettingsStoreApi {
+    // @public
+    overrideSettingsSupportedLevels(settingName: string, levels: SettingLevel[]): void;
+}
+
 // @alpha
 export interface SpacePanelItemProps {
     className?: string;
@@ -438,6 +464,8 @@ export interface SpacePanelItemProps {
 // @public
 export interface StoresApi {
     roomListStore: RoomListStoreApi;
+    // Warning: (ae-incompatible-release-tags) The symbol "settingsStore" is marked as @public, but its signature references "SettingsStoreApi" which is marked as @alpha
+    settingsStore: SettingsStoreApi;
 }
 
 // @public

--- a/packages/module-api/src/api/stores.ts
+++ b/packages/module-api/src/api/stores.ts
@@ -9,6 +9,21 @@ import type { Room } from "../models/Room";
 import { type Watchable } from "./watchable";
 
 /**
+ * Represents the various setting levels supported by the SettingsStore.
+ * @public
+ */
+export enum SettingLevel {
+    DEVICE = "device",
+    ROOM_DEVICE = "room-device",
+    ROOM_ACCOUNT = "room-account",
+    ACCOUNT = "account",
+    ROOM = "room",
+    PLATFORM = "platform",
+    CONFIG = "config",
+    DEFAULT = "default",
+}
+
+/**
  * Provides some basic functionality of the Room List Store from element-web.
  * @public
  */
@@ -25,6 +40,22 @@ export interface RoomListStoreApi {
 }
 
 /**
+ * Provides access to limited functionality of the Settings Store.
+ * @alpha
+ */
+export interface SettingsStoreApi {
+    /**
+     * Change the supported settings level for a given setting.
+     *
+     * @param settingName - The name of the setting that should be changed.
+     * @param levels - The new set of levels to be supported by the setting
+     * @public
+     * @throws If the setting name is not known to Element.
+     */
+    overrideSettingsSupportedLevels(settingName: string, levels: SettingLevel[]): void;
+}
+
+/**
  * Provides access to certain stores from element-web.
  * @public
  */
@@ -33,4 +64,9 @@ export interface StoresApi {
      * Use this to access limited functionality of the RLS from element-web.
      */
     roomListStore: RoomListStoreApi;
+
+    /**
+     * Use this to access limited functionality of the SettingsStore from element-web.
+     */
+    settingsStore: SettingsStoreApi;
 }


### PR DESCRIPTION
We would like to build modules that change whether a setting can be loaded via a config or not. This ended up being 3 changes:

 - Moving SettingLevel to the module API.
 - Refactoring SettingsStore to allow runtime overrides.
 - Exposing a module API for adjusting it.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
