### PR TITLE
Fix broken app icon on debian dock

### DIFF
--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -133,6 +133,15 @@ const config: Omit<Writable<Configuration>, "electronFuses"> & {
         category: "Network;InstantMessaging;Chat",
         icon: "icon.png",
         executableName: variant.name, // element-desktop or element-desktop-nightly
+        desktop: {
+            entry: {
+                // By default, electron builder will set this to variant.productName.
+                // But electron builder also sets the WM_CLASS of the window to variant.name.
+                // This difference will cause the app to launch with no icon and sometimes
+                // prevents app grouping in the taskbar.
+                StartupWMClass: variant.name,
+            },
+        },
     },
     deb: {
         packageCategory: "net",


### PR DESCRIPTION
Closes https://github.com/element-hq/element-web/issues/33472

On my debian 13 dock:
<img width="106" height="73" alt="image" src="https://github.com/user-attachments/assets/7b76c4b2-2ce4-4f54-9b45-883a11760157" />

I can get it to work if I manually edit the desktop file so that `StartupWMClass` is `element-desktop-nightly`.