### PR TITLE
Visually indicate on hover that user menu can be clicked

### DIFF
--- a/apps/web/test/unit-tests/components/views/spaces/__snapshots__/SpacePanel-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/spaces/__snapshots__/SpacePanel-test.tsx.snap
@@ -10,7 +10,7 @@ exports[`<SpacePanel /> should show all activated MetaSpaces in the correct orde
       aria-expanded="false"
       aria-haspopup="menu"
       aria-label="User menu"
-      class="_triggerButton_3x4xf_50"
+      class="_triggerButton_1ejl3_50"
       data-state="closed"
       id="radix-_r_0_"
       type="button"

--- a/packages/shared-components/src/menus/UserMenu/UserMenu.module.css
+++ b/packages/shared-components/src/menus/UserMenu/UserMenu.module.css
@@ -52,6 +52,7 @@
     background: none;
     display: flex;
     color: var(--cpd-color-body-primary);
+    cursor: pointer;
     gap: var(--cpd-space-2x);
     > span {
         height: fit-content;


### PR DESCRIPTION
Seems the `cursor: pointer` style was lost in #32812.

<img width="169" height="126" alt="Screenshot From 2026-05-06 15-36-04" src="https://github.com/user-attachments/assets/54edeac3-1fef-4659-bd2d-7925f0b77a49" />

Notes: none