### PR TITLE
Fix flaky test: Avoid racing the lazy-loaded ManageEventIndexDialog

### DIFF
--- a/apps/web/test/unit-tests/components/views/settings/EventIndexPanel-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/EventIndexPanel-test.tsx
@@ -50,6 +50,8 @@ describe("<EventIndexPanel />", () => {
         });
 
         it("opens event index management dialog", async () => {
+            await import("../../../../../src/async-components/views/dialogs/eventindex/ManageEventIndexDialog");
+
             jest.spyOn(EventIndexPeg, "get").mockReturnValue(new EventIndex());
             getComponent();
 


### PR DESCRIPTION
## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
