### PR TITLE
MSC4287: remove unstable prefix m.org.matrix.custom.backup_disabled

### DIFF
--- a/apps/web/playwright/e2e/crypto/toasts.spec.ts
+++ b/apps/web/playwright/e2e/crypto/toasts.spec.ts
@@ -120,7 +120,6 @@ test.describe("'Turn on key storage' toast", () => {
     test("should show toast if key storage is off but account data is missing", async ({ app, page }) => {
         // Given the backup is disabled but we didn't set account data saying that is expected
         await disableKeyBackup(app);
-        await botClient.setAccountData("m.org.matrix.custom.backup_disabled", {} as any as { disabled: boolean });
         await botClient.setAccountData("m.key_backup", {} as any as { enabled: boolean });
 
         // Wait for the account data setting to stick

--- a/apps/web/src/components/viewmodels/settings/encryption/KeyStoragePanelViewModel.ts
+++ b/apps/web/src/components/viewmodels/settings/encryption/KeyStoragePanelViewModel.ts
@@ -10,11 +10,7 @@ import { CryptoEvent } from "matrix-js-sdk/src/crypto-api";
 import { logger } from "matrix-js-sdk/src/logger";
 
 import { useMatrixClientContext } from "../../../../contexts/MatrixClientContext";
-import {
-    DeviceListener,
-    ACCOUNT_DATA_KEY_M_KEY_BACKUP,
-    ACCOUNT_DATA_KEY_M_KEY_BACKUP_DISABLED_UNSTABLE,
-} from "../../../../device-listener";
+import { DeviceListener, ACCOUNT_DATA_KEY_M_KEY_BACKUP } from "../../../../device-listener";
 import { useEventEmitterAsyncState } from "../../../../hooks/useEventEmitter";
 import { resetKeyBackupAndWait } from "../../../../utils/crypto/resetKeyBackup";
 
@@ -118,9 +114,6 @@ export function useKeyStoragePanelViewModel(): KeyStoragePanelState {
 
                         // Set the flag to say that the user wants backup enabled
                         await matrixClient.setAccountData(ACCOUNT_DATA_KEY_M_KEY_BACKUP, { enabled: true });
-                        await matrixClient.setAccountData(ACCOUNT_DATA_KEY_M_KEY_BACKUP_DISABLED_UNSTABLE, {
-                            disabled: false,
-                        });
                     } else {
                         logger.info("User requested disabling key backup");
                         // This method will delete the key backup as well as server side recovery keys and other
@@ -129,9 +122,6 @@ export function useKeyStoragePanelViewModel(): KeyStoragePanelState {
 
                         // Set the flag to say that the user wants backup disabled
                         await matrixClient.setAccountData(ACCOUNT_DATA_KEY_M_KEY_BACKUP, { enabled: false });
-                        await matrixClient.setAccountData(ACCOUNT_DATA_KEY_M_KEY_BACKUP_DISABLED_UNSTABLE, {
-                            disabled: true,
-                        });
                     }
                 });
             } finally {

--- a/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
+++ b/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
@@ -33,7 +33,6 @@ const KEY_BACKUP_POLL_INTERVAL = 5 * 60 * 1000;
  * disable server side key backups.
  */
 export const ACCOUNT_DATA_KEY_M_KEY_BACKUP = "m.key_backup";
-export const ACCOUNT_DATA_KEY_M_KEY_BACKUP_DISABLED_UNSTABLE = "m.org.matrix.custom.backup_disabled";
 
 /**
  * Account data key to indicate whether the user has chosen to enable or disable recovery.
@@ -152,7 +151,6 @@ export class DeviceListenerCurrentDevice {
      */
     public async recordKeyBackupDisabled(): Promise<void> {
         await this.client.setAccountData(ACCOUNT_DATA_KEY_M_KEY_BACKUP, { enabled: false });
-        await this.client.setAccountData(ACCOUNT_DATA_KEY_M_KEY_BACKUP_DISABLED_UNSTABLE, { disabled: true });
     }
 
     /**
@@ -306,12 +304,9 @@ export class DeviceListenerCurrentDevice {
         const keyBackup = await this.client.getAccountDataFromServer(ACCOUNT_DATA_KEY_M_KEY_BACKUP);
         if (keyBackup) {
             return keyBackup.enabled === false;
+        } else {
+            return false;
         }
-
-        const keyBackupDisabledUnstable = await this.client.getAccountDataFromServer(
-            ACCOUNT_DATA_KEY_M_KEY_BACKUP_DISABLED_UNSTABLE,
-        );
-        return !!keyBackupDisabledUnstable?.disabled;
     }
 
     /**
@@ -361,7 +356,6 @@ export class DeviceListenerCurrentDevice {
             ev.getType().startsWith("m.cross_signing.") ||
             ev.getType() === "m.megolm_backup.v1" ||
             ev.getType() === ACCOUNT_DATA_KEY_M_KEY_BACKUP ||
-            ev.getType() === ACCOUNT_DATA_KEY_M_KEY_BACKUP_DISABLED_UNSTABLE ||
             ev.getType() === RECOVERY_ACCOUNT_DATA_KEY
         ) {
             this.deviceListener.recheck();

--- a/apps/web/test/unit-tests/DeviceListener-test.ts
+++ b/apps/web/test/unit-tests/DeviceListener-test.ts
@@ -25,12 +25,7 @@ import {
 } from "matrix-js-sdk/src/crypto-api";
 import { type CryptoSessionStateChange } from "@matrix-org/analytics-events/types/typescript/CryptoSessionStateChange";
 
-import {
-    DeviceListener,
-    ACCOUNT_DATA_KEY_M_KEY_BACKUP,
-    ACCOUNT_DATA_KEY_M_KEY_BACKUP_DISABLED_UNSTABLE,
-    RECOVERY_ACCOUNT_DATA_KEY,
-} from "../../src/device-listener";
+import { DeviceListener, ACCOUNT_DATA_KEY_M_KEY_BACKUP, RECOVERY_ACCOUNT_DATA_KEY } from "../../src/device-listener";
 import { MatrixClientPeg } from "../../src/MatrixClientPeg";
 import * as SetupEncryptionToast from "../../src/toasts/SetupEncryptionToast";
 import * as UnverifiedSessionToast from "../../src/toasts/UnverifiedSessionToast";
@@ -327,9 +322,7 @@ describe("DeviceListener", () => {
 
             // @ts-ignore implementing a function with complex return type
             mockClient!.getAccountDataFromServer.mockImplementation(async (key) => {
-                if (key === ACCOUNT_DATA_KEY_M_KEY_BACKUP_DISABLED_UNSTABLE) {
-                    return { disabled: true };
-                } else if (key == ACCOUNT_DATA_KEY_M_KEY_BACKUP) {
+                if (key == ACCOUNT_DATA_KEY_M_KEY_BACKUP) {
                     return { enabled: false };
                 } else if (key === RECOVERY_ACCOUNT_DATA_KEY) {
                     return null;
@@ -623,10 +616,6 @@ describe("DeviceListener", () => {
             const instance = await createAndStart();
             await instance.recordKeyBackupDisabled();
 
-            expect(mockClient.setAccountData).toHaveBeenCalledWith("m.org.matrix.custom.backup_disabled", {
-                disabled: true,
-            });
-
             expect(mockClient.setAccountData).toHaveBeenCalledWith("m.key_backup", {
                 enabled: false,
             });
@@ -661,7 +650,7 @@ describe("DeviceListener", () => {
 
                 it("shows the 'Turn on key storage' toast if we never explicitly turned off key storage", async () => {
                     // Given key backup is off but the account data saying we turned it off is not set
-                    // (m.key_backup or m.org.matrix.custom.backup_disabled)
+                    // (m.key_backup)
                     mockClient.getAccountData.mockReturnValue(undefined);
 
                     // When we launch the DeviceListener
@@ -678,8 +667,6 @@ describe("DeviceListener", () => {
                         switch (eventType) {
                             case ACCOUNT_DATA_KEY_M_KEY_BACKUP:
                                 return new MatrixEvent({ content: { enabled: true } });
-                            case ACCOUNT_DATA_KEY_M_KEY_BACKUP_DISABLED_UNSTABLE:
-                                return new MatrixEvent({ content: { disabled: false } });
                             default:
                                 return undefined;
                         }
@@ -727,8 +714,6 @@ describe("DeviceListener", () => {
                         switch (eventType) {
                             case ACCOUNT_DATA_KEY_M_KEY_BACKUP:
                                 return new MatrixEvent({ content: { enabled: true } });
-                            case ACCOUNT_DATA_KEY_M_KEY_BACKUP_DISABLED_UNSTABLE:
-                                return new MatrixEvent({ content: { disabled: false } });
                             default:
                                 return undefined;
                         }
@@ -748,8 +733,6 @@ describe("DeviceListener", () => {
                         switch (eventType) {
                             case ACCOUNT_DATA_KEY_M_KEY_BACKUP:
                                 return new MatrixEvent({ content: { enabled: false } });
-                            case ACCOUNT_DATA_KEY_M_KEY_BACKUP_DISABLED_UNSTABLE:
-                                return new MatrixEvent({ content: { disabled: true } });
                             default:
                                 return undefined;
                         }
@@ -1302,9 +1285,6 @@ describe("DeviceListener", () => {
             it("does not show the 'set up recovery' toast if the user has chosen to disable key storage", async () => {
                 mockClient!.getAccountData.mockImplementation((k: string) => {
                     switch (k) {
-                        case "m.org.matrix.custom.backup_disabled":
-                            return new MatrixEvent({ content: { disabled: true } });
-
                         case "m.key_backup":
                             return new MatrixEvent({ content: { enabled: false } });
 
@@ -1446,8 +1426,6 @@ function mockKeyBackupFromServer(client: MockedObject<MatrixClient>, enabled: bo
         switch (eventType) {
             case ACCOUNT_DATA_KEY_M_KEY_BACKUP:
                 return { enabled } as any;
-            case ACCOUNT_DATA_KEY_M_KEY_BACKUP_DISABLED_UNSTABLE:
-                return { disabled: !enabled } as any;
             default:
                 return null;
         }

--- a/apps/web/test/unit-tests/components/viewmodels/settings/encryption/KeyStoragePanelViewModel-test.ts
+++ b/apps/web/test/unit-tests/components/viewmodels/settings/encryption/KeyStoragePanelViewModel-test.ts
@@ -125,9 +125,6 @@ describe("KeyStoragePanelViewModel", () => {
         );
 
         await result.current.setEnabled(true);
-        expect(mocked(matrixClient.setAccountData)).toHaveBeenCalledWith("m.org.matrix.custom.backup_disabled", {
-            disabled: false,
-        });
 
         expect(mocked(matrixClient.setAccountData)).toHaveBeenCalledWith("m.key_backup", {
             enabled: true,
@@ -146,9 +143,6 @@ describe("KeyStoragePanelViewModel", () => {
         await result.current.setEnabled(false);
 
         expect(mocked(matrixClient.getCrypto()!.disableKeyStorage)).toHaveBeenCalled();
-        expect(mocked(matrixClient.setAccountData)).toHaveBeenCalledWith("m.org.matrix.custom.backup_disabled", {
-            disabled: true,
-        });
         expect(mocked(matrixClient.setAccountData)).toHaveBeenCalledWith("m.key_backup", {
             enabled: false,
         });


### PR DESCRIPTION
On hold for now. https://github.com/element-hq/element-web/pull/33034 was merged on 2026-06-02 so we need to wait long enough for clients to write the value to the stable prefix `m.key_backup` before we turn off support for the unstable prefix.

Related:
* https://github.com/matrix-org/matrix-rust-sdk/pull/6634
* https://github.com/matrix-org/matrix-js-sdk/pull/5351

MSC: https://github.com/matrix-org/matrix-spec-proposals/pull/4287

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
