### PR TITLE
Simplify and speed up DeviceListener

### DIFF
--- a/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
+++ b/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
@@ -172,45 +172,30 @@ export class DeviceListenerCurrentDevice {
             return;
         }
 
-        const secretStorageStatus = await crypto.getSecretStorageStatus();
+        const isCurrentDeviceTrusted = Boolean(
+            (await crypto.getDeviceVerificationStatus(this.client.getSafeUserId(), this.client.deviceId!))
+                ?.crossSigningVerified,
+        );
+
+        if (!isCurrentDeviceTrusted) {
+            // The current device is not trusted: prompt the user to verify
+            return await this.failedCheck("verify_this_session", logSpan, "info", "Current device not verified");
+        }
+
         const crossSigningStatus = await crypto.getCrossSigningStatus();
         const allCrossSigningSecretsCached =
             crossSigningStatus.privateKeysCachedLocally.masterKey &&
             crossSigningStatus.privateKeysCachedLocally.selfSigningKey &&
             crossSigningStatus.privateKeysCachedLocally.userSigningKey;
 
-        const recoveryDisabled = await this.recheckRecoveryDisabled(this.client);
-
-        const isCurrentDeviceTrusted = Boolean(
-            (await crypto.getDeviceVerificationStatus(this.client.getSafeUserId(), this.client.deviceId!))
-                ?.crossSigningVerified,
-        );
-
-        const keyBackupUploadActive = await this.isKeyBackupUploadActive(logSpan);
-        const backupDisabled = await this.recheckBackupDisabled();
-
-        const recoveryIsOk = secretStorageStatus.ready || recoveryDisabled || backupDisabled;
-
-        // We warn if key backup upload is turned off and we have not explicitly
-        // said we are OK with that.
-        const keyBackupUploadIsOk = keyBackupUploadActive || backupDisabled;
-
-        // We warn if key backup is set up, but we don't have the decryption
-        // key, so can't fetch keys from backup.
-        const keyBackupDownloadIsOk =
-            !keyBackupUploadActive || backupDisabled || (await crypto.getSessionBackupPrivateKey()) !== null;
-
-        if (!isCurrentDeviceTrusted) {
-            // The current device is not trusted: prompt the user to verify
-            await this.failedCheck("verify_this_session", logSpan, "info", "Current device not verified");
-        } else if (!allCrossSigningSecretsCached) {
+        if (!allCrossSigningSecretsCached) {
             // cross signing ready & device trusted, but we are missing secrets from our local cache.
             // prompt the user to enter their recovery key.
             const newState = crossSigningStatus.privateKeysInSecretStorage
                 ? "key_storage_out_of_sync"
                 : "identity_needs_reset";
 
-            await this.failedCheck(
+            return await this.failedCheck(
                 newState,
                 logSpan,
                 "info",
@@ -218,28 +203,54 @@ export class DeviceListenerCurrentDevice {
                 crossSigningStatus.privateKeysCachedLocally,
                 crossSigningStatus.privateKeysInSecretStorage,
             );
-        } else if (!keyBackupUploadIsOk) {
-            await this.failedCheck(
+        }
+
+        const keyBackupUploadActive = await this.isKeyBackupUploadActive(logSpan);
+        const backupDisabled = await this.recheckBackupDisabled();
+        // We warn if key backup upload is turned off and we have not explicitly
+        // said we are OK with that.
+        const keyBackupUploadIsOk = keyBackupUploadActive || backupDisabled;
+
+        if (!keyBackupUploadIsOk) {
+            return await this.failedCheck(
                 "turn_on_key_storage",
                 logSpan,
                 "info",
                 "Key backup upload is unexpectedly turned off",
             );
-        } else if (!recoveryIsOk) {
+        }
+
+        const secretStorageStatus = await crypto.getSecretStorageStatus();
+        const recoveryDisabled = await this.recheckRecoveryDisabled(this.client);
+        const recoveryIsOk = secretStorageStatus.ready || recoveryDisabled || backupDisabled;
+
+        if (!recoveryIsOk) {
             if (secretStorageStatus.defaultKeyId === null) {
-                await this.failedCheck("set_up_recovery", logSpan, "info", "No default 4S key");
+                return await this.failedCheck("set_up_recovery", logSpan, "info", "No default 4S key");
             } else {
-                await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "4S is missing secrets", {
+                return await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "4S is missing secrets", {
                     secretStorageStatus,
                 });
             }
-        } else if (!keyBackupDownloadIsOk) {
-            await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "Backup key is not cached locally");
-        } else {
-            // Everything is OK - no need to show a toast
-            logSpan.info("No toast needed");
-            this.setDeviceState("ok", logSpan);
         }
+
+        // We warn if key backup is set up, but we don't have the decryption
+        // key, so can't fetch keys from backup.
+        const keyBackupDownloadIsOk =
+            !keyBackupUploadActive || backupDisabled || (await crypto.getSessionBackupPrivateKey()) !== null;
+
+        if (!keyBackupDownloadIsOk) {
+            return await this.failedCheck(
+                "key_storage_out_of_sync",
+                logSpan,
+                "warn",
+                "Backup key is not cached locally",
+            );
+        }
+
+        // Everything is OK - no need to show a toast
+        logSpan.info("No toast needed");
+        this.setDeviceState("ok", logSpan);
     }
 
     /**

--- a/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
+++ b/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { CryptoEvent, type KeyBackupInfo } from "matrix-js-sdk/src/crypto-api";
+import { type CryptoApi, CryptoEvent, type KeyBackupInfo } from "matrix-js-sdk/src/crypto-api";
 import { LogSpan, type BaseLogger, type Logger } from "matrix-js-sdk/src/logger";
 import {
     type MatrixEvent,
@@ -172,90 +172,29 @@ export class DeviceListenerCurrentDevice {
             return;
         }
 
-        {
-            const isCurrentDeviceTrusted = Boolean(
-                (await crypto.getDeviceVerificationStatus(this.client.getSafeUserId(), this.client.deviceId!))
-                    ?.crossSigningVerified,
-            );
-
-            if (!isCurrentDeviceTrusted) {
-                // The current device is not trusted: prompt the user to verify
-                return await this.failedCheck("verify_this_session", logSpan, "info", "Current device not verified");
-            }
+        let failed = await this.failIfCurrentDeviceNotTrusted(crypto, logSpan);
+        if (failed) {
+            return;
         }
 
-        {
-            const crossSigningStatus = await crypto.getCrossSigningStatus();
-            const allCrossSigningSecretsCached =
-                crossSigningStatus.privateKeysCachedLocally.masterKey &&
-                crossSigningStatus.privateKeysCachedLocally.selfSigningKey &&
-                crossSigningStatus.privateKeysCachedLocally.userSigningKey;
-
-            if (!allCrossSigningSecretsCached) {
-                // cross signing ready & device trusted, but we are missing secrets from our local cache.
-                // prompt the user to enter their recovery key.
-                const newState = crossSigningStatus.privateKeysInSecretStorage
-                    ? "key_storage_out_of_sync"
-                    : "identity_needs_reset";
-
-                return await this.failedCheck(
-                    newState,
-                    logSpan,
-                    "info",
-                    "Some secrets not cached",
-                    crossSigningStatus.privateKeysCachedLocally,
-                    crossSigningStatus.privateKeysInSecretStorage,
-                );
-            }
+        failed = await this.failIfCrossSigningSecretsNotCached(crypto, logSpan);
+        if (failed) {
+            return;
         }
 
-        const keyBackupUploadActive = await this.isKeyBackupUploadActive(logSpan);
-        const backupDisabled = await this.recheckBackupDisabled();
-        {
-            // We warn if key backup upload is turned off and we have not explicitly
-            // said we are OK with that.
-            const keyBackupUploadIsOk = keyBackupUploadActive || backupDisabled;
-
-            if (!keyBackupUploadIsOk) {
-                return await this.failedCheck(
-                    "turn_on_key_storage",
-                    logSpan,
-                    "info",
-                    "Key backup upload is unexpectedly turned off",
-                );
-            }
+        const keyBackupStatus = await this.failIfKeyBackupUploadIsFailing(logSpan);
+        if (keyBackupStatus.failed) {
+            return;
         }
 
-        {
-            const secretStorageStatus = await crypto.getSecretStorageStatus();
-            const recoveryDisabled = await this.recheckRecoveryDisabled(this.client);
-            const recoveryIsOk = secretStorageStatus.ready || recoveryDisabled || backupDisabled;
-
-            if (!recoveryIsOk) {
-                if (secretStorageStatus.defaultKeyId === null) {
-                    return await this.failedCheck("set_up_recovery", logSpan, "info", "No default 4S key");
-                } else {
-                    return await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "4S is missing secrets", {
-                        secretStorageStatus,
-                    });
-                }
-            }
+        failed = await this.failIfRecoveryIsFailing(crypto, logSpan, keyBackupStatus);
+        if (failed) {
+            return;
         }
 
-        {
-            // We warn if key backup is set up, but we don't have the decryption
-            // key, so can't fetch keys from backup.
-            const keyBackupDownloadIsOk =
-                !keyBackupUploadActive || backupDisabled || (await crypto.getSessionBackupPrivateKey()) !== null;
-
-            if (!keyBackupDownloadIsOk) {
-                return await this.failedCheck(
-                    "key_storage_out_of_sync",
-                    logSpan,
-                    "warn",
-                    "Backup key is not cached locally",
-                );
-            }
+        failed = await this.failIfKeyBackupDownloadIsFailing(crypto, logSpan, keyBackupStatus);
+        if (failed) {
+            return;
         }
 
         // Everything is OK - no need to show a toast
@@ -270,6 +209,134 @@ export class DeviceListenerCurrentDevice {
      */
     public getDeviceState(): DeviceState {
         return this.deviceState;
+    }
+
+    /**
+     * If the current device is not trusted (verified via cross-signing), show a
+     * toast and return true. Otherwise, return false.
+     */
+    private async failIfCurrentDeviceNotTrusted(crypto: CryptoApi, logSpan: LogSpan): Promise<boolean> {
+        const status = await crypto.getDeviceVerificationStatus(this.client.getSafeUserId(), this.client.deviceId!);
+
+        if (status?.crossSigningVerified) {
+            return false;
+        } else {
+            // The current device is not trusted: prompt the user to verify
+            await this.failedCheck("verify_this_session", logSpan, "info", "Current device not verified");
+            return true;
+        }
+    }
+
+    /**
+     * If the master, device-signing and user-signing keys are not all cached
+     * locally, show a toast and return true. Otherwise, return false.
+     */
+    private async failIfCrossSigningSecretsNotCached(crypto: CryptoApi, logSpan: LogSpan): Promise<boolean> {
+        const crossSigningStatus = await crypto.getCrossSigningStatus();
+
+        const secretsCached =
+            crossSigningStatus.privateKeysCachedLocally.masterKey &&
+            crossSigningStatus.privateKeysCachedLocally.selfSigningKey &&
+            crossSigningStatus.privateKeysCachedLocally.userSigningKey;
+
+        if (secretsCached) {
+            return false;
+        } else {
+            // cross signing ready & device trusted, but we are missing secrets from our local cache.
+            // prompt the user to enter their recovery key.
+            const newState = crossSigningStatus.privateKeysInSecretStorage
+                ? "key_storage_out_of_sync"
+                : "identity_needs_reset";
+
+            await this.failedCheck(
+                newState,
+                logSpan,
+                "info",
+                "Some secrets not cached",
+                crossSigningStatus.privateKeysCachedLocally,
+                crossSigningStatus.privateKeysInSecretStorage,
+            );
+            return true;
+        }
+    }
+
+    /**
+     * If the upload of the key backup is not working when it should, show a
+     * toast and return true. Otherwise, return false.
+     */
+    private async failIfKeyBackupUploadIsFailing(logSpan: LogSpan): Promise<KeyBackupStatus> {
+        const uploadActive = await this.isKeyBackupUploadActive(logSpan);
+        const disabled = await this.recheckBackupDisabled();
+        let failed;
+
+        // We warn if key backup upload is turned off and we have not explicitly
+        // said we are OK with that.
+        const keyBackupUploadIsOk = uploadActive || disabled;
+
+        if (!keyBackupUploadIsOk) {
+            await this.failedCheck(
+                "turn_on_key_storage",
+                logSpan,
+                "info",
+                "Key backup upload is unexpectedly turned off",
+            );
+            failed = true;
+        } else {
+            failed = false;
+        }
+
+        return { uploadActive, disabled, failed };
+    }
+
+    /**
+     * If the Recovery is enable but not working, show a toast and return true.
+     * Otherwise, return false.
+     */
+    private async failIfRecoveryIsFailing(
+        crypto: CryptoApi,
+        logSpan: LogSpan,
+        keyBackupStatus: KeyBackupStatus,
+    ): Promise<boolean> {
+        const secretStorageStatus = await crypto.getSecretStorageStatus();
+        const recoveryDisabled = await this.recheckRecoveryDisabled(this.client);
+        const recoveryIsOk = secretStorageStatus.ready || recoveryDisabled || keyBackupStatus.disabled;
+
+        if (recoveryIsOk) {
+            return false;
+        } else {
+            if (secretStorageStatus.defaultKeyId === null) {
+                await this.failedCheck("set_up_recovery", logSpan, "info", "No default 4S key");
+            } else {
+                await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "4S is missing secrets", {
+                    secretStorageStatus,
+                });
+            }
+            return true;
+        }
+    }
+
+    /**
+     * If the download of the key backup is not working when it should, show a
+     * toast and return true. Otherwise, return false.
+     */
+    private async failIfKeyBackupDownloadIsFailing(
+        crypto: CryptoApi,
+        logSpan: LogSpan,
+        keyBackupStatus: KeyBackupStatus,
+    ): Promise<boolean> {
+        // We warn if key backup is set up, but we don't have the decryption
+        // key, so can't fetch keys from backup.
+        const keyBackupDownloadIsOk =
+            !keyBackupStatus.uploadActive ||
+            keyBackupStatus.disabled ||
+            (await crypto.getSessionBackupPrivateKey()) !== null;
+
+        if (keyBackupDownloadIsOk) {
+            return false;
+        } else {
+            await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "Backup key is not cached locally");
+            return true;
+        }
     }
 
     /**
@@ -456,4 +523,13 @@ export class DeviceListenerCurrentDevice {
 
         return this.cachedKeyBackupUploadActive;
     };
+}
+
+/**
+ * The current state of Key backup.
+ */
+interface KeyBackupStatus {
+    uploadActive: boolean;
+    disabled: boolean;
+    failed: boolean;
 }

