### PR TITLE
Make sonarcloud happier

### DIFF
--- a/.github/workflows/build_desktop_prepare.yaml
+++ b/.github/workflows/build_desktop_prepare.yaml
@@ -170,7 +170,7 @@ jobs:
               run: |
                   set -e
 
-                  BUNDLE_HASH=$(npx asar l webapp.asar | grep /bundles/ | head -n 1 | sed 's|.*/||')
+                  BUNDLE_HASH=$(pnpm exec asar l webapp.asar | grep /bundles/ | head -n 1 | sed 's|.*/||')
                   WEBAPP_VERSION=$(./scripts/get-version.ts)
                   WEB_VERSION=${WEBAPP_VERSION:0:12}
                   JS_VERSION=${WEBAPP_VERSION:16:12}

--- a/.github/workflows/build_desktop_test.yaml
+++ b/.github/workflows/build_desktop_test.yaml
@@ -75,7 +75,7 @@ jobs:
             # We previously disabled the `EnableNodeCliInspectArguments` fuse, but Playwright requires
             # it to be enabled to test Electron apps, so turn it back on.
             - name: Set EnableNodeCliInspectArguments fuse enabled
-              run: $RUN_AS npx @electron/fuses write --app "$EXECUTABLE" EnableNodeCliInspectArguments=on
+              run: $RUN_AS pnpm exec electron-fuses write --app "$EXECUTABLE" EnableNodeCliInspectArguments=on
               working-directory: apps/desktop
               shell: bash
               env:

--- a/.github/workflows/build_desktop_test.yaml
+++ b/.github/workflows/build_desktop_test.yaml
@@ -80,7 +80,7 @@ jobs:
               shell: bash
               env:
                   # We need sudo on Linux as it is installed in /opt/
-                  RUN_AS: ${{ runner.os == 'Linux' && 'sudo' || '' }}
+                  RUN_AS: ${{ runner.os == 'Linux' && 'sudo -E' || '' }}
                   EXECUTABLE: ${{ steps.executable.outputs.path }}
 
             - name: Run tests

--- a/.github/workflows/build_desktop_test.yaml
+++ b/.github/workflows/build_desktop_test.yaml
@@ -42,6 +42,7 @@ jobs:
                   persist-credentials: false
 
             - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+              id: pnpm
             - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version-file: apps/desktop/.node-version
@@ -75,12 +76,13 @@ jobs:
             # We previously disabled the `EnableNodeCliInspectArguments` fuse, but Playwright requires
             # it to be enabled to test Electron apps, so turn it back on.
             - name: Set EnableNodeCliInspectArguments fuse enabled
-              run: $RUN_AS pnpm exec electron-fuses write --app "$EXECUTABLE" EnableNodeCliInspectArguments=on
+              run: $RUN_AS $PNPM_PATH/pnpm exec electron-fuses write --app "$EXECUTABLE" EnableNodeCliInspectArguments=on
               working-directory: apps/desktop
               shell: bash
               env:
                   # We need sudo on Linux as it is installed in /opt/
-                  RUN_AS: ${{ runner.os == 'Linux' && 'sudo -E' || '' }}
+                  RUN_AS: ${{ runner.os == 'Linux' && 'sudo' || '' }}
+                  PNPM_PATH: ${{ steps.pnpm.outputs.bin_dest }}
                   EXECUTABLE: ${{ steps.executable.outputs.path }}
 
             - name: Run tests

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -35,10 +35,6 @@ jobs:
                   node-version-file: ".node-version"
                   registry-url: "https://registry.npmjs.org"
 
-            # Ensure npm 11.5.1 or later is installed
-            - name: Update npm
-              run: npm install -g npm@latest
-
             - name: 🛠️ Install dependencies
               run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
Remove manual npm update in workflow - no longer necessary
Use already installed deps instead of npx