### PR TITLE
Tidy languageHandler test

### DIFF
--- a/apps/web/src/languageHandler.tsx
+++ b/apps/web/src/languageHandler.tsx
@@ -239,16 +239,6 @@ async function getLanguage(langPath: string): Promise<ICounterpartTranslation> {
 let cachedCustomTranslations: TranslationStringsObject | undefined;
 let cachedCustomTranslationsExpire = 0; // zero to trigger expiration right away
 
-// This awkward class exists so the test runner can get at the function. It is
-// not intended for practical or realistic usage.
-export class CustomTranslationOptions {
-    public static lookupFn?: (url: string) => TranslationStringsObject;
-
-    private constructor() {
-        // static access for tests only
-    }
-}
-
 function doRegisterTranslations(customTranslations: TranslationStringsObject): void {
     // We convert the operator-friendly version into something counterpart can consume.
     // Map: lang → Record: string → translation
@@ -287,9 +277,7 @@ export async function registerCustomTranslations({
     try {
         let json: TranslationStringsObject | undefined;
         if (testOnlyIgnoreCustomTranslationsCache || Date.now() >= cachedCustomTranslationsExpire) {
-            json = CustomTranslationOptions.lookupFn
-                ? CustomTranslationOptions.lookupFn(lookupUrl)
-                : ((await (await fetch(lookupUrl)).json()) as TranslationStringsObject);
+            json = (await (await fetch(lookupUrl)).json()) as TranslationStringsObject;
             cachedCustomTranslations = json;
 
             // Set expiration to the future, but not too far. Just trying to avoid

--- a/apps/web/test/unit-tests/languageHandler-test.tsx
+++ b/apps/web/test/unit-tests/languageHandler-test.tsx
@@ -15,7 +15,6 @@ import SdkConfig from "../../src/SdkConfig";
 import {
     _t,
     _tDom,
-    CustomTranslationOptions,
     getAllLanguagesWithLabels,
     registerCustomTranslations,
     setLanguage,
@@ -31,15 +30,11 @@ import { stubClient } from "../test-utils";
 
 async function setupTranslationOverridesForTests(overrides: TranslationStringsObject) {
     const lookupUrl = "/translations.json";
-    const fn = (url: string): TranslationStringsObject => {
-        expect(url).toEqual(lookupUrl);
-        return overrides;
-    };
 
     SdkConfig.add({
         custom_translations_url: lookupUrl,
     });
-    CustomTranslationOptions.lookupFn = fn;
+    fetchMock.get(lookupUrl, overrides, { name: "i18n-override" });
     await registerCustomTranslations({
         testOnlyIgnoreCustomTranslationsCache: true,
     });
@@ -52,7 +47,7 @@ describe("languageHandler", () => {
 
     afterEach(() => {
         SdkConfig.reset();
-        CustomTranslationOptions.lookupFn = undefined;
+        fetchMock.removeRoute("i18n-override");
     });
 
     it("should support overriding translations", async () => {


### PR DESCRIPTION
Avoid using special test classes in favour of fetchMock