### PR TITLE
Fix pinned message banner disappearing when a pinned message event is unkown

### DIFF
--- a/apps/web/src/components/views/right_panel/PinnedMessagesCard.tsx
+++ b/apps/web/src/components/views/right_panel/PinnedMessagesCard.tsx
@@ -21,7 +21,6 @@ import { useRoomState } from "../../../hooks/useRoomState";
 import RoomContext, { TimelineRenderingType } from "../../../contexts/RoomContext";
 import { ReadPinsEventId } from "./types";
 import { type RoomPermalinkCreator } from "../../../utils/permalinks/Permalinks";
-import { filterBoolean } from "../../../utils/arrays";
 import Modal from "../../../Modal";
 import { UnpinAllDialog } from "../dialogs/UnpinAllDialog";
 import EmptyState from "./EmptyState";
@@ -77,9 +76,7 @@ export function PinnedMessagesCard({ room, onClose, permalinkCreator }: PinnedMe
             />
         );
     } else if (pinnedEvents?.length) {
-        content = (
-            <PinnedMessages events={filterBoolean(pinnedEvents)} room={room} permalinkCreator={permalinkCreator} />
-        );
+        content = <PinnedMessages events={pinnedEvents} room={room} permalinkCreator={permalinkCreator} />;
     } else {
         content = <Spinner />;
     }

--- a/apps/web/src/hooks/usePinnedEvents.ts
+++ b/apps/web/src/hooks/usePinnedEvents.ts
@@ -25,6 +25,7 @@ import { useMatrixClientContext } from "../contexts/MatrixClientContext";
 import { useAsyncMemo } from "./useAsyncMemo";
 import PinningUtils from "../utils/PinningUtils";
 import { batch } from "../utils/promise.ts";
+import { filterBoolean } from "../utils/arrays.ts";
 
 /**
  * Get the pinned event IDs from a room.
@@ -176,18 +177,19 @@ async function fetchPinnedEvent(room: Room, pinnedEventId: string, cli: MatrixCl
  * @param room
  * @param pinnedEventIds
  */
