### PR TITLE
Flush the seshat index when the search box is focused

### DIFF
--- a/apps/web/src/components/viewmodels/right_panel/RoomSummaryCardViewModel.tsx
+++ b/apps/web/src/components/viewmodels/right_panel/RoomSummaryCardViewModel.tsx
@@ -29,6 +29,7 @@ import { DefaultTagID } from "../../../stores/room-list-v3/skip-list/tag";
 import { useEventEmitterState } from "../../../hooks/useEventEmitter";
 import RightPanelStore from "../../../stores/right-panel/RightPanelStore";
 import { RightPanelPhases } from "../../../stores/right-panel/RightPanelStorePhases";
+import EventIndexPeg from "../../../indexing/EventIndexPeg";
 import PosthogTrackers from "../../../PosthogTrackers";
 import { PollHistoryDialog } from "../../views/dialogs/PollHistoryDialog";
 import Modal from "../../../Modal";
@@ -86,6 +87,12 @@ export interface RoomSummaryCardState {
      */
     onUpdateSearchInput: (e: React.KeyboardEvent<HTMLInputElement>) => void;
     /**
+     * The callback when the search input gains focus. Used to flush any pending
+     * event-index commits up front, so the index is fresh by the time the user
+     * finishes typing their query.
+     */
+    onSearchFocus: () => void;
+    /**
      * Callbacks to all the actions button in the right panel
      */
     onRoomMembersClick: () => void;
@@ -134,6 +141,7 @@ const useSearchInput = (
 ): {
     searchInputRef: React.RefObject<HTMLInputElement | null>;
     onUpdateSearchInput: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+    onSearchFocus: () => void;
 } => {
     const searchInputRef = useRef<HTMLInputElement>(null);
 
@@ -142,6 +150,15 @@ const useSearchInput = (
             searchInputRef.current.value = "";
             onSearchCancel?.();
         }
+    };
+
+    // Flush any events background indexing has buffered but not yet committed, so
+    // the local search index is up to date by the time the user runs their query.
+    // Doing it on focus overlaps the commit with them typing; it's a no-op when
+    // there's nothing pending. No-ops harmlessly when there's no event index (e.g.
+    // web/non-desktop).
+    const onSearchFocus = (): void => {
+        void EventIndexPeg.get()?.prepareForSearch();
     };
 
     // Focus the search field when the user clicks on the search button component
@@ -154,6 +171,7 @@ const useSearchInput = (
     return {
         searchInputRef,
         onUpdateSearchInput,
+        onSearchFocus,
     };
 };
 
@@ -257,7 +275,7 @@ export function useRoomSummaryCardViewModel(
     };
 
     // Room Search element ref
-    const { searchInputRef, onUpdateSearchInput } = useSearchInput(onSearchCancel);
+    const { searchInputRef, onUpdateSearchInput, onSearchFocus } = useSearchInput(onSearchCancel);
 
     return {
         isDirectMessage,
@@ -283,6 +301,7 @@ export function useRoomSummaryCardViewModel(
         onRoomPollHistoryClick,
         onReportRoomClick,
         onUpdateSearchInput,
+        onSearchFocus,
         onFavoriteToggleClick,
         onInviteToRoomClick,
     };

--- a/apps/web/src/components/views/right_panel/RoomSummaryCardView.tsx
+++ b/apps/web/src/components/views/right_panel/RoomSummaryCardView.tsx
@@ -218,6 +218,7 @@ const RoomSummaryCardView: React.FC<IProps> = ({
                 className="mx_no_textinput"
                 ref={vm.searchInputRef}
                 autoFocus={focusRoomSearch}
+                onFocus={vm.onSearchFocus}
                 onKeyDown={vm.onUpdateSearchInput}
             />
         </Form.Root>

--- a/apps/web/src/indexing/EventIndex.ts
+++ b/apps/web/src/indexing/EventIndex.ts
@@ -996,6 +996,30 @@ export default class EventIndex extends EventEmitter {
     }
 
     /**
+     * Flush any events that background indexing has buffered but not yet committed
+     * to Tantivy, so a subsequent search sees up-to-date results.
+     *
+     * Seshat batches commits coarsely (COMMIT_TIME) to save power while nobody is
+     * searching, so without an on-demand flush a freshly-received message could be
+     * up to a commit-interval stale in results. The underlying force_commit is a
+     * no-op when nothing is pending, so this is cheap to call speculatively.
+     *
+     * Call this when the user *focuses* the search box (not just on submit) so the
+     * commit overlaps with them typing their query, hiding its latency.
+     */
+    public async prepareForSearch(): Promise<void> {
+        const indexManager = PlatformPeg.get()?.getEventIndexingManager();
+        if (!indexManager) return;
+        try {
+            await indexManager.commitLiveEvents();
+        } catch (e) {
+            // A failed flush just means results may be slightly stale; search can
+            // still proceed against the last committed segments.
+            this.logger.warn("Failed to flush pending events for search", e);
+        }
+    }
+
+    /**
      * Search the event index using the given term for matching events.
      *
      * @param {ISearchArgs} searchArgs The search configuration for the search,
@@ -1006,7 +1030,14 @@ export default class EventIndex extends EventEmitter {
      */
     public async search(searchArgs: ISearchArgs): Promise<IResultRoomEvents | undefined> {
         const indexManager = PlatformPeg.get()?.getEventIndexingManager();
-        return indexManager?.searchEventIndex(searchArgs);
+        if (!indexManager) return undefined;
+
+        // Safety net: usually the flush already happened on search-box focus
+        // (prepareForSearch), so this is a no-op; it only does work if events
+        // arrived between focus and submit. Cheap either way.
+        await this.prepareForSearch();
+
+        return indexManager.searchEventIndex(searchArgs);
     }
 
     /**

--- a/apps/web/test/unit-tests/components/views/right_panel/RoomSummaryCardView-test.tsx
+++ b/apps/web/test/unit-tests/components/views/right_panel/RoomSummaryCardView-test.tsx
@@ -66,6 +66,7 @@ describe("<RoomSummaryCard />", () => {
         pinCount: 0,
         searchInputRef: { current: null },
         onUpdateSearchInput: jest.fn(),
+        onSearchFocus: jest.fn(),
         onRoomMembersClick: jest.fn(),
         onRoomThreadsClick: jest.fn(),
         onRoomFilesClick: jest.fn(),


### PR DESCRIPTION
Seshat now batches its Tantivy commits coarsely (1 minute) to save power, so a freshly-received message can be briefly stale in local search results. Force-commit pending events on demand so search is always up to date.

Add `EventIndex.prepareForSearch()` (a no-op when nothing is pending) and call it from the room search box's `onFocus`, so the commit overlaps with the user typing their query rather than blocking the first result. `search()` also calls it as a cheap safety net for events that arrive between focus and submit.

Builds on https://github.com/element-hq/element-web/pull/33955
Fixes bits of https://github.com/element-hq/element-web/issues/32119
Disclaimer: heavily claude assisted for expedience