### PR TITLE
Fix map tooltip overlapping message composer

### DIFF
--- a/apps/web/src/components/views/messages/MLocationBody.tsx
+++ b/apps/web/src/components/views/messages/MLocationBody.tsx
@@ -132,10 +132,7 @@ export const LocationBodyContent: React.FC<LocationBodyContentProps> = ({
     onClick,
 }) => {
     // Find the message panel boundary so the tooltip hides when it would overlap the composer
-    const boundaryEl = useMemo(
-        () => document.querySelector<HTMLElement>(".mx_RoomView_messagePanel") ?? undefined,
-        [],
-    );
+    const boundaryEl = useMemo(() => document.querySelector<HTMLElement>(".mx_RoomView_messagePanel") ?? undefined, []);
 
     // only pass member to marker when should render avatar marker
     const markerRoomMember = isSelfLocation(mxEvent.getContent()) ? mxEvent.sender : undefined;

--- a/apps/web/src/components/views/messages/MLocationBody.tsx
+++ b/apps/web/src/components/views/messages/MLocationBody.tsx
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { type MatrixEvent, ClientEvent, type ClientEventHandlerMap } from "matrix-js-sdk/src/matrix";
 import { secureRandomString } from "matrix-js-sdk/src/randomstring";
 import { Tooltip } from "@vector-im/compound-web";
@@ -131,6 +131,12 @@ export const LocationBodyContent: React.FC<LocationBodyContentProps> = ({
     onError,
     onClick,
 }) => {
+    // Find the message panel boundary so the tooltip hides when it would overlap the composer
+    const [boundaryEl, setBoundaryEl] = useState<HTMLElement | undefined>(undefined);
+    useEffect(() => {
+        setBoundaryEl(document.querySelector<HTMLElement>(".mx_RoomView_messagePanel") ?? undefined);
+    }, []);
+
     // only pass member to marker when should render avatar marker
     const markerRoomMember = isSelfLocation(mxEvent.getContent()) ? mxEvent.sender : undefined;
     const geoUri = locationEventGeoUri(mxEvent);
@@ -150,7 +156,7 @@ export const LocationBodyContent: React.FC<LocationBodyContentProps> = ({
 
     return (
         <div className="mx_MLocationBody">
-            <Tooltip label={tooltip}>
+            <Tooltip label={tooltip} boundary={boundaryEl}>
                 <div className="mx_MLocationBody_map">{mapElement}</div>
             </Tooltip>
         </div>

--- a/apps/web/src/components/views/messages/MLocationBody.tsx
+++ b/apps/web/src/components/views/messages/MLocationBody.tsx
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import React, { useEffect, useState } from "react";
+import React, { useMemo } from "react";
 import { type MatrixEvent, ClientEvent, type ClientEventHandlerMap } from "matrix-js-sdk/src/matrix";
 import { secureRandomString } from "matrix-js-sdk/src/randomstring";
 import { Tooltip } from "@vector-im/compound-web";
@@ -132,10 +132,10 @@ export const LocationBodyContent: React.FC<LocationBodyContentProps> = ({
     onClick,
 }) => {
     // Find the message panel boundary so the tooltip hides when it would overlap the composer
-    const [boundaryEl, setBoundaryEl] = useState<HTMLElement | undefined>(undefined);
-    useEffect(() => {
-        setBoundaryEl(document.querySelector<HTMLElement>(".mx_RoomView_messagePanel") ?? undefined);
-    }, []);
+    const boundaryEl = useMemo(
+        () => document.querySelector<HTMLElement>(".mx_RoomView_messagePanel") ?? undefined,
+        [],
+    );
 
     // only pass member to marker when should render avatar marker
     const markerRoomMember = isSelfLocation(mxEvent.getContent()) ? mxEvent.sender : undefined;


### PR DESCRIPTION
Fixes #21619 
## Summary
Fix the "Expand map" tooltip on location messages overlapping the message composer by using compound-web's new `boundary` prop on `Tooltip` (added in compound-web v9.5.0).

## Before
<img width="756" height="513" alt="Screenshot from 2026-06-26 23-58-50" src="https://github.com/user-attachments/assets/c7115196-a36b-4fb0-bf9e-1168cb5700a7" />

## After
<img width="756" height="524" alt="Screenshot from 2026-06-27 00-01-12" src="https://github.com/user-attachments/assets/51ea963f-0e2d-4810-ae2b-9b9662d1d7c4" />

## Demonstration
https://github.com/user-attachments/assets/0940fa22-992b-42c0-a614-b924573d5ab7



<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
