### PR TITLE
Room list: remove "Sections are only for you” in edition section dialog

### DIFF
--- a/apps/web/res/css/views/dialogs/_CreateSectionDialog.pcss
+++ b/apps/web/res/css/views/dialogs/_CreateSectionDialog.pcss
@@ -21,3 +21,7 @@
         width: 100%;
     }
 }
+
+.mx_CreateSectionDialog_edition > .mx_Dialog_header {
+    margin-bottom: var(--cpd-space-6x);
+}

--- a/apps/web/src/components/views/dialogs/CreateSectionDialog.tsx
+++ b/apps/web/src/components/views/dialogs/CreateSectionDialog.tsx
@@ -8,6 +8,7 @@
 import React, { useState, type JSX } from "react";
 import { Flex } from "@element-hq/web-shared-components";
 import { Form, Text } from "@vector-im/compound-web";
+import classNames from "classnames";
 
 import BaseDialog from "./BaseDialog";
 import DialogButtons from "../elements/DialogButtons";
@@ -37,15 +38,19 @@ export function CreateSectionDialog({ onFinished, sectionToEdit }: CreateSection
 
     return (
         <BaseDialog
-            className="mx_CreateSectionDialog"
+            className={classNames("mx_CreateSectionDialog", {
+                mx_CreateSectionDialog_edition: isEdition,
+            })}
             onFinished={() => onFinished(false, value)}
             title={isEdition ? _t("create_section_dialog|title_edition") : _t("create_section_dialog|title")}
             hasCancel={true}
         >
             <Flex gap="var(--cpd-space-6x)" direction="column" className="mx_CreateSectionDialog_content">
-                <Text as="span" weight="medium">
-                    {_t("create_section_dialog|description")}
-                </Text>
+                {!isEdition && (
+                    <Text as="span" weight="medium">
+                        {_t("create_section_dialog|description")}
+                    </Text>
+                )}
                 <Form.Root
                     className="mx_CreateSectionDialog_form"
                     onSubmit={(e) => {


### PR DESCRIPTION
Remove "Sections are only for you” in edition section dialog
[Figma](https://www.figma.com/design/qurBlLqjf3mRNpyZ1ffamm/ER-213---Sections?node-id=214-25270&t=ftTEpAma7PgRaaqB-4)

| Before  | After |
| ------------- | ------------- |
| <img width="609" height="552" alt="image" src="https://github.com/user-attachments/assets/54b04926-0160-4789-a597-78d420970bc2" /> | <img width="609" height="552" alt="image" src="https://github.com/user-attachments/assets/b09f0962-8518-4a4f-8c20-6b70394a3aed" /> |