### PR TITLE
Web: Fix typo in `152x152` icon source of `manifest.json`

### DIFF
--- a/apps/web/res/manifest.json
+++ b/apps/web/res/manifest.json
@@ -21,7 +21,7 @@
             "type": "image/png"
         },
         {
-            "src": "/vector-icons/152png",
+            "src": "/vector-icons/152.png",
             "sizes": "152x152",
             "type": "image/png"
         },


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
