### PR TITLE
Remove unused debug logs

### DIFF
--- a/apps/web/src/components/views/rooms/wysiwyg_composer/components/WysiwygAutocomplete.tsx
+++ b/apps/web/src/components/views/rooms/wysiwyg_composer/components/WysiwygAutocomplete.tsx
@@ -8,7 +8,6 @@ Please see LICENSE files in the repository root for full details.
 
 import React, { type JSX, type Ref, type FunctionComponent } from "react";
 import { type FormattingFunctions, type MappedSuggestion } from "@vector-im/matrix-wysiwyg";
-import { logger } from "matrix-js-sdk/src/logger";
 
 import Autocomplete from "../../Autocomplete";
 import { type ICompletion } from "../../../../../autocomplete/Autocompleter";

--- a/apps/web/src/components/views/rooms/wysiwyg_composer/components/WysiwygAutocomplete.tsx
+++ b/apps/web/src/components/views/rooms/wysiwyg_composer/components/WysiwygAutocomplete.tsx
@@ -111,8 +111,6 @@ const WysiwygAutocomplete = ({
     if (!room) return null;
 
     const autoCompleteQuery = buildQuery(suggestion);
-    // debug for https://github.com/vector-im/element-web/issues/26037
-    logger.log(`## 26037 ## Rendering Autocomplete for WysiwygAutocomplete with query: "${autoCompleteQuery}"`);
 
     // TODO - determine if we show all of the /command suggestions, there are some options in the
     // list which don't seem to make sense in this context, specifically /html and /plain

--- a/apps/web/src/components/views/rooms/wysiwyg_composer/hooks/useSuggestion.ts
+++ b/apps/web/src/components/views/rooms/wysiwyg_composer/hooks/useSuggestion.ts
@@ -8,8 +8,7 @@ Please see LICENSE files in the repository root for full details.
 
 import { EMOTICON_TO_EMOJI } from "@matrix-org/emojibase-bindings";
 import { type AllowedMentionAttributes, type MappedSuggestion } from "@vector-im/matrix-wysiwyg";
-import { type SyntheticEvent, useState, type SetStateAction } from "react";
-import { logger } from "matrix-js-sdk/src/logger";
+import { type SyntheticEvent, useState } from "react";
 
 import { isNotNull } from "../../../../../Typeguards";
 

--- a/apps/web/src/components/views/rooms/wysiwyg_composer/hooks/useSuggestion.ts
+++ b/apps/web/src/components/views/rooms/wysiwyg_composer/hooks/useSuggestion.ts
@@ -57,20 +57,7 @@ export function useSuggestion(
     onSelect: (event: SyntheticEvent<HTMLDivElement>) => void;
     suggestion: MappedSuggestion | null;
 } {
-    const [suggestionData, setSuggestionData0] = useState<SuggestionState>(null);
-
-    // debug for https://github.com/vector-im/element-web/issues/26037
-    const setSuggestionData = (suggestionData: SetStateAction<SuggestionState>): void => {
-        // setState allows either the data itself or a callback which returns the data
-        logger.log(
-            `## 26037 ## wysiwyg useSuggestion hook setting suggestion data to ${
-                suggestionData === null || suggestionData instanceof Function
-                    ? suggestionData
-                    : suggestionData.mappedSuggestion.keyChar + suggestionData.mappedSuggestion.text
-            }`,
-        );
-        setSuggestionData0(suggestionData);
-    };
+    const [suggestionData, setSuggestionData] = useState<SuggestionState>(null);
 
     // We create a `selectionchange` handler here because we need to know when the user has moved the cursor,
     // we can not depend on input events only


### PR DESCRIPTION
I noticed this was popping up for https://github.com/vector-im/element-web/issues/26037, which has been closed for some time.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
