### PR TITLE
Add stopUpdatingLabel to Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["github>matrix-org/renovate-config-element-web"],
     "postUpdateOptions": ["pnpmDedupe"],
+    "stopUpdatingLabel": "X-Blocked",
     "packageRules": [
         {
             "groupName": "testcontainers docker digests",


### PR DESCRIPTION
Will mean blocked PRs don't run CI needlessly