### PR TITLE
Fix ImageReplyBodyView test flake

### DIFF
--- a/packages/shared-components/src/room/timeline/event-tile/body/MImageReplyBodyView/ImageReplyBodyView.stories.tsx
+++ b/packages/shared-components/src/room/timeline/event-tile/body/MImageReplyBodyView/ImageReplyBodyView.stories.tsx
@@ -36,7 +36,7 @@ const meta = {
         alt: "Reply preview",
         maxWidth: 57,
         maxHeight: 44,
-        aspectRatio: "57 / 43.95",
+        aspectRatio: "57 / 44",
         placeholder: ImageReplyBodyViewPlaceholder.NONE,
         blurhash: demoBlurhash,
     },

--- a/packages/shared-components/src/room/timeline/event-tile/body/MImageReplyBodyView/ImageReplyBodyView.stories.tsx
+++ b/packages/shared-components/src/room/timeline/event-tile/body/MImageReplyBodyView/ImageReplyBodyView.stories.tsx
@@ -36,7 +36,7 @@ const meta = {
         alt: "Reply preview",
         maxWidth: 57,
         maxHeight: 44,
-        aspectRatio: "57 / 44",
+        aspectRatio: "57 / 43.95",
         placeholder: ImageReplyBodyViewPlaceholder.NONE,
         blurhash: demoBlurhash,
     },
@@ -74,6 +74,13 @@ export const LoadingWithSpinner: Story = {
 export const LoadingWithBlurhash: Story = {
     args: {
         placeholder: ImageReplyBodyViewPlaceholder.BLURHASH,
+    },
+    // The blurhash <canvas> rasterizes to one of two ~33px-apart variants per run;
+    // tolerate that benign jitter rather than flake against the strict 3px default.
+    parameters: {
+        snapshot: {
+            failureThreshold: 100,
+        },
     },
 };
 


### PR DESCRIPTION
An attempt to fix https://github.com/element-hq/element-web/issues/33783

The test seems to flip between two blurhash results that are ~33px different. Upping the threshold to 100px to allow for this and keep it as a smoke test. 