### PR TITLE
Fix playwright screenshot consistency

### DIFF
--- a/packages/playwright-common/docker-entrypoint.sh
+++ b/packages/playwright-common/docker-entrypoint.sh
@@ -1,2 +1,7 @@
 #!/bin/bash
-exec /usr/bin/playwright run-server --port "$PORT" --host 0.0.0.0
+
+# --unsafe allows clients to pass CLI flags to chromium for things like disabling
+# subpixel rendering which we need for consistent screenshots. 
+# Better might be to specify them statically here but unfortunately that's not an
+# option.
+exec /usr/bin/playwright run-server --port "$PORT" --host 0.0.0.0 --unsafe


### PR DESCRIPTION
Add the --unsafe flag because we like to live dangerously, as commented.

FWIW, the playwright PR that introduced this behaviour: https://github.com/microsoft/playwright/pull/40495

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
