### PR TITLE
Room list: add robustness to custom section loading

### DIFF
--- a/apps/web/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/apps/web/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -128,6 +128,7 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
         });
         SpaceStore.instance.on(UPDATE_HOME_BEHAVIOUR, () => this.onActiveSpaceChanged());
         SettingsStore.watchSetting("RoomList.OrderedCustomSections", null, () => this.onOrderedCustomSectionsChange());
+        this.loadCustomSections();
     }
 
     /**
@@ -199,8 +200,6 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
 
     protected async onReady(): Promise<any> {
         if (this.roomSkipList?.initialized || !this.matrixClient) return;
-        await this.loadCustomSections();
-
         const sorter = this.getPreferredSorter(this.matrixClient.getSafeUserId());
 
         this.roomSkipList = new RoomSkipList(sorter, this.getSkipListFilters());
@@ -522,8 +521,8 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
     /**
      * Load the custom sections from the settings store and update the sorted tags.
      */
-    private async loadCustomSections(): Promise<void> {
-        const orderedCustomSections = await getOrderedCustomSections();
+    private loadCustomSections(): void {
+        const orderedCustomSections = getOrderedCustomSections();
         this.sortedTags = [DefaultTagID.Favourite, ...orderedCustomSections, CHATS_TAG, DefaultTagID.LowPriority];
     }
 }

--- a/apps/web/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/apps/web/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -40,7 +40,7 @@ import { DefaultTagID } from "./skip-list/tag";
 import { ExcludeTagsFilter } from "./skip-list/filters/ExcludeTagsFilter";
 import { TagFilter } from "./skip-list/filters/TagFilter";
 import { filterBoolean } from "../../utils/arrays";
-import { CHATS_TAG, createSection, deleteSection, editSection } from "./section";
+import { CHATS_TAG, createSection, deleteSection, editSection, getOrderedCustomSections } from "./section";
 
 /**
  * These are the filters passed to the room skip list.
@@ -522,7 +522,7 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
      * Load the custom sections from the settings store and update the sorted tags.
      */
     private loadCustomSections(): void {
-        const orderedCustomSections = SettingsStore.getValue("RoomList.OrderedCustomSections");
+        const orderedCustomSections = getOrderedCustomSections();
         this.sortedTags = [DefaultTagID.Favourite, ...orderedCustomSections, CHATS_TAG, DefaultTagID.LowPriority];
     }
 }

--- a/apps/web/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/apps/web/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -474,8 +474,8 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
      * Reloads the custom sections, updates the skip list filters to reflect the new order and emits an update.
      * Emit {@link LISTS_UPDATE_EVENT}.
      */
-    private async onOrderedCustomSectionsChange(): Promise<void> {
-        await this.loadCustomSections();
+    private onOrderedCustomSectionsChange(): void {
+        this.loadCustomSections();
         if (!this.roomSkipList) return;
         this.roomSkipList.useNewFilters(this.getSkipListFilters());
         this.scheduleEmit();

--- a/apps/web/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/apps/web/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -128,7 +128,6 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
         });
         SpaceStore.instance.on(UPDATE_HOME_BEHAVIOUR, () => this.onActiveSpaceChanged());
         SettingsStore.watchSetting("RoomList.OrderedCustomSections", null, () => this.onOrderedCustomSectionsChange());
-        this.loadCustomSections();
     }
 
     /**
@@ -200,6 +199,8 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
 
     protected async onReady(): Promise<any> {
         if (this.roomSkipList?.initialized || !this.matrixClient) return;
+        await this.loadCustomSections();
+
         const sorter = this.getPreferredSorter(this.matrixClient.getSafeUserId());
 
         this.roomSkipList = new RoomSkipList(sorter, this.getSkipListFilters());
@@ -474,8 +475,8 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
      * Reloads the custom sections, updates the skip list filters to reflect the new order and emits an update.
      * Emit {@link LISTS_UPDATE_EVENT}.
      */
