### PR TITLE
Add translation menu for selected text on macOS

### DIFF
--- a/apps/desktop/hak/element-translation/build.ts
+++ b/apps/desktop/hak/element-translation/build.ts
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import fsProm from "node:fs/promises";
+import path from "node:path";
+
+import type HakEnv from "../../scripts/hak/hakEnv.ts";
+import type { DependencyInfo } from "../../scripts/hak/dep.ts";
+
+export default async function (hakEnv: HakEnv, moduleInfo: DependencyInfo): Promise<void> {
+    // Stage the loader + package manifest into the output module on every platform so it can
+    // be linked and imported. The native .node binary is macOS-only and is copied separately
+    // via hak.json's `copy` (kept binary-only so universal builds can lipo it).
+    const srcDir = path.join(moduleInfo.moduleHakDir, "native");
+    await fsProm.mkdir(moduleInfo.moduleOutDir, { recursive: true });
+    await fsProm.copyFile(path.join(srcDir, "package.json"), path.join(moduleInfo.moduleOutDir, "package.json"));
+    await fsProm.copyFile(path.join(srcDir, "index.cjs"), path.join(moduleInfo.moduleOutDir, "index.cjs"));
+
+    // macOS-only native addon. On other platforms the stub loader reports translation as
+    // unavailable at runtime.
+    if (!hakEnv.isMac()) return;
+
+    // makeGypEnv sets npm_config_arch / npm_config_target / npm_config_runtime so node-gyp
+    // builds against the correct Electron ABI and architecture.
+    const env = hakEnv.makeGypEnv();
+
+    // This is a standalone package (no pnpm workspace linkage), so we use npm to pull in the
+    // declared node-gyp and then run the build against the Electron headers.
+    console.log("Installing element-translation build dependencies");
+    await hakEnv.spawn("npm", ["install", "--no-audit", "--no-fund"], {
+        cwd: moduleInfo.moduleBuildDir,
+        env,
+        shell: true,
+    });
+
+    console.log("Building element-translation native addon");
+    await hakEnv.spawn("npm", ["run", "build"], {
+        cwd: moduleInfo.moduleBuildDir,
+        env,
+        shell: true,
+    });
+}

--- a/apps/desktop/hak/element-translation/check.ts
+++ b/apps/desktop/hak/element-translation/check.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import fsProm from "node:fs/promises";
+import path from "node:path";
+
+import type HakEnv from "../../scripts/hak/hakEnv.ts";
+import type { DependencyInfo } from "../../scripts/hak/dep.ts";
+
+export default async function (hakEnv: HakEnv, moduleInfo: DependencyInfo): Promise<void> {
+    // This is an in-repo native module, so there is no npm package to fetch. We stage the
+    // source into the build dir here (check runs before fetch); hak's default `fetch` step
+    // then no-ops because the build dir already exists.
+    const srcDir = path.join(moduleInfo.moduleHakDir, "native");
+    await fsProm.cp(srcDir, moduleInfo.moduleBuildDir, { recursive: true });
+
+    // The native addon is macOS-only; nothing more to check on other platforms.
+    if (!hakEnv.isMac()) return;
+
+    try {
+        // node-gyp needs python; try python3 first for a clearer error.
+        await hakEnv.checkTools([["python3", "--version"]]);
+    } catch {
+        await hakEnv.checkTools([["python", "--version"]]);
+    }
+}

--- a/apps/desktop/hak/element-translation/hak.json
+++ b/apps/desktop/hak/element-translation/hak.json
@@ -1,0 +1,7 @@
+{
+    "scripts": {
+        "check": "check.ts",
+        "build": "build.ts"
+    },
+    "copy": "build/Release/translation.node"
+}

--- a/apps/desktop/hak/element-translation/native/binding.gyp
+++ b/apps/desktop/hak/element-translation/native/binding.gyp
@@ -1,0 +1,21 @@
+{
+    "targets": [
+        {
+            "target_name": "translation",
+            "conditions": [
+                [
+                    "OS=='mac'",
+                    {
+                        "sources": ["translation.mm"],
+                        "libraries": ["-framework Cocoa", "-framework AppKit"],
+                        "xcode_settings": {
+                            "CLANG_ENABLE_OBJC_ARC": "YES",
+                            "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                            "OTHER_CPLUSPLUSFLAGS": ["-std=c++17"]
+                        }
+                    }
+                ]
+            ]
+        }
+    ]
+}

