### PR TITLE
Fix "Expand map" tooltip overlapping message composer

### DIFF
--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -47,7 +47,7 @@ const config: Config = {
         "@vector-im/compound-web": "<rootDir>/node_modules/@vector-im/compound-web",
     },
     transformIgnorePatterns: [
-        `${path.join(__dirname, "../..")}/node_modules/.pnpm/(?!(mime|uuid|p-retry|is-network-error|react-merge-refs|is-ip|ip-regex|super-regex|function-timeout|time-span|convert-hrtime|clone-regexp|is-regexp|matrix-web-i18n|await-lock|@element-hq/web-shared-components|react-virtuoso|lodash|domutils|domhandler|domelementtype|dom-serializer|entities)).+$`,
+        `${path.join(__dirname, "../..")}/node_modules/.pnpm/(?!(mime|uuid|p-retry|is-network-error|react-merge-refs|is-ip|ip-regex|super-regex|function-timeout|time-span|convert-hrtime|clone-regexp|is-regexp|matrix-web-i18n|await-lock|@element-hq/web-shared-components|react-virtuoso|lodash|domutils|domhandler|domelementtype|dom-serializer|entities|matrix-js-sdk)).+$`,
     ],
     collectCoverageFrom: [
         "<rootDir>/src/**/*.{js,ts,tsx}",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,7 @@
         "@babel/runtime": "^7.12.5",
         "@element-hq/element-web-module-api": "workspace:*",
         "@element-hq/web-shared-components": "workspace:*",
+        "@floating-ui/react": "^0.27.19",
         "@fontsource/fira-code": "^5",
         "@fontsource/inter": "catalog:",
         "@formatjs/intl-segmenter": "^12.0.0",

--- a/apps/web/src/components/views/messages/MLocationBody.tsx
+++ b/apps/web/src/components/views/messages/MLocationBody.tsx
@@ -6,10 +6,25 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import React from "react";
+import React, { useMemo, useRef, useState, useEffect } from "react";
 import { type MatrixEvent, ClientEvent, type ClientEventHandlerMap } from "matrix-js-sdk/src/matrix";
 import { secureRandomString } from "matrix-js-sdk/src/randomstring";
-import { Tooltip } from "@vector-im/compound-web";
+import {
+    hide,
+    useFloating,
+    autoUpdate,
+    offset,
+    flip,
+    shift,
+    arrow,
+    useHover,
+    useFocus,
+    useDismiss,
+    useRole,
+    useInteractions,
+    FloatingPortal,
+    FloatingArrow,
+} from "@floating-ui/react";
 
 import { _t } from "../../../languageHandler";
 import Modal from "../../../Modal";
@@ -118,6 +133,81 @@ export const LocationBodyFallbackContent: React.FC<{ event: MatrixEvent; error: 
     );
 };
 
