### PR TITLE
Set `type` in auth dict for `m.oauth` UIA stage

### DIFF
--- a/apps/web/src/components/views/auth/InteractiveAuthEntryComponents.tsx
+++ b/apps/web/src/components/views/auth/InteractiveAuthEntryComponents.tsx
@@ -970,7 +970,7 @@ export class MasUnlockCrossSigningAuthEntry extends FallbackAuthEntry<{
     };
 
     private onRetryClick = (): void => {
-        this.props.submitAuthDict({});
+        this.props.submitAuthDict({ type: MasUnlockCrossSigningAuthEntry.LOGIN_TYPE });
     };
 
     public render(): React.ReactNode {

--- a/apps/web/test/unit-tests/components/views/auth/InteractiveAuthEntryComponents-test.tsx
+++ b/apps/web/test/unit-tests/components/views/auth/InteractiveAuthEntryComponents-test.tsx
@@ -96,7 +96,7 @@ describe("<MasUnlockCrossSigningAuthEntry/>", () => {
         renderAuth({ submitAuthDict });
 
         fireEvent.click(screen.getByRole("button", { name: "Retry" }));
-        expect(submitAuthDict).toHaveBeenCalledWith({});
+        expect(submitAuthDict).toHaveBeenCalledWith({ type: AuthType.OAuth });
     });
 });
 


### PR DESCRIPTION
This PR sets the `type` property in the `auth` dict to `m.oauth` when submitting a `MasUnlockCrossSigningAuthEntry` UIA stage. This is necessary for a spec-compliant homeserver to complete the UIA session when using a `m.oauth` stage, which currently is only used by the cross-signing reset endpoint.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
