### PR TITLE
Mocking PasswordScorer.scorePassword to reduce risk of flakiness in ChangePassword-test

### DIFF
--- a/apps/web/test/unit-tests/components/views/settings/ChangePassword-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/ChangePassword-test.tsx
@@ -14,6 +14,16 @@ import { mocked } from "jest-mock";
 import ChangePassword from "../../../../../src/components/views/settings/ChangePassword";
 import { stubClient } from "../../../../test-utils";
 
+jest.mock("../../../../../src/utils/PasswordScorer", () => ({
+    scorePassword: jest.fn(() => ({
+        score: 4,
+        feedback: {
+            warning: "",
+            suggestions: [],
+        },
+    })),
+}));
+
 describe("<ChangePassword />", () => {
     it("renders expected fields", () => {
         const onFinished = jest.fn();


### PR DESCRIPTION
Mocking PasswordScorer.scorePassword to reduce risk of flakiness in ChangePassword-test,
Fixes: https://github.com/element-hq/element-web/issues/33341