### PR TITLE
Deflake sliding sync test

### DIFF
--- a/apps/web/playwright/e2e/sliding-sync/sliding-sync.spec.ts
+++ b/apps/web/playwright/e2e/sliding-sync/sliding-sync.spec.ts
@@ -278,11 +278,12 @@ test.describe("Sliding Sync", () => {
             { roomRescind, clientUserId },
         );
 
+        // toggle the invites filter off again so we see all the rooms again
+        await primaryFilters.getByRole("option", { name: "Invites" }).click();
+
         await page.getByRole("option", { name: "Open room Room to Rescind" }).click();
 
         await page.locator(".mx_RoomView").getByRole("button", { name: "Forget this room", exact: true }).click();
-
-        await primaryFilters.getByRole("option", { name: "Invites" }).click();
 
         // Wait for the rescind to take effect and check the joined list once more
         await expect(page.getByTestId("room-list").getByRole("option")).toHaveCount(2);


### PR DESCRIPTION
It was trying to click the room before it had turned the invite filter off so it was relying on clicking it before the rescind made its way to the UI.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
