### PR TITLE
Remove matrix-js-sdk from onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "pnpm": {
         "onlyBuiltDependencies": [],
         "ignoredBuiltDependencies": [
+            "matrix-js-sdk",
             "@sentry/cli",
             "nx"
         ],

--- a/package.json
+++ b/package.json
@@ -46,9 +46,7 @@
         "yaml": "^2.3.3"
     },
     "pnpm": {
-        "onlyBuiltDependencies": [
-            "matrix-js-sdk"
-        ],
+        "onlyBuiltDependencies": [],
         "ignoredBuiltDependencies": [
             "@sentry/cli",
             "nx"


### PR DESCRIPTION
We don't actually need to build it, and this just wastes CI time