### PR TITLE
Pass tags with INPUT_TAGS in docker bake job

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -12,7 +12,7 @@ export default {
                 // Used in playwright-screenshots.sh
                 "wait-on",
             ],
-            ignoreBinaries: ["awk"],
+            ignoreBinaries: ["awk", "printf"],
         },
         "packages/module-api": {},
         "apps/web": {

--- a/packages/playwright-common/project.json
+++ b/packages/playwright-common/project.json
@@ -18,7 +18,7 @@
         },
         "docker:prebuild": {
             "cache": true,
-            "command": "echo PLAYWRIGHT_VERSION=$(pnpm --silent -- playwright --version | awk '{print $2}') > .env.docker:build",
+            "command": "PLAYWRIGHT_VERSION=$(pnpm --silent -- playwright --version | awk '{print $2}') && printf '%s\\n' \"PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION\" \"INPUT_TAGS=\\\"type=ref,event=branch\\ntype=raw,enable={{is_default_branch}},value=$PLAYWRIGHT_VERSION\\\"\" > .env.docker:build",
             "inputs": [{ "runtime": "pnpm --silent -- playwright --version" }],
             "outputs": ["{projectRoot}/.env.docker:build"],
             "options": { "cwd": "packages/playwright-common" }
@@ -35,8 +35,7 @@
                 "build-args": ["PLAYWRIGHT_VERSION"],
                 "context": "{projectRoot}",
                 "metadata": {
-                    "images": ["ghcr.io/element-hq/element-web/playwright-server"],
-                    "tags": ["type=ref,event=branch", "type=raw,enable={{is_default_branch}},value=$PLAYWRIGHT_VERSION"]
+                    "images": ["ghcr.io/element-hq/element-web/playwright-server"]
                 }
             }
         }


### PR DESCRIPTION
Truly hideous mess of shell to set both env vars in the prebuild step.

As the env var doesn't seem to be available to the actual executor but clearly must be available to the docker that it runs.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
