### PR TITLE
Paint the desktop window in the theme colour to remove the white launch flash

### DIFF
--- a/apps/desktop/src/background-color.test.ts
+++ b/apps/desktop/src/background-color.test.ts
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { describe, expect, it } from "vitest";
+
+import {
+    DARK_BACKGROUND_COLOR,
+    isValidThemeColor,
+    LIGHT_BACKGROUND_COLOR,
+    resolveBackgroundColor,
+} from "./background-color.js";
+
+describe("isValidThemeColor", () => {
+    it.each([
+        "#fff",
+        "#ffffff",
+        "#101317",
+        "#ABC123",
+        "rgb(16, 19, 23)",
+        "rgb(255,255,255)",
+        "rgba(0, 0, 0, 1)",
+        "rgba(16, 19, 23, 1.0)",
+    ])("accepts the opaque CSS colour %s", (color) => {
+        expect(isValidThemeColor(color)).toBe(true);
+    });
+
+    it.each([
+        // translucent values must be rejected to keep the window opaque (#32260 / blurry-font FAQ)
+        "#ffff",
+        "#ffffffff",
+        "#0000",
+        "#00000000",
+        "rgba(16, 19, 23, 0.5)",
+        "rgba(0,0,0,0)",
+        "rgba(255,255,255,0.99)",
+    ])("rejects the translucent colour %s", (color) => {
+        expect(isValidThemeColor(color)).toBe(false);
+    });
+
+    it.each([
+        "",
+        "   ",
+        "white",
+        "transparent",
+        "#ff",
+        "#fffff",
+        "#gggggg",
+        "rgb()",
+        "rgb(1,2)",
+        "javascript:alert(1)",
+        "url(evil)",
+        "rgb(16, 19, 23); background: url(x)",
+    ])("rejects the invalid colour %s", (color) => {
+        expect(isValidThemeColor(color)).toBe(false);
+    });
+
+    it.each([undefined, null, 123, {}, [], true])("rejects the non-string %s", (value) => {
+        expect(isValidThemeColor(value)).toBe(false);
+    });
+});
+
+describe("resolveBackgroundColor", () => {
+    it("returns a valid persisted colour over the theme default", () => {
+        expect(resolveBackgroundColor("rgb(16, 19, 23)", false)).toBe("rgb(16, 19, 23)");
+        expect(resolveBackgroundColor("#abcdef", true)).toBe("#abcdef");
+    });
+
+    it("falls back to the dark default when no persisted colour and the OS prefers dark", () => {
+        expect(resolveBackgroundColor(undefined, true)).toBe(DARK_BACKGROUND_COLOR);
+    });
+
+    it("falls back to the light default when no persisted colour and the OS prefers light", () => {
+        expect(resolveBackgroundColor(undefined, false)).toBe(LIGHT_BACKGROUND_COLOR);
+    });
+
+    it("ignores an invalid persisted colour and uses the theme default", () => {
+        expect(resolveBackgroundColor("not-a-colour", true)).toBe(DARK_BACKGROUND_COLOR);
+        expect(resolveBackgroundColor("", false)).toBe(LIGHT_BACKGROUND_COLOR);
+    });
+
+    it("ignores a translucent persisted colour and uses the opaque theme default", () => {
+        expect(resolveBackgroundColor("rgba(16, 19, 23, 0.5)", true)).toBe(DARK_BACKGROUND_COLOR);
+        expect(resolveBackgroundColor("#101317aa", false)).toBe(LIGHT_BACKGROUND_COLOR);
+    });
+
+    it("exposes the Element canvas colours as the defaults", () => {
+        expect(LIGHT_BACKGROUND_COLOR).toBe("#ffffff");
+        expect(DARK_BACKGROUND_COLOR).toBe("#101317");
+    });
+});

