### PR TITLE
Increase timeout on BeaconViewDialog

### DIFF
--- a/apps/web/test/unit-tests/components/views/beacon/BeaconViewDialog-test.tsx
+++ b/apps/web/test/unit-tests/components/views/beacon/BeaconViewDialog-test.tsx
@@ -101,9 +101,12 @@ describe("<BeaconViewDialog />", () => {
             lat: 51,
         });
         // marker added
-        await waitFor(() => {
-            expect(mockMarker.addTo).toHaveBeenCalledWith(mockMap);
-        });
+        await waitFor(
+            () => {
+                expect(mockMarker.addTo).toHaveBeenCalledWith(mockMap);
+            },
+            { timeout: 5000 },
+        );
     });
 
     it("does not render any own beacon status when user is not live sharing", () => {


### PR DESCRIPTION
standard 1s doesn't seem long enough to avoid flakes

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
