### PR TITLE
Show an inline block when loading URL previews.

### DIFF
--- a/apps/web/src/components/views/messages/TextualBodyFactory.tsx
+++ b/apps/web/src/components/views/messages/TextualBodyFactory.tsx
@@ -32,6 +32,7 @@ import PosthogTrackers from "../../../PosthogTrackers";
 import ImageView from "../elements/ImageView";
 import EditMessageComposer from "../rooms/EditMessageComposer";
 import { EditWysiwygComposer } from "../rooms/wysiwyg_composer";
+import { useSettingValue } from "../../../hooks/useSettings";
 
 const logger = rootLogger.getChild("TextualBodyFactory");
 
@@ -60,6 +61,7 @@ export function TextualBodyFactory(props: Readonly<IBodyProps>): JSX.Element {
     const willHaveWrapper = !!props.replacingEventId || !!props.isSeeingThroughMessageHiddenForModeration || isEmote;
     const stripReply = !props.mxEvent.replacingEvent() && !!getParentEventId(props.mxEvent);
     const contentRef = useRef<TextualBodyContentElement>(null);
+    const showSpinnerOnPreview = useSettingValue("urlPreviewsEnabled_spinner");
 
     const textualBodyVm = useCreateAutoDisposedViewModel(
         () =>
@@ -98,6 +100,7 @@ export function TextualBodyFactory(props: Readonly<IBodyProps>): JSX.Element {
                 client,
                 mxEvent: props.mxEvent,
                 mediaVisible,
+                shouldShowSpinner: showSpinnerOnPreview,
                 onImageClicked: (preview: UrlPreview): void => {
                     if (!preview.image?.imageFull) {
                         return;

--- a/apps/web/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -357,6 +357,11 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
                             level={SettingLevel.DEVICE}
                             requires={["urlPreviewsEnabled"]}
                         />
+                        <SettingsFlag
+                            name="urlPreviewsEnabled_spinner"
+                            level={SettingLevel.DEVICE}
+                            requires={["urlPreviewsEnabled"]}
+                        />
                     </SettingsSubsection>
 
                     <SettingsSubsection heading={_t("settings|preferences|media_heading")} formWrap>

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -2697,6 +2697,10 @@
         },
         "inline_url_previews_default": "Enable previews",
         "inline_url_previews_encrypted": "Enable previews in encrypted rooms",
+        "inline_url_previews_spinner": {
+            "name": "Show spinner when loading URLs",
+            "description": "Load all URL previews, then collapse unavailable ones"
+        },
         "insert_trailing_colon_mentions": "Insert a trailing colon after user mentions at the start of a message",
         "invite_controls": {
             "default_label": "Allow users to invite you to rooms"

--- a/apps/web/src/settings/Settings.tsx
+++ b/apps/web/src/settings/Settings.tsx
@@ -312,6 +312,7 @@ export interface Settings {
     "blacklistUnverifiedDevices": IBaseSetting<boolean>;
     "urlPreviewsEnabled": IBaseSetting<boolean>;
     "urlPreviewsEnabled_e2ee": IBaseSetting<boolean>;
+    "urlPreviewsEnabled_spinner": IBaseSetting<boolean>;
     "notificationsEnabled": IBaseSetting<boolean>;
     "deviceNotificationsEnabled": IBaseSetting<boolean>;
     "notificationSound": IBaseSetting<NotificationSound | false>;
@@ -1175,6 +1176,17 @@ export const SETTINGS: Settings = {
         supportedLevels: [SettingLevel.DEVICE],
         supportedLevelsAreOrdered: true,
         displayName: _td("settings|inline_url_previews_encrypted"),
+        default: false,
+        controller: new RequiresSettingsController([UIFeature.URLPreviews, "urlPreviewsEnabled"]),
+    },
+    // NOT to be shipped, this is for testing only.
+    "urlPreviews_spinner": {
+        // Enabled by default and client configurable as this setting only allows unencrypted
+        // messages to be previewed.
+        supportedLevels: [SettingLevel.ROOM_DEVICE, SettingLevel.DEVICE, SettingLevel.ACCOUNT, SettingLevel.CONFIG],
+        supportedLevelsAreOrdered: true,
+        displayName: _td("settings|inline_url_previews_spinner|name"),
+        description: _td("settings|inline_url_previews_spinner|description"),
         default: false,
         controller: new RequiresSettingsController([UIFeature.URLPreviews, "urlPreviewsEnabled"]),
     },

--- a/apps/web/src/settings/Settings.tsx
+++ b/apps/web/src/settings/Settings.tsx
@@ -1180,7 +1180,7 @@ export const SETTINGS: Settings = {
         controller: new RequiresSettingsController([UIFeature.URLPreviews, "urlPreviewsEnabled"]),
     },
     // NOT to be shipped, this is for testing only.
-    "urlPreviews_spinner": {
+    "urlPreviewsEnabled_spinner": {
         // Enabled by default and client configurable as this setting only allows unencrypted
         // messages to be previewed.
         supportedLevels: [SettingLevel.ROOM_DEVICE, SettingLevel.DEVICE, SettingLevel.ACCOUNT, SettingLevel.CONFIG],

--- a/apps/web/src/viewmodels/message-body/UrlPreviewGroupViewModel.ts
+++ b/apps/web/src/viewmodels/message-body/UrlPreviewGroupViewModel.ts
@@ -27,6 +27,7 @@ const logger = rootLogger.getChild("UrlPreviewGroupViewModel");
 export interface UrlPreviewGroupViewModelProps {
     client: MatrixClient;
     mxEvent: MatrixEvent;
+    shouldShowSpinner: boolean;
     mediaVisible: boolean;
     visible: boolean;
     onImageClicked: (preview: UrlPreview) => void;
@@ -282,6 +283,7 @@ export class UrlPreviewGroupViewModel
             totalPreviewCount: 0,
             previewsLimited: true,
             overPreviewLimit: false,
+            loading: props.shouldShowSpinner,
         });
         this.urlPreviewEnabledByUser = globalThis.localStorage.getItem(storageKey) !== "1";
         this.urlPreviewVisible = props.visible;
@@ -389,6 +391,12 @@ export class UrlPreviewGroupViewModel
      * for the previously-calculated links.
      */
     private async computeSnapshot(): Promise<void> {
+        if (this.props.shouldShowSpinner) {
+            this.snapshot.merge({
+                loading: true,
+                totalPreviewCount: this.links.length,
+            });
+        }
         // This uses MSC4095. If the sender has sent us an empty URL previews bundle
         // then they do not want to have URL previews be visible.
         const bundledLinkPreviews = this.props.mxEvent.getContent()[BUNDLED_LINK_PREVIEWS];
@@ -414,6 +422,7 @@ export class UrlPreviewGroupViewModel
             totalPreviewCount: this.links.length,
             previewsLimited: this.limitPreviews,
             overPreviewLimit: this.links.length > MAX_PREVIEWS_WHEN_LIMITED,
+            loading: false,
         });
     }
 

--- a/apps/web/src/viewmodels/message-body/UrlPreviewGroupViewModel.ts
+++ b/apps/web/src/viewmodels/message-body/UrlPreviewGroupViewModel.ts
@@ -283,7 +283,6 @@ export class UrlPreviewGroupViewModel
             totalPreviewCount: 0,
             previewsLimited: true,
             overPreviewLimit: false,
-            loading: props.shouldShowSpinner,
         });
         this.urlPreviewEnabledByUser = globalThis.localStorage.getItem(storageKey) !== "1";
         this.urlPreviewVisible = props.visible;
@@ -393,7 +392,7 @@ export class UrlPreviewGroupViewModel
     private async computeSnapshot(): Promise<void> {
         if (this.props.shouldShowSpinner) {
             this.snapshot.merge({
-                loading: true,
+                loadingLinks: this.links,
                 totalPreviewCount: this.links.length,
             });
         }
@@ -402,6 +401,7 @@ export class UrlPreviewGroupViewModel
         const bundledLinkPreviews = this.props.mxEvent.getContent()[BUNDLED_LINK_PREVIEWS];
         if (Array.isArray(bundledLinkPreviews) && bundledLinkPreviews.length === 0) {
             return this.snapshot.merge({
+                loadingLinks: undefined,
                 previews: [],
                 totalPreviewCount: 0,
                 previewsLimited: false,
@@ -422,7 +422,7 @@ export class UrlPreviewGroupViewModel
             totalPreviewCount: this.links.length,
             previewsLimited: this.limitPreviews,
             overPreviewLimit: this.links.length > MAX_PREVIEWS_WHEN_LIMITED,
-            loading: false,
+            loadingLinks: undefined,
         });
     }
 

--- a/apps/web/test/viewmodels/message-body/UrlPreviewGroupViewModel-test.ts
+++ b/apps/web/test/viewmodels/message-body/UrlPreviewGroupViewModel-test.ts
@@ -42,6 +42,7 @@ function getViewModel(
         mediaVisible,
         visible,
         onImageClicked,
+        shouldShowSpinner: false,
         mxEvent: mkEvent({
             event: true,
             user: "@foo:bar",

--- a/packages/shared-components/src/room/timeline/event-tile/UrlPreviewGroupView/LinkPreview/LinkPreview.tsx
+++ b/packages/shared-components/src/room/timeline/event-tile/UrlPreviewGroupView/LinkPreview/LinkPreview.tsx
@@ -16,7 +16,7 @@ import { LinkedText } from "../../../../../core/utils/LinkedText";
 import styles from "./LinkPreview.module.css";
 
 export interface LinkPreviewActions {
-    onImageClick: () => void;
+    onImageClick?: () => void;
 }
 
 export type LinkPreviewProps = UrlPreview & LinkPreviewActions;
@@ -95,7 +95,7 @@ export function LinkPreview({ onImageClick, ...preview }: LinkPreviewProps): JSX
             if (!preview.image?.imageFull) {
                 return;
             }
-            onImageClick();
+            onImageClick?.();
         },
         [preview.image?.imageFull, onImageClick],
     );
@@ -107,7 +107,7 @@ export function LinkPreview({ onImageClick, ...preview }: LinkPreviewProps): JSX
     let img: JSX.Element | undefined;
 
     if (preview.image) {
-        if (preview.image.playable) {
+        if (preview.image.playable || !onImageClick) {
             // Playable media do not have clickable images so we don't
             // overlay buttons atop buttons, instead we render a
             // button for them to open the media.
@@ -118,17 +118,19 @@ export function LinkPreview({ onImageClick, ...preview }: LinkPreviewProps): JSX
                     }}
                     className={styles.preview}
                 >
-                    <Button
-                        as="a"
-                        href={preview.link}
-                        aria-label={_t("timeline|url_preview|open_link")}
-                        className={styles.playButton}
-                        target="_blank"
-                        rel="noreferrer noopener"
-                        kind="primary"
-                    >
-                        <PlaySolidIcon width="24px" height="24px" />
-                    </Button>
+                    {preview.image.playable && (
+                        <Button
+                            as="a"
+                            href={preview.link}
+                            aria-label={_t("timeline|url_preview|open_link")}
+                            className={styles.playButton}
+                            target="_blank"
+                            rel="noreferrer noopener"
+                            kind="primary"
+                        >
+                            <PlaySolidIcon width="24px" height="24px" />
+                        </Button>
+                    )}
                 </div>
             );
         } else {

--- a/packages/shared-components/src/room/timeline/event-tile/UrlPreviewGroupView/UrlPreviewGroupView.stories.tsx
+++ b/packages/shared-components/src/room/timeline/event-tile/UrlPreviewGroupView/UrlPreviewGroupView.stories.tsx
@@ -137,6 +137,20 @@ MultiplePreviewsVisible.args = {
     totalPreviewCount: 10,
 };
 
+export const WithLoading = Template.bind({});
+WithLoading.args = {
+    previews: [],
+    totalPreviewCount: 1,
+    loading: true,
+};
+
+export const WithLoadingMultiple = Template.bind({});
+WithLoadingMultiple.args = {
+    previews: [],
+    totalPreviewCount: 3,
+    loading: true,
+};
+
 export const WithCompactView = Template.bind({});
 WithCompactView.args = {
     ...MultiplePreviewsVisible.args,

--- a/packages/shared-components/src/room/timeline/event-tile/UrlPreviewGroupView/UrlPreviewGroupView.stories.tsx
+++ b/packages/shared-components/src/room/timeline/event-tile/UrlPreviewGroupView/UrlPreviewGroupView.stories.tsx
@@ -141,14 +141,14 @@ export const WithLoading = Template.bind({});
 WithLoading.args = {
     previews: [],
     totalPreviewCount: 1,
-    loading: true,
+    loadingLinks: ["https://example.org"],
 };
 
 export const WithLoadingMultiple = Template.bind({});
 WithLoadingMultiple.args = {
     previews: [],
     totalPreviewCount: 3,
-    loading: true,
+    loadingLinks: ["https://example.org", "https://example.org/foo", "https://example.org/bar"],
 };
 
 export const WithCompactView = Template.bind({});

--- a/packages/shared-components/src/room/timeline/event-tile/UrlPreviewGroupView/UrlPreviewGroupView.tsx
+++ b/packages/shared-components/src/room/timeline/event-tile/UrlPreviewGroupView/UrlPreviewGroupView.tsx
@@ -27,6 +27,8 @@ export interface UrlPreviewGroupViewSnapshot {
     previewsLimited: boolean;
     /** Whether more previews exist than are currently rendered. */
     overPreviewLimit: boolean;
+    /** Whether the previews are in a loading state */
+    loading: boolean;
 }
 
 /** Props for the URL preview group view. */
@@ -63,9 +65,20 @@ export type UrlPreviewGroupViewModel = ViewModel<UrlPreviewGroupViewSnapshot, Ur
 export function UrlPreviewGroupView({ vm, className }: UrlPreviewGroupViewProps): JSX.Element | null {
     const { translate: _t } = useI18n();
     const eventPresentationAttributes = useEventPresentationAttributes();
-    const { previews, totalPreviewCount, previewsLimited, overPreviewLimit } = useViewModel(vm);
-    if (previews.length === 0) {
+    const { previews, totalPreviewCount, previewsLimited, overPreviewLimit, loading } = useViewModel(vm);
+
+    let content: JSX.Element[];
+    if (loading && totalPreviewCount) {
+        // TODO: All faked.
+        content = Array.from({ length: totalPreviewCount }).map((_, idx) => (
+            <LinkPreview key={idx} showTooltipOnLink={false} link="https://example.org" title="Loading" siteName="Link preview is being fetched" />
+        ));
+    } else if (previews.length === 0) {
         return null;
+    } else {
+        content = previews.map((preview) => (
+            <LinkPreview key={preview.link} onImageClick={() => vm.onImageClick(preview)} {...preview} />
+        ));
     }
 
     let toggleButton: JSX.Element | undefined;
@@ -82,9 +95,7 @@ export function UrlPreviewGroupView({ vm, className }: UrlPreviewGroupViewProps)
     return (
         <div className={classNames(className, styles.wrapper)} {...eventPresentationAttributes}>
             <div className={styles.previewGroup}>
-                {previews.map((preview) => (
-                    <LinkPreview key={preview.link} onImageClick={() => vm.onImageClick(preview)} {...preview} />
-                ))}
+                {content}
                 {toggleButton}
             </div>
             <IconButton

--- a/packages/shared-components/src/room/timeline/event-tile/UrlPreviewGroupView/UrlPreviewGroupView.tsx
+++ b/packages/shared-components/src/room/timeline/event-tile/UrlPreviewGroupView/UrlPreviewGroupView.tsx
@@ -28,7 +28,7 @@ export interface UrlPreviewGroupViewSnapshot {
     /** Whether more previews exist than are currently rendered. */
     overPreviewLimit: boolean;
     /** Whether the previews are in a loading state */
-    loading: boolean;
+    loadingLinks?: string[];
 }
 
 /** Props for the URL preview group view. */
@@ -65,13 +65,19 @@ export type UrlPreviewGroupViewModel = ViewModel<UrlPreviewGroupViewSnapshot, Ur
 export function UrlPreviewGroupView({ vm, className }: UrlPreviewGroupViewProps): JSX.Element | null {
     const { translate: _t } = useI18n();
     const eventPresentationAttributes = useEventPresentationAttributes();
-    const { previews, totalPreviewCount, previewsLimited, overPreviewLimit, loading } = useViewModel(vm);
+    const { previews, totalPreviewCount, previewsLimited, overPreviewLimit, loadingLinks } = useViewModel(vm);
 
     let content: JSX.Element[];
-    if (loading && totalPreviewCount) {
+    if (loadingLinks?.length && totalPreviewCount) {
         // TODO: All faked.
-        content = Array.from({ length: totalPreviewCount }).map((_, idx) => (
-            <LinkPreview key={idx} showTooltipOnLink={false} link="https://example.org" title="Loading" siteName="Link preview is being fetched" />
+        content = loadingLinks.map((link, idx) => (
+            <LinkPreview
+                key={idx}
+                showTooltipOnLink={false}
+                link={link}
+                title="Loading"
+                siteName={new URL(link).origin}
+            />
         ));
     } else if (previews.length === 0) {
         return null;


### PR DESCRIPTION
The setting is not intended to be merged but to give Product/Design a reference to work off.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
