### PR TITLE
Pluralise the multi-session remove button and confirmation dialog

### DIFF
--- a/apps/web/playwright/e2e/settings/device-management.spec.ts
+++ b/apps/web/playwright/e2e/settings/device-management.spec.ts
@@ -59,7 +59,7 @@ test.describe("Device manager", () => {
         await filteredDeviceListItems.last().click({ force: true });
 
         // sign out from list selection action buttons
-        await tab.getByRole("button", { name: "Remove this device", exact: true }).click();
+        await tab.getByRole("button", { name: "Remove 2 sessions", exact: true }).click();
         await page.getByRole("dialog").getByTestId("dialog-primary-button").click();
 
         // list updated after sign out

--- a/apps/web/src/components/views/settings/devices/FilteredDeviceList.tsx
+++ b/apps/web/src/components/views/settings/devices/FilteredDeviceList.tsx
@@ -324,6 +324,15 @@ export const FilteredDeviceList = ({
                 {selectedDeviceIds.length ? (
                     <>
                         <AccessibleButton
+                            data-testid="cancel-selection-cta"
+                            kind="content_inline"
+                            disabled={isSigningOut}
+                            onClick={() => setSelectedDeviceIds([])}
+                            className="mx_FilteredDeviceList_headerButton"
+                        >
+                            {_t("action|cancel")}
+                        </AccessibleButton>
+                        <AccessibleButton
                             data-testid="sign-out-selection-cta"
                             kind="danger_inline"
                             disabled={isSigningOut}
@@ -332,15 +341,6 @@ export const FilteredDeviceList = ({
                         >
                             {isSigningOut && <Spinner size={16} />}
                             {_t("settings|sessions|sign_out_n_sessions", { count: selectedDeviceIds.length })}
-                        </AccessibleButton>
-                        <AccessibleButton
-                            data-testid="cancel-selection-cta"
-                            kind="content_inline"
-                            disabled={isSigningOut}
-                            onClick={() => setSelectedDeviceIds([])}
-                            className="mx_FilteredDeviceList_headerButton"
-                        >
-                            {_t("action|cancel")}
                         </AccessibleButton>
                     </>
                 ) : (

--- a/apps/web/src/components/views/settings/devices/FilteredDeviceList.tsx
+++ b/apps/web/src/components/views/settings/devices/FilteredDeviceList.tsx
@@ -331,7 +331,7 @@ export const FilteredDeviceList = ({
                             className="mx_FilteredDeviceList_headerButton"
                         >
                             {isSigningOut && <Spinner size={16} />}
-                            {_t("action|sign_out")}
+                            {_t("settings|sessions|sign_out_n_sessions", { count: selectedDeviceIds.length })}
                         </AccessibleButton>
                         <AccessibleButton
                             data-testid="cancel-selection-cta"

--- a/apps/web/src/components/views/settings/tabs/user/SessionManagerTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/SessionManagerTab.tsx
@@ -40,7 +40,7 @@ const LoginWithQR = lazy(() => import("../../../auth/LoginWithQR"));
 
 const confirmSignOut = async (sessionsToSignOutCount: number): Promise<boolean> => {
     const { finished } = Modal.createDialog(QuestionDialog, {
-        title: _t("action|sign_out"),
+        title: _t("settings|sessions|sign_out_n_sessions", { count: sessionsToSignOutCount }),
         description: (
             <div>
                 <p>
@@ -51,7 +51,7 @@ const confirmSignOut = async (sessionsToSignOutCount: number): Promise<boolean> 
             </div>
         ),
         cancelButton: _t("action|cancel"),
-        button: _t("action|sign_out"),
+        button: _t("settings|sessions|sign_out_n_sessions", { count: sessionsToSignOutCount }),
     });
     const [confirmed] = await finished;
 


### PR DESCRIPTION
When multiple sessions are selected in Settings → Sessions → Other Sessions, the bulk remove button — and the confirmation dialog it opens — used the singular `action|sign_out` string **"Remove this device"**. As noted in #33812, the singular "this" misleadingly implies the *current* device is about to be removed.

This swaps those three usages for the existing count-aware `settings|sessions|sign_out_n_sessions` key, which already renders `Remove %(count)s session(s)` and is what the other-sessions overflow menu (`OtherSessionsSectionHeading`) already uses. The label now reads e.g. "Remove 2 sessions". This also covers @richvdh's note that the confirmation dialog had the same problem — its title and confirm button are updated too.

### Changes
- `FilteredDeviceList.tsx` — multi-select remove button
- `SessionManagerTab.tsx` — `confirmSignOut` dialog title and confirm button

No new translation strings are introduced; the reused key already has translations.

This is a regression from #32808 (Sign out → Remove this device).

## Checklist

- [x] I have read through the review guidelines and CONTRIBUTING.md.
- [x] Tests written for new code (and old code if feasible). _The affected controls are already exercised by existing tests via `data-testid` (`sign-out-selection-cta`, `dialog-primary-button`), and the `sign_out_n_sessions` rendering is already asserted by the "Remove 2 sessions" other-sessions test — happy to add an explicit assertion for the multi-select label if preferred._
- [x] New or updated `public`/`exported` symbols have accurate TSDoc documentation. _No exported symbols changed._
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the Contributor License Agreement (CLA).

Fixes #33812
