### PR TITLE
Add mechanism to locally enforce MSC1763 retention rules

### DIFF
--- a/apps/web/playwright/e2e/retention/retention.spec.ts
+++ b/apps/web/playwright/e2e/retention/retention.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import { rejectToastIfExists } from "@element-hq/element-web-playwright-common";
+
+import { test, expect } from "../../element-web-test";
+
+const ONE_MINUTE = 60 * 1000;
+
+test.describe("Retention", () => {
+    test.use({
+        displayName: "Tom",
+        botCreateOpts: {
+            displayName: "Bob",
+        },
+        labsFlags: ["feature_retention"],
+    });
+
+    test.beforeEach(async ({ app, homeserver, page, user }) => {
+        await rejectToastIfExists(page, "Verify this device");
+        await rejectToastIfExists(page, "Notifications");
+    });
+
+    test(
+        "should apply retention to a bunch of messages",
+        { tag: "@screenshot" },
+        async ({ app, homeserver, page, user, bot }) => {
+            await page.clock.install();
+            const roomId = await app.client.createRoom({
+                name: "Test",
+                invite: [bot.credentials.userId],
+                initial_state: [
+                    {
+                        state_key: "",
+                        type: "org.matrix.msc1763.retention",
+                        content: {
+                            max_lifetime: ONE_MINUTE,
+                        },
+                    },
+                ],
+            });
+            // When the bot joins the room
+            await bot.joinRoom(roomId);
+            await app.viewRoomByName("Test");
+            const tiles = (
+                await Promise.all(
+                    Array.from({ length: 5 }).map((_o, index) => bot.sendMessage(roomId, `Message ${index}`)),
+                )
+            ).map(({ event_id: evtId }) =>
+                page.locator(`.mx_RoomView_MessageList .mx_EventTile[data-event-id='${evtId}']`),
+            );
+            for (const tile of tiles) {
+                await expect(tile).toBeVisible();
+            }
+            await page.clock.fastForward(ONE_MINUTE + 1);
+            for (const tile of tiles) {
+                await expect(tile).toBeHidden();
+            }
+        },
+    );
+
+    test.fixme("apply global ", () => {});
+
+    test.fixme("retention rules should apply retrospectively", () => {});
+});

--- a/apps/web/src/MatrixClientPeg.ts
+++ b/apps/web/src/MatrixClientPeg.ts
@@ -301,6 +301,8 @@ class MatrixClientPegClass implements IMatrixClientPeg {
             opts.unstableMSC4429SyncUserProfileFields = ["org.matrix.msc4426.status"];
         }
 
+        opts.unstableMSC1763Retention = SettingsStore.getValue("feature_retention");
+
         if (SettingsStore.getValue("feature_sliding_sync")) {
             throw new UserFriendlyError("sliding_sync_legacy_no_longer_supported");
         }

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -1536,6 +1536,10 @@
             "display_name": "User status",
             "required_msc_support": "Requires MSC4429 (Profile Updates for Legacy Sync)"
         },
+        "feature_retention": {
+            "description": "Automatically remove messages from a room when they reach a configured retention period. Currently only supports reading settings.",
+            "display_name": "Message retention"
+        },
         "feature_wysiwyg_composer_description": "Use rich text instead of Markdown in the message composer.",
         "group_calls": "New group call experience",
         "group_developer": "Developer",

--- a/apps/web/src/settings/Settings.tsx
+++ b/apps/web/src/settings/Settings.tsx
@@ -225,6 +225,7 @@ export interface Settings {
     "feature_dynamic_room_predecessors": IFeature;
     "feature_render_reaction_images": IFeature;
     "feature_new_room_list": IFeature;
+    "feature_retention": IFeature;
     "feature_room_list_sections": IFeature;
     "feature_ask_to_join": IFeature;
     "feature_notifications": IFeature;
@@ -796,6 +797,17 @@ export const SETTINGS: Settings = {
             true,
             true,
         ),
+        default: false,
+    },
+    // TODO: NOTE THIS IS INCOMPATIBLE WITH SLIDING SYNC.
+    "feature_retention": {
+        isFeature: true,
+        labsGroup: LabGroup.Messaging,
+        displayName: _td("labs|feature_retention|display_name"),
+        description: _td("labs|feature_retention|description"),
+        supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG_PRIORITISED,
+        supportedLevelsAreOrdered: true,
+        controller: new ReloadOnChangeController(),
         default: false,
     },
     "useCompactLayout": {


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-js-sdk/pull/5353

Adds a settings flag and playwright tests.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