--- a/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
+++ b/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
@@ -172,80 +172,90 @@ export class DeviceListenerCurrentDevice {
             return;
         }
 
-        const isCurrentDeviceTrusted = Boolean(
-            (await crypto.getDeviceVerificationStatus(this.client.getSafeUserId(), this.client.deviceId!))
-                ?.crossSigningVerified,
-        );
+        {
+            const isCurrentDeviceTrusted = Boolean(
+                (await crypto.getDeviceVerificationStatus(this.client.getSafeUserId(), this.client.deviceId!))
+                    ?.crossSigningVerified,
+            );
 
-        if (!isCurrentDeviceTrusted) {
-            // The current device is not trusted: prompt the user to verify
-            return await this.failedCheck("verify_this_session", logSpan, "info", "Current device not verified");
+            if (!isCurrentDeviceTrusted) {
+                // The current device is not trusted: prompt the user to verify
+                return await this.failedCheck("verify_this_session", logSpan, "info", "Current device not verified");
+            }
         }
 
-        const crossSigningStatus = await crypto.getCrossSigningStatus();
-        const allCrossSigningSecretsCached =
-            crossSigningStatus.privateKeysCachedLocally.masterKey &&
-            crossSigningStatus.privateKeysCachedLocally.selfSigningKey &&
-            crossSigningStatus.privateKeysCachedLocally.userSigningKey;
+        {
+            const crossSigningStatus = await crypto.getCrossSigningStatus();
+            const allCrossSigningSecretsCached =
+                crossSigningStatus.privateKeysCachedLocally.masterKey &&
+                crossSigningStatus.privateKeysCachedLocally.selfSigningKey &&
+                crossSigningStatus.privateKeysCachedLocally.userSigningKey;
 
-        if (!allCrossSigningSecretsCached) {
-            // cross signing ready & device trusted, but we are missing secrets from our local cache.
-            // prompt the user to enter their recovery key.
-            const newState = crossSigningStatus.privateKeysInSecretStorage
-                ? "key_storage_out_of_sync"
-                : "identity_needs_reset";
+            if (!allCrossSigningSecretsCached) {
+                // cross signing ready & device trusted, but we are missing secrets from our local cache.
+                // prompt the user to enter their recovery key.
+                const newState = crossSigningStatus.privateKeysInSecretStorage
+                    ? "key_storage_out_of_sync"
+                    : "identity_needs_reset";
 
-            return await this.failedCheck(
-                newState,
-                logSpan,
-                "info",
-                "Some secrets not cached",
-                crossSigningStatus.privateKeysCachedLocally,
-                crossSigningStatus.privateKeysInSecretStorage,
-            );
+                return await this.failedCheck(
+                    newState,
+                    logSpan,
+                    "info",
+                    "Some secrets not cached",
+                    crossSigningStatus.privateKeysCachedLocally,
+                    crossSigningStatus.privateKeysInSecretStorage,
+                );
+            }
         }
 
         const keyBackupUploadActive = await this.isKeyBackupUploadActive(logSpan);
         const backupDisabled = await this.recheckBackupDisabled();
-        // We warn if key backup upload is turned off and we have not explicitly
-        // said we are OK with that.
-        const keyBackupUploadIsOk = keyBackupUploadActive || backupDisabled;
+        {
+            // We warn if key backup upload is turned off and we have not explicitly
+            // said we are OK with that.
+            const keyBackupUploadIsOk = keyBackupUploadActive || backupDisabled;
 
-        if (!keyBackupUploadIsOk) {
-            return await this.failedCheck(
-                "turn_on_key_storage",
-                logSpan,
-                "info",
-                "Key backup upload is unexpectedly turned off",
-            );
-        }
-
-        const secretStorageStatus = await crypto.getSecretStorageStatus();
-        const recoveryDisabled = await this.recheckRecoveryDisabled(this.client);
-        const recoveryIsOk = secretStorageStatus.ready || recoveryDisabled || backupDisabled;
-
-        if (!recoveryIsOk) {
-            if (secretStorageStatus.defaultKeyId === null) {
-                return await this.failedCheck("set_up_recovery", logSpan, "info", "No default 4S key");
-            } else {
-                return await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "4S is missing secrets", {
-                    secretStorageStatus,
-                });
+            if (!keyBackupUploadIsOk) {
+                return await this.failedCheck(
+                    "turn_on_key_storage",
+                    logSpan,
+                    "info",
+                    "Key backup upload is unexpectedly turned off",
+                );
             }
         }
 
-        // We warn if key backup is set up, but we don't have the decryption
-        // key, so can't fetch keys from backup.
-        const keyBackupDownloadIsOk =
-            !keyBackupUploadActive || backupDisabled || (await crypto.getSessionBackupPrivateKey()) !== null;
+        {
+            const secretStorageStatus = await crypto.getSecretStorageStatus();
+            const recoveryDisabled = await this.recheckRecoveryDisabled(this.client);
+            const recoveryIsOk = secretStorageStatus.ready || recoveryDisabled || backupDisabled;
 
-        if (!keyBackupDownloadIsOk) {
-            return await this.failedCheck(
-                "key_storage_out_of_sync",
-                logSpan,
-                "warn",
-                "Backup key is not cached locally",
-            );
+            if (!recoveryIsOk) {
+                if (secretStorageStatus.defaultKeyId === null) {
+                    return await this.failedCheck("set_up_recovery", logSpan, "info", "No default 4S key");
+                } else {
+                    return await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "4S is missing secrets", {
+                        secretStorageStatus,
+                    });
+                }
+            }
+        }
+
+        {
+            // We warn if key backup is set up, but we don't have the decryption
+            // key, so can't fetch keys from backup.
+            const keyBackupDownloadIsOk =
+                !keyBackupUploadActive || backupDisabled || (await crypto.getSessionBackupPrivateKey()) !== null;
+
+            if (!keyBackupDownloadIsOk) {
+                return await this.failedCheck(
+                    "key_storage_out_of_sync",
+                    logSpan,
+                    "warn",
+                    "Backup key is not cached locally",
+                );
+            }
         }
 
         // Everything is OK - no need to show a toast

--- a/apps/web/test/unit-tests/DeviceListener-test.ts
+++ b/apps/web/test/unit-tests/DeviceListener-test.ts
@@ -591,31 +591,58 @@ describe("DeviceListener", () => {
 
         describe("key backup status", () => {
             it("checks keybackup status when cross signing and secret storage are ready", async () => {
-                // default mocks set cross signing and secret storage to ready
+                // Given our device is verified
+                mockCrypto.getDeviceVerificationStatus.mockResolvedValue({
+                    crossSigningVerified: true,
+                } as any as DeviceVerificationStatus);
+
+                // When we check the current device
                 await createAndStart();
+
+                // Then we get to the code that checks the active session backup
                 expect(mockCrypto.getActiveSessionBackupVersion).toHaveBeenCalled();
             });
 
-            it("checks keybackup status when setup encryption toast has been dismissed", async () => {
-                mockCrypto!.isCrossSigningReady.mockResolvedValue(false);
-                const instance = await createAndStart();
+            it("does not check keybackup status when setup encryption toast has been dismissed", async () => {
+                // Given our device is not verified (this is the default in the mock)
 
+                // And we have run the checks once (and we were told to verify)
+                const instance = await createAndStart();
+                expect(SetupEncryptionToast.showToast).toHaveBeenCalledWith("verify_this_session");
+                mocked(SetupEncryptionToast.showToast).mockClear();
+                mockCrypto.getDeviceVerificationStatus.mockClear();
+
+                // When we dismiss the dialog telling us to set up encryption
                 instance.dismissEncryptionSetup();
                 await flushPromises();
 
-                expect(mockCrypto.getActiveSessionBackupVersion).toHaveBeenCalled();
+                // Then we have rechecked, but stopped when we found the device was not verified
+                expect(mockCrypto.getDeviceVerificationStatus).toHaveBeenCalled();
+                expect(SetupEncryptionToast.showToast).not.toHaveBeenCalled();
             });
 
             it("does not check key backup status again after check is complete", async () => {
-                mockCrypto.getActiveSessionBackupVersion.mockResolvedValue("1");
-                const instance = await createAndStart();
-                expect(mockCrypto.getActiveSessionBackupVersion).toHaveBeenCalled();
+                // Given our device is verified
+                mockCrypto.getDeviceVerificationStatus.mockResolvedValue({
+                    crossSigningVerified: true,
+                } as any as DeviceVerificationStatus);
 
-                // trigger a recheck
-                instance.dismissEncryptionSetup();
+                // And our active backup version is 1
+                mockCrypto.getActiveSessionBackupVersion.mockResolvedValue("1");
+
+                // And we have run the checks once: no toast was shown and we
+                // checked the backup version
+                const instance = await createAndStart();
+                expect(SetupEncryptionToast.showToast).not.toHaveBeenCalled();
+                expect(mockCrypto.getActiveSessionBackupVersion).toHaveBeenCalled();
+                mockCrypto.getActiveSessionBackupVersion.mockClear();
+
+                // When we check again
+                instance.recheck();
                 await flushPromises();
-                // not called again, check was complete last time
-                expect(mockCrypto.getActiveSessionBackupVersion).toHaveBeenCalledTimes(1);
+
+                // Then we didn't re-call getActiveSessionBackupVersion
+                expect(mockCrypto.getActiveSessionBackupVersion).not.toHaveBeenCalled();
             });
         });
 


### PR DESCRIPTION
Break up recheck into separate functions. The intervening commits are intended to make it easier to see that the code is correct - feel free to read them if it helps, or look at the full diff.

Part of https://github.com/element-hq/crypto-internal/issues/305

Depends on https://github.com/element-hq/element-web/pull/32982

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
