### PR TITLE
web-shared-components 0.1.0

### DIFF
--- a/packages/shared-components/package.json
+++ b/packages/shared-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@element-hq/web-shared-components",
-    "version": "0.0.2",
+    "version": "0.1.0",
     "description": "Shared components for Element",
     "author": "New Vector Ltd.",
     "repository": {


### PR DESCRIPTION
I'm not quite sure what has changed in the last 4 months but I feel like we've made some name changes and refactors. I think given https://semver.org/#spec-item-4, it probably warrants a `0.1.0` but the API is still not stable yet.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
