### PR TITLE
Fix "unexpected error" logging when fetching RTC transports from the homeserver

### DIFF
--- a/apps/web/src/stores/CallStore.ts
+++ b/apps/web/src/stores/CallStore.ts
@@ -62,7 +62,10 @@ export class CallStore extends AsyncStoreWithClient<EmptyObject> {
             transports.forEach((t) => this.configuredMatrixRTCTransports.add(t));
         } catch (ex) {
             // Expected, MSC not implemented.
-            if (ex instanceof MatrixError === false || ex.errcode !== "M_NOT_FOUND") {
+            //
+            // Homeservers will return a 404 M_UNRECOGNIZED matrix error if they
+            // don't implement a requested endpoint.
+            if (ex instanceof MatrixError === false || ex.errcode !== "M_UNRECOGNIZED") {
                 logger.warn("Unexpected error when trying to fetch RTC transports", ex);
             }
         }


### PR DESCRIPTION
The previous code assumed that the homeserver would return `M_NOT_FOUND` when the endpoint wasn't implemented. But homeservers should return `M_UNRECOGNIZED` instead in this case.

See https://spec.matrix.org/v1.18/client-server-api/#:~:text=The%20server%20did%20not%20understand%20the%20request%2E

This change has no user-facing impact (other than logging).

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
