### PR TITLE
Make it possible to scroll overflowing hidden events again

### DIFF
--- a/packages/shared-components/src/room/timeline/event-tile/body/ViewSourceEventView/ViewSourceEventView.module.css
+++ b/packages/shared-components/src/room/timeline/event-tile/body/ViewSourceEventView/ViewSourceEventView.module.css
@@ -12,13 +12,12 @@ Please see LICENSE files in the repository root for full details.
     color: var(--cpd-color-text-secondary);
     font-size: var(--cpd-font-size-body-xs);
     width: 100%;
-    /* Override default overflow setting of EventTile */
-    overflow-inline: auto !important;
     line-height: normal;
 }
 
 .source {
     flex: 1;
+    overflow-inline: auto;
 }
 
 pre.source {

--- a/packages/shared-components/src/room/timeline/event-tile/body/ViewSourceEventView/ViewSourceEventView.module.css
+++ b/packages/shared-components/src/room/timeline/event-tile/body/ViewSourceEventView/ViewSourceEventView.module.css
@@ -12,7 +12,8 @@ Please see LICENSE files in the repository root for full details.
     color: var(--cpd-color-text-secondary);
     font-size: var(--cpd-font-size-body-xs);
     width: 100%;
-    overflow-x: auto;
+    /* Override default overflow setting of EventTile */
+    overflow-inline: auto !important;
     line-height: normal;
 }
 


### PR DESCRIPTION
[Screencast From 2026-05-12 17-05-23.webm](https://github.com/user-attachments/assets/b6fcfe80-e66d-40b4-aeae-c52b2581b387)

Hiding from changelog since this is a regression due to https://github.com/element-hq/element-web/pull/33428, which is not released

Notes: none