### PR TITLE
Align the macOS user-menu avatar with the room list / header row

### DIFF
--- a/apps/desktop/src/macos-titlebar.ts
+++ b/apps/desktop/src/macos-titlebar.ts
@@ -16,10 +16,12 @@ export function setupMacosTitleBar(window: BrowserWindow): void {
         cssKey = await window.webContents.insertCSS(`
             /* Create margin of space for the traffic light buttons */
             .mx_UserMenu {
-                /* We zero the margin and use padding as we want to use it as a drag handle */ 
+                /* We zero the margin and use padding as we want to use it as a drag handle */
                 margin-top: 0 !important;
                 margin-left: 0 !important;
-                padding-top: 32px !important;
+                /* 26px aligns the avatar centre with the search field / room header row
+                   while still clearing the traffic light buttons (which end at ~20px) */
+                padding-top: 26px !important;
                 -webkit-app-region: drag;
                 -webkit-user-select: none;
             }
@@ -29,8 +31,8 @@ export function setupMacosTitleBar(window: BrowserWindow): void {
             }
             /* Maintain alignment of the toggle space panel button */
             .mx_SpacePanel_toggleCollapse {
-                /* 19px original top value, 32px margin-top above, 12px original margin-top value */
-                top: calc(19px + 32px - 12px) !important;
+                /* 19px original top value, 26px padding-top above, 12px original margin-top value */
+                top: calc(19px + 26px - 12px) !important;
             }
             /* Prevent the media lightbox sender info from clipping into the traffic light buttons */
             .mx_ImageView_info_wrapper {


### PR DESCRIPTION
Reduce the macOS `.mx_UserMenu` top padding from `32px` to `26px` so the account avatar's centre lines up with the search field / room header row, while still clearing the native traffic-light buttons.

### Problem
On macOS the window is frameless and `setupMacosTitleBar` pads `.mx_UserMenu` down so the avatar clears the traffic-light buttons (`trafficLightPosition: { x: 9, y: 8 }`, buttons end at ~20px). The padding was `32px`, which places the 36px avatar at centre ≈ 50px, while the adjacent search field (`⌘K`) and the room header row are centred ≈ 44px. The resulting ~6px offset makes the avatar look misaligned with the rest of the top row on the new room list.

### Fix
`padding-top: 32px → 26px` on `.mx_UserMenu` (avatar centre ≈ 44px, aligned with the row; still clears the traffic lights at ~20px). The `.mx_SpacePanel_toggleCollapse` offset is updated to match.

### Before / After
![before-after](https://raw.githubusercontent.com/grxtor/element-web/assets-macos-titlebar/macos-titlebar-before-after.png)

Notes: Fix the macOS user-menu avatar being vertically misaligned with the search field / room header on the new room list.
