### PR TITLE
Make DateUtils test non-timezone dependent

### DIFF
--- a/packages/shared-components/src/core/utils/DateUtils.test.ts
+++ b/packages/shared-components/src/core/utils/DateUtils.test.ts
@@ -9,6 +9,13 @@ import { describe, it, expect } from "vitest";
 
 import { formatSeconds, formatDateForInput } from "./DateUtils";
 
+function makeDate(year: number, month: number, day: number): Date {
+    const date = new Date(0);
+    date.setFullYear(year, month - 1, day);
+    date.setHours(0, 0, 0, 0);
+    return date;
+}
+
 describe("formatSeconds", () => {
     it("correctly formats time with hours", () => {
         expect(formatSeconds(60 * 60 * 3 + 60 * 31 + 55)).toBe("03:31:55");
@@ -26,10 +33,12 @@ describe("formatSeconds", () => {
 });
 
 describe("formatDateForInput", () => {
-    it.each([["1993-11-01"], ["1066-10-14"], ["0571-04-22"], ["0062-02-05"]])(
-        "should format %s",
-        (dateString: string) => {
-            expect(formatDateForInput(new Date(dateString))).toBe(dateString);
-        },
-    );
+    it.each([
+        ["1993-11-01", makeDate(1993, 11, 1)],
+        ["1066-10-14", makeDate(1066, 10, 14)],
+        ["0571-04-22", makeDate(571, 4, 22)],
+        ["0062-02-05", makeDate(62, 2, 5)],
+    ])("should format %s", (dateString: string, date: Date) => {
+        expect(formatDateForInput(date)).toBe(dateString);
+    });
 });


### PR DESCRIPTION
This was failing locally because my dev box is set to local time rather than UTC and so the Date class's special date parsing was interpreting some of the dates as a different day.

Use Date's methods to build the actual date we want so we're not reliant on the date objet's parsing - that's not what we're trying to test.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
