### PR TITLE
Ignore thread/filtered timeline resets when re-seeding the index

### DIFF
--- a/apps/web/src/indexing/EventIndex.test.ts
+++ b/apps/web/src/indexing/EventIndex.test.ts
@@ -24,6 +24,7 @@ import {
     MatrixEvent,
     type Room,
     ClientEvent,
+    RoomEvent,
     SyncState,
 } from "matrix-js-sdk/src/matrix";
 import { KnownMembership } from "matrix-js-sdk/src/types";
@@ -168,6 +169,62 @@ describe("EventIndex", () => {
             roomId: "!room2:id",
             token: "token2",
             direction: Direction.Forward,
+        });
+    });
+
+    it("only seeds a gap-fill on the room's own live timeline reset, not thread/filtered resets", async () => {
+        const mockIndexingManager = {
+            loadCheckpoints: vi.fn().mockResolvedValue([]),
+            isEventIndexEmpty: vi.fn().mockResolvedValue(false),
+            addCrawlerCheckpoint: vi.fn().mockResolvedValue(undefined),
+            removeCrawlerCheckpoint: vi.fn(),
+        } as any as Mocked<BaseEventIndexManager>;
+        mockPlatformPeg({ getEventIndexingManager: () => mockIndexingManager });
+
+        // The room's main (unfiltered) timeline set vs. a thread's timeline set. The
+        // SDK re-emits RoomEvent.TimelineReset from both, but only the former is a
+        // genuine history gap; thread resets (e.g. Thread.updateThreadMetadata on
+        // startup) must be ignored.
+        const liveTimelineSet = { id: "live" };
+        const threadTimelineSet = { id: "thread" };
+        const room = {
+            roomId: "!room1:id",
+            getMyMembership: () => KnownMembership.Join,
+            getUnfilteredTimelineSet: () => liveTimelineSet,
+            getLiveTimeline: () => ({ getPaginationToken: () => "token1" }),
+        } as any as Room;
+
+        const mockCrypto = { isEncryptionEnabledInRoom: vi.fn().mockResolvedValue(true) };
+        const mockClient = getMockClientWithEventEmitter({
+            getEventMapper: () => (obj: Partial<IEvent>) => new MatrixEvent(obj),
+            createMessagesRequest: vi.fn(),
+            getCrypto: () => mockCrypto as any,
+            ...mockClientMethodsRooms([room]),
+            isRoomEncrypted: () => true,
+        });
+
+        const indexer = new EventIndex();
+        await indexer.init();
+
+        // A thread (non-unfiltered) timeline reset must be ignored - no checkpoint.
+        mockClient.emit(RoomEvent.TimelineReset, room, threadTimelineSet as any);
+        // Let the async handler run to completion (it bails synchronously, but flush
+        // microtasks to be sure nothing is seeded on a later tick).
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(mockIndexingManager.addCrawlerCheckpoint).not.toHaveBeenCalled();
+
+        // A reset of the room's own live timeline is a real gap - seed a gap-fill.
+        const added = Promise.withResolvers<void>();
+        mockIndexingManager.addCrawlerCheckpoint.mockImplementation(async () => {
+            added.resolve();
+        });
+        mockClient.emit(RoomEvent.TimelineReset, room, liveTimelineSet as any);
+        await added.promise;
+        expect(mockIndexingManager.addCrawlerCheckpoint).toHaveBeenCalledWith({
+            roomId: "!room1:id",
+            token: "token1",
+            direction: Direction.Backward,
+            fullCrawl: false,
         });
     });
 });

--- a/apps/web/src/indexing/EventIndex.ts
+++ b/apps/web/src/indexing/EventIndex.ts
@@ -496,8 +496,17 @@ export default class EventIndex extends EventEmitter {
      * Listens for timeline resets that are caused by a limited timeline to
      * re-add checkpoints for rooms that need to be crawled again.
      */
-    private onTimelineReset = async (room: Room | undefined): Promise<void> => {
+    private onTimelineReset = async (room: Room | undefined, timelineSet?: EventTimelineSet): Promise<void> => {
         if (!room) return;
+        // Only react to resets of the room's main (unfiltered, live) timeline. Thread
+        // and filtered timeline sets re-emit RoomEvent.TimelineReset through the same
+        // event via the SDK's ReEmitter, and their resets - notably the flood from
+        // Thread.updateThreadMetadata as threads hydrate on startup - don't represent a
+        // gap in the room's history. Acting on them seeds spurious gap-fill checkpoints
+        // for every room that has a thread, including long-dead ones, which then
+        // reanimate the crawl list on every launch. A genuine history gap (a limited
+        // sync) resets the *unfiltered* timeline, so we still catch those.
+        if (timelineSet && timelineSet !== room.getUnfilteredTimelineSet()) return;
         // Cheap sync gate first, then the async crypto-aware check.
         if (!MatrixClientPeg.safeGet().isRoomEncrypted(room.roomId)) return;
         if (!(await this.isRoomIndexable(room.roomId))) return;


### PR DESCRIPTION
`onTimelineReset` seeded a backward gap-fill checkpoint on every `RoomEvent.TimelineReset`. But the SDK re-emits that event from thread and filtered timeline sets too (via its ReEmitter), and on startup `Thread.updateThreadMetadata` resets each thread's timeline as threads hydrate. So any room with even one ancient thread got a spurious gap-fill seeded on every launch - long-dead rooms "coming back from the dead" and re-inflating the crawl list each restart.

Only act on resets of the room's own unfiltered live timeline (`room.getUnfilteredTimelineSet()`); a genuine history gap (a limited sync) resets that timeline, so coverage is unchanged. Add a regression test asserting a thread timeline-set reset seeds nothing while a live timeline-set reset still seeds a gap-fill.

Builds on https://github.com/element-hq/element-web/pull/33955
Fixes bits of https://github.com/element-hq/element-web/issues/32119
Disclaimer: heavily claude assisted for expedience