### PR TITLE
Bump @element-hq/web-shared-components to 0.1.1

### DIFF
--- a/packages/shared-components/package.json
+++ b/packages/shared-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@element-hq/web-shared-components",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Shared components for Element",
     "author": "New Vector Ltd.",
     "repository": {


### PR DESCRIPTION
Fix for https://github.com/element-hq/element-web/issues/33911 in `0.1.0`
Includes https://github.com/element-hq/element-web/pull/33914

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
