### PR TITLE
feat(patch B v2): rebrand Attal Président + ServerPicker + register CTA retirés

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -18,6 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Detach HEAD (route docker-package.sh vers git describe, sinon il tente get-version-from-git.sh qui suppose USE_CUSTOM_SDKS=true)
+        run: |
+          git checkout --detach HEAD
+          echo "branch=$(git rev-parse --abbrev-ref HEAD)"
+          echo "describe=$(git describe --abbrev=0 --tags)"
 
       - name: Run patches assertion (gate avant build)
         run: bash scripts/check-patches-applied.sh

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -51,6 +51,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Write Renaissance version into build context (lu par docker-package.sh patché)
+        run: |
+          SHORT_SHA=$(git rev-parse --short=12 HEAD)
+          UPSTREAM_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "renaissance-base")
+          echo "${UPSTREAM_TAG}-renaissance-${SHORT_SHA}" > scripts/.renaissance-version
+          cat scripts/.renaissance-version
+
       - name: Build & push image (context = monorepo root, Dockerfile = apps/web/Dockerfile)
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,0 +1,54 @@
+name: Build & publish image
+
+on:
+  push:
+    branches: [renaissance/main, renaissance/staging]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Run patches assertion (gate avant build)
+        run: bash scripts/check-patches-applied.sh
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags + labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/renaissance/main' }}
+            type=sha,prefix=sha-,format=long
+            type=ref,event=branch
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build & push image (context = monorepo root, Dockerfile = apps/web/Dockerfile)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/web/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/renaissance-patches-check.yml
+++ b/.github/workflows/renaissance-patches-check.yml
@@ -1,0 +1,18 @@
+name: Renaissance patches check
+
+on:
+  pull_request:
+  push:
+    branches: [renaissance/main, renaissance/staging]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Run patches assertion script
+        run: bash scripts/check-patches-applied.sh

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ storybook-static
 # vitepress
 /docs/.vitepress/dist
 /docs/.vitepress/cache
+
+# PATCH-RENAISSANCE-CI: version file généré au build
+scripts/.renaissance-version