-    private onOrderedCustomSectionsChange(): void {
-        this.loadCustomSections();
+    private async onOrderedCustomSectionsChange(): Promise<void> {
+        await this.loadCustomSections();
         if (!this.roomSkipList) return;
         this.roomSkipList.useNewFilters(this.getSkipListFilters());
         this.scheduleEmit();
@@ -521,8 +522,8 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
     /**
      * Load the custom sections from the settings store and update the sorted tags.
      */
-    private loadCustomSections(): void {
-        const orderedCustomSections = getOrderedCustomSections();
+    private async loadCustomSections(): Promise<void> {
+        const orderedCustomSections = await getOrderedCustomSections();
         this.sortedTags = [DefaultTagID.Favourite, ...orderedCustomSections, CHATS_TAG, DefaultTagID.LowPriority];
     }
 }

--- a/apps/web/src/stores/room-list-v3/section.ts
+++ b/apps/web/src/stores/room-list-v3/section.ts
@@ -14,8 +14,6 @@ import { CreateSectionDialog } from "../../components/views/dialogs/CreateSectio
 import { RemoveSectionDialog } from "../../components/views/dialogs/RemoveSectionDialog";
 import { DefaultTagID, type TagID } from "./skip-list/tag";
 
-type Tag = string;
-
 /**
  * A synthetic tag used to represent the "Chats" section, which contains
  * every room that does not belong to any other explicit tag section.
@@ -27,12 +25,14 @@ export const CHATS_TAG = "chats";
  */
 export const CUSTOM_SECTION_TAG_PREFIX = "element.io.section.";
 
+type CustomTag = `${typeof CUSTOM_SECTION_TAG_PREFIX}${string}`;
+
 /**
  * Checks if a given tag is a custom section tag.
  * @param tag - The tag to check.
  * @returns True if the tag is a custom section tag, false otherwise.
  */
-export function isCustomSectionTag(tag: string): boolean {
+export function isCustomSectionTag(tag: string): tag is CustomTag {
     return tag.startsWith(CUSTOM_SECTION_TAG_PREFIX);
 }
 
@@ -58,24 +58,57 @@ export function isSectionTag(tagId: TagID): boolean {
  * Structure of the custom section stored in the settings. The tag is used as a unique identifier for the section, and the name is given by the user.
  */
 type CustomSection = {
-    tag: Tag;
+    tag: CustomTag;
     name: string;
 };
 
 /**
+ * Type guard to check if a value is a valid CustomSection object.
+ */
+function isValidCustomSection(value: unknown): value is CustomSection {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        isCustomSectionTag((value as Record<string, unknown>).tag as string) &&
+        typeof (value as Record<string, unknown>).name === "string"
+    );
+}
+
+/**
  * The custom sections data is stored as a record in the settings, where the key is the section tag and the value is the section data (name and tag).
  */
-export type CustomSectionsData = Record<Tag, CustomSection>;
+export type CustomSectionsData = Record<CustomTag, CustomSection>;
 /**
  * Ordered list of custom section tags.
  */
-export type OrderedCustomSections = Tag[];
+export type OrderedCustomSections = CustomTag[];
 
 /**
  * Retrieves the custom sections data from the settings.
+ * Invalid or malformed entries are dropped and the cleaned data is persisted back to settings.
  */
 export function getCustomSectionData(): CustomSectionsData {
-    return SettingsStore.getValue("RoomList.CustomSectionData") ?? {};
+    const raw = SettingsStore.getValue("RoomList.CustomSectionData");
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+        // The data is malformed, reset it in background
+        SettingsStore.setValue("RoomList.CustomSectionData", null, SettingLevel.ACCOUNT, {});
+        return {};
+    }
+
+    const result: CustomSectionsData = {};
+    let hasInvalid = false;
+    for (const [key, value] of Object.entries(raw)) {
+        if (!isValidCustomSection(value) || value.tag !== key) {
+            logger.warn("Dropping invalid custom section", key, value);
+            hasInvalid = true;
+            continue;
+        }
+        result[key as CustomTag] = value;
+    }
+    // If there were invalid entries, persist the cleaned data back to settings
+    if (hasInvalid) SettingsStore.setValue("RoomList.CustomSectionData", null, SettingLevel.ACCOUNT, result);
+
+    return result;
 }
 
 /**
@@ -106,7 +139,7 @@ export async function createSection(): Promise<string | undefined> {
     const [shouldCreateSection, sectionName] = await modal.finished;
     if (!shouldCreateSection || !sectionName) return undefined;
 
-    const tag = `${CUSTOM_SECTION_TAG_PREFIX}${window.crypto.randomUUID()}`;
+    const tag: CustomTag = `${CUSTOM_SECTION_TAG_PREFIX}${window.crypto.randomUUID()}`;
     const newSection: CustomSection = { tag, name: sectionName };
 
     // Save the new section data
@@ -126,6 +159,10 @@ export async function createSection(): Promise<string | undefined> {
  * @param tag - The tag of the section to edit.
  */
 export async function editSection(tag: string): Promise<void> {
+    if (!isCustomSectionTag(tag)) {
+        logger.info("Unknown section tag, cannot edit section", tag);
+        return;
+    }
     const sectionData = getCustomSectionData();
     const section = sectionData[tag];
     if (!section) {
@@ -150,6 +187,10 @@ export async function editSection(tag: string): Promise<void> {
  * @param isEmpty - Whether the section is empty (has no rooms). If the section is not empty, the confirmation dialog will show a warning message.
  */
 export async function deleteSection(tag: string, isEmpty: boolean): Promise<void> {
+    if (!isCustomSectionTag(tag)) {
+        logger.info("Unknown section tag, cannot delete section", tag);
+        return;
+    }
     const sectionData = getCustomSectionData();
     if (!sectionData[tag]) {
         logger.info("Unknown section tag, cannot delete section", tag);

--- a/apps/web/src/stores/room-list-v3/section.ts
+++ b/apps/web/src/stores/room-list-v3/section.ts
@@ -80,9 +80,18 @@ export function getCustomSectionData(): CustomSectionsData {
 
 /**
  * Retrieves the ordered list of custom section tags from the settings.
+ * If the settings contain tags that are not present in the custom section data, they will be filtered out and the settings will be updated to remove the unknown tags.
  */
-export function getOrderedCustomSections(): OrderedCustomSections {
-    return SettingsStore.getValue("RoomList.OrderedCustomSections") ?? [];
+export async function getOrderedCustomSections(): Promise<OrderedCustomSections> {
+    const sectionData = getCustomSectionData();
+    const rawValue = SettingsStore.getValue("RoomList.OrderedCustomSections");
+    const orderedSections: OrderedCustomSections = Array.isArray(rawValue) ? rawValue : [];
+    const knownSections = orderedSections.filter((tag) => tag in sectionData);
+    if (knownSections.length !== orderedSections.length) {
+        // Some sections were not found in the section data
+        await SettingsStore.setValue("RoomList.OrderedCustomSections", null, SettingLevel.ACCOUNT, knownSections);
+    }
+    return knownSections;
 }
 
 /**
@@ -106,7 +115,7 @@ export async function createSection(): Promise<string | undefined> {
     await SettingsStore.setValue("RoomList.CustomSectionData", null, SettingLevel.ACCOUNT, sectionData);
 
     // Add the new section to the ordered list of sections
-    const orderedSections = SettingsStore.getValue("RoomList.OrderedCustomSections") || [];
+    const orderedSections = await getOrderedCustomSections();
     orderedSections.push(tag);
     await SettingsStore.setValue("RoomList.OrderedCustomSections", null, SettingLevel.ACCOUNT, orderedSections);
     return tag;
@@ -152,8 +161,7 @@ export async function deleteSection(tag: string, isEmpty: boolean): Promise<void
     if (!shouldRemoveSection) return;
 
     // Remove the section from the ordered list of sections
-    const orderedSections = SettingsStore.getValue("RoomList.OrderedCustomSections");
-    const newOrderedSections = orderedSections.filter((sectionTag) => sectionTag !== tag);
+    const newOrderedSections = (await getOrderedCustomSections()).filter((sectionTag) => sectionTag !== tag);
     await SettingsStore.setValue("RoomList.OrderedCustomSections", null, SettingLevel.ACCOUNT, newOrderedSections);
 
     // Remove the section data

--- a/apps/web/src/stores/room-list-v3/section.ts
+++ b/apps/web/src/stores/room-list-v3/section.ts
@@ -72,6 +72,20 @@ export type CustomSectionsData = Record<Tag, CustomSection>;
 export type OrderedCustomSections = Tag[];
 
 /**
+ * Retrieves the custom sections data from the settings.
+ */
+export function getCustomSectionData(): CustomSectionsData {
+    return SettingsStore.getValue("RoomList.CustomSectionData") ?? {};
+}
+
+/**
+ * Retrieves the ordered list of custom section tags from the settings.
+ */
+export function getOrderedCustomSections(): OrderedCustomSections {
+    return SettingsStore.getValue("RoomList.OrderedCustomSections") ?? [];
+}
+
+/**
  * Creates a new custom section by showing a dialog to the user to enter the section name.
  * If the user confirms, it generates a unique tag for the section, saves the section data in the settings, and updates the ordered list of sections.
  *
@@ -87,7 +101,7 @@ export async function createSection(): Promise<string | undefined> {
     const newSection: CustomSection = { tag, name: sectionName };
 
     // Save the new section data
-    const sectionData = SettingsStore.getValue("RoomList.CustomSectionData") || {};
+    const sectionData = getCustomSectionData();
     sectionData[tag] = newSection;
     await SettingsStore.setValue("RoomList.CustomSectionData", null, SettingLevel.ACCOUNT, sectionData);
 
@@ -103,7 +117,7 @@ export async function createSection(): Promise<string | undefined> {
  * @param tag - The tag of the section to edit.
  */
 export async function editSection(tag: string): Promise<void> {
-    const sectionData = SettingsStore.getValue("RoomList.CustomSectionData") || {};
+    const sectionData = getCustomSectionData();
     const section = sectionData[tag];
     if (!section) {
         logger.info("Unknown section tag, cannot edit section", tag);
@@ -127,7 +141,7 @@ export async function editSection(tag: string): Promise<void> {
  * @param isEmpty - Whether the section is empty (has no rooms). If the section is not empty, the confirmation dialog will show a warning message.
  */
 export async function deleteSection(tag: string, isEmpty: boolean): Promise<void> {
-    const sectionData = SettingsStore.getValue("RoomList.CustomSectionData");
+    const sectionData = getCustomSectionData();
     if (!sectionData[tag]) {
         logger.info("Unknown section tag, cannot delete section", tag);
         return;

--- a/apps/web/src/stores/room-list-v3/section.ts
+++ b/apps/web/src/stores/room-list-v3/section.ts
@@ -89,42 +89,24 @@ export type OrderedCustomSections = CustomTag[];
  */
 export function getCustomSectionData(): CustomSectionsData {
     const raw = SettingsStore.getValue("RoomList.CustomSectionData");
-    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
-        // The data is malformed, reset it in background
-        SettingsStore.setValue("RoomList.CustomSectionData", null, SettingLevel.ACCOUNT, {});
-        return {};
-    }
+    // Data are malformed
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return {};
 
-    const result: CustomSectionsData = {};
-    let hasInvalid = false;
-    for (const [key, value] of Object.entries(raw)) {
-        if (!isValidCustomSection(value) || value.tag !== key) {
-            logger.warn("Dropping invalid custom section", key, value);
-            hasInvalid = true;
-            continue;
-        }
-        result[key as CustomTag] = value;
-    }
-    // If there were invalid entries, persist the cleaned data back to settings
-    if (hasInvalid) SettingsStore.setValue("RoomList.CustomSectionData", null, SettingLevel.ACCOUNT, result);
-
-    return result;
+    // Filter out invalid entries
+    return Object.fromEntries(
+        Object.entries(raw).filter(([key, value]) => isValidCustomSection(value) && value.tag === key),
+    ) as CustomSectionsData;
 }
 
 /**
  * Retrieves the ordered list of custom section tags from the settings.
  * If the settings contain tags that are not present in the custom section data, they will be filtered out and the settings will be updated to remove the unknown tags.
  */
-export async function getOrderedCustomSections(): Promise<OrderedCustomSections> {
+export function getOrderedCustomSections(): OrderedCustomSections {
     const sectionData = getCustomSectionData();
     const rawValue = SettingsStore.getValue("RoomList.OrderedCustomSections");
     const orderedSections: OrderedCustomSections = Array.isArray(rawValue) ? rawValue : [];
-    const knownSections = orderedSections.filter((tag) => tag in sectionData);
-    if (knownSections.length !== orderedSections.length) {
-        // Some sections were not found in the section data
-        await SettingsStore.setValue("RoomList.OrderedCustomSections", null, SettingLevel.ACCOUNT, knownSections);
-    }
-    return knownSections;
+    return orderedSections.filter((tag) => tag in sectionData);
 }
 
 /**
@@ -148,7 +130,7 @@ export async function createSection(): Promise<string | undefined> {
     await SettingsStore.setValue("RoomList.CustomSectionData", null, SettingLevel.ACCOUNT, sectionData);
 
     // Add the new section to the ordered list of sections
-    const orderedSections = await getOrderedCustomSections();
+    const orderedSections = getOrderedCustomSections();
     orderedSections.push(tag);
     await SettingsStore.setValue("RoomList.OrderedCustomSections", null, SettingLevel.ACCOUNT, orderedSections);
     return tag;
@@ -202,7 +184,7 @@ export async function deleteSection(tag: string, isEmpty: boolean): Promise<void
     if (!shouldRemoveSection) return;
 
     // Remove the section from the ordered list of sections
-    const newOrderedSections = (await getOrderedCustomSections()).filter((sectionTag) => sectionTag !== tag);
+    const newOrderedSections = getOrderedCustomSections().filter((sectionTag) => sectionTag !== tag);
     await SettingsStore.setValue("RoomList.OrderedCustomSections", null, SettingLevel.ACCOUNT, newOrderedSections);
 
     // Remove the section data

--- a/apps/web/src/viewmodels/room-list/RoomListItemViewModel.ts
+++ b/apps/web/src/viewmodels/room-list/RoomListItemViewModel.ts
@@ -39,8 +39,8 @@ import type { ViewRoomPayload } from "../../dispatcher/payloads/ViewRoomPayload"
 import PosthogTrackers from "../../PosthogTrackers";
 import { type Call, CallEvent } from "../../models/Call";
 import RoomListStoreV3 from "../../stores/room-list-v3/RoomListStoreV3";
+import { getCustomSectionData, isDefaultSectionTag } from "../../stores/room-list-v3/section";
 import { _t } from "../../languageHandler";
-import { isDefaultSectionTag } from "../../stores/room-list-v3/section";
 
 interface RoomItemProps {
     room: Room;
@@ -424,7 +424,7 @@ export class RoomListItemViewModel
      * Order follows the canonical section order from RoomListStoreV3.
      */
     private static buildSections(roomTags: Room["tags"]): Section[] {
-        const customSectionData = SettingsStore.getValue("RoomList.CustomSectionData") || {};
+        const customSectionData = getCustomSectionData();
 
         return (
             RoomListStoreV3.instance.orderedSectionTags

--- a/apps/web/src/viewmodels/room-list/RoomListSectionHeaderViewModel.ts
+++ b/apps/web/src/viewmodels/room-list/RoomListSectionHeaderViewModel.ts
@@ -17,7 +17,7 @@ import { NotificationStateEvents } from "../../stores/notifications/Notification
 import { type RoomNotificationState } from "../../stores/notifications/RoomNotificationState";
 import SettingsStore from "../../settings/SettingsStore";
 import RoomListStoreV3 from "../../stores/room-list-v3/RoomListStoreV3";
-import { getCustomSectionData, isDefaultSectionTag } from "../../stores/room-list-v3/section";
+import { getCustomSectionData, isCustomSectionTag, isDefaultSectionTag } from "../../stores/room-list-v3/section";
 
 interface RoomListSectionHeaderViewModelProps {
     tag: string;
@@ -139,7 +139,7 @@ export class RoomListSectionHeaderViewModel
      * Handle changes to custom section data.
      */
     private onCustomSectionDataChange(): void {
-        const sectionData = getCustomSectionData()[this.props.tag];
+        const sectionData = isCustomSectionTag(this.props.tag) ? getCustomSectionData()[this.props.tag] : undefined;
         if (sectionData) {
             this.snapshot.merge({ title: sectionData.name });
         }

--- a/apps/web/src/viewmodels/room-list/RoomListSectionHeaderViewModel.ts
+++ b/apps/web/src/viewmodels/room-list/RoomListSectionHeaderViewModel.ts
@@ -17,7 +17,7 @@ import { NotificationStateEvents } from "../../stores/notifications/Notification
 import { type RoomNotificationState } from "../../stores/notifications/RoomNotificationState";
 import SettingsStore from "../../settings/SettingsStore";
 import RoomListStoreV3 from "../../stores/room-list-v3/RoomListStoreV3";
-import { isDefaultSectionTag } from "../../stores/room-list-v3/section";
+import { getCustomSectionData, isDefaultSectionTag } from "../../stores/room-list-v3/section";
 
 interface RoomListSectionHeaderViewModelProps {
     tag: string;
@@ -139,8 +139,7 @@ export class RoomListSectionHeaderViewModel
      * Handle changes to custom section data.
      */
     private onCustomSectionDataChange(): void {
-        const customSectionData = SettingsStore.getValue("RoomList.CustomSectionData") || {};
-        const sectionData = customSectionData[this.props.tag];
+        const sectionData = getCustomSectionData()[this.props.tag];
         if (sectionData) {
             this.snapshot.merge({ title: sectionData.name });
         }

--- a/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
+++ b/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
@@ -36,11 +36,10 @@ import { hasCreateRoomRights } from "./utils";
 import { keepIfSame } from "../../utils/keepIfSame";
 import { DefaultTagID } from "../../stores/room-list-v3/skip-list/tag";
 import { RoomListSectionHeaderViewModel } from "./RoomListSectionHeaderViewModel";
-import { getCustomSectionData } from "../../stores/room-list-v3/section";
+import { getCustomSectionData, isCustomSectionTag, CHATS_TAG } from "../../stores/room-list-v3/section";
 import SettingsStore from "../../settings/SettingsStore";
 import { tagRoom } from "../../utils/room/tagRoom";
 import { getSectionTagForRoom } from "../../utils/room/getSectionTagForRoom";
-import { CHATS_TAG } from "../../stores/room-list-v3/section";
 
 /**
  * Tracks the position of the active room within a specific section.
@@ -288,7 +287,7 @@ export class RoomListViewModel
     public getSectionHeaderViewModel(tag: string): RoomListSectionHeaderViewModel {
         if (this.roomSectionHeaderViewModels.has(tag)) return this.roomSectionHeaderViewModels.get(tag)!;
 
-        const title = TAG_TO_TITLE_MAP[tag] || getCustomSectionData()[tag]?.name || tag;
+        const title = TAG_TO_TITLE_MAP[tag] || (isCustomSectionTag(tag) && getCustomSectionData()[tag]?.name) || tag;
         const viewModel = new RoomListSectionHeaderViewModel({
             tag,
             title,
@@ -696,7 +695,9 @@ function computeSections(
 
     const sections = roomsResult.sections
         // Only include sections that have rooms or are custom sections (which may be empty but should still be shown)
-        .filter((section) => section.rooms.length > 0 || customSections[section.tag])
+        .filter(
+            (section) => section.rooms.length > 0 || (isCustomSectionTag(section.tag) && customSections[section.tag]),
+        )
         // Remove roomIds for sections that are currently collapsed according to their section header view model
         .map((section) => ({
             ...section,

--- a/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
+++ b/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
@@ -36,6 +36,7 @@ import { hasCreateRoomRights } from "./utils";
 import { keepIfSame } from "../../utils/keepIfSame";
 import { DefaultTagID } from "../../stores/room-list-v3/skip-list/tag";
 import { RoomListSectionHeaderViewModel } from "./RoomListSectionHeaderViewModel";
+import { getCustomSectionData } from "../../stores/room-list-v3/section";
 import SettingsStore from "../../settings/SettingsStore";
 import { tagRoom } from "../../utils/room/tagRoom";
 import { getSectionTagForRoom } from "../../utils/room/getSectionTagForRoom";
@@ -287,8 +288,7 @@ export class RoomListViewModel
     public getSectionHeaderViewModel(tag: string): RoomListSectionHeaderViewModel {
         if (this.roomSectionHeaderViewModels.has(tag)) return this.roomSectionHeaderViewModels.get(tag)!;
 
-        const customSections = SettingsStore.getValue("RoomList.CustomSectionData");
-        const title = TAG_TO_TITLE_MAP[tag] || customSections[tag]?.name || tag;
+        const title = TAG_TO_TITLE_MAP[tag] || getCustomSectionData()[tag]?.name || tag;
         const viewModel = new RoomListSectionHeaderViewModel({
             tag,
             title,
@@ -692,7 +692,7 @@ function computeSections(
     roomsResult: RoomsResult,
     isSectionExpanded: (tag: string) => boolean,
 ): { sections: Section[]; isFlatList: boolean } {
-    const customSections = SettingsStore.getValue("RoomList.CustomSectionData");
+    const customSections = getCustomSectionData();
 
     const sections = roomsResult.sections
         // Only include sections that have rooms or are custom sections (which may be empty but should still be shown)

--- a/apps/web/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
+++ b/apps/web/test/unit-tests/stores/room-list-v3/RoomListStoreV3-test.ts
@@ -833,6 +833,7 @@ describe("RoomListStoreV3", () => {
             jest.spyOn(SettingsStore, "getValue").mockImplementation((setting: string) => {
                 if (setting === "feature_room_list_sections") return true;
                 if (setting === "RoomList.OrderedCustomSections") return [];
+                if (setting === "RoomList.CustomSectionData") return {};
                 return false;
             });
         }
@@ -1093,6 +1094,7 @@ describe("RoomListStoreV3", () => {
             jest.spyOn(SettingsStore, "getValue").mockImplementation((setting: string) => {
                 if (setting === "feature_room_list_sections") return true;
                 if (setting === "RoomList.OrderedCustomSections") return [];
+                if (setting === "RoomList.CustomSectionData") return {};
                 return false;
             });
 
@@ -1107,11 +1109,13 @@ describe("RoomListStoreV3", () => {
             jest.spyOn(SettingsStore, "getValue").mockImplementation((setting: string) => {
                 if (setting === "feature_room_list_sections") return true;
                 if (setting === "RoomList.OrderedCustomSections") return [customTag];
+                if (setting === "RoomList.CustomSectionData")
+                    return { [customTag]: { tag: customTag, name: "Custom" } };
                 return false;
             });
 
             // Trigger the settings watcher
-            settingsWatcher("RoomList.OrderedCustomSections");
+            await Promise.resolve(settingsWatcher("RoomList.OrderedCustomSections"));
 
             // Now there should be 4 sections (Favourite, custom, Chats, LowPriority)
             expect(store.getSortedRoomsInActiveSpace().sections).toHaveLength(4);

--- a/apps/web/test/unit-tests/stores/room-list-v3/section-test.ts
+++ b/apps/web/test/unit-tests/stores/room-list-v3/section-test.ts
@@ -11,6 +11,7 @@ import {
     createSection,
     editSection,
     deleteSection,
+    getCustomSectionData,
     getOrderedCustomSections,
     isDefaultSectionTag,
     CHATS_TAG,
@@ -24,6 +25,89 @@ import { DefaultTagID } from "../../../../src/stores/room-list-v3/skip-list/tag"
 describe("section", () => {
     afterEach(() => {
         jest.restoreAllMocks();
+    });
+
+    describe("getCustomSectionData", () => {
+        const tag = "element.io.section.abc";
+        const validTag = "element.io.section.valid";
+        const invalidTag = "element.io.section.invalid";
+        const validEntry = { tag: validTag, name: "Valid" };
+
+        beforeEach(() => {
+            jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
+        });
+
+        it.each([null, false, 42, "string", []] as const)("returns an empty object when the raw value is %p", (raw) => {
+            jest.spyOn(SettingsStore, "getValue").mockReturnValue(raw as any);
+            expect(getCustomSectionData()).toEqual({});
+        });
+
+        it("resets settings to {} when the raw value is not a recoverable object", () => {
+            jest.spyOn(SettingsStore, "getValue").mockReturnValue("not-an-object" as any);
+            const setValueSpy = jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
+
+            getCustomSectionData();
+
+            expect(setValueSpy).toHaveBeenCalledWith("RoomList.CustomSectionData", null, expect.anything(), {});
+        });
+
+        it.each([
+            ["tag does not match the record key", { [tag]: { tag: "element.io.section.other", name: "Mismatch" } }],
+            [
+                "the key does not start with the section prefix",
+                { "not-a-section-key": { tag: "not-a-section-key", name: "Bad" } },
+            ],
+            ["the tag does not start with the section prefix", { [tag]: { tag: "not-a-section-tag", name: "Bad" } }],
+            ["tag or name is not a string", { [tag]: { tag, name: 42 } }],
+        ])("drops entries where %s", (_desc, raw) => {
+            jest.spyOn(SettingsStore, "getValue").mockReturnValue(raw as any);
+            expect(getCustomSectionData()).toEqual({});
+        });
+
+        it("returns valid entries and drops invalid ones", () => {
+            jest.spyOn(SettingsStore, "getValue").mockReturnValue({
+                [validTag]: validEntry,
+                [invalidTag]: { tag: "element.io.section.mismatch", name: "Bad" },
+            });
+            expect(getCustomSectionData()).toEqual({ [validTag]: validEntry });
+        });
+
+        it.each([
+            [
+                "tag mismatch",
+                { [validTag]: validEntry, [invalidTag]: { tag: "element.io.section.mismatch", name: "Bad" } },
+                { [validTag]: validEntry },
+            ],
+            [
+                "non-string name",
+                { [validTag]: validEntry, [invalidTag]: { tag: invalidTag, name: 42 } },
+                { [validTag]: validEntry },
+            ],
+        ])("saves cleaned data when an entry has %s", (_desc, raw, expectedSaved) => {
+            jest.spyOn(SettingsStore, "getValue").mockReturnValue(raw as any);
+            const setValueSpy = jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
+
+            getCustomSectionData();
+
+            expect(setValueSpy).toHaveBeenCalledWith(
+                "RoomList.CustomSectionData",
+                null,
+                expect.anything(),
+                expectedSaved,
+            );
+        });
+
+        it.each([
+            ["all entries are valid", { [validTag]: validEntry }],
+            ["the record is empty", {}],
+        ])("does not save when %s", (_desc, raw) => {
+            jest.spyOn(SettingsStore, "getValue").mockReturnValue(raw as any);
+            const setValueSpy = jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
+
+            getCustomSectionData();
+
+            expect(setValueSpy).not.toHaveBeenCalled();
+        });
     });
 
     describe("getOrderedCustomSections", () => {

--- a/apps/web/test/unit-tests/stores/room-list-v3/section-test.ts
+++ b/apps/web/test/unit-tests/stores/room-list-v3/section-test.ts
@@ -28,7 +28,6 @@ describe("section", () => {
     });
 
     describe("getCustomSectionData", () => {
-        const tag = "element.io.section.abc";
         const validTag = "element.io.section.valid";
         const invalidTag = "element.io.section.invalid";
         const validEntry = { tag: validTag, name: "Valid" };
@@ -42,71 +41,12 @@ describe("section", () => {
             expect(getCustomSectionData()).toEqual({});
         });
 
-        it("resets settings to {} when the raw value is not a recoverable object", () => {
-            jest.spyOn(SettingsStore, "getValue").mockReturnValue("not-an-object" as any);
-            const setValueSpy = jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
-
-            getCustomSectionData();
-
-            expect(setValueSpy).toHaveBeenCalledWith("RoomList.CustomSectionData", null, expect.anything(), {});
-        });
-
-        it.each([
-            ["tag does not match the record key", { [tag]: { tag: "element.io.section.other", name: "Mismatch" } }],
-            [
-                "the key does not start with the section prefix",
-                { "not-a-section-key": { tag: "not-a-section-key", name: "Bad" } },
-            ],
-            ["the tag does not start with the section prefix", { [tag]: { tag: "not-a-section-tag", name: "Bad" } }],
-            ["tag or name is not a string", { [tag]: { tag, name: 42 } }],
-        ])("drops entries where %s", (_desc, raw) => {
-            jest.spyOn(SettingsStore, "getValue").mockReturnValue(raw as any);
-            expect(getCustomSectionData()).toEqual({});
-        });
-
         it("returns valid entries and drops invalid ones", () => {
             jest.spyOn(SettingsStore, "getValue").mockReturnValue({
                 [validTag]: validEntry,
                 [invalidTag]: { tag: "element.io.section.mismatch", name: "Bad" },
             });
             expect(getCustomSectionData()).toEqual({ [validTag]: validEntry });
-        });
-
-        it.each([
-            [
-                "tag mismatch",
-                { [validTag]: validEntry, [invalidTag]: { tag: "element.io.section.mismatch", name: "Bad" } },
-                { [validTag]: validEntry },
-            ],
-            [
-                "non-string name",
-                { [validTag]: validEntry, [invalidTag]: { tag: invalidTag, name: 42 } },
-                { [validTag]: validEntry },
-            ],
-        ])("saves cleaned data when an entry has %s", (_desc, raw, expectedSaved) => {
-            jest.spyOn(SettingsStore, "getValue").mockReturnValue(raw as any);
-            const setValueSpy = jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
-
-            getCustomSectionData();
-
-            expect(setValueSpy).toHaveBeenCalledWith(
-                "RoomList.CustomSectionData",
-                null,
-                expect.anything(),
-                expectedSaved,
-            );
-        });
-
-        it.each([
-            ["all entries are valid", { [validTag]: validEntry }],
-            ["the record is empty", {}],
-        ])("does not save when %s", (_desc, raw) => {
-            jest.spyOn(SettingsStore, "getValue").mockReturnValue(raw as any);
-            const setValueSpy = jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
-
-            getCustomSectionData();
-
-            expect(setValueSpy).not.toHaveBeenCalled();
         });
     });
 
@@ -117,30 +57,25 @@ describe("section", () => {
             jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
         });
 
-        it("returns an empty array when the raw value is not an array", async () => {
+        it("returns an empty array when the raw value is not an array", () => {
             jest.spyOn(SettingsStore, "getValue").mockImplementation((setting) => {
                 if (setting === "RoomList.OrderedCustomSections") return "not-an-array";
                 return null;
             });
 
-            const result = await getOrderedCustomSections();
+            const result = getOrderedCustomSections();
             expect(result).toEqual([]);
         });
 
-        it("removes unknown sections and saves the cleaned list", async () => {
+        it("removes unknown sections and saves the cleaned list", () => {
             const knownTag = "element.io.section.known";
             jest.spyOn(SettingsStore, "getValue").mockImplementation((setting) => {
                 if (setting === "RoomList.CustomSectionData") return { [knownTag]: { tag: knownTag, name: "Known" } };
                 if (setting === "RoomList.OrderedCustomSections") return [knownTag, tag];
                 return null;
             });
-            const setValueSpy = jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
 
-            const result = await getOrderedCustomSections();
-            expect(result).toEqual([knownTag]);
-            expect(setValueSpy).toHaveBeenCalledWith("RoomList.OrderedCustomSections", null, expect.anything(), [
-                knownTag,
-            ]);
+            expect(getOrderedCustomSections()).toEqual([knownTag]);
         });
     });
 

--- a/apps/web/test/unit-tests/stores/room-list-v3/section-test.ts
+++ b/apps/web/test/unit-tests/stores/room-list-v3/section-test.ts
@@ -48,6 +48,16 @@ describe("section", () => {
             });
             expect(getCustomSectionData()).toEqual({ [validTag]: validEntry });
         });
+
+        it("drops entries that fail the isValidCustomSection check", () => {
+            jest.spyOn(SettingsStore, "getValue").mockReturnValue({
+                "element.io.section.null-val": null,
+                "element.io.section.str-val": "not-an-object",
+                "element.io.section.bad-tag": { tag: "not-a-custom-tag", name: "Bad" },
+                "element.io.section.bad-name": { tag: "element.io.section.bad-name", name: 42 },
+            });
+            expect(getCustomSectionData()).toEqual({});
+        });
     });
 
     describe("getOrderedCustomSections", () => {
@@ -157,6 +167,12 @@ describe("section", () => {
             jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
         });
 
+        it("does nothing if the tag is not a custom section tag", async () => {
+            const createDialogSpy = jest.spyOn(Modal, "createDialog");
+            await editSection("m.favourite");
+            expect(createDialogSpy).not.toHaveBeenCalled();
+        });
+
         it("does nothing if the section does not exist", async () => {
             jest.spyOn(SettingsStore, "getValue").mockReturnValue({});
             const createDialogSpy = jest.spyOn(Modal, "createDialog");
@@ -220,6 +236,12 @@ describe("section", () => {
                 return null;
             });
             jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
+        });
+
+        it("does nothing if the tag is not a custom section tag", async () => {
+            const createDialogSpy = jest.spyOn(Modal, "createDialog");
+            await deleteSection("m.favourite", false);
+            expect(createDialogSpy).not.toHaveBeenCalled();
         });
 
         it("does nothing if the section does not exist", async () => {

--- a/apps/web/test/unit-tests/stores/room-list-v3/section-test.ts
+++ b/apps/web/test/unit-tests/stores/room-list-v3/section-test.ts
@@ -8,12 +8,13 @@
 import Modal from "../../../../src/Modal";
 import SettingsStore from "../../../../src/settings/SettingsStore";
 import {
-    CHATS_TAG,
-    CUSTOM_SECTION_TAG_PREFIX,
     createSection,
     editSection,
     deleteSection,
+    getOrderedCustomSections,
     isDefaultSectionTag,
+    CHATS_TAG,
+    CUSTOM_SECTION_TAG_PREFIX,
     isSectionTag,
 } from "../../../../src/stores/room-list-v3/section";
 import { CreateSectionDialog } from "../../../../src/components/views/dialogs/CreateSectionDialog";
@@ -23,6 +24,40 @@ import { DefaultTagID } from "../../../../src/stores/room-list-v3/skip-list/tag"
 describe("section", () => {
     afterEach(() => {
         jest.restoreAllMocks();
+    });
+
+    describe("getOrderedCustomSections", () => {
+        const tag = "element.io.section.abc";
+
+        beforeEach(() => {
+            jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
+        });
+
+        it("returns an empty array when the raw value is not an array", async () => {
+            jest.spyOn(SettingsStore, "getValue").mockImplementation((setting) => {
+                if (setting === "RoomList.OrderedCustomSections") return "not-an-array";
+                return null;
+            });
+
+            const result = await getOrderedCustomSections();
+            expect(result).toEqual([]);
+        });
+
+        it("removes unknown sections and saves the cleaned list", async () => {
+            const knownTag = "element.io.section.known";
+            jest.spyOn(SettingsStore, "getValue").mockImplementation((setting) => {
+                if (setting === "RoomList.CustomSectionData") return { [knownTag]: { tag: knownTag, name: "Known" } };
+                if (setting === "RoomList.OrderedCustomSections") return [knownTag, tag];
+                return null;
+            });
+            const setValueSpy = jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
+
+            const result = await getOrderedCustomSections();
+            expect(result).toEqual([knownTag]);
+            expect(setValueSpy).toHaveBeenCalledWith("RoomList.OrderedCustomSections", null, expect.anything(), [
+                knownTag,
+            ]);
+        });
     });
 
     describe("createSection", () => {
@@ -69,6 +104,8 @@ describe("section", () => {
             const existingTag = "element.io.section.existing";
             jest.spyOn(SettingsStore, "getValue").mockImplementation((setting) => {
                 if (setting === "RoomList.OrderedCustomSections") return [existingTag];
+                if (setting === "RoomList.CustomSectionData")
+                    return { [existingTag]: { tag: existingTag, name: "Existing" } };
                 return null;
             });
             jest.spyOn(Modal, "createDialog").mockReturnValue({
@@ -79,15 +116,16 @@ describe("section", () => {
 
             await createSection();
 
-            const customDataCall = setValueSpy.mock.calls.find(([name]) => name === "RoomList.CustomSectionData");
-            const savedSection = Object.values(customDataCall![3] as Record<string, { tag: string; name: string }>)[0];
-            expect(savedSection.name).toBe("My Section");
-            expect(savedSection.tag).toMatch(/^element\.io\.section\./);
-
             const orderedCall = setValueSpy.mock.calls.find(([name]) => name === "RoomList.OrderedCustomSections");
             const savedOrder = orderedCall![3] as string[];
             expect(savedOrder[0]).toBe(existingTag);
             expect(savedOrder[1]).toMatch(/^element\.io\.section\./);
+
+            const newTag = savedOrder[1];
+            const customDataCall = setValueSpy.mock.calls.find(([name]) => name === "RoomList.CustomSectionData");
+            const savedSection = (customDataCall![3] as Record<string, { tag: string; name: string }>)[newTag];
+            expect(savedSection.name).toBe("My Section");
+            expect(savedSection.tag).toBe(newTag);
         });
     });
 
@@ -157,7 +195,8 @@ describe("section", () => {
 
         beforeEach(() => {
             jest.spyOn(SettingsStore, "getValue").mockImplementation((setting) => {
-                if (setting === "RoomList.CustomSectionData") return { [tag]: { tag, name: "My Section" } };
+                if (setting === "RoomList.CustomSectionData")
+                    return { [tag]: { tag, name: "My Section" }, [otherTag]: { tag: otherTag, name: "Other Section" } };
                 if (setting === "RoomList.OrderedCustomSections") return [otherTag, tag];
                 return null;
             });

--- a/apps/web/test/viewmodels/room-list/RoomListItemViewModel-test.tsx
+++ b/apps/web/test/viewmodels/room-list/RoomListItemViewModel-test.tsx
@@ -80,8 +80,10 @@ describe("RoomListItemViewModel", () => {
         jest.spyOn(SettingsStore, "getValue").mockImplementation((setting) => {
             if (setting === "RoomList.showMessagePreview") return false;
             if (setting === "RoomList.OrderedCustomSections") return [];
+            if (setting === "RoomList.CustomSectionData") return {};
             return false;
         });
+        jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
         jest.spyOn(SettingsStore, "watchSetting").mockImplementation(() => "watcher-id");
 
         jest.spyOn(MessagePreviewStore.instance, "getPreviewForRoom").mockResolvedValue(null);

--- a/apps/web/test/viewmodels/room-list/RoomListSectionHeaderViewModel-test.ts
+++ b/apps/web/test/viewmodels/room-list/RoomListSectionHeaderViewModel-test.ts
@@ -154,6 +154,19 @@ describe("RoomListSectionHeaderViewModel", () => {
 
             expect(vm.getSnapshot().title).toBe("My Section");
         });
+
+        it("should not update title when tag is not a custom section tag", () => {
+            const vm = new RoomListSectionHeaderViewModel({
+                tag: "m.favourite",
+                title: "Favourites",
+                spaceId: "!space:server",
+                onToggleExpanded,
+            });
+
+            watchCallback();
+
+            expect(vm.getSnapshot().title).toBe("Favourites");
+        });
     });
 
     describe("editSection", () => {


### PR DESCRIPTION
Closes https://github.com/element-hq/element-web/issues/33470
The custom section data is in the account data and could be malformed and corrupted by an external source. In order to avoid the room list to crash and to be robust.