### PR TITLE
Improve session ID handling in OIDC protocol

### DIFF
--- a/apps/desktop/src/protocol.ts
+++ b/apps/desktop/src/protocol.ts
@@ -129,9 +129,11 @@ export default class ProtocolHandler {
                 const store = this.readStore();
                 let sessionId = parsedUrl.searchParams.get(SEARCH_PARAM);
                 if (!sessionId) {
-                    // In OIDC, we must shuttle the value in the `state` param rather than `element-desktop-ssoid`
-                    // We encode it as a suffix like `:element-desktop-ssoid:XXYYZZ`
-                    sessionId = parsedUrl.searchParams.get("state")!.split(`:${SEARCH_PARAM}:`)[1];
+                    // In OIDC, state may be in query string or fragment depending on server implementation
+                    const stateFromQuery = parsedUrl.searchParams.get("state");
+                    const stateFromFragment = new URLSearchParams(parsedUrl.hash.slice(1)).get("state");
+                    const state = stateFromQuery ?? stateFromFragment;
+                    sessionId = state?.split(`:${SEARCH_PARAM}:`)[1];
                 }
                 console.log("Forwarding to profile: ", store[sessionId]);
                 return store[sessionId];


### PR DESCRIPTION
## Summary

`getProfileFromDeeplink` crashes with a null pointer error when the OIDC 
callback URL contains `state` in the URL fragment rather than the query 
string. This causes login to silently fail on Linux when using matrix.org 
as the homeserver.

## Details

RFC 6749 section 4.1.2 specifies that `state` should be returned in the 
query string for the Authorization Code Flow. However, some OIDC servers 
(including matrix.org) return `state` in the URL fragment for native app 
custom scheme callbacks, causing a null pointer crash in 
`getProfileFromDeeplink` when calling `.split()` on a null value.

This change reads `state` from both the query string and the fragment, 
preferring the query string, to handle both compliant and non-compliant 
server implementations gracefully.

Fixes #33328