### PR TITLE
Speed up PR CI

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -206,6 +206,8 @@ jobs:
         needs: prepare_ed
         name: "Desktop Windows"
         uses: ./.github/workflows/build_desktop_windows.yaml
+        # Skip Windows builds on PRs, as the Linux amd64 build is enough of a smoke test and includes the screenshot tests
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'X-Run-All-Tests')
         strategy:
             matrix:
                 arch: [x64, ia32, arm64]
@@ -223,10 +225,13 @@ jobs:
                 arch: [amd64, arm64]
                 runAllTests:
                     - ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'X-Run-All-Tests') }}
-                # We ship static sqlcipher builds, so delegate testing the system builds to the merge queue
                 exclude:
+                    # We ship static sqlcipher builds, so delegate testing the system builds to the merge queue
                     - runAllTests: false
                       sqlcipher: system
+                    # Additionally skip arm64 system builds on PRs, as the amd64 test is enough for a smoke test and includes the screenshot tests
+                    - runAllTests: false
+                      arch: arm64
         with:
             sqlcipher: ${{ matrix.sqlcipher }}
             arch: ${{ matrix.arch }}
@@ -236,6 +241,8 @@ jobs:
         needs: prepare_ed
         name: "Desktop macOS"
         uses: ./.github/workflows/build_desktop_macos.yaml
+        # Skip Windows builds on PRs, as the Linux amd64 build is enough of a smoke test and includes the screenshot tests
+        if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'X-Run-All-Tests')
         with:
             blob_report: true
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -241,7 +241,8 @@ jobs:
         needs: prepare_ed
         name: "Desktop macOS"
         uses: ./.github/workflows/build_desktop_macos.yaml
-        # Skip Windows builds on PRs, as the Linux amd64 build is enough of a smoke test and includes the screenshot tests
+        # Skip macOS builds on PRs, as the Linux amd64 build is enough of a smoke test and includes the screenshot tests
+        # and we have a very low limit of concurrent macos runners (5) across the Github org.
         if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'X-Run-All-Tests')
         with:
             blob_report: true


### PR DESCRIPTION
By skipping some desktop tests in pull requests and instead only running them in the Merge Queue
