### PR TITLE
Fix double tooltip on collapsed Quick Settings button

### DIFF
--- a/apps/web/src/components/views/spaces/QuickSettingsButton.tsx
+++ b/apps/web/src/components/views/spaces/QuickSettingsButton.tsx
@@ -144,7 +144,6 @@ const QuickSettingsButton: React.FC<{
             aria-label={_t("quick_settings|title")}
             className={classNames("mx_QuickSettingsButton", { expanded: !isPanelCollapsed })}
             onClick={openMenu}
-            title={isPanelCollapsed ? _t("quick_settings|title") : undefined}
             ref={handle}
             aria-expanded={!isPanelCollapsed}
         >

--- a/apps/web/test/unit-tests/components/views/spaces/__snapshots__/SpacePanel-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/spaces/__snapshots__/SpacePanel-test.tsx.snap
@@ -371,7 +371,6 @@ exports[`<SpacePanel /> should show all activated MetaSpaces in the correct orde
       role="button"
       style="--cpd-icon-button-size: 32px;"
       tabindex="0"
-      title="Quick settings"
     >
       <div
         class="_indicator-icon_147l5_17"


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-web/issues/33902