--- a/LICENSE-NOTICE.md
+++ b/LICENSE-NOTICE.md
@@ -1,0 +1,11 @@
+# License Notice
+
+Renaissance Chat Web is a fork of [Element Web](https://github.com/element-hq/element-web) licensed under AGPLv3.
+
+Modifications Renaissance (cf. [PATCHES.md](PATCHES.md)) :
+- Pré-câblage du homeserver Synapse Renaissance (`https://chat.attalpresident.fr`, server_name `attalpresident.fr`)
+- ServerPicker masqué (`disable_custom_urls: true`)
+- Normalisation du username (ajout automatique du suffix `:attalpresident.fr`)
+- Redirect du flow Registration vers la landing onboarding Renaissance
+
+Source publique de ce fork : <https://github.com/parti-renaissance/renaissance-chat-web> (AGPLv3)

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -5,15 +5,22 @@ Maintenu à jour à chaque PR ou rebase upstream. Source de vérité pour la cha
 **Base upstream** : tag `v1.12.21`
 **Branche Renaissance** : `renaissance/main`
 
-## B — Onboarding pré-câblé Renaissance
+## B — Onboarding pré-câblé Renaissance (v2 — brand Attal Président + login hardening)
 
 - **Fichiers** :
-  - `apps/web/config.sample.json` (override values default_server_config + brand + disable_custom_urls + permalink_prefix + room_directory)
-  - `apps/web/src/components/views/elements/ServerPicker.tsx` (hide si `disable_custom_urls === true`)
-  - `apps/web/src/components/structures/auth/Login.tsx` (normalize username + invite link Renaissance)
-  - `apps/web/src/components/structures/auth/Registration.tsx` (redirect vers `https://chat.attalpresident.fr/onboard/`)
-- **Marker code** : `PATCH-RENAISSANCE-B`
-- **Conflit attendu au rebase** : moyen (composants React touchés régulièrement par upstream)
+  - `apps/web/config.sample.json` :
+    - v1 : default_server_config + disable_custom_urls + permalink_prefix + room_directory
+    - **v2** : `brand: "Attal Président"` (vs "Renaissance Chat")
+  - `apps/web/webapp/manifest.json` (v2) :
+    - `name: "Attal Président"` + `short_name: "Attal"` (vs "Element" upstream)
+    - Suppression `related_applications` (les suggestions Element Android/iOS ne concernent pas Attal Président)
+  - `apps/web/src/components/views/elements/ServerPicker.tsx` (v1, hide si `disable_custom_urls === true` — filet upstream)
+  - `apps/web/src/components/structures/auth/Login.tsx` :
+    - v1 : normalize username + invite link Renaissance
+    - **v2** : ServerPicker plus rendu du tout + footer "Créer un compte" supprimé (inscription token-only via /onboard/) + imports `UIFeature` et `ServerPicker` retirés
+  - `apps/web/src/components/structures/auth/Registration.tsx` (v1, redirect vers `https://chat.attalpresident.fr/onboard/`)
+- **Marker code** : `PATCH-RENAISSANCE-B` (v1) + `PATCH-RENAISSANCE-B v2` (v2 deltas)
+- **Conflit attendu au rebase** : moyen (composants React touchés régulièrement par upstream — Login.tsx en particulier)
 - **Alternative si rebase casse** : ré-appliquer la logique en lisant ce ledger + script `scripts/check-patches-applied.sh`
 
 ## CI — Build pipeline Renaissance

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -16,6 +16,16 @@ Maintenu à jour à chaque PR ou rebase upstream. Source de vérité pour la cha
 - **Conflit attendu au rebase** : moyen (composants React touchés régulièrement par upstream)
 - **Alternative si rebase casse** : ré-appliquer la logique en lisant ce ledger + script `scripts/check-patches-applied.sh`
 
+## CI — Build pipeline Renaissance
+
+- **Fichiers** :
+  - `scripts/docker-package.sh` (override : version lue depuis `scripts/.renaissance-version`, plus git describe sur bind-mount .git ro qui ne tient pas sur branch renaissance/main)
+  - `.github/workflows/build-publish.yml` (build OCI image vers ghcr.io)
+  - `.github/workflows/renaissance-patches-check.yml` (assertion markers post-rebase)
+- **Marker code** : `PATCH-RENAISSANCE-CI`
+- **Conflit attendu au rebase** : faible (scripts/ peu touchés upstream)
+- **Alternative si rebase casse** : ré-écrire docker-package.sh simple (cf. fichier actuel)
+
 ## A — Branding visuel (différé V1.1)
 
 À implémenter post-validation pilots V1 fonctionnel. Voir spec `docs/specs/2026-06-18-fork-element-v1-pwa-web-only.md` côté repo synapse.

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,0 +1,21 @@
+# Patches Renaissance Chat Web V1
+
+Maintenu à jour à chaque PR ou rebase upstream. Source de vérité pour la chaîne de patches Renaissance appliquée par-dessus Element Web.
+
+**Base upstream** : tag `v1.12.21`
+**Branche Renaissance** : `renaissance/main`
+
+## B — Onboarding pré-câblé Renaissance
+
+- **Fichiers** :
+  - `apps/web/config.sample.json` (override values default_server_config + brand + disable_custom_urls + permalink_prefix + room_directory)
+  - `apps/web/src/components/views/elements/ServerPicker.tsx` (hide si `disable_custom_urls === true`)
+  - `apps/web/src/components/structures/auth/Login.tsx` (normalize username + invite link Renaissance)
+  - `apps/web/src/components/structures/auth/Registration.tsx` (redirect vers `https://chat.attalpresident.fr/onboard/`)
+- **Marker code** : `PATCH-RENAISSANCE-B`
+- **Conflit attendu au rebase** : moyen (composants React touchés régulièrement par upstream)
+- **Alternative si rebase casse** : ré-appliquer la logique en lisant ce ledger + script `scripts/check-patches-applied.sh`
+
+## A — Branding visuel (différé V1.1)
+
+À implémenter post-validation pilots V1 fonctionnel. Voir spec `docs/specs/2026-06-18-fork-element-v1-pwa-web-only.md` côté repo synapse.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# Renaissance Chat Web
+
+Fork de [Element Web](https://github.com/element-hq/element-web) (AGPLv3) pré-câblé sur le homeserver Synapse Renaissance `https://chat.attalpresident.fr` (server_name `attalpresident.fr`).
+
+Voir [PATCHES.md](PATCHES.md) pour la chaîne de patches Renaissance appliquée par-dessus Element Web, et [LICENSE-NOTICE.md](LICENSE-NOTICE.md) pour la notice de licence du fork.
+
+**Base upstream** : tag `v1.12.21`
+**Branche Renaissance** : `renaissance/main`
+
+---
+
 [![Chat](https://img.shields.io/matrix/element-web:matrix.org?logo=matrix)](https://matrix.to/#/#element-web:matrix.org)
 ![Tests](https://github.com/element-hq/element-web/actions/workflows/tests.yaml/badge.svg)
 ![Static Analysis](https://github.com/element-hq/element-web/actions/workflows/static_analysis.yaml/badge.svg)

--- a/apps/web/config.sample.json
+++ b/apps/web/config.sample.json
@@ -1,19 +1,17 @@
 {
+    "_patch_renaissance_b_marker": "see PATCHES.md",
     "default_server_config": {
         "m.homeserver": {
-            "base_url": "https://matrix-client.matrix.org",
-            "server_name": "matrix.org"
-        },
-        "m.identity_server": {
-            "base_url": "https://vector.im"
+            "base_url": "https://chat.attalpresident.fr",
+            "server_name": "attalpresident.fr"
         }
     },
-    "disable_custom_urls": false,
-    "disable_guests": false,
+    "disable_custom_urls": true,
+    "disable_guests": true,
     "disable_login_language_selector": false,
-    "disable_3pid_login": false,
+    "disable_3pid_login": true,
     "force_verification": false,
-    "brand": "Element",
+    "brand": "Renaissance Chat",
     "integrations_ui_url": "https://scalar.vector.im/",
     "integrations_rest_url": "https://scalar.vector.im/api",
     "integrations_widgets_urls": [
@@ -23,17 +21,14 @@
         "https://scalar-staging.vector.im/api"
     ],
     "default_widget_container_height": 280,
-    "default_country_code": "GB",
+    "default_country_code": "FR",
     "show_labs_settings": false,
     "features": {},
     "default_federate": true,
     "default_theme": "light",
+    "permalink_prefix": "https://chat.attalpresident.fr",
     "room_directory": {
-        "servers": ["matrix.org"]
-    },
-    "enable_presence_by_hs_url": {
-        "https://matrix.org": false,
-        "https://matrix-client.matrix.org": false
+        "servers": ["attalpresident.fr"]
     },
     "setting_defaults": {
         "breadcrumbs": true
@@ -45,5 +40,11 @@
         "url": "https://call.element.io",
         "brand": "Element Call"
     },
-    "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx"
+    "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx",
+    "custom": {
+        "renaissance_chat": {
+            "invite_link_url": "https://chat.attalpresident.fr/onboard/",
+            "support_email": "chat-support@parti-renaissance.fr"
+        }
+    }
 }

--- a/apps/web/config.sample.json
+++ b/apps/web/config.sample.json
@@ -11,7 +11,7 @@
     "disable_login_language_selector": false,
     "disable_3pid_login": true,
     "force_verification": false,
-    "brand": "Renaissance Chat",
+    "brand": "Attal Président",
     "integrations_ui_url": "https://scalar.vector.im/",
     "integrations_rest_url": "https://scalar.vector.im/api",
     "integrations_widgets_urls": [

--- a/apps/web/res/manifest.json
+++ b/apps/web/res/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "Element",
-    "short_name": "Element",
+    "name": "Attal Président",
+    "short_name": "Attal",
     "display": "standalone",
     "theme_color": "#76CFA6",
     "start_url": "index.html",
@@ -39,22 +39,6 @@
             "src": "/vector-icons/1024.png",
             "sizes": "1024x1024",
             "type": "image/png"
-        }
-    ],
-    "related_applications": [
-        {
-            "platform": "play",
-            "url": "https://play.google.com/store/apps/details?id=im.vector.app",
-            "id": "im.vector.app"
-        },
-        {
-            "platform": "f-droid",
-            "url": "https://f-droid.org/repository/browse/?fdid=im.vector.app",
-            "id": "im.vector.app"
-        },
-        {
-            "platform": "itunes",
-            "url": "https://apps.apple.com/app/vector/id1083446067"
         }
     ]
 }

--- a/apps/web/src/IConfigOptions.ts
+++ b/apps/web/src/IConfigOptions.ts
@@ -215,6 +215,14 @@ export interface IConfigOptions {
     };
 
     modules?: string[];
+
+    // PATCH-RENAISSANCE-B: extension custom Renaissance (onboarding landing link, support email)
+    custom?: {
+        renaissance_chat?: {
+            invite_link_url?: string;
+            support_email?: string;
+        };
+    };
 }
 
 export interface ISsoRedirectOptions {

--- a/apps/web/src/components/structures/auth/Login.tsx
+++ b/apps/web/src/components/structures/auth/Login.tsx
@@ -20,13 +20,13 @@ import AutoDiscoveryUtils from "../../../utils/AutoDiscoveryUtils";
 import AuthPage from "../../views/auth/AuthPage";
 import PlatformPeg from "../../../PlatformPeg";
 import SettingsStore from "../../../settings/SettingsStore";
-import { UIFeature } from "../../../settings/UIFeature";
+// PATCH-RENAISSANCE-B v2 : import UIFeature retiré (footer "Créer un compte" supprimé, plus de gate de feature flag à vérifier)
 import { type IMatrixClientCreds } from "../../../MatrixClientPeg";
 import PasswordLogin from "../../views/auth/PasswordLogin";
 import InlineSpinner from "../../views/elements/InlineSpinner";
 import Spinner from "../../views/elements/Spinner";
 import SSOButtons from "../../views/elements/SSOButtons";
-import ServerPicker from "../../views/elements/ServerPicker";
+// PATCH-RENAISSANCE-B v2 : import ServerPicker retiré (composant non rendu, homeserver câblé via config)
 import AuthBody from "../../views/auth/AuthBody";
 import AuthHeader from "../../views/auth/AuthHeader";
 import AccessibleButton, { type ButtonEvent } from "../../views/elements/AccessibleButton";
@@ -529,23 +529,10 @@ class LoginComponent extends React.PureComponent<IProps, IState> {
                     )}
                 </div>
             );
-        } else if (this.props.onRegisterClick && SettingsStore.getValue(UIFeature.Registration)) {
-            footer = (
-                <span className="mx_AuthBody_changeFlow">
-                    {_t(
-                        "auth|create_account_prompt",
-                        {},
-                        {
-                            a: (sub) => (
-                                <AccessibleButton kind="link_inline" onClick={this.onTryRegisterClick}>
-                                    {sub}
-                                </AccessibleButton>
-                            ),
-                        },
-                    )}
-                </span>
-            );
         }
+        // PATCH-RENAISSANCE-B v2 : footer "Créer un compte" supprimé
+        // L'inscription Renaissance se fait exclusivement via token/onboarding (cf. ADR 0015).
+        // Afficher un CTA "Create account" ouvrirait un flow qui ne marche pas (pas de registration ouverte).
 
         return (
             <AuthPage>
@@ -557,11 +544,7 @@ class LoginComponent extends React.PureComponent<IProps, IState> {
                     </h1>
                     {errorTextSection}
                     {serverDeadSection}
-                    <ServerPicker
-                        serverConfig={this.props.serverConfig}
-                        onServerConfigChange={this.props.onServerConfigChange}
-                        disabled={this.isBusy()}
-                    />
+                    {/* PATCH-RENAISSANCE-B v2 : ServerPicker retiré — homeserver attalpresident.fr câblé via default_server_config + disable_custom_urls */}
                     {this.renderLoginComponentForFlows()}
                     {this.props.children}
                     {footer}

--- a/apps/web/src/components/structures/auth/Login.tsx
+++ b/apps/web/src/components/structures/auth/Login.tsx
@@ -13,6 +13,7 @@ import { type SSOFlow, SSOAction } from "matrix-js-sdk/src/matrix";
 import { Button } from "@vector-im/compound-web";
 
 import { _t, UserFriendlyError } from "../../../languageHandler";
+import SdkConfig from "../../../SdkConfig";
 import Login, { type ClientLoginFlow, type OidcNativeFlow } from "../../../Login";
 import { messageForConnectionError, messageForLoginError } from "../../../utils/ErrorUtils";
 import AutoDiscoveryUtils from "../../../utils/AutoDiscoveryUtils";
@@ -33,6 +34,20 @@ import { type ValidatedServerConfig } from "../../../utils/ValidatedServerConfig
 import { filterBoolean } from "../../../utils/arrays";
 import { startOidcLogin } from "../../../utils/oidc/authorize";
 import { ModuleApi } from "../../../modules/Api.ts";
+
+// PATCH-RENAISSANCE-B: normalize username
+function normalizeRenaissanceUsername(raw: string): string {
+    let username = raw.trim();
+    const defaultServer =
+        SdkConfig.get("default_server_config")?.["m.homeserver"]?.server_name || "attalpresident.fr";
+    if (!username) return username;
+    if (!username.startsWith("@") && !username.includes(":")) {
+        username = `@${username}:${defaultServer}`;
+    } else if (username.startsWith("@") && !username.includes(":")) {
+        username = `${username}:${defaultServer}`;
+    }
+    return username;
+}
 
 interface IProps {
     serverConfig: ValidatedServerConfig;
@@ -156,6 +171,10 @@ class LoginComponent extends React.PureComponent<IProps, IState> {
         phoneNumber: string | undefined,
         password: string,
     ): Promise<void> => {
+        // PATCH-RENAISSANCE-B: normalize username avant submit
+        if (username) {
+            username = normalizeRenaissanceUsername(username);
+        }
         if (!this.state.serverIsAlive) {
             this.setState({ busy: true });
             // Do a quick liveliness check on the URLs

--- a/apps/web/src/components/structures/auth/Registration.tsx
+++ b/apps/web/src/components/structures/auth/Registration.tsx
@@ -44,6 +44,7 @@ import Spinner from "../../views/elements/Spinner";
 import { AuthHeaderDisplay } from "./header/AuthHeaderDisplay";
 import { AuthHeaderProvider } from "./header/AuthHeaderProvider";
 import SettingsStore from "../../../settings/SettingsStore";
+import SdkConfig from "../../../SdkConfig";
 import { type ValidatedServerConfig } from "../../../utils/ValidatedServerConfig";
 import { startOidcLogin } from "../../../utils/oidc/authorize";
 
@@ -156,6 +157,12 @@ export default class Registration extends React.Component<IProps, IState> {
     }
 
     public componentDidMount(): void {
+        // PATCH-RENAISSANCE-B: redirect vers landing onboarding Renaissance
+        const inviteLinkUrl = SdkConfig.get("custom")?.renaissance_chat?.invite_link_url;
+        if (inviteLinkUrl) {
+            window.location.href = inviteLinkUrl;
+            return;
+        }
         this.replaceClient(this.props.serverConfig);
         //triggers a confirmation dialog for data loss before page unloads/refreshes
         window.addEventListener("beforeunload", this.unloadCallback);

--- a/apps/web/src/components/views/elements/ServerPicker.tsx
+++ b/apps/web/src/components/views/elements/ServerPicker.tsx
@@ -51,6 +51,11 @@ const onHelpClick = (): void => {
 };
 
 const ServerPicker: React.FC<IProps> = ({ title, dialogTitle, serverConfig, onServerConfigChange, disabled }) => {
+    // PATCH-RENAISSANCE-B: hide server picker si disable_custom_urls
+    if (SdkConfig.get("disable_custom_urls") === true) {
+        return null;
+    }
+
     const disableCustomUrls = SdkConfig.get("disable_custom_urls");
 
     let editBtn;

--- a/scripts/check-patches-applied.sh
+++ b/scripts/check-patches-applied.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# PATCH-RENAISSANCE-B assertion script
+# Used by CI to validate patches stay applied post-rebase
+set -euo pipefail
+
+errors=0
+
+check() {
+  local pattern="$1"
+  local paths="$2"
+  local label="$3"
+  if grep -rq "$pattern" $paths 2>/dev/null; then
+    echo "OK $label"
+  else
+    echo "FAIL $label — pattern '$pattern' absent in $paths"
+    errors=$((errors + 1))
+  fi
+}
+
+check "PATCH-RENAISSANCE-B" "apps/web/src/components/structures/auth/ apps/web/src/components/views/elements/" "Patch B (onboarding React) markers present"
+check "_patch_renaissance_b_marker" "apps/web/config.sample.json" "Patch B config.sample.json marker present"
+check "chat.attalpresident.fr" "apps/web/config.sample.json" "Homeserver pre-cabled in config"
+check "attalpresident.fr" "apps/web/config.sample.json" "server_name pre-cabled in config"
+
+if [ "$errors" -gt 0 ]; then
+  echo ""
+  echo "$errors Renaissance patches missing — rebase likely broke them"
+  exit 1
+fi
+
+echo ""
+echo "All Renaissance patches in place"

--- a/scripts/check-patches-applied.sh
+++ b/scripts/check-patches-applied.sh
@@ -22,6 +22,11 @@ check "_patch_renaissance_b_marker" "apps/web/config.sample.json" "Patch B confi
 check "chat.attalpresident.fr" "apps/web/config.sample.json" "Homeserver pre-cabled in config"
 check "attalpresident.fr" "apps/web/config.sample.json" "server_name pre-cabled in config"
 
+# v2 (2026-06-25) — brand Attal Président + login hardening
+check "Attal Président" "apps/web/config.sample.json" "v2 brand Attal Président in config.sample.json"
+check "Attal Président" "apps/web/res/manifest.json" "v2 brand Attal Président in manifest.json (PWA install name)"
+check "PATCH-RENAISSANCE-B v2" "apps/web/src/components/structures/auth/Login.tsx" "v2 Login.tsx markers (ServerPicker + register footer removed)"
+
 if [ "$errors" -gt 0 ]; then
   echo ""
   echo "$errors Renaissance patches missing — rebase likely broke them"

--- a/scripts/docker-package.sh
+++ b/scripts/docker-package.sh
@@ -1,21 +1,19 @@
 #!/usr/bin/env bash
+# PATCH-RENAISSANCE-CI: override docker-package.sh upstream
+# Upstream version tente git describe / git rev-parse sur un bind-mount .git ro
+# qui ne contient pas toujours les tags (cas branch renaissance/main fork).
+# Renaissance build : VERSION lu depuis scripts/.renaissance-version (écrit par le
+# workflow GH Actions avant docker build). Fallback "renaissance-dev" si absent.
 
 set -ex
 
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
-
 DIR=$(dirname "$0")
 
-# If the branch comes out as HEAD then we're probably checked out to a tag, so if the thing is *not*
-# coming out as HEAD then we're on a branch. When we're on a branch, we want to resolve ourselves to
-# a few SHAs rather than a version.
-if [[ $BRANCH != HEAD && ! $BRANCH =~ heads/v.+ ]]
-then
-    DIST_VERSION=$("$DIR"/get-version-from-git.sh)
-else
-    DIST_VERSION=$(git describe --abbrev=0 --tags)
+if [ -f "$DIR/.renaissance-version" ]; then
+    DIST_VERSION=$(cat "$DIR/.renaissance-version" | head -n 1 | tr -d '[:space:]')
 fi
 
+DIST_VERSION="${DIST_VERSION:-renaissance-dev}"
 DIST_VERSION=$("$DIR"/normalize-version.sh "$DIST_VERSION")
 
 VERSION=$DIST_VERSION pnpm --dir apps/web build


### PR DESCRIPTION
## Contexte

Feedback Victor 2026-06-25 : rebrand de \"Renaissance Chat\" vers **\"Attal Président\"** + simplification UX login (plus de question de serveur, plus de bouton créer un compte).

## Diff

### Brand
- \`config.sample.json\` : \`brand: \"Renaissance Chat\"\` → \`brand: \"Attal Président\"\`
- \`res/manifest.json\` (PWA) : \`name: \"Element\"\` + \`short_name: \"Element\"\` → \`\"Attal Président\"\` + \`\"Attal\"\`
- \`res/manifest.json\` : suppression \`related_applications\` (Element Android/iOS hors scope)

### Login.tsx hardening (PATCH-RENAISSANCE-B v2)
- ServerPicker JSX retiré — homeserver \`attalpresident.fr\` câblé via \`default_server_config\` + \`disable_custom_urls\` dans config
- Footer \"Créer un compte\" retiré — inscription Renaissance token-only via \`/onboard/\` (ADR 0015)
- Imports \`UIFeature\` et \`ServerPicker\` retirés (orphelins après suppression des usages)
- Markers \`PATCH-RENAISSANCE-B v2\` sur chaque modif pour rebase upstream

### Ledger
- \`PATCHES.md\` : section B amendée avec sub-bullets v1/v2 par fichier
- \`scripts/check-patches-applied.sh\` : 3 nouveaux checks (brand config + brand manifest + markers Login.tsx v2)

## Vérif locale

\`bash scripts/check-patches-applied.sh\` → 7 OK / 0 FAIL.

## Plan post-merge

1. CI \`build-publish.yml\` reconstruit l'image OCI \`ghcr.io/parti-renaissance/renaissance-chat-web:latest\` (~5 min)
2. Côté repo synapse : re-run \`playbook 05 prod\` (force_source pull → restart container, ~3 min)
3. Verif externe :
   - \`curl https://chat.attalpresident.fr/web/config.json\` → \`brand: \"Attal Président\"\`
   - \`curl https://chat.attalpresident.fr/web/manifest.json\` → \`name: \"Attal Président\"\` + plus de related_applications
   - Ouvrir \`/web/\` → écran login sans ServerPicker, sans CTA \"Créer un compte\"

## Test plan

- [ ] CI \`patches-check\` verte (7 markers OK)
- [ ] CI \`build-publish\` verte → image OCI pushée
- [ ] Re-deploy prod réussi
- [ ] Tests visuels Victor (login + PWA install nom)