### PR TITLE
Show the right cursor when hovering over a space

### DIFF
--- a/apps/web/res/css/structures/_SpacePanel.pcss
+++ b/apps/web/res/css/structures/_SpacePanel.pcss
@@ -125,7 +125,8 @@ Please see LICENSE files in the repository root for full details.
         align-items: center;
         padding: 4px 4px 4px 0;
         width: 100%;
-        cursor: pointer;
+        /* Override the unlayered cursor: grab; rule from react-beautiful-dnd */
+        cursor: pointer !important;
 
         &.mx_SpaceButton_active {
             &:not(.mx_SpaceButton_narrow) .mx_SpaceButton_selectionWrapper {


### PR DESCRIPTION
Fixes a regression in b0ee6f5323400897dde29b9a715f16f59b91d731 where a 'grab' cursor would be shown when hovering over a space, even though the most salient way to interact with it is by clicking.

|Before|After|
|-|-|
|<img width="137" height="59" alt="Screenshot From 2026-05-01 12-52-05" src="https://github.com/user-attachments/assets/d760de2f-8d9e-4dcb-8a05-97d245ed7318" />|<img width="137" height="59" alt="Screenshot From 2026-05-01 12-51-43" src="https://github.com/user-attachments/assets/dfc38cc4-89f7-4b91-8b40-ae9acd5377ee" />|

Notes: none