### PR TITLE
Fix jest tests

### DIFF
--- a/apps/web/jest.config.ts
+++ b/apps/web/jest.config.ts
@@ -35,6 +35,7 @@ const config: Config = {
         "\\.(gif|png|ttf|woff2)$": "<rootDir>/__mocks__/imageMock.js",
         "\\.svg$": "<rootDir>/__mocks__/svg.js",
         "\\$webapp/i18n/languages.json": "<rootDir>/__mocks__/languages.json",
+        "^matrix-js-sdk(.*)$": "<rootDir>/../../node_modules/matrix-js-sdk$1",
         "^react$": "<rootDir>/node_modules/react",
         "^react-dom$": "<rootDir>/node_modules/react-dom",
         "decoderWorker\\.min\\.js": "<rootDir>/__mocks__/empty.js",


### PR DESCRIPTION
As of https://github.com/element-hq/element-web/pull/33573 (some?) jest tests fail with "SyntaxError: Cannot use import statement outside a module" when importing js-sdk. It removes js-sdk from moduleNameMapper in jest config although I'm not sure why. This puts it back so js-sdk resolves to the copy linked by our pnpm link script, which also makes get transformed.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
