### PR TITLE
Fix matrix-js-sdk linking on Windows

### DIFF
--- a/developer_guide.md
+++ b/developer_guide.md
@@ -45,6 +45,8 @@ Set up your local development link by creating a `.link-config` file with conten
 matrix-js-sdk=/path/to/matrix-js-sdk
 ```
 
+**Note for Windows users**: Your link config path might need escaping. For example, `matrix-js-sdk=C:\\path\\to\\matrix-js-sdk`.
+
 Switch to the `apps/web` directory: `cd apps/web`
 
 Configure the app by copying `config.sample.json` to `config.json` and
@@ -56,6 +58,8 @@ Finally, build and start Element itself:
 pnpm install
 pnpm start
 ```
+
+**Note for Windows users**: `pnpm start` needs to be run from a terminal with bash/shell support.
 
 Wait a few seconds for the initial build to finish; you should see something like:
 

--- a/scripts/pnpm-link.ts
+++ b/scripts/pnpm-link.ts
@@ -34,7 +34,7 @@ try {
         try {
             try {
                 const stat = await fs.lstat(dependencyPath);
-                console.log(`Existing is ${stat.isSymbolicLink() ? 'symlink' : 'directory'}`);
+                console.log(`Existing is ${stat.isSymbolicLink() ? "symlink" : "directory"}`);
                 if (stat.isSymbolicLink()) {
                     const linkPath = await fs.readlink(dependencyPath);
                     if (linkPath === path) {
@@ -44,7 +44,7 @@ try {
                         await fs.unlink(dependencyPath);
                     }
                 } else {
-                    await fs.rm(dependencyPath, {recursive: true});
+                    await fs.rm(dependencyPath, { recursive: true });
                 }
             } catch (e: any) {
                 // fs.lstat throws ENOENT if the path doesn't exist (on Windows)
@@ -56,7 +56,7 @@ try {
             }
 
             console.log(`Linking ${dependency} to ${path}`);
-            await fs.symlink(path, dependencyPath, 'junction'); // use a junction type to avoid EPERM errors on Windows
+            await fs.symlink(path, dependencyPath, "junction"); // use a junction type to avoid EPERM errors on Windows
 
             const pkgJson = await fs.readFile(join(path, "package.json"), "utf-8");
             const pkgManager = JSON.parse(pkgJson)["packageManager"]?.split("@").at(0) ?? "yarn";

--- a/scripts/pnpm-link.ts
+++ b/scripts/pnpm-link.ts
@@ -32,21 +32,31 @@ try {
         const dependencyPath = join(nodeModulesPath, dependency);
 
         try {
-            const stat = await fs.stat(dependencyPath);
-            if (stat.isSymbolicLink()) {
-                const linkPath = await fs.readlink(dependencyPath);
-                if (linkPath === path) {
-                    // already done
-                    continue;
+            try {
+                const stat = await fs.lstat(dependencyPath);
+                console.log(`Existing is ${stat.isSymbolicLink() ? 'symlink' : 'directory'}`);
+                if (stat.isSymbolicLink()) {
+                    const linkPath = await fs.readlink(dependencyPath);
+                    if (linkPath === path) {
+                        // already done
+                        continue;
+                    } else {
+                        await fs.unlink(dependencyPath);
+                    }
                 } else {
-                    await fs.unlink(dependencyPath);
+                    await fs.rm(dependencyPath, {recursive: true});
                 }
-            } else {
-                await fs.rm(dependencyPath, { recursive: true });
+            } catch (e: any) {
+                // fs.lstat throws ENOENT if the path doesn't exist (on Windows)
+                if (e.code === "ENOENT") {
+                    console.log("Received ENOENT error on dependency path - assuming it doesn't exist");
+                } else {
+                    throw e;
+                }
             }
 
             console.log(`Linking ${dependency} to ${path}`);
-            await fs.symlink(path, dependencyPath);
+            await fs.symlink(path, dependencyPath, 'junction'); // use a junction type to avoid EPERM errors on Windows
 
             const pkgJson = await fs.readFile(join(path, "package.json"), "utf-8");
             const pkgManager = JSON.parse(pkgJson)["packageManager"]?.split("@").at(0) ?? "yarn";


### PR DESCRIPTION
This doesn't address the fact that `sh` is used somewhere in the `pnpm start` pipeline, but it at least tries to warn Windows users that it'll need to be supported in their terminal.

This otherwise fixes three bugs. The issues *should* have zero impact on Linux/Mac environments, but I don't have a reasonable way to test those.

1. `fs.stat` follows symlinks and would always return `false` on `isSymbolicLink`. This is independent of Windows, but the fix is to use `lstat` instead.
2. `fs.lstat`/`fs.stat` throws `ENOENT` when the directory/link doesn't exist, which fails linking. This PR catches the error and re-throws non-ENOENT errors instead.
3. Regular directory symlinks require Administrator privileges on Windows. Junction links are *technically* different, but not in a way which affects how the link operates for Element Web developers. It may affect how developers using remote (Windows) machines see the paths, but that use case is highly unusual. 

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
