### PR TITLE
Update developer guide to put `.link-config` in the correct place

### DIFF
--- a/developer_guide.md
+++ b/developer_guide.md
@@ -32,21 +32,23 @@ pnpm install
 popd
 ```
 
-Clone the repo and switch to the `element-web/apps/web` directory:
+Clone the repo and switch to that directory:
 
 ```bash
 git clone https://github.com/element-hq/element-web.git
-cd element-web/apps/web
+cd element-web
 ```
-
-Configure the app by copying `config.sample.json` to `config.json` and
-modifying it. See the [configuration docs](docs/config.md) for details.
 
 Set up your local development link by creating a `.link-config` file with contents like:
 
 ```
 matrix-js-sdk=/path/to/matrix-js-sdk
 ```
+
+Switch to the `apps/web` directory: `cd apps/web`
+
+Configure the app by copying `config.sample.json` to `config.json` and
+modifying it. See the [configuration docs](docs/config.md) for details.
 
 Finally, build and start Element itself:
 


### PR DESCRIPTION
Following the steps as written will lead to `apps/web/.link-config` being created instead, which doesn't work.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