+const BoundaryAwareTooltip: React.FC<{ label: string; children: React.ReactElement }> = ({ label, children }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const arrowRef = useRef<SVGSVGElement>(null);
+    const [boundaryEl, setBoundaryEl] = useState<HTMLElement | null>(null);
+
+    useEffect(() => {
+        setBoundaryEl(document.querySelector(".mx_RoomView_messagePanel"));
+    }, []);
+
+    const middleware = useMemo(
+        () => [
+            offset(6),
+            flip({
+                boundary: boundaryEl ? [boundaryEl] : undefined,
+                fallbackAxisSideDirection: "start",
+                padding: 5,
+            }),
+            shift({ padding: 5 }),
+            hide({ strategy: "escaped", padding: 6, boundary: boundaryEl ? [boundaryEl] : undefined }),
+            arrow({ element: arrowRef }),
+        ],
+        [boundaryEl],
+    );
+
+    const { refs, floatingStyles, context } = useFloating({
+        open: isOpen,
+        onOpenChange: setIsOpen,
+        placement: "bottom",
+        middleware,
+        whileElementsMounted: autoUpdate,
+    });
+
+    const { getReferenceProps, getFloatingProps } = useInteractions([
+        useHover(context, { move: false, delay: { open: 300, close: 0 }, mouseOnly: true }),
+        useFocus(context),
+        useDismiss(context),
+        useRole(context, { role: "tooltip" }),
+    ]);
+
+    const escaped = context.middlewareData?.hide?.escaped ?? false;
+
+    return (
+        <>
+            {React.cloneElement(children, getReferenceProps({ ref: refs.setReference }))}
+            <FloatingPortal>
+                {isOpen && (
+                    <div
+                        ref={refs.setFloating}
+                        style={{
+                            ...floatingStyles,
+                            font: "var(--cpd-font-body-xs-medium)",
+                            padding: "var(--cpd-space-1-5x) var(--cpd-space-3x)",
+                            background: "var(--cpd-color-alpha-gray-1400)",
+                            color: "var(--cpd-color-text-on-solid-primary)",
+                            borderRadius: 4,
+                            cursor: "pointer",
+                            ...(escaped ? { visibility: "hidden" as const } : {}),
+                        }}
+                        {...getFloatingProps()}
+                    >
+                        <FloatingArrow
+                            ref={arrowRef}
+                            context={context}
+                            width={10}
+                            height={6}
+                            style={{ fill: "var(--cpd-color-alpha-gray-1400)" }}
+                        />
+                        {label}
+                    </div>
+                )}
+            </FloatingPortal>
+        </>
+    );
+};
+
 interface LocationBodyContentProps {
     mxEvent: MatrixEvent;
     mapId: string;
@@ -151,9 +241,9 @@ export const LocationBodyContent: React.FC<LocationBodyContentProps> = ({
 
     return (
         <div className="mx_MLocationBody">
-            <Tooltip label={tooltip}>
+            <BoundaryAwareTooltip label={tooltip}>
                 <div className="mx_MLocationBody_map">{mapElement}</div>
-            </Tooltip>
+            </BoundaryAwareTooltip>
         </div>
     );
 };

--- a/apps/web/test/unit-tests/components/views/messages/__snapshots__/MLocationBody-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/messages/__snapshots__/MLocationBody-test.tsx.snap
@@ -34,7 +34,6 @@ exports[`MLocationBody <MLocationBody> without error renders map correctly 1`] =
     class="mx_MLocationBody"
   >
     <div
-      aria-labelledby="react-use-id-1"
       class="mx_MLocationBody_map"
     >
       <div
@@ -76,7 +75,6 @@ exports[`MLocationBody <MLocationBody> without error renders marker correctly fo
     class="mx_MLocationBody"
   >
     <div
-      aria-labelledby="react-use-id-1"
       class="mx_MLocationBody_map"
     >
       <div

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -511,6 +511,9 @@ importers:
       '@element-hq/web-shared-components':
         specifier: workspace:*
         version: link:../../packages/shared-components
+      '@floating-ui/react':
+        specifier: ^0.27.19
+        version: 0.27.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@fontsource/fira-code':
         specifier: ^5
         version: 5.2.7
@@ -2957,11 +2960,23 @@ packages:
   '@floating-ui/core@1.7.4':
     resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
   '@floating-ui/dom@1.7.5':
     resolution: {integrity: sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==}
 
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
   '@floating-ui/react-dom@2.1.7':
     resolution: {integrity: sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -2972,8 +2987,17 @@ packages:
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
 
+  '@floating-ui/react@0.27.19':
+    resolution: {integrity: sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==}
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@fontsource/fira-code@5.2.7':
     resolution: {integrity: sha512-tnB9NNund9TwIym8/7DMJe573nlPEQb+fKUV5GL8TBYXjIhDvL0D7mgmNVNQUPhXp+R7RylQeiBdkA4EbOHPGQ==}
@@ -15636,14 +15660,29 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.10
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
   '@floating-ui/dom@1.7.5':
     dependencies:
       '@floating-ui/core': 1.7.4
       '@floating-ui/utils': 0.2.10
 
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
   '@floating-ui/react-dom@2.1.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@floating-ui/dom': 1.7.5
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -15655,7 +15694,17 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       tabbable: 6.4.0
 
+  '@floating-ui/react@0.27.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      tabbable: 6.4.0
+
   '@floating-ui/utils@0.2.10': {}
+
+  '@floating-ui/utils@0.2.11': {}
 
   '@fontsource/fira-code@5.2.7': {}
 


### PR DESCRIPTION
Fixes #21619

## Summary

The "Expand map" tooltip on location messages was rendered through a `FloatingPortal`, allowing it to overlap UI elements outside the visible message panel, including the message composer while scrolling.

The existing compound-web `<Tooltip>` component does not expose the Floating UI middleware required to implement boundary-aware positioning and visibility behavior.

This change replaces the tooltip with a custom `BoundaryAwareTooltip` built on `@floating-ui/react` that:

* Flips above the map when there is insufficient space below it
* Hides when it escapes the visible message panel boundary

## Before

<img width="733" height="456" alt="Screenshot from 2026-05-30 18-11-11" src="https://github.com/user-attachments/assets/77f023c6-cb9f-4ec8-add3-d984e7476a35" />

The tooltip remains visible and can overlap the message composer when the timeline is scrolled.

## After

<img width="733" height="579" alt="Screenshot from 2026-05-30 18-14-07" src="https://github.com/user-attachments/assets/f7cfa0aa-90e1-4928-bcea-c39521517015" />

The tooltip flips above the map when space below becomes constrained and becomes hidden when it escapes the visible message panel boundary.

## Demonstration

https://github.com/user-attachments/assets/f9898835-32b0-4671-a979-0750ff1ea6dc

A short screen recording is attached to demonstrate the scrolling behavior, tooltip flipping, and boundary-aware hiding. The issue and fix are easier to observe in motion than through static screenshots.

## Testing

1. Open a room containing a location message
2. Hover over the map and verify the "Expand map" tooltip appears
3. Scroll down so the map approaches the message composer
4. Verify the tooltip flips above the map instead of overlapping the composer
5. Continue scrolling until the tooltip would escape the visible message panel boundary
6. Verify the tooltip becomes hidden
7. Run:

```bash
cd apps/web
pnpm exec jest --no-coverage test/unit-tests/components/views/messages/MLocationBody-test.tsx
```

Expected result:

* 6 tests pass
* 4 snapshots pass

## Notes

* Adds `@floating-ui/react` as a direct dependency (previously only available transitively through `@vector-im/compound-web`)
* Includes a separate commit adding `matrix-js-sdk` to Jest's `transformIgnorePatterns`
* The Jest change addresses a pre-existing test infrastructure issue encountered while running the location message test suite and is intentionally isolated from the feature change for easier review



<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)