--- a/apps/desktop/src/background-color.ts
+++ b/apps/desktop/src/background-color.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+/**
+ * Resolves the native window background colour so the window can be painted in the
+ * right colour before the web app's CSS has loaded, avoiding the white flash on launch.
+ * See https://github.com/element-hq/element-web/issues/32260.
+ */
+
+/** The Element/Compound light theme canvas background (`--cpd-color-bg-canvas-default`). */
+export const LIGHT_BACKGROUND_COLOR = "#ffffff";
+/** The Element/Compound dark theme canvas background (`--cpd-color-bg-canvas-default`). */
+export const DARK_BACKGROUND_COLOR = "#101317";
+
+// Opaque hex only: `#rgb` / `#rrggbb`. Alpha forms (`#rgba` / `#rrggbbaa`) are rejected — they are
+// not opaque, and Electron interprets hex alpha in a different byte order anyway.
+const HEX_COLOR_RE = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
+// `rgb(r, g, b)` or fully-opaque `rgba(r, g, b, 1)` as emitted by `getComputedStyle().backgroundColor`.
+// A fractional alpha (anything other than 1) is rejected so the window background stays opaque.
+const RGB_COLOR_RE = /^rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}\s*(?:,\s*1(?:\.0+)?\s*)?\)$/i;
+
+/**
+ * Validates that an untrusted value is an **opaque** CSS colour we can safely hand to Electron's
+ * `BrowserWindow` background. Only the opaque hex (`#rgb` / `#rrggbb`) and `rgb()` / fully-opaque
+ * `rgba(…, 1)` forms emitted by the renderer's computed style are accepted. Translucent colours
+ * (any alpha below 1) and anything else (named colours, `transparent`, arbitrary strings) are
+ * rejected: a non-opaque window background reintroduces blurry font rendering and a see-through
+ * launch window, and rejecting junk stops a buggy or compromised renderer poisoning the persisted value.
+ */
+export function isValidThemeColor(value: unknown): value is string {
+    return typeof value === "string" && (HEX_COLOR_RE.test(value) || RGB_COLOR_RE.test(value));
+}
+
+/**
+ * Picks the background colour for the main window.
+ *
+ * Prefers the colour the renderer last reported (persisted across launches, so the window
+ * matches a user's chosen theme even when it differs from the OS theme). When there is no
+ * valid persisted colour — e.g. the first ever launch — it falls back to the OS appearance
+ * so that dark-mode users do not get a white flash.
+ *
+ * @param persistedColor - the colour last reported by the renderer, if any
+ * @param prefersDark - whether the OS is currently using a dark appearance (`nativeTheme.shouldUseDarkColors`)
+ */
+export function resolveBackgroundColor(persistedColor: string | undefined, prefersDark: boolean): string {
+    if (isValidThemeColor(persistedColor)) return persistedColor;
+    return prefersDark ? DARK_BACKGROUND_COLOR : LIGHT_BACKGROUND_COLOR;
+}

--- a/apps/desktop/src/electron-main.ts
+++ b/apps/desktop/src/electron-main.ts
@@ -21,6 +21,7 @@ import {
     session,
     protocol,
     desktopCapturer,
+    nativeTheme,
 } from "electron";
 // eslint-disable-next-line n/file-extension-in-import
 import * as Sentry from "@sentry/electron/main";
@@ -42,6 +43,7 @@ import { _t, AppLocalization } from "./language-helper.js";
 import { setDisplayMediaCallback } from "./displayMediaCallback.js";
 import { setupMacosTitleBar } from "./macos-titlebar.js";
 import { setupMediaAuth } from "./media-auth.js";
+import { resolveBackgroundColor } from "./background-color.js";
 import { getBuildConfig } from "./build-config.js";
 import { getAsarPath } from "./asar.js";
 import { getIconPath } from "./icon.js";