--- a/apps/desktop/hak/element-translation/native/index.cjs
+++ b/apps/desktop/hak/element-translation/native/index.cjs
@@ -1,0 +1,36 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+// Loader for the native macOS translation addon. On platforms where the addon
+// wasn't built (non-macOS, or build skipped) this degrades gracefully so callers
+// can simply treat translation as unavailable.
+
+let native = null;
+try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    native = require("./build/Release/translation.node");
+} catch {
+    native = null;
+}
+
+module.exports = {
+    isAvailable() {
+        try {
+            return !!native && native.isAvailable();
+        } catch {
+            return false;
+        }
+    },
+    showTranslation(viewHandle, text, x, y, width, height) {
+        if (!native) return;
+        try {
+            native.showTranslation(viewHandle, text, x, y, width, height);
+        } catch {
+            // ignore — best effort
+        }
+    },
+};

--- a/apps/desktop/hak/element-translation/native/package.json
+++ b/apps/desktop/hak/element-translation/native/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "element-translation",
+    "version": "1.0.0",
+    "description": "Native macOS translation popover for Element Desktop",
+    "main": "index.cjs",
+    "private": true,
+    "license": "AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial",
+    "scripts": {
+        "build": "node-gyp rebuild"
+    },
+    "devDependencies": {
+        "node-gyp": "^11.0.0"
+    }
+}

