### PR TITLE
Fix message search showing an error dialog after every sync when indexing fails

### DIFF
--- a/apps/web/src/indexing/EventIndex.test.ts
+++ b/apps/web/src/indexing/EventIndex.test.ts
@@ -30,6 +30,7 @@ import {
 import EventIndex from "./EventIndex.ts";
 import {
     emitPromise,
+    flushPromises,
     getMockClientWithEventEmitter,
     mockClientMethodsRooms,
     mockPlatformPeg,
@@ -37,6 +38,11 @@ import {
 import type BaseEventIndexManager from "./BaseEventIndexManager.ts";
 import { type ICrawlerCheckpoint } from "./BaseEventIndexManager.ts";
 import SettingsStore from "../settings/SettingsStore.ts";
+import { logErrorAndShowErrorDialog } from "../utils/ErrorUtils.tsx";
+
+vi.mock("../utils/ErrorUtils.tsx", () => ({
+    logErrorAndShowErrorDialog: vi.fn(),
+}));
 
 afterEach(() => {
     vi.restoreAllMocks();
@@ -165,6 +171,69 @@ describe("EventIndex", () => {
             roomId: "!room2:id",
             token: "token2",
             direction: Direction.Forward,
+        });
+    });
+
+    describe("sync error circuit breaker (#33501)", () => {
+        async function setUpFailingSync(): Promise<{
+            indexer: EventIndex;
+            mockClient: Mocked<MatrixClient>;
+            mockIndexingManager: Mocked<BaseEventIndexManager>;
+            getEventIndexingManager: ReturnType<typeof vi.fn>;
+            cancelCrawler: ReturnType<typeof vi.fn>;
+        }> {
+            const mockIndexingManager = {
+                loadCheckpoints: vi.fn().mockResolvedValue([]),
+                isEventIndexEmpty: vi.fn().mockResolvedValue(false),
+                commitLiveEvents: vi.fn().mockRejectedValue(new Error("indexer boom")),
+            } as any as Mocked<BaseEventIndexManager>;
+            const getEventIndexingManager = vi.fn(() => mockIndexingManager);
+            mockPlatformPeg({ getEventIndexingManager });
+
+            const mockClient = getMockClientWithEventEmitter({
+                getEventMapper: () => (obj: Partial<IEvent>) => new MatrixEvent(obj),
+                createMessagesRequest: vi.fn(),
+                ...mockClientMethodsRooms([]),
+            });
+
+            const indexer = new EventIndex();
+            await indexer.init();
+
+            const cancelCrawler = vi.fn();
+            const indexerWithCrawler = indexer as unknown as { crawler: { cancel: () => void } | null };
+            vi.spyOn(indexer, "startCrawler").mockImplementation(() => {
+                indexerWithCrawler.crawler = { cancel: cancelCrawler };
+            });
+            vi.spyOn(indexer, "stopCrawler");
+            vi.mocked(logErrorAndShowErrorDialog).mockClear();
+
+            return { indexer, mockClient, mockIndexingManager, getEventIndexingManager, cancelCrawler };
+        }
+
+        it("reports the first unexpected sync failure and stops the crawler", async () => {
+            const { indexer, mockClient, mockIndexingManager, cancelCrawler } = await setUpFailingSync();
+
+            mockClient.emit(ClientEvent.Sync, SyncState.Syncing, null, {});
+            await flushPromises();
+
+            expect(mockIndexingManager.commitLiveEvents).toHaveBeenCalledTimes(1);
+            expect(logErrorAndShowErrorDialog).toHaveBeenCalledTimes(1);
+            expect(indexer.stopCrawler).toHaveBeenCalledTimes(1);
+            expect(cancelCrawler).toHaveBeenCalledTimes(1);
+        });
+
+        it("does not re-enter the indexer or show another dialog after the breaker trips", async () => {
+            const { indexer, mockClient, mockIndexingManager, getEventIndexingManager } = await setUpFailingSync();
+
+            mockClient.emit(ClientEvent.Sync, SyncState.Syncing, null, {});
+            await flushPromises();
+            mockClient.emit(ClientEvent.Sync, SyncState.Syncing, null, {});
+            await flushPromises();
+
+            expect(indexer.startCrawler).toHaveBeenCalledTimes(1);
+            expect(getEventIndexingManager).toHaveBeenCalledTimes(2);
+            expect(mockIndexingManager.commitLiveEvents).toHaveBeenCalledTimes(1);
+            expect(logErrorAndShowErrorDialog).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/apps/web/src/indexing/EventIndex.ts
+++ b/apps/web/src/indexing/EventIndex.ts
@@ -81,6 +81,14 @@ export default class EventIndex extends EventEmitter {
      */
     private needsInitialCheckpoints = false;
 
+    /**
+     * Circuit-breaker flag: set to true once the indexer has thrown an unexpected error in the sync
+     * handler and we have told the user about it. Once set, we stop indexing and suppress further
+     * error dialogs so that a persistent failure doesn't pop up a dialog after every `/sync`, which
+     * previously made the app unusable. See https://github.com/element-hq/element-web/issues/33501.
+     */
+    private indexingErrored = false;
+
     private readonly logger;
 
     public constructor() {
@@ -199,6 +207,10 @@ export default class EventIndex extends EventEmitter {
     private onSync = (state: SyncState, prevState: SyncState | null, data?: SyncStateData): void => {
         if (state != SyncState.Syncing) return;
 
+        // Circuit-breaker: once indexing has hit an unexpected error we stop trying, to avoid
+        // repeatedly hitting the same failure and flooding the user with error dialogs (#33501).
+        if (this.indexingErrored) return;
+
         const onSyncInner = async (): Promise<void> => {
             const indexManager = PlatformPeg.get()?.getEventIndexingManager();
             if (!indexManager) return;
@@ -216,6 +228,14 @@ export default class EventIndex extends EventEmitter {
         };
 
         onSyncInner().catch((e) => {
+            // Guard against multiple in-flight syncs racing past the check above before the flag is set.
+            if (this.indexingErrored) {
+                this.logger.error("Event indexer threw an error (already reported to the user)", e);
+                return;
+            }
+            this.indexingErrored = true;
+            // Stop the background crawler so we don't keep churning against a broken index.
+            this.stopCrawler();
             logErrorAndShowErrorDialog("Event indexer threw an unexpected error", e);
         });
     };


### PR DESCRIPTION
### Problem

A native Seshat (Tantivy) writer-thread panic — surfaced from the Neon module as
`internal error … SendError { .. }` — makes `EventIndex.onSync` call
`logErrorAndShowErrorDialog` on **every** `/sync`. Once the index is in this state the user
gets a modal error dialog every few seconds, which makes the app effectively unusable until
the indexer recovers.

### Fix

Add an `indexingErrored` circuit-breaker to `EventIndex`:

- On the first unexpected error in the sync handler, report it **once**, then call
  `stopCrawler()` so the background crawler stops churning against a broken index.
- Subsequent syncs early-return, so the dialog is never shown repeatedly.
- A small race guard ensures that concurrent in-flight syncs report at most once.

This is intentionally minimal and self-contained — it changes only the error-handling path,
not indexing behaviour on the happy path.

### Tests

New Vitest coverage in `EventIndex.test.ts`:

- the first unexpected sync failure shows the error dialog exactly once and stops the crawler;
- after the breaker has tripped, a later sync does **not** re-enter the indexer and does **not**
  show another dialog.

`eslint` and the type-check pass on the changed files.

Fixes #33501

Notes: Fix message search showing an error dialog after every sync when the local indexer hits a persistent failure.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
