### PR TITLE
Room list: remove logic to expand a section when a filter is selected

### DIFF
--- a/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
+++ b/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
@@ -205,16 +205,6 @@ export class RoomListViewModel
         // Update roomsMap immediately before clearing VMs
         this.updateRoomsMap(this.roomsResult);
 
-        // When a filter is toggled on, expand sections that have results so they're visible
-        if (newFilter) {
-            for (const section of this.roomsResult.sections) {
-                if (section.rooms.length > 0) {
-                    const sectionHeaderVM = this.roomSectionHeaderViewModels.get(section.tag);
-                    if (sectionHeaderVM) sectionHeaderVM.isExpanded = true;
-                }
-            }
-        }
-
         this.updateRoomListData();
     };
 

--- a/apps/web/test/viewmodels/room-list/RoomListViewModel-test.tsx
+++ b/apps/web/test/viewmodels/room-list/RoomListViewModel-test.tsx
@@ -970,33 +970,6 @@ describe("RoomListViewModel", () => {
                 expect(snapshot.sections[0].roomIds).toEqual(["!fav1:server"]);
             });
 
-            it("should expand collapsed sections that have results when a filter is toggled on", () => {
-                viewModel = new RoomListViewModel({ client: matrixClient });
-
-                // Collapse the favourite section
-                const favHeader = viewModel.getSectionHeaderViewModel(DefaultTagID.Favourite);
-                favHeader.onClick();
-                expect(favHeader.isExpanded).toBe(false);
-
-                // Toggle a filter that returns rooms in the favourite section
-                jest.spyOn(RoomListStoreV3.instance, "getSortedRoomsInActiveSpace").mockReturnValue({
-                    spaceId: "home",
-                    sections: [
-                        { tag: DefaultTagID.Favourite, rooms: [favRoom1] },
-                        { tag: CHATS_TAG, rooms: [] },
-                        { tag: DefaultTagID.LowPriority, rooms: [] },
-                    ],
-                    filterKeys: [FilterEnum.UnreadFilter],
-                });
-                viewModel.onToggleFilter("unread");
-
-                // The favourite section should be expanded and its rooms visible
-                expect(favHeader.isExpanded).toBe(true);
-                const snapshot = viewModel.getSnapshot();
-                const favSection = snapshot.sections.find((s) => s.id === DefaultTagID.Favourite);
-                expect(favSection!.roomIds).toEqual(["!fav1:server"]);
-            });
-
             describe("custom section visibility by originating space", () => {
                 const customTag = `${CUSTOM_SECTION_TAG_PREFIX}test-uuid` as const;
 


### PR DESCRIPTION
Remove logic to expand a section when a filter is selected.
[Updated figma](https://www.figma.com/design/qurBlLqjf3mRNpyZ1ffamm/ER-213---Sections?node-id=155-32920&t=1pF24cfsFE7hyl8Z-4)