-export function useFetchedPinnedEvents(room: Room, pinnedEventIds: string[]): Array<MatrixEvent | null> | null {
+export function useFetchedPinnedEvents(room: Room, pinnedEventIds: string[]): Array<MatrixEvent> {
     const cli = useMatrixClientContext();
 
-    return useAsyncMemo(
+    const events = useAsyncMemo(
         () => {
             const fetchPromises = pinnedEventIds.map((eventId) => () => fetchPinnedEvent(room, eventId, cli));
             // Fetch the pinned events in batches of 10
             return batch(fetchPromises, 10);
         },
         [cli, room, pinnedEventIds],
-        null,
+        [],
     );
+    return filterBoolean(events);
 }
 
 /**
@@ -196,15 +198,7 @@ export function useFetchedPinnedEvents(room: Room, pinnedEventIds: string[]): Ar
  * @param room
  * @param pinnedEventIds
  */
-export function useSortedFetchedPinnedEvents(room: Room, pinnedEventIds: string[]): Array<MatrixEvent | null> {
+export function useSortedFetchedPinnedEvents(room: Room, pinnedEventIds: string[]): Array<MatrixEvent> {
     const pinnedEvents = useFetchedPinnedEvents(room, pinnedEventIds);
-    return useMemo(() => {
-        if (!pinnedEvents) return [];
-
-        return pinnedEvents.sort((a, b) => {
-            if (!a) return -1;
-            if (!b) return 1;
-            return a.getTs() - b.getTs();
-        });
-    }, [pinnedEvents]);
+    return useMemo(() => pinnedEvents.sort((a, b) => a.getTs() - b.getTs()), [pinnedEvents]);
 }

--- a/apps/web/test/unit-tests/components/views/right_panel/PinnedMessagesCard-test.tsx
+++ b/apps/web/test/unit-tests/components/views/right_panel/PinnedMessagesCard-test.tsx
@@ -294,6 +294,23 @@ describe("<PinnedMessagesCard />", () => {
             await initPinnedMessagesCard([], [pin]);
             expect(screen.queryAllByRole("listitem")).toHaveLength(0);
         });
+
+        it("should filter out null events returned by useFetchedPinnedEvents and only display valid events", async () => {
+            // RoomCreate is not a pinnable event type — useFetchedPinnedEvents returns null for it
+            const unpinnableEvent = mkEvent({
+                event: true,
+                type: EventType.RoomCreate,
+                content: {},
+                room: "!room:example.org",
+                user: "@alice:example.org",
+            });
+            // pin1 is a valid pinnable message, unpinnableEvent causes useFetchedPinnedEvents to return null
+            // useSortedFetchedPinnedEvents must filter out the null, leaving only pin1
+            await initPinnedMessagesCard([pin1], [unpinnableEvent]);
+
+            await waitFor(() => expect(screen.queryAllByRole("listitem")).toHaveLength(1));
+            expect(screen.getByText("First pinned message")).toBeInTheDocument();
+        });
     });
 
     describe("unpin all", () => {

--- a/apps/web/test/unit-tests/components/views/right_panel/__snapshots__/PinnedMessagesCard-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/right_panel/__snapshots__/PinnedMessagesCard-test.tsx.snap
@@ -329,7 +329,7 @@ exports[`<PinnedMessagesCard /> unpin all should not allow to unpinall 1`] = `
         </p>
       </div>
       <button
-        aria-labelledby="_r_10f_"
+        aria-labelledby="_r_10u_"
         class="_icon-button_1215g_8"
         data-kind="secondary"
         data-testid="base-card-close-button"
@@ -387,13 +387,13 @@ exports[`<PinnedMessagesCard /> unpin all should not allow to unpinall 1`] = `
               class="mx_PinnedEventTile_top"
             >
               <span
-                aria-labelledby="_r_10m_"
+                aria-labelledby="_r_115_"
                 class="mx_PinnedEventTile_sender mx_Username_color3"
               >
                 @alice:example.org
               </span>
               <button
-                aria-describedby="_r_10l_"
+                aria-describedby="_r_114_"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-haspopup="menu"
@@ -401,7 +401,7 @@ exports[`<PinnedMessagesCard /> unpin all should not allow to unpinall 1`] = `
                 class="_icon-button_1215g_8"
                 data-kind="primary"
                 data-state="closed"
-                id="radix-_r_10r_"
+                id="radix-_r_11a_"
                 role="button"
                 style="--cpd-icon-button-size: 24px;"
                 tabindex="0"
@@ -427,7 +427,7 @@ exports[`<PinnedMessagesCard /> unpin all should not allow to unpinall 1`] = `
             </div>
             <div
               class="mx_MTextBody mx_EventTile_content _root_1hgc7_8 _text_1hgc7_13"
-              id="_r_10l_"
+              id="_r_114_"
             >
               <div
                 class="mx_EventTile_body translate"
@@ -468,13 +468,13 @@ exports[`<PinnedMessagesCard /> unpin all should not allow to unpinall 1`] = `
               class="mx_PinnedEventTile_top"
             >
               <span
-                aria-labelledby="_r_10u_"
+                aria-labelledby="_r_11d_"
                 class="mx_PinnedEventTile_sender mx_Username_color3"
               >
                 @alice:example.org
               </span>
               <button
-                aria-describedby="_r_10t_"
+                aria-describedby="_r_11c_"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-haspopup="menu"
@@ -482,7 +482,7 @@ exports[`<PinnedMessagesCard /> unpin all should not allow to unpinall 1`] = `
                 class="_icon-button_1215g_8"
                 data-kind="primary"
                 data-state="closed"
-                id="radix-_r_113_"
+                id="radix-_r_11i_"
                 role="button"
                 style="--cpd-icon-button-size: 24px;"
                 tabindex="0"
@@ -508,7 +508,7 @@ exports[`<PinnedMessagesCard /> unpin all should not allow to unpinall 1`] = `
             </div>
             <div
               class="mx_MTextBody mx_EventTile_content _root_1hgc7_8 _text_1hgc7_13"
-              id="_r_10t_"
+              id="_r_11c_"
             >
               <div
                 class="mx_EventTile_body translate"


### PR DESCRIPTION
Closes https://github.com/element-hq/element-web/issues/33476

In the logs:
```
2026-05-08T08:43:19.035Z E Error looking up pinned event $OAeW4OAq-tGhTZiD9j2OAeeEKWsqzfqfxcR1FoWYpr4 in room !jnRBKzeIWZAqAqtQQR:synapse.neftm.ru
2026-05-08T08:43:19.035Z E MatrixError: [403] You don't have permission to access that event. (https://synapse.neftm.ru/_matrix/client/v1/rooms/!jnRBKzeIWZAqAqtQQR%3Asynapse.neftm.ru/relations/%24OAeW4OAq-tGhTZiD9j2OAeeEKWsqzfqfxcR1FoWYpr4/m.replace?limit=1)
M_FORBIDDEN: MatrixError: [403] You don't have permission to access that event. (https://synapse.neftm.ru/_matrix/client/v1/rooms/!jnRBKzeIWZAqAqtQQR%3Asynapse.neftm.ru/relations/%24OAeW4OAq-tGhTZiD9j2OAeeEKWsqzfqfxcR1FoWYpr4/m.replace?limit=1)
    at l (vector://vector/webapp/bundles/7301ce335b9a023b7ddd/3264.js:2:25770)
    at h.requestOtherUrl (vector://vector/webapp/bundles/7301ce335b9a023b7ddd/3264.js:2:23166)
    at async h.doAuthedRequest (vector://vector/webapp/bundles/7301ce335b9a023b7ddd/3264.js:2:21130)
    at async Promise.all (index 1)
    at async ye.relations (vector://vector/webapp/bundles/7301ce335b9a023b7ddd/9544.js:2:81499)
    at async Promise.all (index 1)
    at async vector://vector/webapp/bundles/7301ce335b9a023b7ddd/element-web-app.js:1:387251
    at async Promise.all (index 0)
    at async i (vector://vector/webapp/bundles/7301ce335b9a023b7ddd/init.js:1:1540805)
```
We forgot to filter the unavailable events.