### PR TITLE
Press tab instead of blurring in playwright test

### DIFF
--- a/apps/web/playwright/e2e/settings/room-settings/room-security-tab.spec.ts
+++ b/apps/web/playwright/e2e/settings/room-settings/room-security-tab.spec.ts
@@ -100,7 +100,7 @@ test.describe("Roles & Permissions room settings tab", () => {
             await ourComboBox.selectOption("Custom level");
             const ourPl = settings.getByRole("spinbutton", { name: user.userId });
             await ourPl.fill("80");
-            await ourPl.blur(); // Shows a warning on
+            await page.keyboard.press("Tab"); // Shows a warning on
 
             // Accept the de-op
             await page.getByRole("button", { name: "Continue" }).click();


### PR DESCRIPTION
This was flaking a lot: try a regular keypress instead of trying to blur the element (which is closer to an actual user interaction anyway).

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
