### PR TITLE
Promote LaTeX rendering feature to stable

### DIFF
--- a/apps/web/src/settings/Settings.tsx
+++ b/apps/web/src/settings/Settings.tsx
@@ -207,7 +207,7 @@ export interface Settings {
     [Features.NotificationSettings2]: IFeature;
     "feature_msc3531_hide_messages_pending_moderation": IFeature;
     "feature_report_to_moderators": IFeature;
-    "feature_latex_maths": IFeature;
+    "feature_latex_maths": IBaseSetting<boolean>;
     "feature_wysiwyg_composer": IFeature;
     "feature_mjolnir": IFeature;
     "feature_custom_themes": IFeature;
@@ -478,12 +478,10 @@ export const SETTINGS: Settings = {
         default: false,
     },
     "feature_latex_maths": {
-        isFeature: true,
-        labsGroup: LabGroup.Messaging,
         displayName: _td("labs|latex_maths"),
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG_PRIORITISED,
         supportedLevelsAreOrdered: true,
-        default: false,
+        default: true,
     },
     "feature_wysiwyg_composer": {
         isFeature: true,

--- a/docs/labs.md
+++ b/docs/labs.md
@@ -15,10 +15,6 @@ dropped. Ask in the room if you are unclear about any details here.**
 A new version of the "Report" dialog that lets users send abuse reports directly to room moderators,
 if the room supports it.
 
-## Render LaTeX maths in messages (`feature_latex_maths`)
-
-Enables rendering of LaTeX maths in messages using [KaTeX](https://katex.org/). LaTeX between single dollar-signs is interpreted as inline maths and double dollar-signs as display maths (i.e. centred on its own line).
-
 ## Message pinning (`feature_pinning`)
 
 Allows you to pin messages in the room. To pin a message, use the 3 dots to the right of the message


### PR DESCRIPTION
This starts the work on removing the `feature_latex_maths` implementation from labs to stable.


## Outstanding concerns

This does not provide users with any way to *send* LaTeX, so this isn't a full implementation but the the rendering that is implemented is spec compliant.

## Checklist

- [ ] Check that the implementation matches https://spec.matrix.org/latest/client-server-api/#mathematical-messages
- [ ] Test coverage is good
- [ ] Should we remove the feature flag also?