### PR TITLE
Room list: exclude default section from room list item menu

### DIFF
--- a/apps/web/src/viewmodels/room-list/RoomListItemViewModel.ts
+++ b/apps/web/src/viewmodels/room-list/RoomListItemViewModel.ts
@@ -423,8 +423,11 @@ export class RoomListItemViewModel
 
         return (
             RoomListStoreV3.instance.orderedSectionTags
-                // Exclude the Chats section because the user toggle the other sections to move rooms in and out of the Chats section.
-                .filter((tag) => tag !== CHATS_TAG)
+                // Exclude the Chats because the user toggle the other sections to move rooms in and out of the Chats section.
+                // Also exclude the default sections because they are available as toggles in the main context menu, and we don't want them to be duplicated in the "Move to section" submenu.
+                .filter(
+                    (tag) => tag !== CHATS_TAG && tag !== DefaultTagID.Favourite && tag !== DefaultTagID.LowPriority,
+                )
                 .map((tag) => ({
                     tag,
                     name: RoomListItemViewModel.getSectionName(tag, customSectionData),

--- a/apps/web/test/viewmodels/room-list/RoomListItemViewModel-test.tsx
+++ b/apps/web/test/viewmodels/room-list/RoomListItemViewModel-test.tsx
@@ -620,7 +620,7 @@ describe("RoomListItemViewModel", () => {
             ]);
         });
 
-        it("should include sections from orderedSectionTags excluding CHATS_TAG", () => {
+        it("should include sections from orderedSectionTags excluding CHATS_TAG, favourite, and low priority", () => {
             jest.spyOn(SettingsStore, "getValue").mockImplementation((setting) => {
                 if (setting === "feature_room_list_sections") return true;
                 return false;
@@ -628,11 +628,11 @@ describe("RoomListItemViewModel", () => {
             viewModel = new RoomListItemViewModel({ room, client: matrixClient });
 
             const sections = viewModel.getSnapshot().sections;
-            expect(sections.map((s) => s.tag)).toEqual([DefaultTagID.Favourite, customTag, DefaultTagID.LowPriority]);
+            expect(sections.map((s) => s.tag)).toEqual([customTag]);
         });
 
         it("should mark the room current section as selected", () => {
-            room.tags = { [DefaultTagID.Favourite]: { order: 0 } };
+            room.tags = { [customTag]: { order: 0 } };
             jest.spyOn(SettingsStore, "getValue").mockImplementation((setting) => {
                 if (setting === "feature_room_list_sections") return true;
                 return false;
@@ -640,8 +640,7 @@ describe("RoomListItemViewModel", () => {
             viewModel = new RoomListItemViewModel({ room, client: matrixClient });
 
             const sections = viewModel.getSnapshot().sections;
-            expect(sections.find((s) => s.tag === DefaultTagID.Favourite)?.isSelected).toBe(true);
-            expect(sections.find((s) => s.tag === DefaultTagID.LowPriority)?.isSelected).toBe(false);
+            expect(sections.find((s) => s.tag === customTag)?.isSelected).toBe(true);
         });
 
         it("should use custom section name from CustomSectionData", () => {
@@ -669,7 +668,7 @@ describe("RoomListItemViewModel", () => {
             });
 
             viewModel = new RoomListItemViewModel({ room, client: matrixClient });
-            expect(viewModel.getSnapshot().sections).toHaveLength(3); // Favourite, custom, LowPriority
+            expect(viewModel.getSnapshot().sections).toHaveLength(1);
 
             // Simulate reordering: custom section removed
             jest.spyOn(RoomListStoreV3.instance, "orderedSectionTags", "get").mockReturnValue([
@@ -679,10 +678,7 @@ describe("RoomListItemViewModel", () => {
             ]);
             watchCallback("RoomList.OrderedCustomSections", null, null as any, null, null);
 
-            expect(viewModel.getSnapshot().sections.map((s) => s.tag)).toEqual([
-                DefaultTagID.Favourite,
-                DefaultTagID.LowPriority,
-            ]);
+            expect(viewModel.getSnapshot().sections.map((s) => s.tag)).toEqual([]);
         });
     });
 


### PR DESCRIPTION
Closes https://github.com/element-hq/element-web/issues/33277

Exclude default sections from `Move to` menu in the room list item.

<img width="1803" height="1199" alt="image" src="https://github.com/user-attachments/assets/e22e35b0-fd19-46d5-ba35-d63b106762fb" />