### PR TITLE
Fix non-urgent toast inline link being invisible on light theme

### DIFF
--- a/apps/web/res/css/structures/_NonUrgentToastContainer.pcss
+++ b/apps/web/res/css/structures/_NonUrgentToastContainer.pcss
@@ -23,5 +23,15 @@ Please see LICENSE files in the repository root for full details.
         /* in all themes. */
         background-color: #17191c;
         color: #fff;
+
+        /* Inline links inherit `--cpd-color-text-primary` from
+         * `_AccessibleButton.pcss`, which is theme-dependent — on light
+         * theme that is a dark colour, which is invisible against this
+         * container's hard-coded dark background. Pin the link colour to
+         * white so it stays readable in both themes, matching the
+         * container's intentional theme-independence noted above. */
+        .mx_AccessibleButton.mx_AccessibleButton_kind_link_inline {
+            color: #fff;
+        }
     }
 }


### PR DESCRIPTION
Fixes #33494.

cc @t3chguy since you're the most recent committer to `_NonUrgentToastContainer.pcss`.

## The bug

In light theme, the `requests` inline link inside the `Your server isn't responding to some requests` toast is invisible — the text collapses into the toast's background.

## Root cause

`apps/web/res/css/structures/_NonUrgentToastContainer.pcss` hard-codes the container's background to `#17191c` and its base text colour to `#fff`, with an explicit comment:

```pcss
/* We don't use variables on the colours because we want it to be the same */
/* in all themes. */
background-color: #17191c;
color: #fff;
```

So the container is always dark, in every theme. But the inline `requests` link is rendered as `AccessibleButton kind="link_inline"`, whose colour rule in `apps/web/res/css/views/elements/_AccessibleButton.pcss` is:

```pcss
&.mx_AccessibleButton_kind_link,
&.mx_AccessibleButton_kind_link_inline {
    color: var(--cpd-color-text-primary);
}
```

`--cpd-color-text-primary` is theme-dependent. In light theme it resolves to a dark colour. Dark text on `#17191c` is effectively invisible — that is the bug.

## The fix

Pin the inline-link colour to `#fff` inside `.mx_NonUrgentToastContainer_toast`, so it follows the container's intentional theme-independent styling. The fix is scoped to the container and the specific `link_inline` kind, so it cannot leak outside the non-urgent toasts and it does not affect any other inline links elsewhere in the app.

```pcss
.mx_NonUrgentToastContainer_toast {
    /* ... existing ... */

    .mx_AccessibleButton.mx_AccessibleButton_kind_link_inline {
        color: #fff;
    }
}
```

+10 LOC including the explanatory comment.

## Verification

- Pure CSS change, no behaviour change outside `.mx_NonUrgentToastContainer_toast`.
- Selector specificity: `.mx_NonUrgentToastContainer .mx_NonUrgentToastContainer_toast .mx_AccessibleButton.mx_AccessibleButton_kind_link_inline` (0,4,0) overrides the upstream `&.mx_AccessibleButton_kind_link_inline` (0,2,0) — no `!important` needed.
- Manual visual confirmation against the issue screenshot: the dark toast is unchanged, the previously-invisible `requests` link now shows white.
- No new tests added (visual-only change, no logic).