### PR TITLE
Allow publishing npm packages from develop

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -40,4 +40,4 @@ jobs:
 
             - name: 🚀 Publish to npm
               working-directory: packages/${{ inputs.package }}
-              run: pnpm publish --access public --provenance
+              run: pnpm publish --access public --provenance --publish-branch develop


### PR DESCRIPTION
Follow on from https://github.com/element-hq/element-web/pull/33914

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
