### PR TITLE
Exporter: replace naming logic with eventId + MIME-based extensions

### DIFF
--- a/apps/web/src/utils/exportUtils/Exporter.ts
+++ b/apps/web/src/utils/exportUtils/Exporter.ts
@@ -27,7 +27,7 @@ type BlobFile = {
 
 type FileDetails = {
     directory: string;
-    name: string;
+    eventId: string;
     date: string;
     extension: string;
     count?: number;
@@ -242,25 +242,57 @@ export default abstract class Exporter {
         return blob;
     }
 
-    public splitFileName(file: string): string[] {
-        const lastDot = file.lastIndexOf(".");
-        if (lastDot === -1) return [file, ""];
-        const fileName = file.slice(0, lastDot);
-        const ext = file.slice(lastDot + 1);
-        return [fileName, "." + ext];
+    private static readonly MIME_TO_EXT: Record<string, string> = {
+        "application/pdf": ".pdf",
+        "audio/ogg": ".ogg",
+        "audio/mp4": ".m4a",
+        "audio/mpeg": ".mp3",
+        "image/gif": ".gif",
+        "image/jpeg": ".jpg",
+        "image/jpg": ".jpg",
+        "image/png": ".png",
+        "image/webp": ".webp",
+        "text/plain": ".txt",
+        "video/mp4": ".mp4",
+        "video/webm": ".webm",
+    };
+
+    public getFileExtension(event: MatrixEvent): string {
+        if (event.getType() === "m.sticker") return ".png";
+        if (isVoiceMessage(event)) return ".ogg";
+        const content = event.getContent();
+        const msgtype = content.msgtype;
+        if (msgtype === "m.text" || msgtype === "m.notice") return ".txt";
+        const mime = content.info?.mimetype;
+        if (typeof mime === "string") {
+            const ext = Exporter.MIME_TO_EXT[mime.toLowerCase()];
+            if (ext) return ext;
+        }
+        const filename = content.filename;
+        if (typeof filename === "string") {
+            // Fallback to previous method of splitting on "."
+            const lastDot = filename.lastIndexOf(".");
+            if (lastDot !== -1 && lastDot < filename.length - 1) {
+                const rawExt = filename.slice(lastDot + 1);
+                if (rawExt) return "." + rawExt;
+            }
+        }
+        // Last resort fallback to a somewhat "generic" extension but log
+        // the issue
+        console.warn("Unknown file type, defaulting to .bin", event.getType(), content);
+        return ".bin";
     }
 
     protected makeUniqueFilePath(details: FileDetails): string {
-        const makePath = ({ directory, name, date, extension, count = 0 }: FileDetails): string =>
-            `${directory}/${name}-${date}${count > 0 ? ` (${count})` : ""}${extension}`;
-        const defaultPath = makePath(details);
-        const count = this.fileNames.get(defaultPath) || 0;
-        this.fileNames.set(defaultPath, count + 1);
+        const { directory, eventId, extension } = details;
+        const safeEventId = eventId.replace(/[^a-zA-Z0-9]/g, "");
+        const path = `${directory}/${safeEventId}${extension}`;
+        const count = this.fileNames.get(path) || 0;
+        this.fileNames.set(path, count + 1);
         if (count > 0) {
-            return makePath({ ...details, count });
+            return `${directory}/${safeEventId}_(${count})${extension}`;
         }
-
-        return defaultPath;
+        return path;
     }
 
     public getFilePath(event: MatrixEvent): string {
@@ -279,17 +311,11 @@ export default abstract class Exporter {
             default:
                 fileDirectory = event.getType() === "m.sticker" ? "stickers" : "files";
         }
-        const fileDate = formatFullDateNoDay(new Date(event.getTs()));
-        let [fileName, fileExt] = this.splitFileName(event.getContent().body);
-
-        if (event.getType() === "m.sticker") fileExt = ".png";
-        if (isVoiceMessage(event)) fileExt = ".ogg";
-
         return this.makeUniqueFilePath({
             directory: fileDirectory,
-            name: fileName,
-            date: fileDate,
-            extension: fileExt,
+            eventId: event.getId() ?? `missing-id-${event.getTs()}-`,
+            date: formatFullDateNoDay(new Date(event.getTs())),
+            extension: this.getFileExtension(event),
         });
     }
 

--- a/apps/web/src/utils/exportUtils/Exporter.ts
+++ b/apps/web/src/utils/exportUtils/Exporter.ts
@@ -16,7 +16,6 @@ import { ExportType, type IExportOptions } from "./exportUtils";
 import { decryptFile } from "../DecryptFile";
 import { mediaFromContent } from "../../customisations/Media";
 import { formatFullDateNoDay, formatFullDateNoDayISO } from "../../DateUtils";
-import { isVoiceMessage } from "../EventUtils";
 import { _t } from "../../languageHandler";
 import SdkConfig from "../../SdkConfig";
 
@@ -258,27 +257,27 @@ export default abstract class Exporter {
     };
 
     public getFileExtension(event: MatrixEvent): string {
-        if (event.getType() === "m.sticker") return ".png";
-        if (isVoiceMessage(event)) return ".ogg";
         const content = event.getContent();
-        const msgtype = content.msgtype;
-        if (msgtype === "m.text" || msgtype === "m.notice") return ".txt";
         const mime = content.info?.mimetype;
+        // If a mimetype is available, just use that
         if (typeof mime === "string") {
             const ext = Exporter.MIME_TO_EXT[mime.toLowerCase()];
             if (ext) return ext;
         }
+        // Otherwise, text and notice are text
+        const msgtype = content.msgtype;
+        if (msgtype === "m.text" || msgtype === "m.notice") return ".txt";
+        // If those fall through, fallback to splitting on "."
         const filename = content.filename;
-        if (typeof filename === "string") {
-            // Fallback to previous method of splitting on "."
+        if (typeof filename === "string") {            
             const lastDot = filename.lastIndexOf(".");
             if (lastDot !== -1 && lastDot < filename.length - 1) {
                 const rawExt = filename.slice(lastDot + 1);
                 if (rawExt) return "." + rawExt;
             }
         }
-        // Last resort fallback to a somewhat "generic" extension but log
-        // the issue
+        // Last resort fallback to a somewhat "generic" extension
+        // and also log the issue
         console.warn("Unknown file type, defaulting to .bin", event.getType(), content);
         return ".bin";
     }

--- a/apps/web/src/utils/exportUtils/Exporter.ts
+++ b/apps/web/src/utils/exportUtils/Exporter.ts
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { Direction, type MatrixEvent, type Relations, type Room } from "matrix-js-sdk/src/matrix";
+import { Direction, type MatrixEvent, MsgType, type Relations, type Room } from "matrix-js-sdk/src/matrix";
 import { type EventType, type MediaEventContent, type RelationType } from "matrix-js-sdk/src/types";
 import { saveAs } from "file-saver";
 import { logger } from "matrix-js-sdk/src/logger";
@@ -241,6 +241,12 @@ export default abstract class Exporter {
         return blob;
     }
 
+    private static readonly MSGTYPES_TO_EXT: Record<string,string> = {
+        [MsgType.Text]: ".txt",
+        [MsgType.Notice]: ".txt",
+        [MsgType.Emote]: ".txt",
+    };
+
     private static readonly MIME_TO_EXT: Record<string, string> = {
         "application/pdf": ".pdf",
         "audio/ogg": ".ogg",
@@ -258,16 +264,16 @@ export default abstract class Exporter {
 
     public getFileExtension(event: MatrixEvent): string {
         const content = event.getContent();
-        const mime = content.info?.mimetype;
-        // If a mimetype is available, just use that
-        if (typeof mime === "string") {
-            const ext = Exporter.MIME_TO_EXT[mime.toLowerCase()];
-            if (ext) return ext;
-        }
-        // Otherwise, text and notice are text
         const msgtype = content.msgtype;
-        if (msgtype === "m.text" || msgtype === "m.notice") return ".txt";
-        // If those fall through, fallback to splitting on "."
+        if (msgtype) {
+            const msgtypeExt = Exporter.MSGTYPES_TO_EXT[msgtype.toLowerCase()];
+            if (msgtypeExt) return msgtypeExt;
+        }
+        const mime = content.info?.mimetype;
+        if (typeof mime === "string") {
+            const mimeExt = Exporter.MIME_TO_EXT[mime.toLowerCase()];
+            if (mimeExt) return mimeExt;
+        }
         const filename = content.filename;
         if (typeof filename === "string") {            
             const lastDot = filename.lastIndexOf(".");
@@ -276,9 +282,7 @@ export default abstract class Exporter {
                 if (rawExt) return "." + rawExt;
             }
         }
-        // Last resort fallback to a somewhat "generic" extension
-        // and also log the issue
-        console.warn("Unknown file type, defaulting to .bin", event.getType(), content);
+        console.warn("Unknown file type, extension set to .bin by default:", content);
         return ".bin";
     }
 

--- a/apps/web/src/utils/exportUtils/Exporter.ts
+++ b/apps/web/src/utils/exportUtils/Exporter.ts
@@ -241,7 +241,7 @@ export default abstract class Exporter {
         return blob;
     }
 
-    private static readonly MSGTYPES_TO_EXT: Record<string,string> = {
+    private static readonly MSGTYPES_TO_EXT: Record<string, string> = {
         [MsgType.Text]: ".txt",
         [MsgType.Notice]: ".txt",
         [MsgType.Emote]: ".txt",
@@ -275,7 +275,7 @@ export default abstract class Exporter {
             if (mimeExt) return mimeExt;
         }
         const filename = content.filename;
-        if (typeof filename === "string") {            
+        if (typeof filename === "string") {
             const lastDot = filename.lastIndexOf(".");
             if (lastDot !== -1 && lastDot < filename.length - 1) {
                 const rawExt = filename.slice(lastDot + 1);

--- a/apps/web/src/utils/exportUtils/exportUtils.test.ts
+++ b/apps/web/src/utils/exportUtils/exportUtils.test.ts
@@ -292,17 +292,13 @@ describe("export", function () {
         );
     });
 
-    it("tests the file extension splitter", function () {
-        const exporter = new PlainTextExporter(mockRoom, ExportType.Beginning, mockExportOptions, setProgressText);
-        const fileNameWithExtensions: Record<string, [string, string]> = {
-            "": ["", ""],
-            "name": ["name", ""],
-            "name.txt": ["name", ".txt"],
-            ".htpasswd": ["", ".htpasswd"],
-            "name.with.many.dots.myext": ["name.with.many.dots", ".myext"],
-        };
-        for (const fileName in fileNameWithExtensions) {
-            expect(exporter.splitFileName(fileName)).toStrictEqual(fileNameWithExtensions[fileName]);
+    it("tests uniqueness of getFilePath exporter function output", function () {
+        const exporter = new HTMLExporter(mockRoom, ExportType.Beginning, mockExportOptions, setProgressText);
+        const filePaths: Array<string> = [];
+        for (const event of events) {
+            const filePath = exporter.getFilePath(event);
+            expect(filePaths.indexOf(filePath)).toBeLessThan(0);
+            filePaths.push(filePath);
         }
     });
 


### PR DESCRIPTION
Remove reliance on user-provided strings for exported media paths and replace with deterministic eventId (or timestamp as fallback ) to avoid invalid characters and unsafe filesystem names.

Introduce MIME-based extension resolution and explicit fallback rules for text, sticker, and voice message types.

Update one test to match new function and check for uniqueness.

See also: https://github.com/element-hq/element-web/issues/33356

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible). => One test updated
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation. => NA
- [x] Linter and other CI checks pass. => `pnpm lint` returns ✂️  Excellent, Knip found no issues and `pnpm test` show no relevant failures.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
