### PR TITLE
Apply danger button class to ConfirmRedactDialog

### DIFF
--- a/apps/web/res/css/_components.pcss
+++ b/apps/web/res/css/_components.pcss
@@ -124,6 +124,7 @@
 @import "./views/dialogs/_ChangelogDialog.pcss";
 @import "./views/dialogs/_CompoundDialog.pcss";
 @import "./views/dialogs/_ConfirmKeyStorageOffDialog.pcss";
+@import "./views/dialogs/_ConfirmRedactDialog.pcss";
 @import "./views/dialogs/_ConfirmSpaceUserActionDialog.pcss";
 @import "./views/dialogs/_ConfirmUserActionDialog.pcss";
 @import "./views/dialogs/_CreateRoomDialog.pcss";

--- a/apps/web/res/css/views/dialogs/_ConfirmRedactDialog.pcss
+++ b/apps/web/res/css/views/dialogs/_ConfirmRedactDialog.pcss
@@ -1,0 +1,12 @@
+/*
+Copyright 2024 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+.mx_ConfirmRedactDialog_buttonContent {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cpd-space-1x);
+}

--- a/apps/web/src/components/views/dialogs/ConfirmRedactDialog.tsx
+++ b/apps/web/src/components/views/dialogs/ConfirmRedactDialog.tsx
@@ -39,6 +39,7 @@ export default class ConfirmRedactDialog extends React.Component<IProps> {
                 placeholder={_t("redact|reason_label")}
                 focus
                 button={_t("action|remove")}
+                primaryButtonClass="danger"
             />
         );
     }

--- a/apps/web/src/components/views/dialogs/ConfirmRedactDialog.tsx
+++ b/apps/web/src/components/views/dialogs/ConfirmRedactDialog.tsx
@@ -8,6 +8,7 @@ Please see LICENSE files in the repository root for full details.
 
 import { type IRedactOpts, type MatrixEvent } from "matrix-js-sdk/src/matrix";
 import React from "react";
+import DeleteIcon from "@vector-im/compound-design-tokens/assets/web/icons/delete";
 
 import { _t } from "../../../languageHandler";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
@@ -38,8 +39,13 @@ export default class ConfirmRedactDialog extends React.Component<IProps> {
                 description={description}
                 placeholder={_t("redact|reason_label")}
                 focus
-                button={_t("action|remove")}
+                button={
+                    <span className="mx_ConfirmRedactDialog_buttonContent">
+                        <DeleteIcon /> {_t("action|remove")}
+                    </span>
+                }
                 primaryButtonClass="danger"
+                cancelButtonClass="secondary"
             />
         );
     }

--- a/apps/web/src/components/views/dialogs/TextInputDialog.tsx
+++ b/apps/web/src/components/views/dialogs/TextInputDialog.tsx
@@ -25,6 +25,7 @@ interface IProps {
     hasCancel: boolean;
     validator?: (fieldState: IFieldState) => Promise<IValidationResult>; // result of withValidation
     fixedWidth?: boolean;
+    primaryButtonClass?: string;
     onFinished(ok?: false, text?: void): void;
     onFinished(ok: true, text: string): void;
 }
@@ -128,6 +129,7 @@ export default class TextInputDialog extends React.Component<IProps, IState> {
                 </form>
                 <DialogButtons
                     primaryButton={this.state.busy ? _t(this.props.busyMessage) : this.props.button}
+                    primaryButtonClass={this.props.primaryButtonClass}
                     disabled={this.state.busy}
                     onPrimaryButtonClick={this.onOk}
                     onCancel={this.onCancel}

--- a/apps/web/src/components/views/dialogs/TextInputDialog.tsx
+++ b/apps/web/src/components/views/dialogs/TextInputDialog.tsx
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import React, { type ChangeEvent, createRef } from "react";
+import React, { type ChangeEvent, type ReactNode, createRef } from "react";
 
 import Field from "../elements/Field";
 import { _t, _td } from "../../../languageHandler";
@@ -19,13 +19,14 @@ interface IProps {
     description: React.ReactNode;
     value: string;
     placeholder?: string;
-    button?: string;
+    button?: ReactNode;
     busyMessage: TranslationKey;
     focus: boolean;
     hasCancel: boolean;
     validator?: (fieldState: IFieldState) => Promise<IValidationResult>; // result of withValidation
     fixedWidth?: boolean;
     primaryButtonClass?: string;
+    cancelButtonClass?: string;
     onFinished(ok?: false, text?: void): void;
     onFinished(ok: true, text: string): void;
 }
@@ -130,6 +131,7 @@ export default class TextInputDialog extends React.Component<IProps, IState> {
                 <DialogButtons
                     primaryButton={this.state.busy ? _t(this.props.busyMessage) : this.props.button}
                     primaryButtonClass={this.props.primaryButtonClass}
+                    cancelButtonClass={this.props.cancelButtonClass}
                     disabled={this.state.busy}
                     onPrimaryButtonClick={this.onOk}
                     onCancel={this.onCancel}

--- a/apps/web/test/unit-tests/components/views/dialogs/ConfirmRedactDialog-test.tsx
+++ b/apps/web/test/unit-tests/components/views/dialogs/ConfirmRedactDialog-test.tsx
@@ -6,12 +6,15 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import React from "react";
 import { type MatrixClient, type MatrixEvent } from "matrix-js-sdk/src/matrix";
-import { screen, act } from "jest-matrix-react";
+import { render, screen, act } from "jest-matrix-react";
 import userEvent from "@testing-library/user-event";
 
 import { flushPromises, mkEvent, stubClient } from "../../../../test-utils";
-import { createRedactEventDialog } from "../../../../../src/components/views/dialogs/ConfirmRedactDialog";
+import ConfirmRedactDialog, {
+    createRedactEventDialog,
+} from "../../../../../src/components/views/dialogs/ConfirmRedactDialog";
 
 describe("ConfirmRedactDialog", () => {
     const roomId = "!room:example.com";
@@ -55,5 +58,81 @@ describe("ConfirmRedactDialog", () => {
         await expect(confirmDeleteVoiceBroadcastStartedEvent()).rejects.toThrow(
             `cannot redact event ${mxEvent.getId()} without room ID`,
         );
+    });
+
+    describe("rendering", () => {
+        it("renders the confirm dialog with danger button class", () => {
+            const event = mkEvent({
+                event: true,
+                type: "m.room.message",
+                room: roomId,
+                content: {},
+                user: client.getSafeUserId(),
+            });
+
+            render(<ConfirmRedactDialog event={event} onFinished={jest.fn()} />);
+
+            expect(screen.getByText("Confirm Removal")).toBeInTheDocument();
+            expect(screen.getByText("Are you sure you wish to remove (delete) this event?")).toBeInTheDocument();
+            expect(screen.getByText("Remove")).toBeInTheDocument();
+
+            const primaryButton = screen.getByTestId("dialog-primary-button");
+            expect(primaryButton).toHaveClass("mx_Dialog_primary");
+            expect(primaryButton).toHaveClass("danger");
+        });
+
+        it("renders extended description for state events", () => {
+            const stateEvent = mkEvent({
+                event: true,
+                type: "m.room.name",
+                room: roomId,
+                content: {},
+                user: client.getSafeUserId(),
+                skey: "",
+            });
+
+            render(<ConfirmRedactDialog event={stateEvent} onFinished={jest.fn()} />);
+
+            expect(
+                screen.getByText(
+                    "Are you sure you wish to remove (delete) this event? Note that removing room changes like this could undo the change.",
+                ),
+            ).toBeInTheDocument();
+        });
+
+        it("renders a reason field with placeholder", () => {
+            const event = mkEvent({
+                event: true,
+                type: "m.room.message",
+                room: roomId,
+                content: {},
+                user: client.getSafeUserId(),
+            });
+
+            render(<ConfirmRedactDialog event={event} onFinished={jest.fn()} />);
+
+            expect(screen.getByLabelText("Reason (optional)")).toBeInTheDocument();
+        });
+
+        it("calls onFinished with reason when primary button is clicked", async () => {
+            const onFinished = jest.fn();
+            const event = mkEvent({
+                event: true,
+                type: "m.room.message",
+                room: roomId,
+                content: {},
+                user: client.getSafeUserId(),
+            });
+
+            render(<ConfirmRedactDialog event={event} onFinished={onFinished} />);
+
+            const input = screen.getByRole("textbox");
+            await userEvent.type(input, "spam");
+
+            const primaryButton = screen.getByTestId("dialog-primary-button");
+            await userEvent.click(primaryButton);
+
+            expect(onFinished).toHaveBeenCalledWith(true, "spam");
+        });
     });
 });

--- a/apps/web/test/unit-tests/components/views/dialogs/ConfirmRedactDialog-test.tsx
+++ b/apps/web/test/unit-tests/components/views/dialogs/ConfirmRedactDialog-test.tsx
@@ -61,7 +61,7 @@ describe("ConfirmRedactDialog", () => {
     });
 
     describe("rendering", () => {
-        it("renders the confirm dialog with danger button class", () => {
+        it("renders the confirm dialog with danger button class and delete icon", () => {
             const event = mkEvent({
                 event: true,
                 type: "m.room.message",
@@ -70,7 +70,7 @@ describe("ConfirmRedactDialog", () => {
                 user: client.getSafeUserId(),
             });
 
-            render(<ConfirmRedactDialog event={event} onFinished={jest.fn()} />);
+            const { container } = render(<ConfirmRedactDialog event={event} onFinished={jest.fn()} />);
 
             expect(screen.getByText("Confirm Removal")).toBeInTheDocument();
             expect(screen.getByText("Are you sure you wish to remove (delete) this event?")).toBeInTheDocument();
@@ -79,6 +79,9 @@ describe("ConfirmRedactDialog", () => {
             const primaryButton = screen.getByTestId("dialog-primary-button");
             expect(primaryButton).toHaveClass("mx_Dialog_primary");
             expect(primaryButton).toHaveClass("danger");
+
+            // Verify DeleteIcon is present inside the primary button
+            expect(primaryButton.querySelector("svg")).toBeInTheDocument();
         });
 
         it("renders extended description for state events", () => {
@@ -133,6 +136,21 @@ describe("ConfirmRedactDialog", () => {
             await userEvent.click(primaryButton);
 
             expect(onFinished).toHaveBeenCalledWith(true, "spam");
+        });
+
+        it("applies secondary class to the cancel button", () => {
+            const event = mkEvent({
+                event: true,
+                type: "m.room.message",
+                room: roomId,
+                content: {},
+                user: client.getSafeUserId(),
+            });
+
+            render(<ConfirmRedactDialog event={event} onFinished={jest.fn()} />);
+
+            const cancelButton = screen.getByTestId("dialog-cancel-button");
+            expect(cancelButton).toHaveClass("secondary");
         });
     });
 });

--- a/apps/web/test/unit-tests/components/views/dialogs/TextInputDialog-test.tsx
+++ b/apps/web/test/unit-tests/components/views/dialogs/TextInputDialog-test.tsx
@@ -1,0 +1,98 @@
+/*
+Copyright 2024 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import React from "react";
+import { render, screen } from "jest-matrix-react";
+import userEvent from "@testing-library/user-event";
+
+import TextInputDialog from "../../../../../src/components/views/dialogs/TextInputDialog";
+
+describe("TextInputDialog", () => {
+    const defaultProps = {
+        title: "Test title",
+        description: "Test description",
+        value: "",
+        button: "OK",
+        focus: false,
+        hasCancel: true,
+        onFinished: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("renders title and description", () => {
+        render(<TextInputDialog {...defaultProps} />);
+
+        expect(screen.getByText("Test title")).toBeInTheDocument();
+        expect(screen.getByText("Test description")).toBeInTheDocument();
+    });
+
+    it("renders a field with the given placeholder", () => {
+        render(<TextInputDialog {...defaultProps} placeholder="Enter value" />);
+
+        expect(screen.getByLabelText("Enter value")).toBeInTheDocument();
+    });
+
+    it("renders the primary button with the given button text", () => {
+        render(<TextInputDialog {...defaultProps} button="Submit" />);
+
+        expect(screen.getByText("Submit")).toBeInTheDocument();
+    });
+
+    it("applies primaryButtonClass to the primary button", () => {
+        render(<TextInputDialog {...defaultProps} primaryButtonClass="danger" />);
+
+        const primaryButton = screen.getByTestId("dialog-primary-button");
+        expect(primaryButton).toHaveClass("mx_Dialog_primary");
+        expect(primaryButton).toHaveClass("danger");
+    });
+
+    it("does not add extra class when primaryButtonClass is not provided", () => {
+        render(<TextInputDialog {...defaultProps} />);
+
+        const primaryButton = screen.getByTestId("dialog-primary-button");
+        expect(primaryButton).toHaveClass("mx_Dialog_primary");
+        expect(primaryButton).not.toHaveClass("danger");
+    });
+
+    it("calls onFinished(true, text) when the primary button is clicked", async () => {
+        const onFinished = jest.fn();
+        render(<TextInputDialog {...defaultProps} onFinished={onFinished} />);
+
+        const input = screen.getByRole("textbox");
+        await userEvent.type(input, "hello");
+
+        const primaryButton = screen.getByTestId("dialog-primary-button");
+        await userEvent.click(primaryButton);
+
+        expect(onFinished).toHaveBeenCalledWith(true, "hello");
+    });
+
+    it("calls onFinished(false) when cancel is clicked", async () => {
+        const onFinished = jest.fn();
+        render(<TextInputDialog {...defaultProps} onFinished={onFinished} />);
+
+        const cancelButton = screen.getByTestId("dialog-cancel-button");
+        await userEvent.click(cancelButton);
+
+        expect(onFinished).toHaveBeenCalledWith(false);
+    });
+
+    it("renders a cancel button when hasCancel is true", () => {
+        render(<TextInputDialog {...defaultProps} hasCancel={true} />);
+
+        expect(screen.getByTestId("dialog-cancel-button")).toBeInTheDocument();
+    });
+
+    it("does not render a cancel button when hasCancel is false", () => {
+        render(<TextInputDialog {...defaultProps} hasCancel={false} />);
+
+        expect(screen.queryByTestId("dialog-cancel-button")).not.toBeInTheDocument();
+    });
+});

--- a/apps/web/test/unit-tests/components/views/dialogs/TextInputDialog-test.tsx
+++ b/apps/web/test/unit-tests/components/views/dialogs/TextInputDialog-test.tsx
@@ -95,4 +95,11 @@ describe("TextInputDialog", () => {
 
         expect(screen.queryByTestId("dialog-cancel-button")).not.toBeInTheDocument();
     });
+
+    it("applies cancelButtonClass to the cancel button", () => {
+        render(<TextInputDialog {...defaultProps} cancelButtonClass="secondary" />);
+
+        const cancelButton = screen.getByTestId("dialog-cancel-button");
+        expect(cancelButton).toHaveClass("secondary");
+    });
 });


### PR DESCRIPTION
ADD
- `primaryButtonClass` prop to TextInputDialog

CHANGE
- Pass `primaryButtonClass="danger"` to TextInputDialog in ConfirmRedactDialog

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)

Description:
Adds an optional primaryButtonClass prop to TextInputDialog that is forwarded to DialogButtons, allowing consumers to style the primary button. Uses this in ConfirmRedactDialog by passing "danger" so the "Remove" button in the redaction confirmation dialog is visually styled as a destructive action, making it clearer to users that the action cannot be easily undone.

## Before

<img width="919" height="432" alt="image" src="https://github.com/user-attachments/assets/399627d6-09bd-4d3d-aa95-c585cb6972b9" />

## After

<img width="802" height="358" alt="image" src="https://github.com/user-attachments/assets/619cdba5-b722-461f-9652-cf2ad3a3e099" />