--- a/apps/desktop/hak/element-translation/native/translation.mm
+++ b/apps/desktop/hak/element-translation/native/translation.mm
@@ -1,0 +1,161 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+// Native macOS translation popover, backed by the private TranslationUI.framework
+// (the same approach Safari/Helium use). Everything is guarded so that any failure
+// to load the private framework simply reports "not available" rather than crashing.
+
+#include <node_api.h>
+
+#import <Cocoa/Cocoa.h>
+#import <objc/message.h>
+#import <objc/runtime.h>
+
+// Keep the currently presented popover alive
+static NSPopover *sCurrentPopover = nil;
+// Local event monitor used to dismiss the popover when the user scrolls. In Electron the
+// timeline scroll is a Chromium/DOM scroll, not a native NSScrollView event, so NSPopover's
+// Transient behaviour never sees it — we watch the raw scroll NSEvent instead.
+static id sScrollMonitor = nil;
+
+// Tear down the active popover + scroll monitor. Must run on the main thread.
+static void DismissCurrentPopover(void) {
+    if (sScrollMonitor) {
+        [NSEvent removeMonitor:sScrollMonitor];
+        sScrollMonitor = nil;
+    }
+    if (sCurrentPopover) {
+        [sCurrentPopover close];
+        sCurrentPopover = nil;
+    }
+}
+
+// Resolve the private `LTUITranslationViewController` class from TranslationUI.framework.
+// Cached; returns nil (once) if the framework can't be loaded or the class is missing.
+static Class TranslationViewControllerClass(void) {
+    static Class cls = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        @try {
+            NSBundle *bundle =
+                [NSBundle bundleWithPath:@"/System/Library/PrivateFrameworks/TranslationUI.framework"];
+            if (bundle && [bundle load]) {
+                cls = NSClassFromString(@"LTUITranslationViewController");
+            }
+        } @catch (__unused NSException *e) {
+            cls = nil;
+        }
+    });
+    return cls;
+}
+
+// isAvailable(): boolean
+static napi_value IsAvailable(napi_env env, napi_callback_info info) {
+    bool available = (TranslationViewControllerClass() != nil);
+    napi_value result;
+    napi_get_boolean(env, available, &result);
+    return result;
+}
+
+// showTranslation(viewHandle: Buffer, text: string, x: number, y: number, width: number, height: number): void
+// `viewHandle` is BrowserWindow.getNativeWindowHandle() — a Buffer wrapping the NSView* pointer.
+// The rect is expected to already be in the source view's (AppKit, bottom-left origin) coordinate space.
+static napi_value ShowTranslation(napi_env env, napi_callback_info info) {
+    size_t argc = 6;
+    napi_value argv[6];
+    if (napi_get_cb_info(env, info, &argc, argv, NULL, NULL) != napi_ok || argc < 6) {
+        return NULL;
+    }
+
+    void *bufData = NULL;
+    size_t bufLen = 0;
+    if (napi_get_buffer_info(env, argv[0], &bufData, &bufLen) != napi_ok || !bufData ||
+        bufLen < sizeof(void *)) {
+        return NULL;
+    }
+    NSView *sourceView = (__bridge NSView *)(*reinterpret_cast<void **>(bufData));
+
+    size_t textLen = 0;
+    napi_get_value_string_utf8(env, argv[1], NULL, 0, &textLen);
+    char *textBuf = static_cast<char *>(malloc(textLen + 1));
+    if (!textBuf) return NULL;
+    napi_get_value_string_utf8(env, argv[1], textBuf, textLen + 1, &textLen);
+    NSString *text = [NSString stringWithUTF8String:textBuf];
+    free(textBuf);
+
+    double x = 0, y = 0, w = 0, h = 0;
+    napi_get_value_double(env, argv[2], &x);
+    napi_get_value_double(env, argv[3], &y);
+    napi_get_value_double(env, argv[4], &w);
+    napi_get_value_double(env, argv[5], &h);
+    NSRect rect = NSMakeRect(x, y, w, h);
+
+    Class cls = TranslationViewControllerClass();
+    if (!cls || !sourceView || text.length == 0) {
+        return NULL;
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        @try {
+            id vc = [[cls alloc] initWithNibName:nil bundle:nil];
+
+            SEL setTextSel = NSSelectorFromString(@"setText:");
+            SEL setSourceViewSel = NSSelectorFromString(@"setSourceView:");
+            SEL setEditableSel = NSSelectorFromString(@"setIsSourceEditable:");
+
+            NSAttributedString *attr = [[NSAttributedString alloc] initWithString:text];
+            if ([vc respondsToSelector:setTextSel]) {
+                ((void (*)(id, SEL, NSAttributedString *))objc_msgSend)(vc, setTextSel, attr);
+            }
+            if ([vc respondsToSelector:setSourceViewSel]) {
+                ((void (*)(id, SEL, NSView *))objc_msgSend)(vc, setSourceViewSel, sourceView);
+            }
+            if ([vc respondsToSelector:setEditableSel]) {
+                ((void (*)(id, SEL, BOOL))objc_msgSend)(vc, setEditableSel, NO);
+            }
+
+            NSPopover *popover = [[NSPopover alloc] init];
+            popover.behavior = NSPopoverBehaviorTransient;
+            popover.contentViewController = (NSViewController *)vc;
+
+            // Replace any popover/monitor still around from a previous invocation.
+            DismissCurrentPopover();
+
+            sCurrentPopover = popover; // retain across the run loop so it isn't dismissed instantly
+            [popover showRelativeToRect:rect ofView:sourceView preferredEdge:NSRectEdgeMaxY];
+
+            // Dismiss the popover as soon as the user scrolls outside it (e.g. the room timeline).
+            sScrollMonitor = [NSEvent
+                addLocalMonitorForEventsMatchingMask:NSEventMaskScrollWheel
+                                             handler:^NSEvent *(NSEvent *event) {
+                                                 NSWindow *popoverWindow =
+                                                     sCurrentPopover.contentViewController.view.window;
+                                                 if (event.window && event.window == popoverWindow) {
+                                                     return event; // scroll inside the popover — keep open
+                                                 }
+                                                 DismissCurrentPopover();
+                                                 return event;
+                                             }];
+        } @catch (NSException *e) {
+            NSLog(@"[element-translation] failed to present translation popover: %@", e);
+            sCurrentPopover = nil;
+        }
+    });
+
+    return NULL;
+}
+
+static napi_value Init(napi_env env, napi_value exports) {
+    napi_value fnAvailable, fnShow;
+    napi_create_function(env, NULL, 0, IsAvailable, NULL, &fnAvailable);
+    napi_set_named_property(env, exports, "isAvailable", fnAvailable);
+    napi_create_function(env, NULL, 0, ShowTranslation, NULL, &fnShow);
+    napi_set_named_property(env, exports, "showTranslation", fnShow);
+    return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -98,7 +98,8 @@
         "vitest": "catalog:"
     },
     "hakDependencies": {
-        "matrix-seshat": "5.0.0"
+        "matrix-seshat": "5.0.0",
+        "element-translation": "1.0.0"
     },
     "nx": {
         "includedScripts": [

--- a/apps/desktop/src/@types/element-translation.d.ts
+++ b/apps/desktop/src/@types/element-translation.d.ts
@@ -1,0 +1,32 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+declare module "element-translation" {
+    /**
+     * Whether the native macOS translation popover is available
+     * (i.e. the private TranslationUI.framework loaded successfully).
+     */
+    export function isAvailable(): boolean;
+
+    /**
+     * Show the native macOS translation popover.
+     * @param viewHandle the NSView* handle from BrowserWindow.getNativeWindowHandle()
+     * @param text the text to translate
+     * @param x rect origin x, in the source view's (AppKit, bottom-left origin) coordinate space
+     * @param y rect origin y, in the source view's coordinate space
+     * @param width rect width
+     * @param height rect height
+     */
+    export function showTranslation(
+        viewHandle: Buffer,
+        text: string,
+        x: number,
+        y: number,
+        width: number,
+        height: number,
+    ): void;
+}

--- a/apps/desktop/src/i18n/strings/en_EN.json
+++ b/apps/desktop/src/i18n/strings/en_EN.json
@@ -14,6 +14,7 @@
         "redo": "Redo",
         "select_all": "Select All",
         "show_hide": "Show/Hide",
+        "translate": "Translate",
         "undo": "Undo",
         "zoom_in": "Zoom In",
         "zoom_out": "Zoom Out"

--- a/apps/desktop/src/ipc.ts
+++ b/apps/desktop/src/ipc.ts
@@ -12,6 +12,7 @@ import { randomArray } from "./utils.js";
 import { getDisplayMediaCallback, setDisplayMediaCallback } from "./displayMediaCallback.js";
 import Store, { clearDataAndRelaunch } from "./store.js";
 import { getConfig } from "./config.js";
+import { isTranslationAvailable, showTranslation } from "./translation.js";
 
 let focusHandlerAttached = false;
 ipcMain.on("loudNotification", function (): void {
@@ -106,6 +107,14 @@ ipcMain.on("ipcCall", async function (_ev: IpcMainEvent, payload) {
             break;
         case "getAvailableSpellCheckLanguages":
             ret = global.mainWindow.webContents.session.availableSpellCheckerLanguages;
+            break;
+
+        case "getTranslationAvailable":
+            ret = isTranslationAvailable();
+            break;
+
+        case "showTranslation":
+            showTranslation(global.mainWindow, args[0]?.text, args[0]?.rect);
             break;
 
         case "getPickleKey":

--- a/apps/desktop/src/translation.ts
+++ b/apps/desktop/src/translation.ts
@@ -1,0 +1,74 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import type { BrowserWindow } from "electron";
+
+interface NativeTranslation {
+    isAvailable(): boolean;
+    showTranslation(viewHandle: Buffer, text: string, x: number, y: number, width: number, height: number): void;
+}
+
+let translationSupported = false;
+let nativeTranslation: NativeTranslation | undefined;
+
+try {
+    // macOS-only native addon backed by the private TranslationUI.framework.
+    if (process.platform === "darwin") {
+        // `element-translation` is a CommonJS module; when imported into ESM, Node only synthesizes
+        // named exports it can statically detect, so we use the `default` (the real module.exports).
+        const mod = (await import("element-translation")) as unknown as {
+            default?: NativeTranslation;
+        } & NativeTranslation;
+        nativeTranslation = mod.default ?? mod;
+        translationSupported = true;
+    }
+} catch (e) {
+    if ((<NodeJS.ErrnoException>e).code === "MODULE_NOT_FOUND") {
+        console.log("Native translation isn't installed, message translation is disabled.");
+    } else {
+        console.warn("Native translation unexpected error:", e);
+    }
+}
+
+export interface TranslationRect {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+/**
+ * Whether the native macOS translation popover can be shown.
+ */
+export function isTranslationAvailable(): boolean {
+    try {
+        return translationSupported && !!nativeTranslation?.isAvailable();
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Show the native macOS translation popover for the given text, anchored at the given
+ * rect. The rect is provided by the renderer in CSS pixels relative to the top-left of
+ * the web contents; we convert it into the content view's AppKit coordinate space
+ * (bottom-left origin) before handing it to the addon.
+ */
+export function showTranslation(win: BrowserWindow, text: string, rect: TranslationRect): void {
+    if (!isTranslationAvailable() || !text || !rect) return;
+
+    try {
+        const handle = win.getNativeWindowHandle();
+        const [, contentHeight] = win.getContentSize();
+        // Flip the Y axis: DOM coordinates have a top-left origin, AppKit views a bottom-left one.
+        const x = rect.x;
+        const y = contentHeight - (rect.y + rect.height);
+        nativeTranslation!.showTranslation(handle, text, x, y, rect.width, rect.height);
+    } catch (e) {
+        console.error("Failed to show native translation popover", e);
+    }
+}

--- a/apps/desktop/src/webcontents-handler.ts
+++ b/apps/desktop/src/webcontents-handler.ts
@@ -19,6 +19,7 @@ import {
     type MenuItemConstructorOptions,
     type IpcMainEvent,
     type Event,
+    BrowserWindow,
 } from "electron";
 import url from "node:url";
 import path from "node:path";
@@ -26,6 +27,7 @@ import path from "node:path";
 import { _t } from "./language-helper.js";
 import { saveImageToFile } from "./save-image.js";
 import { getConfig } from "./config.js";
+import { isTranslationAvailable, showTranslation } from "./translation.js";
 
 const MAILTO_PREFIX = "mailto:";
 
@@ -240,8 +242,47 @@ function cutCopyPasteSelectContextMenus(
     return options;
 }
 
+function translateContextMenuItem(params: ContextMenuParams, webContents: WebContents): MenuItemConstructorOptions[] {
+    if (!params.selectionText || !isTranslationAvailable()) return [];
+    const win = BrowserWindow.fromWebContents(webContents);
+    if (!win) return [];
+
+    return [
+        { type: "separator" },
+        {
+            label: _t("action|translate"),
+            click: async (): Promise<void> => {
+                // Anchor at the selected text's bounding rect (matching the in-message behaviour)
+                // rather than the mouse position. Electron's context-menu params don't expose a
+                // selection rect, so read it from the renderer; fall back to the click point (a 1x1
+                // rect, since NSPopover treats an empty rect as "anchor to the whole view").
+                let rect = { x: params.x, y: params.y, width: 1, height: 1 };
+                try {
+                    const selRect = await webContents.executeJavaScript(
+                        `(() => {
+                            const s = window.getSelection();
+                            if (!s || s.rangeCount === 0) return null;
+                            const r = s.getRangeAt(0).getBoundingClientRect();
+                            return { x: r.x, y: r.y, width: r.width, height: r.height };
+                        })()`,
+                    );
+                    if (selRect && selRect.width > 0 && selRect.height > 0) {
+                        rect = selRect;
+                    }
+                } catch {
+                    // ignore — fall back to the click point
+                }
+                showTranslation(win, params.selectionText, rect);
+            },
+        },
+    ];
+}
+
 function onSelectedContextMenu(ev: Event, params: ContextMenuParams, webContents: WebContents): void {
-    const items = cutCopyPasteSelectContextMenus(params, webContents);
+    const items = [
+        ...cutCopyPasteSelectContextMenus(params, webContents),
+        ...translateContextMenuItem(params, webContents),
+    ];
     const popupMenu = Menu.buildFromTemplate(items);
 
     // popup() requires an options object even for no options

--- a/apps/web/src/BasePlatform.ts
+++ b/apps/web/src/BasePlatform.ts
@@ -175,6 +175,21 @@ export default abstract class BasePlatform {
     }
 
     /**
+     * Returns true if the platform can show a native translation UI for arbitrary text
+     * (e.g. the macOS system translation popover on desktop).
+     */
+    public supportsNativeTranslation(): boolean {
+        return false;
+    }
+
+    /**
+     * Show a native translation UI for the given text, anchored at the given rect.
+     * @param text the text to translate
+     * @param rect the anchor rectangle, in CSS pixels relative to the top-left of the viewport
+     */
+    public translate(text: string, rect: DOMRectReadOnly): void {}
+
+    /**
      * Returns true if the platform supports displaying
      * notifications, otherwise false.
      * @returns {boolean} whether the platform supports displaying notifications

--- a/apps/web/src/components/views/context_menus/MessageContextMenu.tsx
+++ b/apps/web/src/components/views/context_menus/MessageContextMenu.tsx
@@ -41,9 +41,11 @@ import {
     ShareIcon,
     CopyIcon,
     TreeIcon,
+    TranslateIcon,
 } from "@vector-im/compound-design-tokens/assets/web/icons";
 
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
+import PlatformPeg from "../../../PlatformPeg";
 import dis from "../../../dispatcher/dispatcher";
 import { _t } from "../../../languageHandler";
 import Modal from "../../../Modal";
@@ -333,6 +335,16 @@ export default class MessageContextMenu extends React.Component<IProps, IState> 
                 text: "\n" + quotedText + "\n\n ",
                 timelineRenderingType: this.context.timelineRenderingType,
             });
+        }
+        this.closeMenu();
+    };
+
+    private onTranslateClick = (): void => {
+        const platform = PlatformPeg.get();
+        const selection = window.getSelection();
+        const text = getSelectedText();
+        if (platform && text.trim().length > 0 && selection && selection.rangeCount > 0) {
+            platform.translate(text, selection.getRangeAt(0).getBoundingClientRect());
         }
         this.closeMenu();
     };
@@ -632,6 +644,18 @@ export default class MessageContextMenu extends React.Component<IProps, IState> 
             );
         }
 
+        let translateButton: JSX.Element | undefined;
+        if (rightClick && PlatformPeg.get()?.supportsNativeTranslation() && selectedText) {
+            translateButton = (
+                <IconizedContextMenuOption
+                    icon={<TranslateIcon />}
+                    label={_t("action|translate")}
+                    triggerOnMouseDown={true} // use onMouseDown so the selection isn't cleared when we click
+                    onClick={this.onTranslateClick}
+                />
+            );
+        }
+
         let editButton: JSX.Element | undefined;
         if (rightClick && canEditContent(cli, mxEvent)) {
             editButton = (
@@ -697,11 +721,12 @@ export default class MessageContextMenu extends React.Component<IProps, IState> 
         }
 
         let nativeItemsList: JSX.Element | undefined;
-        if (copyButton || quoteButton || copyLinkButton) {
+        if (copyButton || quoteButton || translateButton || copyLinkButton) {
             nativeItemsList = (
                 <IconizedContextMenuOptionList>
                     {copyButton}
                     {quoteButton}
+                    {translateButton}
                     {copyLinkButton}
                 </IconizedContextMenuOptionList>
             );

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -113,6 +113,7 @@
         "submit": "Submit",
         "subscribe": "Subscribe",
         "transfer": "Transfer",
+        "translate": "Translate",
         "trust": "Trust",
         "try_again": "Try again",
         "unban": "Unban",

--- a/apps/web/src/vector/platform/ElectronPlatform.test.ts
+++ b/apps/web/src/vector/platform/ElectronPlatform.test.ts
@@ -327,6 +327,51 @@ describe("ElectronPlatform", () => {
         });
     });
 
+    describe("native translation", () => {
+        it("makes correct ipc call to show translation", () => {
+            const platform = new ElectronPlatform();
+            mockElectron.send.mockClear();
+            platform.translate("bonjour", {
+                x: 10,
+                y: 20,
+                width: 30,
+                height: 40,
+            } as DOMRectReadOnly);
+
+            const [, { name, args }] = mockElectron.send.mock.calls[0];
+            expect(name).toEqual("showTranslation");
+            expect(args).toEqual([
+                {
+                    text: "bonjour",
+                    rect: { x: 10, y: 20, width: 30, height: 40 },
+                },
+            ]);
+        });
+
+        it("reports translation as unavailable until the availability probe resolves", () => {
+            const platform = new ElectronPlatform();
+            expect(platform.supportsNativeTranslation()).toBe(false);
+        });
+
+        it("reports translation as available when the availability probe resolves positively", async () => {
+            const platform = new ElectronPlatform();
+            // @ts-ignore private
+            jest.spyOn(platform.ipc, "call").mockResolvedValue(true);
+            // @ts-ignore private
+            await platform.refreshTranslationAvailability();
+            expect(platform.supportsNativeTranslation()).toBe(true);
+        });
+
+        it("reports translation as unavailable when the availability probe rejects", async () => {
+            const platform = new ElectronPlatform();
+            // @ts-ignore private
+            jest.spyOn(platform.ipc, "call").mockRejectedValue(new Error("no ipc"));
+            // @ts-ignore private
+            await platform.refreshTranslationAvailability();
+            expect(platform.supportsNativeTranslation()).toBe(false);
+        });
+    });
+
     describe("versions", () => {
         it("calls install update", () => {
             const platform = new ElectronPlatform();

--- a/apps/web/src/vector/platform/ElectronPlatform.tsx
+++ b/apps/web/src/vector/platform/ElectronPlatform.tsx
@@ -97,6 +97,7 @@ export default class ElectronPlatform extends BasePlatform {
     private badgeOverlayRenderer?: BadgeOverlayRenderer;
     private config!: IConfigOptions;
     private supportedSettings?: Record<string, boolean>;
+    private nativeTranslationAvailable = false;
     private clientStartedPromiseWithResolvers = Promise.withResolvers<void>();
 
     public constructor() {
@@ -233,6 +234,17 @@ export default class ElectronPlatform extends BasePlatform {
         if (supportsBadgeOverlay) {
             this.badgeOverlayRenderer = new BadgeOverlayRenderer();
         }
+        // Probe translation availability in the background: the result is only needed once a context
+        // menu is opened, so we must not block startup on the IPC reply.
+        void this.refreshTranslationAvailability();
+    }
+
+    private async refreshTranslationAvailability(): Promise<void> {
+        try {
+            this.nativeTranslationAvailable = !!(await this.ipc.call("getTranslationAvailable"));
+        } catch {
+            this.nativeTranslationAvailable = false;
+        }
     }
 
     public async getConfig(): Promise<IConfigOptions | undefined> {
@@ -278,6 +290,17 @@ export default class ElectronPlatform extends BasePlatform {
 
     public allowOverridingNativeContextMenus(): boolean {
         return true;
+    }
+
+    public supportsNativeTranslation(): boolean {
+        return this.nativeTranslationAvailable;
+    }
+
+    public translate(text: string, rect: DOMRectReadOnly): void {
+        void this.ipc.call("showTranslation", {
+            text,
+            rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+        });
     }
 
     public setNotificationCount(count: number): void {

--- a/apps/web/test/unit-tests/components/views/context_menus/MessageContextMenu-test.tsx
+++ b/apps/web/test/unit-tests/components/views/context_menus/MessageContextMenu-test.tsx
@@ -17,6 +17,7 @@ import {
     Beacon,
     getBeaconInfoIdentifier,
     EventType,
+    MsgType,
     FeatureSupport,
     Thread,
     M_POLL_KIND_DISCLOSED,
@@ -31,7 +32,14 @@ import { type RoomContextType, TimelineRenderingType } from "../../../../../src/
 import { canEditContent } from "../../../../../src/utils/EventUtils";
 import { copyPlaintext, getSelectedText } from "../../../../../src/utils/strings";
 import MessageContextMenu from "../../../../../src/components/views/context_menus/MessageContextMenu";
-import { makeBeaconEvent, makeBeaconInfoEvent, makeLocationEvent, stubClient } from "../../../../test-utils";
+import {
+    makeBeaconEvent,
+    makeBeaconInfoEvent,
+    makeLocationEvent,
+    mockPlatformPeg,
+    stubClient,
+    unmockPlatformPeg,
+} from "../../../../test-utils";
 import dispatcher from "../../../../../src/dispatcher/dispatcher";
 import SettingsStore from "../../../../../src/settings/SettingsStore";
 import { ReadPinsEventId } from "../../../../../src/components/views/right_panel/types";
@@ -431,6 +439,64 @@ describe("MessageContextMenu", () => {
             expect(quoteButton).toBeFalsy();
 
             isSelectionWithinSingleTextBody.mockRestore();
+        });
+    });
+
+    describe("translate button", () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
+        afterEach(() => {
+            unmockPlatformPeg();
+        });
+
+        const queryTranslateButton = (): Element | null => document.querySelector('li[aria-label="Translate"]');
+
+        it("shows translate button when there is a selection and the platform supports native translation", () => {
+            mockPlatformPeg({ supportsNativeTranslation: () => true });
+            mocked(getSelectedText).mockReturnValue("hello");
+            createRightClickMenuWithContent(createMessageEventContent("hello world"));
+            expect(queryTranslateButton()).toBeTruthy();
+        });
+
+        it("does not show translate button when there is no selection", () => {
+            mockPlatformPeg({ supportsNativeTranslation: () => true });
+            mocked(getSelectedText).mockReturnValue("");
+            createRightClickMenuWithContent(createMessageEventContent("hello world"));
+            expect(queryTranslateButton()).toBeFalsy();
+        });
+
+        it("does not show translate button when the platform does not support native translation", () => {
+            mockPlatformPeg({ supportsNativeTranslation: () => false });
+            mocked(getSelectedText).mockReturnValue("hello");
+            createRightClickMenuWithContent(createMessageEventContent("hello world"));
+            expect(queryTranslateButton()).toBeFalsy();
+        });
+
+        it("shows translate button for any message type when there is a selection", () => {
+            mockPlatformPeg({ supportsNativeTranslation: () => true });
+            mocked(getSelectedText).mockReturnValue("selected words");
+            // Not a text message (e.g. an image), but with a selection it should still be offered.
+            createRightClickMenuWithContent({ msgtype: MsgType.Image, body: "image.png" });
+            expect(queryTranslateButton()).toBeTruthy();
+        });
+
+        it("translates the selected text, anchored at the selection", () => {
+            const platform = mockPlatformPeg({ supportsNativeTranslation: () => true, translate: jest.fn() });
+            mocked(getSelectedText).mockReturnValue("just this");
+            const mockRange = { getBoundingClientRect: () => new DOMRect(1, 2, 3, 4) } as unknown as Range;
+            const getSelectionSpy = jest.spyOn(window, "getSelection").mockReturnValue({
+                rangeCount: 1,
+                getRangeAt: () => mockRange,
+            } as unknown as Selection);
+
+            createRightClickMenuWithContent(createMessageEventContent("hello world"));
+            fireEvent.mouseDown(queryTranslateButton()!);
+
+            expect(platform.translate).toHaveBeenCalledWith("just this", expect.anything());
+
+            getSelectionSpy.mockRestore();
         });
     });
 

--- a/knip.ts
+++ b/knip.ts
@@ -88,6 +88,11 @@ export default {
             ignoreDependencies: [
                 // Brought in via hak scripts
                 "matrix-seshat",
+                "element-translation",
+            ],
+            ignoreUnresolved: [
+                // Native addon built by hak at package time, not present in the source tree
+                /translation\.node$/,
             ],
             ignoreBinaries: [
                 // Used to build seshat (optional)


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-desktop/issues/2740 which I created a while ago. 

> [!IMPORTANT]
> This approach is inspired by https://github.com/imputnet/helium-macos/pull/269, I hope there won't be any licensing issues.

The "Translate" Menu lives together with native menus like "Copy/Paste" both in Element's context menu and the native selection menu.

To load the `TranslationUI.framework` and present an `NSPopover` via `LTUITranslationViewController`, a small Objective-C++ N-API add-on is added, which is wired through the existing `ipcCall` channel.

Meta discussion: https://github.com/element-hq/element-meta/discussions/3258

## AI Disclosure

Claude implemented this, I know macOS development pretty well and review the Objective C++ myself and fully understand the reason behind it.

For the TypeScript part, I did my best to review it, it seems good to me, but I could be wrong.

I also asked 2 other Claude sessions to do a review-audit loop.

---

https://github.com/user-attachments/assets/68227b2e-dfec-490b-9db6-0de0dee6d413

| ![Xnip2026-06-23_23-43-55](https://github.com/user-attachments/assets/26927346-ad22-41ac-8883-d64da11c0583) | ![Xnip2026-06-23_23-44-48](https://github.com/user-attachments/assets/3eb25cb9-6bfd-4604-965f-fc41b825c179) | ![Xnip2026-06-23_23-44-15](https://github.com/user-attachments/assets/e6a53254-dd3a-4ae7-8281-3b037756c425) |
|---|---|---|