### PR TITLE
Room list: display compose menu when sections are enabled

### DIFF
--- a/apps/web/src/viewmodels/room-list/RoomListHeaderViewModel.ts
+++ b/apps/web/src/viewmodels/room-list/RoomListHeaderViewModel.ts
@@ -289,19 +289,20 @@ function computeHeaderSpaceState(
     spaceStore: SpaceStoreClass,
     matrixClient: MatrixClient,
 ): Omit<RoomListHeaderViewSnapshot, "activeSortOption" | "isMessagePreviewEnabled"> {
+    const isSectionFeatureEnabled = SettingsStore.getValue("feature_room_list_sections");
+
     const activeSpace = spaceStore.activeSpaceRoom;
     const title = getHeaderTitle(spaceStore);
 
     const canCreateRoom = hasCreateRoomRights(matrixClient, activeSpace);
     const canCreateVideoRoom = getCanCreateVideoRoom(canCreateRoom);
-    const displayComposeMenu = canCreateRoom;
+    const displayComposeMenu = isSectionFeatureEnabled || canCreateRoom;
     const displaySpaceMenu = Boolean(activeSpace);
     const canInviteInSpace = Boolean(
         activeSpace?.getJoinRule() === JoinRule.Public || activeSpace?.canInvite(matrixClient.getSafeUserId()),
     );
     const canAccessSpaceSettings = Boolean(activeSpace && shouldShowSpaceSettings(activeSpace));
 
-    const isSectionFeatureEnabled = SettingsStore.getValue("feature_room_list_sections");
     const useComposeIcon = !isSectionFeatureEnabled;
     const canCreateSection = isSectionFeatureEnabled;
 

--- a/apps/web/test/viewmodels/room-list/RoomListHeaderViewModel-test.ts
+++ b/apps/web/test/viewmodels/room-list/RoomListHeaderViewModel-test.ts
@@ -129,6 +129,18 @@ describe("RoomListHeaderViewModel", () => {
             expect(snapshot.canCreateRoom).toBe(false);
         });
 
+        it("should display compose menu when section feature is enabled@", () => {
+            jest.spyOn(SettingsStore, "getValue").mockImplementation((settingName: string) => {
+                if (settingName === "feature_room_list_sections") return true;
+                return false;
+            });
+
+            vm = new RoomListHeaderViewModel({ matrixClient, spaceStore: SpaceStore.instance });
+
+            const snapshot = vm.getSnapshot();
+            expect(snapshot.displayComposeMenu).toBe(true);
+        });
+
         it("should show invite option when space is public", () => {
             jest.spyOn(SpaceStore.instance, "activeSpace", "get").mockReturnValue(mockSpace.roomId);
             jest.spyOn(SpaceStore.instance, "activeSpaceRoom", "get").mockReturnValue(mockSpace);


### PR DESCRIPTION
Epic https://github.com/element-hq/element-web/issues/32439
This PR always display the compose menu of the room list header when sections are enabled. This menu wasn't displayed in a space when the user can't create room so the user wasn't able to create section through this menu in this kind of space.

<img width="619" height="828" alt="image" src="https://github.com/user-attachments/assets/d2077d58-75f2-4018-9f84-cf6b1492a692" />