### PR TITLE
Properly save `undefined` id tokens from OIDC login

### DIFF
--- a/apps/web/src/utils/oidc/authorize.ts
+++ b/apps/web/src/utils/oidc/authorize.ts
@@ -86,7 +86,7 @@ type CompleteOidcLoginResponse = {
     // refreshToken gained from OIDC token issuer, when falsy token cannot be refreshed
     refreshToken?: string;
     // idToken gained from OIDC token issuer
-    idToken: string;
+    idToken?: string;
     // this client's id as registered with the OIDC issuer
     clientId: string;
     // issuer used during authentication

--- a/apps/web/src/utils/oidc/persistOidcSettings.ts
+++ b/apps/web/src/utils/oidc/persistOidcSettings.ts
@@ -25,10 +25,12 @@ const idTokenClaimsStorageKey = "mx_oidc_id_token_claims";
  * @param idToken
  * @param idTokenClaims
  */
-export const persistOidcAuthenticatedSettings = (clientId: string, issuer: string, idToken: string): void => {
+export const persistOidcAuthenticatedSettings = (clientId: string, issuer: string, idToken: string | undefined): void => {
     localStorage.setItem(clientIdStorageKey, clientId);
     localStorage.setItem(tokenIssuerStorageKey, issuer);
-    localStorage.setItem(idTokenStorageKey, idToken);
+    if (idToken) {
+        localStorage.setItem(idTokenStorageKey, idToken);
+    }
 };
 
 /**

--- a/apps/web/src/utils/oidc/persistOidcSettings.ts
+++ b/apps/web/src/utils/oidc/persistOidcSettings.ts
@@ -25,7 +25,11 @@ const idTokenClaimsStorageKey = "mx_oidc_id_token_claims";
  * @param idToken
  * @param idTokenClaims
  */
-export const persistOidcAuthenticatedSettings = (clientId: string, issuer: string, idToken: string | undefined): void => {
+export const persistOidcAuthenticatedSettings = (
+    clientId: string,
+    issuer: string,
+    idToken: string | undefined,
+): void => {
     localStorage.setItem(clientIdStorageKey, clientId);
     localStorage.setItem(tokenIssuerStorageKey, issuer);
     if (idToken) {

--- a/apps/web/test/unit-tests/utils/oidc/persistOidcSettings-test.ts
+++ b/apps/web/test/unit-tests/utils/oidc/persistOidcSettings-test.ts
@@ -53,7 +53,7 @@ describe("persist OIDC settings", () => {
             persistOidcAuthenticatedSettings(clientId, issuer, undefined);
             expect(localStorage.setItem).toHaveBeenCalledWith("mx_oidc_client_id", clientId);
             expect(localStorage.setItem).toHaveBeenCalledWith("mx_oidc_token_issuer", issuer);
-            expect(localStorage.setItem).not.toHaveBeenCalledWith("mx_oidc_id_token", idToken);
+            expect(localStorage.setItem).toHaveBeenCalledTimes(5);
         })
     });
 

--- a/apps/web/test/unit-tests/utils/oidc/persistOidcSettings-test.ts
+++ b/apps/web/test/unit-tests/utils/oidc/persistOidcSettings-test.ts
@@ -53,7 +53,7 @@ describe("persist OIDC settings", () => {
             persistOidcAuthenticatedSettings(clientId, issuer, undefined);
             expect(localStorage.setItem).toHaveBeenCalledWith("mx_oidc_client_id", clientId);
             expect(localStorage.setItem).toHaveBeenCalledWith("mx_oidc_token_issuer", issuer);
-            expect(localStorage.setItem).toHaveBeenCalledTimes(5);
+            expect(localStorage.getItem("mx_oidc_id_token")).toBeFalsy();
         })
     });
 

--- a/apps/web/test/unit-tests/utils/oidc/persistOidcSettings-test.ts
+++ b/apps/web/test/unit-tests/utils/oidc/persistOidcSettings-test.ts
@@ -54,7 +54,7 @@ describe("persist OIDC settings", () => {
             expect(localStorage.setItem).toHaveBeenCalledWith("mx_oidc_client_id", clientId);
             expect(localStorage.setItem).toHaveBeenCalledWith("mx_oidc_token_issuer", issuer);
             expect(localStorage.getItem("mx_oidc_id_token")).toBeFalsy();
-        })
+        });
     });
 
     describe("getStoredOidcTokenIssuer()", () => {

--- a/apps/web/test/unit-tests/utils/oidc/persistOidcSettings-test.ts
+++ b/apps/web/test/unit-tests/utils/oidc/persistOidcSettings-test.ts
@@ -48,6 +48,13 @@ describe("persist OIDC settings", () => {
             expect(localStorage.setItem).toHaveBeenCalledWith("mx_oidc_token_issuer", issuer);
             expect(localStorage.setItem).toHaveBeenCalledWith("mx_oidc_id_token", idToken);
         });
+
+        it("should not set idToken in localStorage when idToken is undefined", () => {
+            persistOidcAuthenticatedSettings(clientId, issuer, undefined);
+            expect(localStorage.setItem).toHaveBeenCalledWith("mx_oidc_client_id", clientId);
+            expect(localStorage.setItem).toHaveBeenCalledWith("mx_oidc_token_issuer", issuer);
+            expect(localStorage.setItem).not.toHaveBeenCalledWith("mx_oidc_id_token", idToken);
+        })
     });
 
     describe("getStoredOidcTokenIssuer()", () => {


### PR DESCRIPTION
This pull request prevents `persistOidcAuthenticatedSettings` from saving the string `"undefined"` in local storage if the OAuth issuer didn't return an ID token. This prevents Element from hanging on startup due to failing to parse `"undefined"` as a JWT.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
