### PR TITLE
Another attempt at fixing the docker bake error

### DIFF
--- a/packages/playwright-common/project.json
+++ b/packages/playwright-common/project.json
@@ -32,8 +32,7 @@
                 "platforms": ["linux/amd64", "linux/arm64"],
                 "provenance": "true",
                 "sbom": true,
-                "env-file": ["{projectRoot}/.env.docker:build"],
-                "build-args": ["PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION"],
+                "build-args": ["PLAYWRIGHT_VERSION"],
                 "context": "{projectRoot}",
                 "metadata": {
                     "images": ["ghcr.io/element-hq/element-web/playwright-server"],


### PR DESCRIPTION
Turns out the .env.docker:build is read automatically by nx when running that project step, so it should be in the env. It might just be that using the `x=$x` format means docker gets the $ literally because no shell is involved here, so we need to use the plain `x` format so docker knows to take it from the environment itself.

That's the theory, anyway.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
