### PR TITLE
Add Module Composer API

### DIFF
--- a/apps/web/src/components/structures/RoomView.tsx
+++ b/apps/web/src/components/structures/RoomView.tsx
@@ -1293,14 +1293,17 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             }
 
             case Action.ComposerInsert: {
-                if (payload.composerType) break;
+                const composerInsertPayload = payload as ComposerInsertPayload;
+                if (composerInsertPayload.composerType) break;
 
-                let timelineRenderingType: TimelineRenderingType = payload.timelineRenderingType;
+                // If the dispatchee didn't request a timeline rendering type, use the current one.
+                let timelineRenderingType: TimelineRenderingType =
+                    composerInsertPayload.timelineRenderingType ?? this.state.timelineRenderingType;
                 // ThreadView handles Action.ComposerInsert itself due to it having its own editState
                 if (timelineRenderingType === TimelineRenderingType.Thread) break;
                 if (
                     this.state.timelineRenderingType === TimelineRenderingType.Search &&
-                    payload.timelineRenderingType === TimelineRenderingType.Search
+                    composerInsertPayload.timelineRenderingType === TimelineRenderingType.Search
                 ) {
                     // we don't have the composer rendered in this state, so bring it back first
                     await this.onCancelSearchClick();
@@ -1309,7 +1312,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
 
                 // re-dispatch to the correct composer
                 defaultDispatcher.dispatch<ComposerInsertPayload>({
-                    ...(payload as ComposerInsertPayload),
+                    ...composerInsertPayload,
                     timelineRenderingType,
                     composerType: this.state.editState ? ComposerType.Edit : ComposerType.Send,
                 });

--- a/apps/web/src/components/structures/RoomView.tsx
+++ b/apps/web/src/components/structures/RoomView.tsx
@@ -1296,11 +1296,9 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                 const composerInsertPayload = payload as ComposerInsertPayload;
                 if (composerInsertPayload.composerType) break;
 
-                // If the dispatchee didn't request a timeline rendering type, use the current one.
-                let timelineRenderingType: TimelineRenderingType =
-                    composerInsertPayload.timelineRenderingType ?? this.state.timelineRenderingType;
+                let timelineRenderingType: TimelineRenderingType | undefined;
                 // ThreadView handles Action.ComposerInsert itself due to it having its own editState
-                if (timelineRenderingType === TimelineRenderingType.Thread) break;
+                if (composerInsertPayload.timelineRenderingType === TimelineRenderingType.Thread) break;
                 if (
                     this.state.timelineRenderingType === TimelineRenderingType.Search &&
                     composerInsertPayload.timelineRenderingType === TimelineRenderingType.Search
@@ -1309,6 +1307,12 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                     await this.onCancelSearchClick();
                     timelineRenderingType = TimelineRenderingType.Room;
                 }
+
+                // If the dispatchee didn't request a timeline rendering type, use the current one.
+                timelineRenderingType =
+                    timelineRenderingType ??
+                    composerInsertPayload.timelineRenderingType ??
+                    this.state.timelineRenderingType;
 
                 // re-dispatch to the correct composer
                 defaultDispatcher.dispatch<ComposerInsertPayload>({

--- a/apps/web/src/components/structures/ThreadView.tsx
+++ b/apps/web/src/components/structures/ThreadView.tsx
@@ -168,14 +168,13 @@ export default class ThreadView extends React.Component<IProps, IState> {
         switch (payload.action) {
             case Action.ComposerInsert: {
                 const insertPayload = payload as ComposerInsertPayload;
-                const timelineRenderingType = insertPayload.timelineRenderingType;
                 if (insertPayload.composerType) break;
-                if (timelineRenderingType !== TimelineRenderingType.Thread) break;
+                if (insertPayload.timelineRenderingType !== TimelineRenderingType.Thread) break;
 
                 // re-dispatch to the correct composer
                 dis.dispatch<ComposerInsertPayload>({
                     ...insertPayload,
-                    timelineRenderingType,
+                    timelineRenderingType: TimelineRenderingType.Thread,
                     composerType: this.state.editState ? ComposerType.Edit : ComposerType.Send,
                 });
                 break;

--- a/apps/web/src/components/structures/ThreadView.tsx
+++ b/apps/web/src/components/structures/ThreadView.tsx
@@ -167,12 +167,15 @@ export default class ThreadView extends React.Component<IProps, IState> {
         }
         switch (payload.action) {
             case Action.ComposerInsert: {
-                if (payload.composerType) break;
-                if (payload.timelineRenderingType !== TimelineRenderingType.Thread) break;
+                const insertPayload = payload as ComposerInsertPayload;
+                const timelineRenderingType = insertPayload.timelineRenderingType;
+                if (insertPayload.composerType) break;
+                if (timelineRenderingType !== TimelineRenderingType.Thread) break;
 
                 // re-dispatch to the correct composer
                 dis.dispatch<ComposerInsertPayload>({
-                    ...(payload as ComposerInsertPayload),
+                    ...insertPayload,
+                    timelineRenderingType,
                     composerType: this.state.editState ? ComposerType.Edit : ComposerType.Send,
                 });
                 break;

--- a/apps/web/src/dispatcher/payloads/ComposerInsertPayload.ts
+++ b/apps/web/src/dispatcher/payloads/ComposerInsertPayload.ts
@@ -15,32 +15,18 @@ export enum ComposerType {
     Edit = "edit",
 }
 
-/**
- * Explicit composer insert to target
- */
-interface IBaseComposerInsertPayloadExplicit extends ActionPayload {
+interface IBaseComposerInsertPayload extends ActionPayload {
     action: Action.ComposerInsert;
-    timelineRenderingType: TimelineRenderingType;
-    composerType: ComposerType;
-}
-
-/**
- * Explicit composer insert to current target.
- */
-interface IBaseComposerInsertPayloadImplicit extends ActionPayload {
-    action: Action.ComposerInsert;
-    composerType?: undefined; // undefined if this should be re-dispatched to the correct composer
     timelineRenderingType?: TimelineRenderingType; // undefined if this should just use the current in-focus type.
+    composerType?: ComposerType; // falsy if should be re-dispatched to the correct composer
 }
 
-type IBaseComposerInsertPayload = IBaseComposerInsertPayloadExplicit | IBaseComposerInsertPayloadImplicit;
-
-type IComposerInsertMentionPayload = IBaseComposerInsertPayload & {
+interface IComposerInsertMentionPayload extends IBaseComposerInsertPayload {
     userId: string;
-};
+}
 
-type IComposerInsertPlaintextPayload = IBaseComposerInsertPayload & {
+interface IComposerInsertPlaintextPayload extends IBaseComposerInsertPayload {
     text: string;
-};
+}
 
 export type ComposerInsertPayload = IComposerInsertMentionPayload | IComposerInsertPlaintextPayload;

--- a/apps/web/src/dispatcher/payloads/ComposerInsertPayload.ts
+++ b/apps/web/src/dispatcher/payloads/ComposerInsertPayload.ts
@@ -15,18 +15,32 @@ export enum ComposerType {
     Edit = "edit",
 }
 
-interface IBaseComposerInsertPayload extends ActionPayload {
+/**
+ * Explicit composer insert to target
+ */
+interface IBaseComposerInsertPayloadExplicit extends ActionPayload {
     action: Action.ComposerInsert;
     timelineRenderingType: TimelineRenderingType;
-    composerType?: ComposerType; // falsy if should be re-dispatched to the correct composer
+    composerType: ComposerType;
 }
 
-interface IComposerInsertMentionPayload extends IBaseComposerInsertPayload {
+/**
+ * Explicit composer insert to current target.
+ */
+interface IBaseComposerInsertPayloadImplicit extends ActionPayload {
+    action: Action.ComposerInsert;
+    composerType?: undefined; // undefined if this should be re-dispatched to the correct composer
+    timelineRenderingType?: TimelineRenderingType; // undefined if this should just use the current in-focus type.
+}
+
+type IBaseComposerInsertPayload = IBaseComposerInsertPayloadExplicit | IBaseComposerInsertPayloadImplicit;
+
+type IComposerInsertMentionPayload = IBaseComposerInsertPayload & {
     userId: string;
-}
+};
 
-interface IComposerInsertPlaintextPayload extends IBaseComposerInsertPayload {
+type IComposerInsertPlaintextPayload = IBaseComposerInsertPayload & {
     text: string;
-}
+};
 
 export type ComposerInsertPayload = IComposerInsertMentionPayload | IComposerInsertPlaintextPayload;

--- a/apps/web/src/modules/Api.ts
+++ b/apps/web/src/modules/Api.ts
@@ -33,6 +33,8 @@ import { StoresApi } from "./StoresApi.ts";
 import { WidgetLifecycleApi } from "./WidgetLifecycleApi.ts";
 import { WidgetApi } from "./WidgetApi.ts";
 import { CustomisationsApi } from "./customisationsApi.ts";
+import { ComposerApi } from "./ComposerApi.ts";
+import defaultDispatcher from "../dispatcher/dispatcher.ts";
 
 const legacyCustomisationsFactory = <T extends object>(baseCustomisations: T) => {
     let used = false;
@@ -94,6 +96,7 @@ export class ModuleApi implements Api {
     public readonly rootNode = document.getElementById("matrixchat")!;
     public readonly client = new ClientApi();
     public readonly stores = new StoresApi();
+    public readonly composer = new ComposerApi(defaultDispatcher);
 
     public createRoot(element: Element): Root {
         return createRoot(element);

--- a/apps/web/src/modules/ComposerApi.ts
+++ b/apps/web/src/modules/ComposerApi.ts
@@ -1,0 +1,23 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { type ComposerApi as ModuleComposerApi } from "@element-hq/element-web-module-api";
+
+import defaultDispatcher from "../dispatcher/dispatcher";
+import { Action } from "../dispatcher/actions";
+import type { ComposerInsertPayload } from "../dispatcher/payloads/ComposerInsertPayload";
+import { TimelineRenderingType } from "../contexts/RoomContext";
+
+export class ComposerApi implements ModuleComposerApi {
+    public insertTextIntoComposer(text: string): void {
+        defaultDispatcher.dispatch({
+            action: Action.ComposerInsert,
+            text,
+            timelineRenderingType: TimelineRenderingType.Room,
+        } satisfies ComposerInsertPayload);
+    }
+}

--- a/apps/web/src/modules/ComposerApi.ts
+++ b/apps/web/src/modules/ComposerApi.ts
@@ -14,10 +14,10 @@ import type { ComposerInsertPayload } from "../dispatcher/payloads/ComposerInser
 export class ComposerApi implements ModuleComposerApi {
     public constructor(private readonly dispatcher: MatrixDispatcher) {}
 
-    public insertTextIntoComposer(text: string): void {
+    public insertPlaintextIntoComposer(plaintext: string): void {
         this.dispatcher.dispatch({
             action: Action.ComposerInsert,
-            text,
+            text: plaintext,
         } satisfies ComposerInsertPayload);
     }
 }

--- a/apps/web/src/modules/ComposerApi.ts
+++ b/apps/web/src/modules/ComposerApi.ts
@@ -7,17 +7,17 @@ Please see LICENSE files in the repository root for full details.
 
 import { type ComposerApi as ModuleComposerApi } from "@element-hq/element-web-module-api";
 
-import defaultDispatcher from "../dispatcher/dispatcher";
+import type { MatrixDispatcher } from "../dispatcher/dispatcher";
 import { Action } from "../dispatcher/actions";
 import type { ComposerInsertPayload } from "../dispatcher/payloads/ComposerInsertPayload";
-import { TimelineRenderingType } from "../contexts/RoomContext";
 
 export class ComposerApi implements ModuleComposerApi {
+    public constructor(private readonly dispatcher: MatrixDispatcher) {}
+
     public insertTextIntoComposer(text: string): void {
-        defaultDispatcher.dispatch({
+        this.dispatcher.dispatch({
             action: Action.ComposerInsert,
             text,
-            timelineRenderingType: TimelineRenderingType.Room,
         } satisfies ComposerInsertPayload);
     }
 }

--- a/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
@@ -1078,7 +1078,6 @@ describe("RoomView", () => {
 
     describe("handles Action.ComposerInsert", () => {
         it("redispatches an empty composerType, timelineRenderingType with the current state", async () => {
-            jest.spyOn(defaultDispatcher, "dispatch");
             await mountRoomView();
             const promise = untilDispatch((payload) => {
                 try {
@@ -1100,7 +1099,6 @@ describe("RoomView", () => {
             await promise;
         });
         it("redispatches an empty composerType with the current state", async () => {
-            jest.spyOn(defaultDispatcher, "dispatch");
             await mountRoomView();
             const promise = untilDispatch((payload) => {
                 try {
@@ -1121,6 +1119,34 @@ describe("RoomView", () => {
                 timelineRenderingType: TimelineRenderingType.Room,
             } satisfies ComposerInsertPayload);
             await promise;
+        });
+        it("ignores payloads with a timelineRenderingType != TimelineRenderingType.Thread", async () => {
+            await mountRoomView();
+            const promise = untilDispatch(
+                (payload) => {
+                    try {
+                        expect(payload).toStrictEqual({
+                            action: Action.ComposerInsert,
+                            text: "Hello world",
+                            timelineRenderingType: TimelineRenderingType.Thread,
+                            composerType: ComposerType.Send,
+                        });
+                    } catch {
+                        return false;
+                    }
+                    return true;
+                },
+                defaultDispatcher,
+                500,
+            );
+            defaultDispatcher.dispatch({
+                action: Action.ComposerInsert,
+                text: "Hello world",
+                composerType: ComposerType.Send,
+                timelineRenderingType: TimelineRenderingType.Room,
+                viaTest: true,
+            } satisfies ComposerInsertPayload);
+            await expect(promise).rejects.toThrow();
         });
     });
 

--- a/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
@@ -71,6 +71,7 @@ import ErrorDialog from "../../../../src/components/views/dialogs/ErrorDialog.ts
 import * as pinnedEventHooks from "../../../../src/hooks/usePinnedEvents";
 import { TimelineRenderingType } from "../../../../src/contexts/RoomContext";
 import { ModuleApi } from "../../../../src/modules/Api";
+import { ComposerInsertPayload, ComposerType } from "../../../../src/dispatcher/payloads/ComposerInsertPayload.ts";
 
 // Used by group calls
 jest.spyOn(MediaDeviceHandler, "getDevices").mockResolvedValue({
@@ -1073,6 +1074,54 @@ describe("RoomView", () => {
 
         // It should now force a reload
         expect(onRoomViewUpdateMock).toHaveBeenCalledWith(true);
+    });
+
+    describe("handles Action.ComposerInsert", () => {
+        it("redispatches an empty composerType, timelineRenderingType with the current state", async () => {
+            jest.spyOn(defaultDispatcher, "dispatch");
+            await mountRoomView();
+            const promise = untilDispatch((payload) => {
+                try {
+                    expect(payload).toEqual({
+                        action: Action.ComposerInsert,
+                        text: "Hello world",
+                        timelineRenderingType: TimelineRenderingType.Room,
+                        composerType: ComposerType.Send,
+                    });
+                } catch {
+                    return false;
+                }
+                return true;
+            }, defaultDispatcher);
+            defaultDispatcher.dispatch({
+                action: Action.ComposerInsert,
+                text: "Hello world",
+            } satisfies ComposerInsertPayload);
+            await promise;
+        });
+        it("redispatches an empty composerType with the current state", async () => {
+            jest.spyOn(defaultDispatcher, "dispatch");
+            await mountRoomView();
+            const promise = untilDispatch((payload) => {
+                try {
+                    expect(payload).toEqual({
+                        action: Action.ComposerInsert,
+                        text: "Hello world",
+                        timelineRenderingType: TimelineRenderingType.Room,
+                        composerType: ComposerType.Send,
+                    });
+                } catch {
+                    return false;
+                }
+                return true;
+            }, defaultDispatcher);
+            defaultDispatcher.dispatch({
+                action: Action.ComposerInsert,
+                text: "Hello world",
+                timelineRenderingType: TimelineRenderingType.Room,
+            } satisfies ComposerInsertPayload);
+            await promise;
+        });
     });
 
     describe("when there is a RoomView", () => {

--- a/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
@@ -71,7 +71,7 @@ import ErrorDialog from "../../../../src/components/views/dialogs/ErrorDialog.ts
 import * as pinnedEventHooks from "../../../../src/hooks/usePinnedEvents";
 import { TimelineRenderingType } from "../../../../src/contexts/RoomContext";
 import { ModuleApi } from "../../../../src/modules/Api";
-import { ComposerInsertPayload, ComposerType } from "../../../../src/dispatcher/payloads/ComposerInsertPayload.ts";
+import { type ComposerInsertPayload, ComposerType } from "../../../../src/dispatcher/payloads/ComposerInsertPayload.ts";
 
 // Used by group calls
 jest.spyOn(MediaDeviceHandler, "getDevices").mockResolvedValue({

--- a/apps/web/test/unit-tests/components/structures/ThreadView-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/ThreadView-test.tsx
@@ -34,10 +34,9 @@ import { getRoomContext } from "../../../test-utils/room";
 import { mkMessage, stubClient } from "../../../test-utils/test-utils";
 import { mkThread } from "../../../test-utils/threads";
 import { ScopedRoomContextProvider } from "../../../../src/contexts/ScopedRoomContext.tsx";
-import defaultDispatcher from "../../../../src/dispatcher/dispatcher";
 import { untilDispatch } from "../../../test-utils/utilities.ts";
 import { TimelineRenderingType } from "../../../../src/contexts/RoomContext.ts";
-import { ComposerInsertPayload, ComposerType } from "../../../../src/dispatcher/payloads/ComposerInsertPayload.ts";
+import { type ComposerInsertPayload, ComposerType } from "../../../../src/dispatcher/payloads/ComposerInsertPayload.ts";
 
 describe("ThreadView", () => {
     const ROOM_ID = "!roomId:example.org";
@@ -229,8 +228,8 @@ describe("ThreadView", () => {
                     return false;
                 }
                 return true;
-            }, defaultDispatcher);
-            defaultDispatcher.dispatch({
+            }, dispatcher);
+            dispatcher.dispatch({
                 action: Action.ComposerInsert,
                 text: "Hello world",
                 timelineRenderingType: TimelineRenderingType.Thread,
@@ -253,10 +252,10 @@ describe("ThreadView", () => {
                     }
                     return true;
                 },
-                defaultDispatcher,
+                dispatcher,
                 500,
             );
-            defaultDispatcher.dispatch({
+            dispatcher.dispatch({
                 action: Action.ComposerInsert,
                 text: "Hello world",
                 composerType: ComposerType.Send,
@@ -282,10 +281,10 @@ describe("ThreadView", () => {
                     }
                     return true;
                 },
-                defaultDispatcher,
+                dispatcher,
                 500,
             );
-            defaultDispatcher.dispatch({
+            dispatcher.dispatch({
                 action: Action.ComposerInsert,
                 text: "Hello world",
                 composerType: ComposerType.Send,

--- a/apps/web/test/unit-tests/components/structures/ThreadView-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/ThreadView-test.tsx
@@ -34,6 +34,10 @@ import { getRoomContext } from "../../../test-utils/room";
 import { mkMessage, stubClient } from "../../../test-utils/test-utils";
 import { mkThread } from "../../../test-utils/threads";
 import { ScopedRoomContextProvider } from "../../../../src/contexts/ScopedRoomContext.tsx";
+import defaultDispatcher from "../../../../src/dispatcher/dispatcher";
+import { untilDispatch } from "../../../test-utils/utilities.ts";
+import { TimelineRenderingType } from "../../../../src/contexts/RoomContext.ts";
+import { ComposerInsertPayload, ComposerType } from "../../../../src/dispatcher/payloads/ComposerInsertPayload.ts";
 
 describe("ThreadView", () => {
     const ROOM_ID = "!roomId:example.org";
@@ -207,6 +211,89 @@ describe("ThreadView", () => {
             action: Action.ViewRoom,
             room_id: room.roomId,
             metricsTrigger: undefined,
+        });
+    });
+
+    describe("handles Action.ComposerInsert", () => {
+        it("redispatches a payload of timelineRenderingType=Thread", async () => {
+            await getComponent();
+            const promise = untilDispatch((payload) => {
+                try {
+                    expect(payload).toEqual({
+                        action: Action.ComposerInsert,
+                        text: "Hello world",
+                        timelineRenderingType: TimelineRenderingType.Thread,
+                        composerType: ComposerType.Send,
+                    });
+                } catch {
+                    return false;
+                }
+                return true;
+            }, defaultDispatcher);
+            defaultDispatcher.dispatch({
+                action: Action.ComposerInsert,
+                text: "Hello world",
+                timelineRenderingType: TimelineRenderingType.Thread,
+            } satisfies ComposerInsertPayload);
+            await promise;
+        });
+        it("ignores payloads with a composerType", async () => {
+            await getComponent();
+            const promise = untilDispatch(
+                (payload) => {
+                    try {
+                        expect(payload).toStrictEqual({
+                            action: Action.ComposerInsert,
+                            text: "Hello world",
+                            timelineRenderingType: TimelineRenderingType.Thread,
+                            composerType: ComposerType.Send,
+                        });
+                    } catch {
+                        return false;
+                    }
+                    return true;
+                },
+                defaultDispatcher,
+                500,
+            );
+            defaultDispatcher.dispatch({
+                action: Action.ComposerInsert,
+                text: "Hello world",
+                composerType: ComposerType.Send,
+                timelineRenderingType: TimelineRenderingType.Thread,
+                // Ensure we don't accidentally pick up this emit by strictly checking above.
+                viaTest: true,
+            } satisfies ComposerInsertPayload);
+            await expect(promise).rejects.toThrow();
+        });
+        it("ignores payloads with a timelineRenderingType != TimelineRenderingType.Thread", async () => {
+            await getComponent();
+            const promise = untilDispatch(
+                (payload) => {
+                    try {
+                        expect(payload).toStrictEqual({
+                            action: Action.ComposerInsert,
+                            text: "Hello world",
+                            timelineRenderingType: TimelineRenderingType.Thread,
+                            composerType: ComposerType.Send,
+                        });
+                    } catch {
+                        return false;
+                    }
+                    return true;
+                },
+                defaultDispatcher,
+                500,
+            );
+            defaultDispatcher.dispatch({
+                action: Action.ComposerInsert,
+                text: "Hello world",
+                composerType: ComposerType.Send,
+                timelineRenderingType: TimelineRenderingType.Room,
+                // Ensure we don't accidentally pick up this emit by strictly checking above.
+                viaTest: true,
+            } satisfies ComposerInsertPayload);
+            await expect(promise).rejects.toThrow();
         });
     });
 });

--- a/apps/web/test/unit-tests/components/structures/__snapshots__/RoomView-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/structures/__snapshots__/RoomView-test.tsx.snap
@@ -247,9 +247,9 @@ exports[`RoomView for a local room in state ERROR should match the snapshot 1`] 
           class="_actions_n7ud0_61"
         >
           <button
-            class="_button_13vu4_8 _primaryAction_1xryk_20 _has-icon_13vu4_60"
+            class="_button_1nw83_8 _primaryAction_1xryk_20 _has-icon_1nw83_60"
             data-kind="primary"
-            data-size="sm"
+            data-size="md"
             role="button"
             tabindex="0"
           >
@@ -1062,7 +1062,7 @@ exports[`RoomView invites renders an invite room 1`] = `
           Decline
         </div>
         <button
-          class="_button_13vu4_8 _destructive_13vu4_110"
+          class="_button_1nw83_8 _destructive_1nw83_110"
           data-kind="tertiary"
           data-size="lg"
           role="button"

--- a/apps/web/test/unit-tests/components/structures/__snapshots__/RoomView-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/structures/__snapshots__/RoomView-test.tsx.snap
@@ -247,9 +247,9 @@ exports[`RoomView for a local room in state ERROR should match the snapshot 1`] 
           class="_actions_n7ud0_61"
         >
           <button
-            class="_button_1nw83_8 _primaryAction_1xryk_20 _has-icon_1nw83_60"
+            class="_button_13vu4_8 _primaryAction_1xryk_20 _has-icon_13vu4_60"
             data-kind="primary"
-            data-size="md"
+            data-size="sm"
             role="button"
             tabindex="0"
           >
@@ -1062,7 +1062,7 @@ exports[`RoomView invites renders an invite room 1`] = `
           Decline
         </div>
         <button
-          class="_button_1nw83_8 _destructive_1nw83_110"
+          class="_button_13vu4_8 _destructive_13vu4_110"
           data-kind="tertiary"
           data-size="lg"
           role="button"

--- a/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/EditWysiwygComposer-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/EditWysiwygComposer-test.tsx
@@ -283,8 +283,10 @@ describe("EditWysiwygComposer", () => {
         // It adds the composerType fields where the value refers if the composer is in editing or not
         // The listeners in the RTE ignore the message if the composerType is missing in the payload
         const dispatcherRef = defaultDispatcher.register((payload: ActionPayload) => {
+            const insertPayload = payload as ComposerInsertPayload;
             defaultDispatcher.dispatch<ComposerInsertPayload>({
-                ...(payload as ComposerInsertPayload),
+                ...insertPayload,
+                timelineRenderingType: insertPayload.timelineRenderingType!,
                 composerType: ComposerType.Edit,
             });
         });

--- a/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/SendWysiwygComposer-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/SendWysiwygComposer-test.tsx
@@ -48,11 +48,13 @@ describe("SendWysiwygComposer", () => {
     const registerId = defaultDispatcher.register((payload) => {
         switch (payload.action) {
             case Action.ComposerInsert: {
-                if (payload.composerType) break;
+                const insertPayload = payload as ComposerInsertPayload;
+                if (insertPayload.composerType) break;
 
                 // re-dispatch to the correct composer
                 defaultDispatcher.dispatch<ComposerInsertPayload>({
-                    ...(payload as ComposerInsertPayload),
+                    ...insertPayload,
+                    timelineRenderingType: insertPayload.timelineRenderingType!,
                     composerType: ComposerType.Send,
                 });
                 break;

--- a/apps/web/test/unit-tests/modules/ComposerApi-test.ts
+++ b/apps/web/test/unit-tests/modules/ComposerApi-test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { Action } from "../../../src/dispatcher/actions";
+import type { MatrixDispatcher } from "../../../src/dispatcher/dispatcher";
+import { ComposerApi } from "../../../src/modules/ComposerApi";
+
+describe("ComposerApi", () => {
+    it("should be able to insert text via insertTextIntoComposer()", () => {
+        const dispatcher = {
+            dispatch: jest.fn(),
+        } as unknown as MatrixDispatcher;
+        const api = new ComposerApi(dispatcher);
+        api.insertTextIntoComposer("Hello world");
+        expect(dispatcher.dispatch).toHaveBeenCalledWith({
+            action: Action.ComposerInsert,
+            text: "Hello world",
+        });
+    });
+});

--- a/apps/web/test/unit-tests/modules/ComposerApi-test.ts
+++ b/apps/web/test/unit-tests/modules/ComposerApi-test.ts
@@ -15,7 +15,7 @@ describe("ComposerApi", () => {
             dispatch: jest.fn(),
         } as unknown as MatrixDispatcher;
         const api = new ComposerApi(dispatcher);
-        api.insertTextIntoComposer("Hello world");
+        api.insertPlaintextIntoComposer("Hello world");
         expect(dispatcher.dispatch).toHaveBeenCalledWith({
             action: Action.ComposerInsert,
             text: "Hello world",

--- a/packages/module-api/element-web-module-api.api.md
+++ b/packages/module-api/element-web-module-api.api.md
@@ -47,6 +47,10 @@ export interface Api extends LegacyModuleApiExtension, LegacyCustomisationsApiEx
     // @alpha
     readonly builtins: BuiltinsApi;
     readonly client: ClientApi;
+    // Warning: (ae-forgotten-export) The symbol "ComposerApi" needs to be exported by the entry point index.d.ts
+    //
+    // @alpha
+    readonly composer: ComposerApi;
     readonly config: ConfigApi;
     createRoot(element: Element): Root;
     // @alpha

--- a/packages/module-api/element-web-module-api.api.md
+++ b/packages/module-api/element-web-module-api.api.md
@@ -47,8 +47,6 @@ export interface Api extends LegacyModuleApiExtension, LegacyCustomisationsApiEx
     // @alpha
     readonly builtins: BuiltinsApi;
     readonly client: ClientApi;
-    // Warning: (ae-forgotten-export) The symbol "ComposerApi" needs to be exported by the entry point index.d.ts
-    //
     // @alpha
     readonly composer: ComposerApi;
     readonly config: ConfigApi;
@@ -99,6 +97,11 @@ export interface ClientApi {
 // @alpha @deprecated (undocumented)
 export interface ComponentVisibilityCustomisations {
     shouldShowComponent?(component: "UIComponent.sendInvites" | "UIComponent.roomCreation" | "UIComponent.spaceCreation" | "UIComponent.exploreRooms" | "UIComponent.addIntegrations" | "UIComponent.filterContainer" | "UIComponent.roomOptionsMenu"): boolean;
+}
+
+// @alpha
+export interface ComposerApi {
+    insertTextIntoComposer(text: string): void;
 }
 
 // @public

--- a/packages/module-api/element-web-module-api.api.md
+++ b/packages/module-api/element-web-module-api.api.md
@@ -101,7 +101,7 @@ export interface ComponentVisibilityCustomisations {
 
 // @alpha
 export interface ComposerApi {
-    insertTextIntoComposer(text: string): void;
+    insertPlaintextIntoComposer(plaintext: string): void;
 }
 
 // @public

--- a/packages/module-api/src/api/composer.ts
+++ b/packages/module-api/src/api/composer.ts
@@ -6,15 +6,15 @@ Please see LICENSE files in the repository root for full details.
 */
 
 /**
- * API to alter the message composer.
+ * API to interact with the message composer.
  * @alpha Likely to change
  */
 export interface ComposerApi {
     /**
      * Insert plaintext into the current composer.
-     * @param text - The plain text to insert
+     * @param plaintext - The plain text to insert
      * @returns Returns immediately, does not await action.
      * @alpha Likely to change
      */
-    insertTextIntoComposer(text: string): void;
+    insertPlaintextIntoComposer(plaintext: string): void;
 }

--- a/packages/module-api/src/api/composer.ts
+++ b/packages/module-api/src/api/composer.ts
@@ -1,3 +1,10 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
 /**
  * API to alter the message composer.
  * @alpha Likely to change

--- a/packages/module-api/src/api/composer.ts
+++ b/packages/module-api/src/api/composer.ts
@@ -1,0 +1,13 @@
+/**
+ * API to alter the message composer.
+ * @alpha Likely to change
+ */
+export interface ComposerApi {
+    /**
+     * Insert plaintext into the current composer.
+     * @param text - The plain text to insert
+     * @returns Returns immediately, does not await action.
+     * @alpha Likely to change
+     */
+    insertTextIntoComposer(text: string): void;
+}

--- a/packages/module-api/src/api/index.ts
+++ b/packages/module-api/src/api/index.ts
@@ -23,6 +23,7 @@ import { type ClientApi } from "./client.ts";
 import { type WidgetLifecycleApi } from "./widget-lifecycle.ts";
 import { type WidgetApi } from "./widget.ts";
 import { type CustomisationsApi } from "./customisations.ts";
+import { type ComposerApi } from "./composer.ts";
 
 /**
  * Module interface for modules to implement.
@@ -158,6 +159,12 @@ export interface Api
      * @alpha Subject to change.
      */
     readonly customisations: CustomisationsApi;
+
+    /**
+     * Allows modules to customise the message composer.
+     * @alpha Subject to change.
+     */
+    readonly composer: ComposerApi;
 
     /**
      * Create a ReactDOM root for rendering React components.

--- a/packages/module-api/src/index.ts
+++ b/packages/module-api/src/index.ts
@@ -11,6 +11,7 @@ export type { Config, ConfigApi } from "./api/config";
 export type { I18nApi, Variables, Translations, SubstitutionValue, Tags } from "./api/i18n";
 export type * from "./models/event";
 export type * from "./models/Room";
+export type * from "./api/composer";
 export type * from "./api/custom-components";
 export type * from "./api/extras";
 export type * from "./api/legacy-modules";


### PR DESCRIPTION
Split out from #33166

Part of a series of PRs to extend the Module API for the integrations team.

This one is the smallest change to add the ability to insert text into the composer.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
