### PR TITLE
Use the env file when buiding playwright common docker

### DIFF
--- a/packages/playwright-common/Dockerfile
+++ b/packages/playwright-common/Dockerfile
@@ -1,7 +1,6 @@
-ARG PLAYWRIGHT_VERSION
-FROM mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble
 # Expose the argument to this build stage
 ARG PLAYWRIGHT_VERSION
+FROM mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble
 
 WORKDIR /work
 

--- a/packages/playwright-common/project.json
+++ b/packages/playwright-common/project.json
@@ -32,6 +32,7 @@
                 "platforms": ["linux/amd64", "linux/arm64"],
                 "provenance": "true",
                 "sbom": true,
+                "env-file": ["{projectRoot}/.env.docker:build"],
                 "build-args": ["PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION"],
                 "context": "{projectRoot}",
                 "metadata": {


### PR DESCRIPTION
The docker builds failed due to the variable for being available

I can't really test this so not actually certain this fixes the bug.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
