### PR TITLE
Bump @element-hq/element-web-playwright-common version to 4.1.0

### DIFF
--- a/packages/playwright-common/package.json
+++ b/packages/playwright-common/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@element-hq/element-web-playwright-common",
     "type": "module",
-    "version": "4.0.0",
+    "version": "4.1.0",
     "license": "SEE LICENSE IN README.md",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Since I want to do a release containing the new toasts utils.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
