### PR TITLE
Fix issue using pnpm start

### DIFF
--- a/packages/module-api/vite.config.ts
+++ b/packages/module-api/vite.config.ts
@@ -5,9 +5,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.
 */
 
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { defineConfig, mergeConfig } from "vitest/config";
+import { defineConfig, mergeConfig, type Plugin } from "vitest/config";
 import dts from "unplugin-dts/vite";
 import externalGlobals from "rollup-plugin-external-globals";
 import baseConfig from "@element-hq/vite-common/vite.config";
@@ -15,6 +16,35 @@ import baseConfig from "@element-hq/vite-common/vite.config";
 import packageJson from "./package.json" with { type: "json" };
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const apiTypesFileName = "element-web-module-api-alpha.d.ts";
+
+function copyPackageTypesEntry(): Plugin {
+    return {
+        name: "element-web-module-api-types-entry",
+        writeBundle(options): void {
+            const outDir = options.dir ?? resolve(__dirname, "lib");
+            const entryTypesPath = resolve(outDir, "index.d.ts");
+            const packageTypesPath = resolve(outDir, apiTypesFileName);
+
+            if (!existsSync(entryTypesPath)) return;
+
+            const source = readFileSync(entryTypesPath, "utf-8");
+            writeFileSync(
+                packageTypesPath,
+                source.replace("sourceMappingURL=index.d.ts.map", `sourceMappingURL=${apiTypesFileName}.map`),
+            );
+
+            const entryTypesMapPath = resolve(outDir, "index.d.ts.map");
+            if (!existsSync(entryTypesMapPath)) return;
+
+            const sourceMap = readFileSync(entryTypesMapPath, "utf-8");
+            writeFileSync(
+                `${packageTypesPath}.map`,
+                sourceMap.replace('"file":"index.d.ts"', `"file":"${apiTypesFileName}"`),
+            );
+        },
+    };
+}
 
 export default mergeConfig(
     baseConfig,
@@ -31,6 +61,7 @@ export default mergeConfig(
         },
         plugins: [
             dts(),
+            copyPackageTypesEntry(),
             externalGlobals({
                 // Reuse React from the host app
                 react: "window.React",

--- a/packages/shared-components/vite.config.ts
+++ b/packages/shared-components/vite.config.ts
@@ -16,6 +16,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const cssLayerOrder = "@layer compound-tokens, compound-web, shared-components, app-web;";
 const sharedComponentsLayer = "shared-components";
 
+const cssAssetBaseName = "element-web-shared-components";
 const cssAssetFileName = "element-web-shared-components.css";
 
 function layerCssAssets(): Plugin {
@@ -62,6 +63,7 @@ export default defineConfig({
             // to keep the existing package.json `require` paths working.
             formats: ["es", "cjs"],
             fileName: (format, entryName) => `${entryName}.${format === "es" ? "js" : "umd.cjs"}`,
+            cssFileName: cssAssetBaseName,
         },
         outDir: "dist",
         rolldownOptions: {


### PR DESCRIPTION
This PR fixes the issue below, but I not confident that it won't impact any other builds etc.

To reproduce the issue:
1 - Nuke node_modules folders
2 - pnpm install
3 - Go to app/web and do pnpm start

Changes:

- shared-components: Vite now emits element-web-shared-components.css directly, removing the rename race that made webpack miss the file.

 - module-api: the watch build now also writes element-web-module-api-alpha.d.ts, matching the package’s declared types path.

Command line output showing the error:

xyz@xyz:[element-web-folder]$ pnpm start

> element-web@1.12.18 start [element-web-folder]/apps/web
> nx start

> nx run @element-hq/element-web-module-api:start

> vite build --watch

vite v8.0.10 building client environment for production...

watching for file changes...

build started...
✓ 52 modules transformed.

[unplugin:dts] Start generate declaration files...
[unplugin:dts] Declaration files built in 3019ms.

computing gzip size...
lib/element-web-plugin-engine.js  34.47 kB │ gzip: 9.10 kB │ map: 115.51 kB

built in 3169ms.

build started...
✓ 52 modules transformed.
computing gzip size...
lib/element-web-plugin-engine.umd.cjs  26.81 kB │ gzip: 8.28 kB │ map: 115.03 kB

built in 179ms.

> nx run element-web:prebuild:rethemendex  [local cache]

> nx run element-web:prebuild:rethemendex

> pnpm run rethemendex


> element-web@1.12.18 rethemendex [element-web-folder]/apps/web
> sh ./res/css/rethemendex.sh


> nx run element-web:prebuild:module_system  [local cache]

> node module_system/scripts/install.ts


> nx run @element-hq/web-shared-components:start

> vite build --watch

vite v8.0.10 building client environment for production...

watching for file changes...

build started...
src/core/i18n/I18nApi.ts:14:8 - error TS7016: Could not find a declaration file for module '@element-hq/element-web-module-api'. '[element-web-folder]/packages/module-api/lib/element-web-plugin-engine.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/element-hq__element-web-module-api` if it exists or add a new declaration (.d.ts) file containing `declare module '@element-hq/element-web-module-api';`

14 } from "@element-hq/element-web-module-api";
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/core/i18n/i18nContext.ts:9:30 - error TS7016: Could not find a declaration file for module '@element-hq/element-web-module-api'. '[element-web-folder]/packages/module-api/lib/element-web-plugin-engine.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/element-hq__element-web-module-api` if it exists or add a new declaration (.d.ts) file containing `declare module '@element-hq/element-web-module-api';`

9 import { type I18nApi } from "@element-hq/element-web-module-api";
                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/core/utils/humanize.ts:9:30 - error TS7016: Could not find a declaration file for module '@element-hq/element-web-module-api'. '[element-web-folder]/packages/module-api/lib/element-web-plugin-engine.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/element-hq__element-web-module-api` if it exists or add a new declaration (.d.ts) file containing `declare module '@element-hq/element-web-module-api';`

9 import { type I18nApi } from "@element-hq/element-web-module-api";
                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/core/viewmodel/Disposables.ts:54:20 - error TS2345: Argument of type 'string | symbol' is not assignable to parameter of type 'string | number'.
  Type 'symbol' is not assignable to type 'string | number'.

54         emitter.on(event, callback);
                      ~~~~~
src/core/viewmodel/Disposables.ts:56:25 - error TS2345: Argument of type 'string | symbol' is not assignable to parameter of type 'string | number'.
  Type 'symbol' is not assignable to type 'string | number'.

56             emitter.off(event, callback);
                           ~~~~~
src/room/timeline/event-tile/body/DecryptionFailureBodyView/DecryptionFailureBodyView.tsx:11:30 - error TS7016: Could not find a declaration file for module '@element-hq/element-web-module-api'. '[element-web-folder]/packages/module-api/lib/element-web-plugin-engine.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/element-hq__element-web-module-api` if it exists or add a new declaration (.d.ts) file containing `declare module '@element-hq/element-web-module-api';`

11 import { type I18nApi } from "@element-hq/element-web-module-api";
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/room/timeline/event-tile/body/MjolnirBodyView/MjolnirBodyView.tsx:55:29 - error TS7006: Parameter 'sub' implicitly has an 'any' type.

55                         a: (sub) => (
                               ~~~

✓ 1225 modules transformed.

[unplugin:dts] Start generate declaration files...
[unplugin:dts] Start bundling declaration files...
Analysis will use the bundled TypeScript version 5.9.3
*** The target project appears to use TypeScript 6.0.3 which is newer than the bundled compiler engine; consider upgrading API Extractor.
Analysis will use the bundled TypeScript version 5.9.3
*** The target project appears to use TypeScript 6.0.3 which is newer than the bundled compiler engine; consider upgrading API Extractor.
[unplugin:dts] Declaration files built in 34578ms.

computing gzip size...
dist/web-shared-components.css          77.18 kB │ gzip:  13.49 kB
dist/numbers.js                          0.46 kB │ gzip:   0.26 kB
dist/element-web-shared-components.js  650.79 kB │ gzip: 179.64 kB

built in 35952ms.

build started...
✓ 1224 modules transformed.
computing gzip size...
dist/web-shared-components.css               77.18 kB │ gzip:  13.49 kB
dist/numbers.umd.cjs                          0.47 kB │ gzip:   0.29 kB
dist/element-web-shared-components.umd.cjs  502.81 kB │ gzip: 162.07 kB

built in 1821ms.

> nx run element-web:start

> webpack-dev-server --output-path webapp --output-filename=bundles/_dev_/[name].js --output-chunk-filename=bundles/_dev_/[name].js --mode development

◇ injected env (0) from .env // tip: ⌘ suppress logs { quiet: true }
<i> [webpack-dev-server] Project is running at:
<i> [webpack-dev-server] Loopback: http://localhost:8080/, http://[::1]:8080/
<i> [webpack-dev-server] On Your Network (IPv4): http://172.27.172.192:8080/
<i> [webpack-dev-server] Content not from webpack is served from './webapp' directory
<i> [webpack-dev-middleware] wait until bundle finished: /
<e> [webpack-dev-middleware] ModuleNotFoundError: Module not found: Error: Can't resolve '@element-hq/web-shared-components/dist/element-web-shared-components.css' in '[element-web-folder]/apps/web/src/vector'
<e>     at [element-web-folder]/node_modules/webpack/lib/Compilation.js:2143:28
<e>     at [element-web-folder]/node_modules/webpack/lib/NormalModuleFactory.js:1076:13
<e>     at eval (eval at create ([element-web-folder]/node_modules/tapable/lib/HookCodeFactory.js:31:10), <anonymous>:10:1)
<e>     at [element-web-folder]/node_modules/webpack/lib/NormalModuleFactory.js:456:22
<e>     at eval (eval at create ([element-web-folder]/node_modules/tapable/lib/HookCodeFactory.js:31:10), <anonymous>:9:1)
<e>     at [element-web-folder]/node_modules/webpack/lib/NormalModuleFactory.js:642:22
<e>     at [element-web-folder]/node_modules/webpack/lib/NormalModuleFactory.js:193:10
<e>     at [element-web-folder]/node_modules/webpack/lib/NormalModuleFactory.js:917:25
<e>     at [element-web-folder]/node_modules/webpack/lib/NormalModuleFactory.js:1162:8
<e>     at [element-web-folder]/node_modules/webpack/lib/NormalModuleFactory.js:1292:5
<e>     at [element-web-folder]/node_modules/neo-async/async.js:6883:13
<e>     at [element-web-folder]/node_modules/webpack/lib/NormalModuleFactory.js:1275:45
<e>     at finishWithoutResolve ([element-web-folder]/node_modules/enhanced-resolve/lib/Resolver.js:590:11)
<e>     at [element-web-folder]/node_modules/enhanced-resolve/lib/Resolver.js:679:14
<e>     at [element-web-folder]/node_modules/enhanced-resolve/lib/Resolver.js:740:5
<e>     at eval (eval at create ([element-web-folder]/node_modules/tapable/lib/HookCodeFactory.js:31:10), <anonymous>:16:1)
<e>     at [element-web-folder]/node_modules/enhanced-resolve/lib/Resolver.js:740:5
<e>     at eval (eval at create ([element-web-folder]/node_modules/tapable/lib/HookCodeFactory.js:31:10), <anonymous>:27:1)
<e>     at [element-web-folder]/node_modules/enhanced-resolve/lib/DescriptionFilePlugin.js:89:43
<e>     at [element-web-folder]/node_modules/enhanced-resolve/lib/Resolver.js:740:5
<e>     at eval (eval at create ([element-web-folder]/node_modules/tapable/lib/HookCodeFactory.js:31:10), <anonymous>:16:1)
<e>     at [element-web-folder]/node_modules/enhanced-resolve/lib/forEachBail.js:39:13
<e>     at [element-web-folder]/node_modules/enhanced-resolve/lib/AliasUtils.js:166:11
<e>     at next ([element-web-folder]/node_modules/enhanced-resolve/lib/forEachBail.js:35:3)
<e>     at forEachBail ([element-web-folder]/node_modules/enhanced-resolve/lib/forEachBail.js:49:9)
<e>     at aliasResolveHandler ([element-web-folder]/node_modules/enhanced-resolve/lib/AliasUtils.js:62:2)
<e>     at [element-web-folder]/node_modules/enhanced-resolve/lib/AliasPlugin.js:37:5
<e>     at _next0 (eval at create ([element-web-folder]/node_modules/tapable/lib/HookCodeFactory.js:31:10), <anonymous>:8:1)
<e>     at eval (eval at create ([element-web-folder]/node_modules/tapable/lib/HookCodeFactory.js:31:10), <anonymous>:30:1)
<e>     at [element-web-folder]/node_modules/enhanced-resolve/lib/Resolver.js:740:5
<e>     at eval (eval at create ([element-web-folder]/node_modules/tapable/lib/HookCodeFactory.js:31:10), <anonymous>:16:1)
<e>     at [element-web-folder]/node_modules/enhanced-resolve/lib/Resolver.js:740:5
<e>     at eval (eval at create ([element-web-folder]/node_modules/tapable/lib/HookCodeFactory.js:31:10), <anonymous>:16:1)
<e>     at [element-web-folder]/node_modules/enhanced-resolve/lib/Resolver.js:740:5
<e>     at eval (eval at create ([element-web-folder]/node_modules/tapable/lib/HookCodeFactory.js:31:10), <anonymous>:27:1)
<e>     at [element-web-folder]/node_modules/enhanced-resolve/lib/DescriptionFilePlugin.js:89:43
<e>     at [element-web-folder]/node_modules/enhanced-resolve/lib/Resolver.js:740:5
<e>     at eval (eval at create ([element-web-folder]/node_modules/tapable/lib/HookCodeFactory.js:31:10), <anonymous>:16:1)
<e>     at [element-web-folder]/node_modules/enhanced-resolve/lib/Resolver.js:740:5
<e>     at eval (eval at create ([element-web-folder]/node_modules/tapable/lib/HookCodeFactory.js:31:10), <anonymous>:15:1)
<e>     at [element-web-folder]/node_modules/enhanced-resolve/lib/DirectoryExistsPlugin.js:43:15
<e>     at process.processTicksAndRejections (node:internal/process/task_queues:89:21)
<e> resolve '@element-hq/web-shared-components/dist/element-web-shared-components.css' in '[element-web-folder]/apps/web/src/vector'
<e>   Parsed request is a module
<e>   using description file: [element-web-folder]/apps/web/package.json (relative path: ./src/vector)
<e>     Field 'browser' doesn't contain a valid alias configuration
<e>     resolve as module
<e>       [element-web-folder]/apps/web/src/vector/node_modules doesn't exist or is not a directory
<e>       [element-web-folder]/apps/web/src/node_modules doesn't exist or is not a directory
<e>       looking for modules in [element-web-folder]/apps/web/node_modules
<e>         existing directory [element-web-folder]/apps/web/node_modules/@element-hq/web-shared-components
<e>           using description file: [element-web-folder]/apps/web/node_modules/@element-hq/web-shared-components/package.json (relative path: .)
<e>             using exports field: ./dist/element-web-shared-components.css
<e>               using description file: [element-web-folder]/apps/web/node_modules/@element-hq/web-shared-components/package.json (relative path: ./dist/element-web-shared-components.css)
<e>                 no extension
<e>                   Field 'browser' doesn't contain a valid alias configuration
<e>                   [element-web-folder]/apps/web/node_modules/@element-hq/web-shared-components/dist/element-web-shared-components.css doesn't exist
<e>                 .js
<e>                   Field 'browser' doesn't contain a valid alias configuration
<e>                   [element-web-folder]/apps/web/node_modules/@element-hq/web-shared-components/dist/element-web-shared-components.css.js doesn't exist
<e>                 .json
<e>                   Field 'browser' doesn't contain a valid alias configuration
<e>                   [element-web-folder]/apps/web/node_modules/@element-hq/web-shared-components/dist/element-web-shared-components.css.json doesn't exist
<e>                 .ts
<e>                   Field 'browser' doesn't contain a valid alias configuration
<e>                   [element-web-folder]/apps/web/node_modules/@element-hq/web-shared-components/dist/element-web-shared-components.css.ts doesn't exist
<e>                 .tsx
<e>                   Field 'browser' doesn't contain a valid alias configuration
<e>                   [element-web-folder]/apps/web/node_modules/@element-hq/web-shared-components/dist/element-web-shared-components.css.tsx doesn't exist
<e>                 as directory
<e>                   [element-web-folder]/apps/web/node_modules/@element-hq/web-shared-components/dist/element-web-shared-components.css doesn't exist
<e>       [element-web-folder]/apps/node_modules doesn't exist or is not a directory
<e>       looking for modules in [element-web-folder]/node_modules
<e>         [element-web-folder]/node_modules/@element-hq/web-shared-components doesn't exist
<e>       /home/xyz/xyz/xyz/node_modules doesn't exist or is not a directory
<e>       /home/xyz/xyz/node_modules doesn't exist or is not a directory
<e>       /home/xyz/node_modules doesn't exist or is not a directory
<e>       /home/node_modules doesn't exist or is not a directory
<e>       /node_modules doesn't exist or is not a directory

———————————————————————————————————————————————————————————————————————————————————————————————————————————

 NX   Cancelled running target start for project element-web (1m)


 ELIFECYCLE  Command failed with exit code 130.


