### PR TITLE
Realign the User Menu profile picture on desktop

### DIFF
--- a/apps/desktop/src/macos-titlebar.ts
+++ b/apps/desktop/src/macos-titlebar.ts
@@ -20,7 +20,6 @@ export function setupMacosTitleBar(window: BrowserWindow): void {
                 margin-top: 0 !important;
                 margin-left: 0 !important;
                 padding-top: 32px !important;
-                padding-left: 20px !important;
                 -webkit-app-region: drag;
                 -webkit-user-select: none;
             }


### PR DESCRIPTION
Before:
<img width="114" height="98" alt="Screenshot 2026-05-27 at 12 40 48" src="https://github.com/user-attachments/assets/e2b23b69-8ee3-4abf-af3a-5219431a5b94" />

After:
<img width="106" height="91" alt="Screenshot 2026-05-27 at 12 31 02" src="https://github.com/user-attachments/assets/26655001-7dd4-4800-90b2-bdbba0c03b38" />


The button already shoves itself left so we don't need the macos style to do so as well.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
