### PR TITLE
Add mechanism to locally enforce MSC1763 retention rules

### DIFF
--- a/apps/web/playwright/e2e/retention/retention.spec.ts
+++ b/apps/web/playwright/e2e/retention/retention.spec.ts
@@ -7,9 +7,29 @@
 
 import { rejectToastIfExists } from "@element-hq/element-web-playwright-common";
 
-import { test, expect } from "../../element-web-test";
+import { test, expect, type TestFixtures } from "../../element-web-test";
+import type { Page } from "@playwright/test";
 
 const ONE_MINUTE = 60 * 1000;
+
+async function checkRetentionInRoom(
+    { bot, app, page }: Pick<TestFixtures, "app" | "bot"> & { page: Page },
+    roomId: string,
+) {
+    // When the bot joins the room
+    await bot.joinRoom(roomId);
+    await app.viewRoomByName("Test");
+    const tiles = (
+        await Promise.all(Array.from({ length: 5 }).map((_o, index) => bot.sendMessage(roomId, `Message ${index}`)))
+    ).map(({ event_id: evtId }) => page.locator(`.mx_RoomView_MessageList .mx_EventTile[data-event-id='${evtId}']`));
+    for (const tile of tiles) {
+        await expect(tile).toBeVisible();
+    }
+    await page.clock.fastForward(ONE_MINUTE + 1);
+    for (const tile of tiles) {
+        await expect(tile).toBeHidden();
+    }
+}
 
 test.describe("Retention", () => {
     test.use({
@@ -23,47 +43,110 @@ test.describe("Retention", () => {
     test.beforeEach(async ({ app, homeserver, page, user }) => {
         await rejectToastIfExists(page, "Verify this device");
         await rejectToastIfExists(page, "Notifications");
+        await page.clock.install();
     });
 
-    test(
-        "should apply retention to a bunch of messages",
-        { tag: "@screenshot" },
-        async ({ app, homeserver, page, user, bot }) => {
-            await page.clock.install();
-            const roomId = await app.client.createRoom({
-                name: "Test",
-                invite: [bot.credentials.userId],
-                initial_state: [
-                    {
-                        state_key: "",
-                        type: "org.matrix.msc1763.retention",
-                        content: {
+    test("should apply retention to a bunch of messages", async ({ app, homeserver, page, user, bot }) => {
+        const roomId = await app.client.createRoom({
+            name: "Test",
+            invite: [bot.credentials.userId],
+            initial_state: [
+                {
+                    state_key: "",
+                    type: "org.matrix.msc1763.retention",
+                    content: {
+                        max_lifetime: ONE_MINUTE,
+                    },
+                },
+            ],
+        });
+        // When the bot joins the room
+        await checkRetentionInRoom({ app, bot, page }, roomId);
+    });
+
+    test("global retention rules should apply ", async ({ app, bot, page }) => {
+        const roomId = await app.client.createRoom({
+            name: "Test",
+            invite: [bot.credentials.userId],
+        });
+        await page.route("**/_matrix/client/unstable/org.matrix.msc1763/retention/configuration", (route) => {
+            return route.fulfill({
+                json: {
+                    policies: {
+                        "*": {
                             max_lifetime: ONE_MINUTE,
                         },
                     },
-                ],
+                },
             });
-            // When the bot joins the room
-            await bot.joinRoom(roomId);
-            await app.viewRoomByName("Test");
-            const tiles = (
-                await Promise.all(
-                    Array.from({ length: 5 }).map((_o, index) => bot.sendMessage(roomId, `Message ${index}`)),
-                )
-            ).map(({ event_id: evtId }) =>
-                page.locator(`.mx_RoomView_MessageList .mx_EventTile[data-event-id='${evtId}']`),
-            );
-            for (const tile of tiles) {
-                await expect(tile).toBeVisible();
-            }
-            await page.clock.fastForward(ONE_MINUTE + 1);
-            for (const tile of tiles) {
-                await expect(tile).toBeHidden();
-            }
-        },
-    );
+        });
+        // We poll the config every so often, so ensure we pull it here.
+        // await page.clock.runFor(90000);
+        // Having to wrench this one because runFor isn't working out.
+        await page.evaluate(() => {
+            void window.mxMatrixClientPeg.get().retentionPolicyService["poll"]();
+        });
+        await checkRetentionInRoom({ app, bot, page }, roomId);
+    });
 
-    test.fixme("apply global ", () => {});
+    test("retention rules should apply after restart", async ({ app, bot, page }) => {
+        const roomId = await app.client.createRoom({
+            name: "Test",
+            invite: [bot.credentials.userId],
+        });
+        await bot.joinRoom(roomId);
+        await app.viewRoomByName("Test");
+        const tiles = (
+            await Promise.all(Array.from({ length: 5 }).map((_o, index) => bot.sendMessage(roomId, `Message ${index}`)))
+        ).map(({ event_id: evtId }) =>
+            page.locator(`.mx_RoomView_MessageList .mx_EventTile[data-event-id='${evtId}']`),
+        );
+        for (const tile of tiles) {
+            await expect(tile).toBeVisible();
+        }
+        // Reload and apply new policy
+        await page.reload();
+        await page.clock.fastForward(ONE_MINUTE + 1);
+        await page.route("**/_matrix/client/unstable/org.matrix.msc1763/retention/configuration", (route) => {
+            return route.fulfill({
+                json: {
+                    policies: {
+                        "*": {
+                            max_lifetime: ONE_MINUTE,
+                        },
+                    },
+                },
+            });
+        });
+        await app.viewRoomByName("Test");
+        for (const tile of tiles) {
+            await expect(tile).toBeHidden();
+        }
+    });
 
-    test.fixme("retention rules should apply retrospectively", () => {});
+    test("should stop applying retention when the policy is removed", async ({ app, homeserver, page, user, bot }) => {
+        const currentTime = new Date();
+        const roomId = await app.client.createRoom({
+            name: "Test",
+            invite: [bot.credentials.userId],
+            initial_state: [
+                {
+                    state_key: "",
+                    type: "org.matrix.msc1763.retention",
+                    content: {
+                        max_lifetime: ONE_MINUTE,
+                    },
+                },
+            ],
+        });
+        // When the bot joins the room
+        await checkRetentionInRoom({ app, bot, page }, roomId);
+
+        // Check that retention rules no longer apply.
+        await page.clock.setFixedTime(currentTime);
+        const { event_id: eventId } = await bot.sendMessage(roomId, `Message afterwards`);
+        await app.client.sendStateEvent(roomId, "org.matrix.msc1763.retention", {});
+        await page.clock.fastForward(ONE_MINUTE + 1);
+        await expect(page.locator(`.mx_RoomView_MessageList .mx_EventTile[data-event-id='${eventId}']`)).toBeVisible();
+    });
 });

--- a/apps/web/playwright/e2e/retention/retention.spec.ts
+++ b/apps/web/playwright/e2e/retention/retention.spec.ts
@@ -65,14 +65,7 @@ test.describe("Retention", () => {
     });
 
     test("global retention rules should apply ", async ({ app, bot, page }) => {
-        let retentionIsAvailable = false;
         await page.route("**/_matrix/client/unstable/org.matrix.msc1763/retention/configuration", (route) => {
-            if (!retentionIsAvailable) {
-                return route.fulfill({
-                    json: { errcode: "M_UNRECOGNIZED", error: "Unrecognized request" },
-                    status: 404,
-                });
-            }
             return route.fulfill({
                 json: {
                     policies: {
@@ -86,14 +79,6 @@ test.describe("Retention", () => {
         const roomId = await app.client.createRoom({
             name: "Test",
             invite: [bot.credentials.userId],
-        });
-        // Test that retention rules are re-fetched after initially being unavailable.
-        retentionIsAvailable = true;
-        // We poll the config every so often, so ensure we pull it here.
-        // await page.clock.runFor(90000);
-        // Having to wrench this one because runFor isn't working out.
-        await page.evaluate(() => {
-            void window.mxMatrixClientPeg.get().retentionPolicyService["poll"]();
         });
         await checkRetentionInRoom({ app, bot, page }, roomId);
     });

--- a/apps/web/playwright/e2e/retention/retention.spec.ts
+++ b/apps/web/playwright/e2e/retention/retention.spec.ts
@@ -16,9 +16,8 @@ async function checkRetentionInRoom(
     { bot, app, page }: Pick<TestFixtures, "app" | "bot"> & { page: Page },
     roomId: string,
 ) {
-    // When the bot joins the room
     await bot.joinRoom(roomId);
-    await app.viewRoomByName("Test");
+    await app.viewRoomById(roomId);
     const tiles = (
         await Promise.all(Array.from({ length: 5 }).map((_o, index) => bot.sendMessage(roomId, `Message ${index}`)))
     ).map(({ event_id: evtId }) => page.locator(`.mx_RoomView_MessageList .mx_EventTile[data-event-id='${evtId}']`));
@@ -60,27 +59,36 @@ test.describe("Retention", () => {
                 },
             ],
         });
-        // When the bot joins the room
+        // When the bot joins the room=
+        await bot.joinRoom(roomId);
+        await app.viewRoomByName("Test");
         await checkRetentionInRoom({ app, bot, page }, roomId);
     });
 
-    test("global retention rules should apply ", async ({ app, bot, page }) => {
-        await page.route("**/_matrix/client/unstable/org.matrix.msc1763/retention/configuration", (route) => {
-            return route.fulfill({
-                json: {
-                    policies: {
-                        "*": {
-                            max_lifetime: ONE_MINUTE,
+    test.describe("global retention rules", () => {
+        test.use({
+            page: async ({ page }, runFixture) => {
+                await page.route("**/_matrix/client/unstable/org.matrix.msc1763/retention/configuration", (route) => {
+                    return route.fulfill({
+                        json: {
+                            policies: {
+                                "*": {
+                                    max_lifetime: ONE_MINUTE,
+                                },
+                            },
                         },
-                    },
-                },
+                    });
+                });
+                await runFixture(page);
+            },
+        });
+        test("should apply", async ({ app, bot, page }) => {
+            const roomId = await app.client.createRoom({
+                name: "Test",
+                invite: [bot.credentials.userId],
             });
+            await checkRetentionInRoom({ app, bot, page }, roomId);
         });
-        const roomId = await app.client.createRoom({
-            name: "Test",
-            invite: [bot.credentials.userId],
-        });
-        await checkRetentionInRoom({ app, bot, page }, roomId);
     });
 
     test("retention rules should apply after restart", async ({ app, bot, page }) => {
@@ -133,9 +141,7 @@ test.describe("Retention", () => {
                 },
             ],
         });
-        // When the bot joins the room
         await checkRetentionInRoom({ app, bot, page }, roomId);
-
         // Check that retention rules no longer apply.
         await page.clock.setFixedTime(currentTime);
         const { event_id: eventId } = await bot.sendMessage(roomId, `Message afterwards`);

--- a/apps/web/playwright/e2e/retention/retention.spec.ts
+++ b/apps/web/playwright/e2e/retention/retention.spec.ts
@@ -65,11 +65,14 @@ test.describe("Retention", () => {
     });
 
     test("global retention rules should apply ", async ({ app, bot, page }) => {
-        const roomId = await app.client.createRoom({
-            name: "Test",
-            invite: [bot.credentials.userId],
-        });
+        let retentionIsAvailable = false;
         await page.route("**/_matrix/client/unstable/org.matrix.msc1763/retention/configuration", (route) => {
+            if (!retentionIsAvailable) {
+                return route.fulfill({
+                    json: { errcode: "M_UNRECOGNIZED", error: "Unrecognized request" },
+                    status: 404,
+                });
+            }
             return route.fulfill({
                 json: {
                     policies: {
@@ -80,6 +83,12 @@ test.describe("Retention", () => {
                 },
             });
         });
+        const roomId = await app.client.createRoom({
+            name: "Test",
+            invite: [bot.credentials.userId],
+        });
+        // Test that retention rules are re-fetched after initially being unavailable.
+        retentionIsAvailable = true;
         // We poll the config every so often, so ensure we pull it here.
         // await page.clock.runFor(90000);
         // Having to wrench this one because runFor isn't working out.

--- a/apps/web/playwright/e2e/retention/retention.spec.ts
+++ b/apps/web/playwright/e2e/retention/retention.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import { rejectToastIfExists } from "@element-hq/element-web-playwright-common";
+
+import { test, expect } from "../../element-web-test";
+
+const ONE_MINUTE = 60 * 1000;
+
+test.describe("Retention", () => {
+    test.use({
+        displayName: "Tom",
+        botCreateOpts: {
+            displayName: "Bob",
+        },
+        labsFlags: ["feature_retention"],
+    });
+
+    test.beforeEach(async ({ app, homeserver, page, user }) => {
+        await rejectToastIfExists(page, "Verify this device");
+        await rejectToastIfExists(page, "Notifications");
+    });
+
+    test(
+        "should apply retention to a bunch of messages",
+        { tag: "@screenshot" },
+        async ({ app, homeserver, page, user, bot }) => {
+            await page.clock.install();
+            const roomId = await app.client.createRoom({
+                name: "Test",
+                invite: [bot.credentials.userId],
+                initial_state: [
+                    {
+                        state_key: "",
+                        type: "org.matrix.msc1763.retention",
+                        content: {
+                            max_lifetime: ONE_MINUTE,
+                        },
+                    },
+                ],
+            });
+            // When the bot joins the room
+            await bot.joinRoom(roomId);
+            await app.viewRoomByName("Test");
+            const tiles = (
+                await Promise.all(
+                    Array.from({ length: 5 }).map((_o, index) => bot.sendMessage(roomId, `Message ${index}`)),
+                )
+            ).map(({ event_id: evtId }) =>
+                page.locator(`.mx_RoomView_MessageList .mx_EventTile[data-event-id='${evtId}']`),
+            );
+            for (const tile of tiles) {
+                await expect(tile).toBeVisible();
+            }
+            await page.clock.fastForward(ONE_MINUTE + 1);
+            for (const tile of tiles) {
+                await expect(tile).toBeHidden();
+            }
+        },
+    );
+
+    test.fixme("apply global ", () => {});
+
+    test.fixme("retention rules should apply retrospectively", () => {});
+});

--- a/apps/web/src/MatrixClientPeg.ts
+++ b/apps/web/src/MatrixClientPeg.ts
@@ -301,6 +301,8 @@ class MatrixClientPegClass implements IMatrixClientPeg {
             opts.unstableMSC4429SyncUserProfileFields = ["org.matrix.msc4426.status"];
         }
 
+        opts.unstableMSC1763Retention = SettingsStore.getValue("feature_retention");
+
         if (SettingsStore.getValue("feature_sliding_sync")) {
             throw new UserFriendlyError("sliding_sync_legacy_no_longer_supported");
         }

--- a/apps/web/src/MatrixClientPeg.ts
+++ b/apps/web/src/MatrixClientPeg.ts
@@ -301,8 +301,6 @@ class MatrixClientPegClass implements IMatrixClientPeg {
             opts.unstableMSC4429SyncUserProfileFields = ["org.matrix.msc4426.status"];
         }
 
-        opts.unstableMSC1763Retention = SettingsStore.getValue("feature_retention");
-
         if (SettingsStore.getValue("feature_sliding_sync")) {
             throw new UserFriendlyError("sliding_sync_legacy_no_longer_supported");
         }
@@ -443,6 +441,7 @@ class MatrixClientPegClass implements IMatrixClientPeg {
             // can toggle on without reloading and also be accessed immediately after login.
             cryptoCallbacks: { ...crossSigningCallbacks },
             enableEncryptedStateEvents: SettingsStore.getValue("feature_msc4362_encrypted_state_events"),
+            unstableMSC1763Retention: SettingsStore.getValue("feature_retention"),
             roomNameGenerator: (_: string, state: RoomNameState) => {
                 switch (state.type) {
                     case RoomNameType.Generated:

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -1536,6 +1536,10 @@
             "display_name": "User status",
             "required_msc_support": "Requires MSC4429 (Profile Updates for Legacy Sync)"
         },
+        "feature_retention": {
+            "description": "Automatically remove messages from a room when they reach a configured retention period. Currently only supports reading settings.",
+            "display_name": "Message retention"
+        },
         "feature_wysiwyg_composer_description": "Use rich text instead of Markdown in the message composer.",
         "group_calls": "New group call experience",
         "group_developer": "Developer",

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -1533,6 +1533,7 @@
         "feature_disable_call_per_sender_encryption": "Disable per-sender encryption for Element Call",
         "feature_retention": {
             "description": "Automatically remove messages from a room when they reach a configured retention period. Currently only supports reading settings.",
+            "disabled_sliding_sync": "Retention cannot be enabled when Sliding Sync is enabled.",
             "display_name": "Message retention"
         },
         "feature_user_status": {

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -1531,14 +1531,14 @@
         "experimental_section": "Early previews",
         "extended_profiles_msc_support": "Requires your server to support MSC4133",
         "feature_disable_call_per_sender_encryption": "Disable per-sender encryption for Element Call",
+        "feature_retention": {
+            "description": "Automatically remove messages from a room when they reach a configured retention period. Currently only supports reading settings.",
+            "display_name": "Message retention"
+        },
         "feature_user_status": {
             "description": "Enables being able to see and set a current status.",
             "display_name": "User status",
             "required_msc_support": "Requires MSC4429 (Profile Updates for Legacy Sync)"
-        },
-        "feature_retention": {
-            "description": "Automatically remove messages from a room when they reach a configured retention period. Currently only supports reading settings.",
-            "display_name": "Message retention"
         },
         "feature_wysiwyg_composer_description": "Use rich text instead of Markdown in the message composer.",
         "group_calls": "New group call experience",

--- a/apps/web/src/settings/Settings.tsx
+++ b/apps/web/src/settings/Settings.tsx
@@ -225,6 +225,7 @@ export interface Settings {
     "feature_dynamic_room_predecessors": IFeature;
     "feature_render_reaction_images": IFeature;
     "feature_new_room_list": IFeature;
+    "feature_retention": IFeature;
     "feature_room_list_sections": IFeature;
     "feature_ask_to_join": IFeature;
     "feature_notifications": IFeature;
@@ -796,6 +797,17 @@ export const SETTINGS: Settings = {
             true,
             true,
         ),
+        default: false,
+    },
+    // TODO: NOTE THIS IS INCOMPATIBLE WITH SLIDING SYNC.
+    "feature_retention": {
+        isFeature: true,
+        labsGroup: LabGroup.Messaging,
+        displayName: _td("labs|feature_retention|display_name"),
+        description: _td("labs|feature_retention|description"),
+        supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG_PRIORITISED,
+        supportedLevelsAreOrdered: true,
+        controller: new ReloadOnChangeController(),
         default: false,
     },
     "useCompactLayout": {

--- a/apps/web/src/settings/Settings.tsx
+++ b/apps/web/src/settings/Settings.tsx
@@ -799,7 +799,6 @@ export const SETTINGS: Settings = {
         ),
         default: false,
     },
-    // TODO: NOTE THIS IS INCOMPATIBLE WITH SLIDING SYNC.
     "feature_retention": {
         isFeature: true,
         labsGroup: LabGroup.Messaging,
@@ -807,7 +806,13 @@ export const SETTINGS: Settings = {
         description: _td("labs|feature_retention|description"),
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG_PRIORITISED,
         supportedLevelsAreOrdered: true,
-        controller: new ReloadOnChangeController(),
+        controller: new IncompatibleController(
+            "feature_sliding_sync",
+            false,
+            true,
+            _td("labs|feature_retention|disabled_sliding_sync"),
+            true,
+        ),
         default: false,
     },
     "useCompactLayout": {

--- a/apps/web/src/settings/controllers/IncompatibleController.ts
+++ b/apps/web/src/settings/controllers/IncompatibleController.ts
@@ -22,7 +22,7 @@ export default class IncompatibleController extends SettingController {
         private settingName: BooleanSettingKey,
         private forcedValue: any = false,
         private incompatibleValue: any | ((v: any) => boolean) = true,
-        private disabledMessage?: string,
+        private readonly disabledMessage?: string,
         private readonly forceReload = false,
     ) {
         super();

--- a/apps/web/src/settings/controllers/IncompatibleController.ts
+++ b/apps/web/src/settings/controllers/IncompatibleController.ts
@@ -10,6 +10,7 @@ import SettingController from "./SettingController";
 import { type SettingLevel } from "../SettingLevel";
 import SettingsStore from "../SettingsStore";
 import { type BooleanSettingKey } from "../Settings.tsx";
+import PlatformPeg from "../../PlatformPeg.ts";
 
 /**
  * Enforces that a boolean setting cannot be enabled if the incompatible setting
@@ -21,6 +22,8 @@ export default class IncompatibleController extends SettingController {
         private settingName: BooleanSettingKey,
         private forcedValue: any = false,
         private incompatibleValue: any | ((v: any) => boolean) = true,
+        private disabledMessage?: string,
+        private readonly forceReload = false,
     ) {
         super();
     }
@@ -37,8 +40,11 @@ export default class IncompatibleController extends SettingController {
         return null; // no override
     }
 
-    public get settingDisabled(): boolean {
-        return this.incompatibleSetting;
+    public get settingDisabled(): boolean | string {
+        if (this.incompatibleSetting) {
+            return this.disabledMessage ?? true;
+        }
+        return false;
     }
 
     public get incompatibleSetting(): boolean {
@@ -46,5 +52,11 @@ export default class IncompatibleController extends SettingController {
             return this.incompatibleValue(SettingsStore.getValue(this.settingName));
         }
         return SettingsStore.getValue(this.settingName) === this.incompatibleValue;
+    }
+
+    public onChange(): void {
+        if (this.forceReload) {
+            PlatformPeg.get()?.reload();
+        }
     }
 }


### PR DESCRIPTION
Requires https://github.com/matrix-org/matrix-js-sdk/pull/5353

Adds a settings flag and playwright tests.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