@@ -246,8 +248,11 @@ app.on("ready", async () => {
     console.debug("Opening main window");
     const preloadScript = path.normalize(`${__dirname}/preload.cjs`);
     global.mainWindow = new BrowserWindow({
-        // https://www.electronjs.org/docs/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do
-        backgroundColor: "#fff",
+        // An opaque background avoids blurry font rendering
+        // (https://www.electronjs.org/docs/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do)
+        // and paints the window in the user's theme colour before the web app's CSS loads,
+        // avoiding the white launch flash (https://github.com/element-hq/element-web/issues/32260).
+        backgroundColor: resolveBackgroundColor(store.get("backgroundColor"), nativeTheme.shouldUseDarkColors),
 
         titleBarStyle: process.platform === "darwin" ? "hidden" : "default",
         trafficLightPosition: { x: 9, y: 8 },

--- a/apps/desktop/src/ipc.test.ts
+++ b/apps/desktop/src/ipc.test.ts
@@ -5,10 +5,11 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { expect, describe, it, vi } from "vitest";
+import { expect, describe, it, vi, beforeAll, beforeEach, afterEach } from "vitest";
 import { ipcMain, type IpcMainInvokeEvent } from "electron";
 
 import { getConfig } from "./config.js";
+import Store from "./store.js";
 
 vi.mock("electron", () => ({
     ipcMain: {
@@ -32,5 +33,69 @@ describe("getConfig", () => {
 
         expect(handler!(new Event("test") as unknown as IpcMainInvokeEvent)).toStrictEqual(config);
         expect(getConfig).toHaveBeenCalled();
+    });
+});
+
+describe("setThemeColor", () => {
+    let handler: (ev: unknown, color: unknown) => void;
+    let set: ReturnType<typeof vi.fn>;
+    let get: ReturnType<typeof vi.fn>;
+    let setBackgroundColor: ReturnType<typeof vi.fn>;
+    let instanceSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeAll(async () => {
+        await import("./ipc.js");
+        handler = vi.mocked(ipcMain.on).mock.calls.find(([channel]) => channel === "setThemeColor")![1] as never;
+        expect(handler).toBeDefined();
+    });
+
+    beforeEach(() => {
+        set = vi.fn();
+        get = vi.fn();
+        setBackgroundColor = vi.fn();
+        instanceSpy = vi.spyOn(Store, "instance", "get").mockReturnValue({ get, set } as unknown as Store);
+        (global as unknown as { mainWindow: unknown }).mainWindow = { setBackgroundColor };
+    });
+
+    afterEach(() => {
+        instanceSpy.mockRestore();
+        (global as unknown as { mainWindow: unknown }).mainWindow = null;
+    });
+
+    it("persists a valid colour and repaints the live window", () => {
+        handler({}, "rgb(16, 19, 23)");
+
+        expect(set).toHaveBeenCalledWith("backgroundColor", "rgb(16, 19, 23)");
+        expect(setBackgroundColor).toHaveBeenCalledWith("rgb(16, 19, 23)");
+    });
+
+    it("ignores an invalid colour", () => {
+        handler({}, "javascript:alert(1)");
+
+        expect(set).not.toHaveBeenCalled();
+        expect(setBackgroundColor).not.toHaveBeenCalled();
+    });
+
+    it("ignores a non-string payload", () => {
+        handler({}, { malicious: true });
+
+        expect(set).not.toHaveBeenCalled();
+        expect(setBackgroundColor).not.toHaveBeenCalled();
+    });
+
+    it("does not throw when there is no window", () => {
+        (global as unknown as { mainWindow: unknown }).mainWindow = null;
+
+        expect(() => handler({}, "#101317")).not.toThrow();
+        expect(set).toHaveBeenCalledWith("backgroundColor", "#101317");
+    });
+
+    it("does not re-persist or repaint when the colour is unchanged", () => {
+        get.mockReturnValue("#101317");
+
+        handler({}, "#101317");
+
+        expect(set).not.toHaveBeenCalled();
+        expect(setBackgroundColor).not.toHaveBeenCalled();
     });
 });

--- a/apps/desktop/src/ipc.ts
+++ b/apps/desktop/src/ipc.ts
@@ -12,6 +12,7 @@ import { randomArray } from "./utils.js";
 import { getDisplayMediaCallback, setDisplayMediaCallback } from "./displayMediaCallback.js";
 import Store, { clearDataAndRelaunch } from "./store.js";
 import { getConfig } from "./config.js";
+import { isValidThemeColor } from "./background-color.js";
 
 let focusHandlerAttached = false;
 ipcMain.on("loudNotification", function (): void {
@@ -25,6 +26,19 @@ ipcMain.on("loudNotification", function (): void {
             focusHandlerAttached = true;
         }
     }
+});
+
+// The renderer reports its resolved theme background colour here. We persist it so the next
+// launch can paint the native window in the same colour (avoiding the white launch flash,
+// https://github.com/element-hq/element-web/issues/32260) and update the live window too.
+ipcMain.on("setThemeColor", function (_ev: IpcMainEvent, color: unknown): void {
+    const store = Store.instance;
+    if (!store || !isValidThemeColor(color)) return;
+    // switchTheme() fires this on every theme resolution, so skip the synchronous disk write
+    // and repaint when nothing changed.
+    if (store.get("backgroundColor") === color) return;
+    store.set("backgroundColor", color);
+    global.mainWindow?.setBackgroundColor(color);
 });
 
 let powerSaveBlockerId: number | null = null;

--- a/apps/desktop/src/preload.cts
+++ b/apps/desktop/src/preload.cts
@@ -34,6 +34,7 @@ const CHANNELS = [
     "homeserverUrl",
     "serverSupportedVersions",
     "showToast",
+    "setThemeColor",
 ];
 
 contextBridge.exposeInMainWorld("electron", {

--- a/apps/desktop/src/store.ts
+++ b/apps/desktop/src/store.ts
@@ -80,6 +80,11 @@ interface StoreData {
     safeStorageBackendMigrate?: boolean;
     /** whether to open the app at login minimised, only valid when app.openAtLogin is true */
     openAtLoginMinimised: boolean;
+    /**
+     * the last theme background colour reported by the renderer, used to paint the native
+     * window before the web app's CSS loads and avoid a white flash on launch (#32260)
+     */
+    backgroundColor?: string;
 }
 
 /**
@@ -226,6 +231,9 @@ class Store extends ElectronStore<StoreData> {
                 openAtLoginMinimised: {
                     type: "boolean",
                     default: true,
+                },
+                backgroundColor: {
+                    type: "string",
                 },
             },
         });

--- a/apps/web/src/@types/global.d.ts
+++ b/apps/web/src/@types/global.d.ts
@@ -67,7 +67,8 @@ type ElectronChannel =
     | "userAccessToken"
     | "homeserverUrl"
     | "serverSupportedVersions"
-    | "showToast";
+    | "showToast"
+    | "setThemeColor";
 
 declare global {
     // use `number` as the return type in all cases for globalThis.set{Interval,Timeout},

--- a/apps/web/src/theme.ts
+++ b/apps/web/src/theme.ts
@@ -387,6 +387,10 @@ export async function setTheme(theme?: string): Promise<void> {
             if (bodyStyles.backgroundColor) {
                 const metaElement = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]')!;
                 metaElement.content = bodyStyles.backgroundColor;
+                // On desktop, report the resolved theme background colour to the main process so it can
+                // paint the native window in the same colour on the next launch, avoiding a white flash.
+                // https://github.com/element-hq/element-web/issues/32260
+                window.electron?.send("setThemeColor", bodyStyles.backgroundColor);
             }
             resolve();
         };

--- a/apps/web/test/unit-tests/theme-test.ts
+++ b/apps/web/test/unit-tests/theme-test.ts
@@ -52,6 +52,7 @@ describe("theme", () => {
 
         afterEach(() => {
             jest.useRealTimers();
+            delete (window as { electron?: unknown }).electron;
         });
 
         it("should switch theme on onload call", async () => {
@@ -189,6 +190,35 @@ describe("theme", () => {
             expect(spy).toHaveBeenCalledWith("--sidebar-color-0pct", "#abcdef00");
             expect(spy).toHaveBeenCalledWith("--sidebar-color-15pct", "#abcdef26");
             expect(spy).toHaveBeenCalledWith("--sidebar-color-50pct", "#abcdef80");
+        });
+
+        it("reports the resolved theme background colour to the desktop app", async () => {
+            jest.spyOn(global, "getComputedStyle").mockReturnValue({
+                backgroundColor: "rgb(16, 19, 23)",
+            } as CSSStyleDeclaration);
+            const send = jest.fn();
+            (window as { electron?: unknown }).electron = { send, on: jest.fn() } as any;
+
+            await new Promise((resolve) => {
+                setTheme("dark").then(resolve);
+                darkTheme.onload!({} as Event);
+            });
+
+            expect(send).toHaveBeenCalledWith("setThemeColor", "rgb(16, 19, 23)");
+        });
+
+        it("does not report or throw when not running on desktop", async () => {
+            jest.spyOn(global, "getComputedStyle").mockReturnValue({
+                backgroundColor: "rgb(255, 255, 255)",
+            } as CSSStyleDeclaration);
+            delete (window as { electron?: unknown }).electron;
+
+            await expect(
+                new Promise((resolve) => {
+                    setTheme("light").then(resolve);
+                    lightTheme.onload!({} as Event);
+                }),
+            ).resolves.toBeUndefined();
         });
     });
 


### PR DESCRIPTION
### Problem

The main `BrowserWindow` was created with a hard-coded `backgroundColor: "#fff"`, so the native
window painted white on every launch until the web app's CSS loaded. The result is a white flash
on startup — most jarring for dark-theme users, who briefly see a full-window white rectangle
before the dark UI appears (#32260).

### Fix

Resolve the window background colour at creation time instead of hard-coding white:

- The renderer reports its resolved theme background colour to the main process over a new
  `setThemeColor` IPC channel whenever the theme is applied.
- The main process **validates** the value is an *opaque* CSS colour (`#rgb` / `#rrggbb` /
  `rgb()` / fully-opaque `rgba(…, 1)`), persists it, and repaints the live window. Translucent or
  non-colour values are rejected, so a buggy or compromised renderer can't poison the persisted
  background (which would reintroduce blurry font rendering or a see-through window).
- On launch the window is painted with the persisted colour, falling back to the OS appearance
  (`nativeTheme.shouldUseDarkColors`) on the very first run — so dark-mode users no longer get a
  white flash.

The colour resolution and validation live in a pure `background-color.ts` module so they can be
unit-tested in isolation.

### Tests

- `background-color.test.ts` (Vitest, 32 passing) — validation and resolution, including the
  opaque-only colour rules.
- `ipc.test.ts` — the `setThemeColor` handler: persist + repaint, reject invalid/non-string,
  no-window safety, and skip when unchanged.
- `theme-test.ts` (Jest) — the renderer reports the colour on desktop and is a no-op off desktop.

Fixes #32260

Notes: Removes the white flash when launching the desktop app by painting the native window in the user's theme colour before the web app loads.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
