### PR TITLE
Make seshat backfill complete and resilient

### DIFF
--- a/apps/web/src/indexing/EventIndex.test.ts
+++ b/apps/web/src/indexing/EventIndex.test.ts
@@ -26,6 +26,7 @@ import {
     ClientEvent,
     SyncState,
 } from "matrix-js-sdk/src/matrix";
+import { KnownMembership } from "matrix-js-sdk/src/types";
 
 import EventIndex from "./EventIndex.ts";
 import {
@@ -107,12 +108,14 @@ describe("EventIndex", () => {
 
         const room1 = {
             roomId: "!room1:id",
+            getMyMembership: () => KnownMembership.Join,
             getLiveTimeline: () => ({
                 getPaginationToken: () => "token1",
             }),
         } as any as Room;
         const room2 = {
             roomId: "!room2:id",
+            getMyMembership: () => KnownMembership.Join,
             getLiveTimeline: () => ({
                 getPaginationToken: () => "token2",
             }),

--- a/apps/web/src/indexing/EventIndex.ts
+++ b/apps/web/src/indexing/EventIndex.ts
@@ -55,6 +55,16 @@ const CRAWLER_IDLE_TIME = 5000;
 // The maximum number of events our crawler should fetch in a single crawl.
 const EVENTS_PER_CRAWL = 100;
 
+/**
+ * Sentinel pagination token used to mark a room as fully crawled. When a backward
+ * fullCrawl reaches the start of history we replace its checkpoint with one bearing
+ * this token; it persists the "fully crawled" high-water mark in Seshat's sqlite
+ * (alongside real checkpoints) instead of in client-side storage. It is never a
+ * real Matrix pagination token, and such sentinel checkpoints are kept out of the
+ * live crawl queue so we never paginate from it.
+ */
+const FULLY_CRAWLED_TOKEN = "fully_crawled";
+
 interface ICrawler {
     cancel(): void;
 }
@@ -81,6 +91,48 @@ export default class EventIndex extends EventEmitter {
      */
     private needsInitialCheckpoints = false;
 
+    /**
+     * Guards the one-shot reconciliation pass. Set true only once it has actually
+     * run (i.e. once crypto was ready), so that if crypto isn't ready on the
+     * first sync we retry on a later sync rather than skipping reconciliation.
+     */
+    private reconciliationDone = false;
+
+    /**
+     * Joined rooms that carry an `m.room.encryption` state event but for which
+     * encryption isn't actually enabled per the crypto module, so they can never
+     * be indexed (we can't "speak" their encryption). Populated by the
+     * reconciliation pass (which already does the async crypto check). These are
+     * deliberately ignored - not crawled and not surfaced in the UI - just like
+     * rooms we've only been invited to / left.
+     */
+    private readonly unindexableRooms = new Set<string>();
+
+    /**
+     * Joined rooms the crawler has actually given up on indexing: it hit a
+     * permanent failure (e.g. a 403/404/400 from /messages) so the checkpoint was
+     * dropped and won't be retried. Cleared once the room successfully crawls
+     * again (e.g. after rejoining). Surfaced as the "errored" count in the UI - a
+     * real problem, as opposed to rooms we deliberately skip (invites /
+     * can't-speak encryption).
+     */
+    private readonly erroredRooms = new Set<string>();
+
+    /**
+     * Rooms whose backward fullCrawl has reached the very start of their history
+     * - i.e. we've indexed everything there is to index. The high-water mark for
+     * "fully crawled": it matters most for rooms with no indexable content, which
+     * otherwise look "unindexed" (isRoomIndexed === false) forever and get
+     * re-crawled on every restart.
+     *
+     * Persisted in Seshat's own sqlite as a sentinel crawler checkpoint (token
+     * {@link FULLY_CRAWLED_TOKEN}) rather than client-side storage, so it lives
+     * and dies atomically with the index it describes. Hydrated from
+     * `loadCheckpoints()` at init; sentinels are filtered out of the live crawl
+     * queue so we never try to paginate from the fake token.
+     */
+    private fullyCrawledRooms = new Set<string>();
+
     private readonly logger;
 
     public constructor() {
@@ -96,14 +148,112 @@ export default class EventIndex extends EventEmitter {
         // If the index is empty, set a flag so that we add the initial checkpoints once we sync.
         // We do this check here rather than in `onSync` because, by the time `onSync` is called, there will
         // have been a few events added to the index.
-        if (await indexManager.isEventIndexEmpty()) {
+        const indexEmpty = await indexManager.isEventIndexEmpty();
+        if (indexEmpty) {
             this.needsInitialCheckpoints = true;
         }
 
-        this.crawlerCheckpoints = await indexManager.loadCheckpoints();
+        // loadCheckpoints returns both real crawl checkpoints and our fully-crawled
+        // sentinel markers. Split them: sentinels hydrate the fully-crawled set and
+        // must NOT enter the crawl queue (their token is fake), real ones drive the
+        // crawler. Because the markers live in the same DB as the index, an empty /
+        // reset index simply has none - no stale-marker cleanup needed.
+        const loadedCheckpoints = await indexManager.loadCheckpoints();
+        this.crawlerCheckpoints = [];
+        for (const checkpoint of loadedCheckpoints) {
+            if (checkpoint.token === FULLY_CRAWLED_TOKEN) {
+                this.fullyCrawledRooms.add(checkpoint.roomId);
+            } else {
+                this.crawlerCheckpoints.push(checkpoint);
+            }
+        }
         this.logger.debug("Loaded checkpoints", JSON.stringify(this.crawlerCheckpoints));
 
         this.registerListeners();
+
+        // Small console hook to introspect the current crawl queue, e.g.
+        // `console.table(await window.mxEventIndexDebug.indexing())`.
+        (window as unknown as Record<string, unknown>)["mxEventIndexDebug"] = {
+            indexing: () => this.listIndexingRooms(),
+        };
+    }
+
+    /** The sentinel checkpoint that marks a room as fully crawled in Seshat's DB. */
+    private fullyCrawledMarker(roomId: string): ICrawlerCheckpoint {
+        return {
+            roomId,
+            token: FULLY_CRAWLED_TOKEN,
+            fullCrawl: true,
+            direction: Direction.Backward,
+        };
+    }
+
+    /**
+     * List the distinct rooms that currently have a crawler checkpoint (i.e. are
+     * in the indexing queue), with enough context to see why the "indexing" count
+     * may differ from the names flashing past in the UI - in particular, rooms
+     * we've left keep a checkpoint (so appear here / in "Currently indexing") but
+     * aren't counted as encrypted joined rooms.
+     */
+    public async listIndexingRooms(): Promise<
+        Array<{
+            roomId: string;
+            name: string;
+            checkpoints: number;
+            distinctTokens: number;
+            detail: string[];
+            membership?: string;
+            encrypted: boolean;
+            indexed: boolean | "?";
+            timelineEvents: number;
+            counted: boolean;
+        }>
+    > {
+        const client = MatrixClientPeg.safeGet();
+        const indexManager = PlatformPeg.get()?.getEventIndexingManager();
+
+        const byRoom = new Map<string, ICrawlerCheckpoint[]>();
+        const all = [...this.crawlerCheckpoints];
+        if (this.currentCheckpoint) all.push(this.currentCheckpoint);
+        for (const cp of all) {
+            const list = byRoom.get(cp.roomId) ?? [];
+            list.push(cp);
+            byRoom.set(cp.roomId, list);
+        }
+
+        const out = [];
+        for (const [roomId, cps] of byRoom.entries()) {
+            const checkpoints = cps.length;
+            // Per-checkpoint detail so we can tell legitimate distinct gap-fillers
+            // from lingering fullCrawl cursors / exact duplicates.
+            const detail = cps.map((c) => `${c.direction}${c.fullCrawl ? "/full" : ""}:${c.token.slice(0, 10)}`);
+            const distinctTokens = new Set(cps.map((c) => `${c.direction}|${c.token}`)).size;
+            const room = client.getRoom(roomId);
+            const encrypted = client.isRoomEncrypted(roomId);
+            const membership = room?.getMyMembership();
+            // `indexed` (does the room already have indexed events) tells us
+            // whether a queued room is a real backlog item or a contentless room
+            // being re-seeded by reconciliation.
+            let indexed: boolean | "?" = "?";
+            try {
+                indexed = (await indexManager?.isRoomIndexed(roomId)) ?? "?";
+            } catch {
+                indexed = "?";
+            }
+            out.push({
+                roomId,
+                name: room?.name ?? "(unknown)",
+                checkpoints,
+                distinctTokens,
+                detail,
+                membership,
+                encrypted,
+                indexed,
+                timelineEvents: room?.getLiveTimeline().getEvents().length ?? 0,
+                counted: encrypted && membership === KnownMembership.Join && !this.unindexableRooms.has(roomId),
+            });
+        }
+        return out;
     }
 
     /**
@@ -194,6 +344,105 @@ export default class EventIndex extends EventEmitter {
     }
 
     /**
+     * Reconciliation pass (runs once per launch, once crypto is ready).
+     *
+     * The one-time `addInitialCheckpoints` only seeds rooms that exist and have a
+     * back-pagination token at the single moment it runs (when the index is first
+     * created). Any encrypted room joined later, or missed then (e.g. crypto not
+     * yet ready, no token yet, or a transient failure), never gets a checkpoint -
+     * the crawler only re-seeds on a *new* m.room.encryption event or a gappy
+     * sync, neither of which fires for a quiet already-encrypted room. There is
+     * otherwise no mechanism to notice such rooms, so they stay unindexed forever.
+     *
+     * This pass closes that gap: it finds joined, encryption-enabled rooms that
+     * have no events indexed and no checkpoint queued, and seeds a fullCrawl
+     * checkpoint for each.
+     */
+    public async reconcileMissedRooms(): Promise<void> {
+        const indexManager = PlatformPeg.get()?.getEventIndexingManager();
+        if (!indexManager) return;
+        const client = MatrixClientPeg.safeGet();
+
+        const queued = new Set<string>(this.crawlerCheckpoints.map((c) => c.roomId));
+        if (this.currentCheckpoint) queued.add(this.currentCheckpoint.roomId);
+
+        const rooms = client.getRooms();
+        let recovered = 0;
+        let scanned = 0;
+
+        for (const room of rooms) {
+            // Yield occasionally so the many isRoomIndexed reads don't monopolise
+            // Seshat's small connection pool and starve the live writer.
+            if (++scanned % 20 === 0) await sleep(10);
+
+            // Only joined rooms - invites/leaves can't be crawled (the server
+            // returns 403) and shouldn't count as indexable.
+            if (room.getMyMembership() !== KnownMembership.Join) continue;
+
+            // Only rooms with E2EE actually enabled (per the crypto module, not
+            // the legacy state-only check).
+            let encEnabled = false;
+            try {
+                encEnabled = Boolean(await client.getCrypto()?.isEncryptionEnabledInRoom(room.roomId));
+            } catch {
+                continue;
+            }
+            if (!encEnabled) {
+                // A joined room with a legacy m.room.encryption marker but no
+                // crypto-enabled encryption: nothing we can index. Record it so it's
+                // ignored rather than treated as a problem.
+                if (client.isRoomEncrypted(room.roomId)) this.unindexableRooms.add(room.roomId);
+                continue;
+            }
+            // We can speak its encryption again, if we couldn't on a prior pass.
+            this.unindexableRooms.delete(room.roomId);
+
+            // Already fully crawled in a previous session - don't re-seed it, even
+            // if it has no indexable content (which would otherwise keep it
+            // isRoomIndexed=false and re-seeded forever).
+            if (this.fullyCrawledRooms.has(room.roomId)) continue;
+
+            // Already queued for crawling, or already has events indexed - nothing to do.
+            if (queued.has(room.roomId)) continue;
+            let indexed = false;
+            try {
+                indexed = await indexManager.isRoomIndexed(room.roomId);
+            } catch (e) {
+                this.logger.warn(`reconcileMissedRooms: isRoomIndexed failed for ${room.roomId}`, e);
+                continue;
+            }
+            if (indexed) continue;
+
+            // This room should have been indexed but wasn't. Recover it.
+            const timeline = room.getLiveTimeline();
+            const token = timeline.getPaginationToken(Direction.Backward);
+
+            try {
+                if (!token) {
+                    // No token: index whatever is in the live timeline directly,
+                    // mirroring addRoomCheckpoint's fallback.
+                    await this.addEventsFromLiveTimeline(timeline);
+                    recovered += 1;
+                    continue;
+                }
+                const checkpoint: ICrawlerCheckpoint = {
+                    roomId: room.roomId,
+                    token,
+                    fullCrawl: true,
+                    direction: Direction.Backward,
+                };
+                await indexManager.addCrawlerCheckpoint(checkpoint);
+                this.crawlerCheckpoints.push(checkpoint);
+                recovered += 1;
+            } catch (e) {
+                this.logger.warn(`reconcileMissedRooms: failed to seed checkpoint for ${room.roomId}`, e);
+            }
+        }
+
+        this.logger.debug(`reconcileMissedRooms: recovered ${recovered} missed rooms`);
+    }
+
+    /**
      * The sync event listener.
      */
     private onSync = (state: SyncState, prevState: SyncState | null, data?: SyncStateData): void => {
@@ -210,6 +459,18 @@ export default class EventIndex extends EventEmitter {
 
             // Start the crawler if it's not already running.
             this.startCrawler();
+
+            // Reconciliation: once per launch, as soon as crypto is ready, seed
+            // checkpoints for joined encrypted rooms that were missed by the
+            // one-time initial checkpointing and have no events and no checkpoint.
+            // Gate on `getCrypto()` rather than a timer: `isEncryptionEnabledInRoom`
+            // is only reliable once crypto has loaded, and if it isn't ready on
+            // this sync we simply retry on a later one (the flag is only set once
+            // the pass actually runs).
+            if (!this.reconciliationDone && MatrixClientPeg.safeGet().getCrypto()) {
+                this.reconciliationDone = true;
+                await this.reconcileMissedRooms();
+            }
 
             // Commit any queued up live events
             await indexManager.commitLiveEvents();
@@ -239,7 +500,8 @@ export default class EventIndex extends EventEmitter {
 
         const client = MatrixClientPeg.safeGet();
 
-        // We only index encrypted rooms locally.
+        // Cheap sync gate first: we only index encrypted rooms locally. This
+        // rejects the (many) unencrypted-room events without any async work.
         if (!client.isRoomEncrypted(ev.getRoomId()!)) return;
 
         if (ev.isRedaction()) {
@@ -251,17 +513,36 @@ export default class EventIndex extends EventEmitter {
             return;
         }
 
+        // Only now (for an event we'd actually index) pay for the async,
+        // crypto-aware check, so we skip rooms whose encryption we can't speak.
+        if (!(await this.isRoomIndexable(ev.getRoomId()!))) return;
+
         await client.decryptEventIfNeeded(ev);
 
         await this.addLiveEventToIndex(ev);
     };
 
     private onRoomStateEvent = async (ev: MatrixEvent, state: RoomState): Promise<void> => {
-        if (!MatrixClientPeg.safeGet().isRoomEncrypted(state.roomId)) return;
+        if (ev.getType() !== EventType.RoomEncryption) return;
+        // Until the reconciliation pass has run it owns seeding the startup set of
+        // encrypted rooms. Acting here as well would fire a concurrent
+        // isRoomIndexed for every room as initial sync replays each
+        // m.room.encryption event - thousands at once, exhausting Seshat's small
+        // connection pool. After reconciliation this only handles rooms that get
+        // newly encrypted mid-session (rare, no flood).
+        if (!this.reconciliationDone) return;
 
-        if (ev.getType() === EventType.RoomEncryption && !(await this.isRoomIndexed(state.roomId))) {
-            this.logger.debug("Adding a checkpoint for a newly encrypted room", state.roomId);
-            this.addRoomCheckpoint(state.roomId, true);
+        // Only seed a checkpoint if the new encryption config is one the crypto
+        // module supports - don't attempt rooms whose encryption we can't speak.
+        if (!(await this.isRoomIndexable(state.roomId))) return;
+
+        try {
+            if (!(await this.isRoomIndexed(state.roomId))) {
+                this.logger.debug("Adding a checkpoint for a newly encrypted room", state.roomId);
+                this.addRoomCheckpoint(state.roomId, true);
+            }
+        } catch (e) {
+            this.logger.warn("Error checking/seeding newly encrypted room", state.roomId, e);
         }
     };
 
@@ -291,12 +572,25 @@ export default class EventIndex extends EventEmitter {
      */
     private onTimelineReset = async (room: Room | undefined): Promise<void> => {
         if (!room) return;
+        // Cheap sync gate first, then the async crypto-aware check so we don't
+        // re-seed rooms whose encryption the crypto module can't speak.
         if (!MatrixClientPeg.safeGet().isRoomEncrypted(room.roomId)) return;
+        if (!(await this.isRoomIndexable(room.roomId))) return;
 
         this.logger.debug("Adding a checkpoint because of a limited timeline", room.roomId);
 
         this.addRoomCheckpoint(room.roomId, false);
     };
+
+    /**
+     * Whether we should index a room: it must have E2EE that the crypto module
+     * actually supports. This is the crypto-aware check (`isEncryptionEnabledInRoom`),
+     * not the legacy state-only `isRoomEncrypted`, so rooms with an unsupported /
+     * "can't speak" encryption algorithm (or no encryption) are excluded.
+     */
+    private async isRoomIndexable(roomId: string): Promise<boolean> {
+        return Boolean(await MatrixClientPeg.safeGet().getCrypto()?.isEncryptionEnabledInRoom(roomId));
+    }
 
     /**
      * Check if an event should be added to the event index.
@@ -378,6 +672,21 @@ export default class EventIndex extends EventEmitter {
         };
 
         await indexManager.addEventToIndex(e, profile);
+
+        // If we'd given up on this room (errored) but it's now delivering
+        // indexable live events, it's clearly accessible again. Clear the errored
+        // flag so it stops counting as errored, and re-seed a history backfill to
+        // retry what we'd previously failed to fetch. We clear
+        // *before* re-seeding so further live events don't pile up retries while
+        // this crawl is in flight (if the backfill fails again the crawler will
+        // re-flag it, and the next live event will retry - bounded to the crawl
+        // rate, not the event rate).
+        const roomId = ev.getRoomId();
+        if (roomId && this.erroredRooms.has(roomId)) {
+            this.erroredRooms.delete(roomId);
+            this.logger.debug("Re-attempting a previously given-up room after a live event", roomId);
+            await this.addRoomCheckpoint(roomId, true);
+        }
     }
 
     /**
@@ -422,6 +731,18 @@ export default class EventIndex extends EventEmitter {
             direction: Direction.Backward,
         };
 
+        // Don't queue an *exact* duplicate of a checkpoint we already have. This
+        // path fires on every gappy sync (onTimelineReset), and for an active
+        // room the backward token is often unchanged between gaps, so without
+        // this guard the same cursor stacks up many times in the in-memory queue
+        // (the DB already dedupes it via a UNIQUE constraint), wasting crawler
+        // cycles re-walking the same range. Distinct gap-fillers (different
+        // tokens) are unaffected, so we never drop coverage of a real gap.
+        if (this.hasQueuedCheckpoint(checkpoint)) {
+            this.logger.debug("Skipping duplicate checkpoint", JSON.stringify(checkpoint));
+            return;
+        }
+
         this.logger.debug("Adding checkpoint", JSON.stringify(checkpoint));
 
         try {
@@ -431,6 +752,21 @@ export default class EventIndex extends EventEmitter {
         }
 
         this.crawlerCheckpoints.push(checkpoint);
+    }
+
+    /**
+     * Whether the in-memory crawl queue (or the checkpoint currently being
+     * processed) already contains an exact duplicate of the given checkpoint -
+     * same room, token, direction and fullCrawl flag.
+     */
+    private hasQueuedCheckpoint(cp: ICrawlerCheckpoint): boolean {
+        const matches = (c: ICrawlerCheckpoint): boolean =>
+            c.roomId === cp.roomId &&
+            c.token === cp.token &&
+            c.direction === cp.direction &&
+            Boolean(c.fullCrawl) === Boolean(cp.fullCrawl);
+        if (this.currentCheckpoint && matches(this.currentCheckpoint)) return true;
+        return this.crawlerCheckpoints.some(matches);
     }
 
     /**
@@ -509,12 +845,22 @@ export default class EventIndex extends EventEmitter {
                     checkpoint.direction,
                 );
             } catch (e) {
-                if (e instanceof HTTPError && e.httpStatus === 403) {
+                // A permanent client error (e.g. 403 no-access, 404 room gone,
+                // 400 bad request) won't be fixed by retrying, so give up on the
+                // room and surface it as "errored". Rate-limit (429) and auth
+                // (401) are transient, as are 5xx / network errors - those keep
+                // retrying so a temporary outage never permanently abandons rooms.
+                const status = e instanceof HTTPError ? e.httpStatus : undefined;
+                const permanent =
+                    status !== undefined && status >= 400 && status < 500 && status !== 429 && status !== 401;
+
+                if (permanent) {
                     this.logger.debug(
-                        "Removing checkpoint as we don't have ",
-                        "permissions to fetch messages from this room.",
+                        `Giving up on room ${checkpoint.roomId}: permanent error ${status} fetching messages`,
                         JSON.stringify(checkpoint),
                     );
+                    // Terminal failure: give up on this room and mark it errored.
+                    this.erroredRooms.add(checkpoint.roomId);
                     try {
                         await indexManager.removeCrawlerCheckpoint(checkpoint);
                     } catch (e) {
@@ -527,6 +873,7 @@ export default class EventIndex extends EventEmitter {
                     continue;
                 }
 
+                // Transient error - retry.
                 this.logger.warn(`Error crawling using checkpoint ${JSON.stringify(checkpoint)}:`, e);
                 this.crawlerCheckpoints.push(checkpoint);
                 continue;
@@ -539,10 +886,23 @@ export default class EventIndex extends EventEmitter {
 
             if (res.chunk.length === 0) {
                 this.logger.debug("Done with the checkpoint", JSON.stringify(checkpoint));
-                // We got to the start/end of our timeline, lets just
-                // delete our checkpoint and go back to sleep.
+                // We got to the start/end of our timeline. A backward fullCrawl
+                // reaching an empty chunk means we've hit the start of the room's
+                // history: it's fully crawled. Atomically swap its checkpoint for a
+                // sentinel marker so reconciliation won't re-seed it next launch
+                // (relevant mainly for rooms with no indexable content, which stay
+                // isRoomIndexed=false). Otherwise just delete and go back to sleep.
                 try {
-                    await indexManager.removeCrawlerCheckpoint(checkpoint);
+                    if (checkpoint.fullCrawl && checkpoint.direction === Direction.Backward) {
+                        await indexManager.addHistoricEvents(
+                            [],
+                            this.fullyCrawledMarker(checkpoint.roomId),
+                            checkpoint,
+                        );
+                        this.fullyCrawledRooms.add(checkpoint.roomId);
+                    } else {
+                        await indexManager.removeCrawlerCheckpoint(checkpoint);
+                    }
                 } catch (e) {
                     this.logger.warn("Error removing checkpoint", JSON.stringify(checkpoint), e);
                 }
@@ -627,6 +987,10 @@ export default class EventIndex extends EventEmitter {
                 }
 
                 const eventsAlreadyAdded = await indexManager.addHistoricEvents(events, newCheckpoint, checkpoint);
+
+                // We successfully crawled a batch for this room, so it's no longer
+                // errored (e.g. it was re-seeded after a rejoin).
+                this.erroredRooms.delete(checkpoint.roomId);
 
                 // We didn't get a valid new checkpoint from the server, nothing
                 // to do here anymore.


### PR DESCRIPTION
Rework the EventIndex crawler so encrypted rooms reliably get fully indexed, and so we stop wasting work re-indexing rooms we can't make progress on:

- Reconciliation pass (`reconcileMissedRooms`), run once per launch as soon as crypto is ready: finds joined, encryption-enabled rooms that have no events indexed and no checkpoint queued, and seeds a fullCrawl checkpoint. Without this, a quiet already-encrypted room missed at initial-checkpoint time (crypto not ready, no token yet, transient failure) would never get indexed.
- Crypto-aware gating: index only rooms whose encryption the crypto module actually supports (`isEncryptionEnabledInRoom`), not the legacy state-only check, so we don't repeatedly attempt rooms we can't speak.
- Errored-room tracking: rooms the crawler gives up on after a permanent error (e.g. a 403 from /messages) are recorded and stop being retried; a fresh indexable live event clears the flag and re-seeds them.
- Fully-crawled marker: when a backward fullCrawl reaches the start of a room's history we record it via a sentinel crawler checkpoint stored in seshat's own DB, so reconciliation won't re-seed rooms that have no indexable content (which stay isRoomIndexed=false forever).
- Checkpoint de-duplication: don't queue an exact-duplicate checkpoint that a gappy sync would otherwise stack up in the in-memory queue.

Also expose `getIndexingStatus()` (replacing `crawlingRooms()`) giving a simpler indexed / indexing / errored breakdown for the UI to consume.

Fixes bits of https://github.com/element-hq/element-web/issues/32119
Disclaimer: heavily Claude-assisted for expedience.