### PR TITLE
Add a setting to disable smooth scrolling and honour prefers-reduced-motion

### DIFF
--- a/apps/web/src/components/views/rooms/RoomSublist.tsx
+++ b/apps/web/src/components/views/rooms/RoomSublist.tsx
@@ -37,6 +37,7 @@ import { DefaultTagID, type TagID } from "../../../stores/room-list-v3/skip-list
 import RoomListLayoutStore from "../../../stores/room-list/RoomListLayoutStore";
 import RoomListStore, { LISTS_UPDATE_EVENT, LISTS_LOADING_EVENT } from "../../../stores/room-list/RoomListStore";
 import { arrayFastClone, arrayHasOrderChange } from "../../../utils/arrays";
+import { getScrollBehavior } from "../../../utils/scrollBehavior";
 import { objectExcluding, objectHasDiff } from "../../../utils/objects";
 import type ResizeNotifier from "../../../utils/ResizeNotifier";
 import ContextMenu, {
@@ -432,7 +433,7 @@ export default class RoomSublist extends React.Component<IProps, IState> {
 
         if ((isStickyBottom && !isAtBottom) || (isStickyTop && !isAtTop)) {
             // is sticky - jump to list
-            sublist.scrollIntoView({ behavior: "smooth" });
+            sublist.scrollIntoView({ behavior: getScrollBehavior() });
         } else {
             // on screen - toggle collapse
             const isExpanded = this.state.isExpanded;
@@ -440,7 +441,7 @@ export default class RoomSublist extends React.Component<IProps, IState> {
             // if the bottom list is collapsed then scroll it in so it doesn't expand off screen
             if (!isExpanded && isStickyBottom) {
                 setTimeout(() => {
-                    sublist.scrollIntoView({ behavior: "smooth" });
+                    sublist.scrollIntoView({ behavior: getScrollBehavior() });
                 }, 0);
             }
         }

--- a/apps/web/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -152,6 +152,7 @@ export default class PreferencesUserSettingsTab extends React.Component<EmptyObj
         "showJoinLeaves",
         "showDisplaynameChanges",
         "showChatEffects",
+        "Accessibility.disableSmoothScrolling",
         "showAvatarChanges",
         "Pill.shouldShowPillAvatar",
         "TextualBody.enableBigEmoji",

--- a/apps/web/src/components/views/settings/tabs/user/SessionManagerTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/SessionManagerTab.tsx
@@ -32,6 +32,7 @@ import { type FilterVariation } from "../../devices/filter";
 import { OtherSessionsSectionHeading } from "../../devices/OtherSessionsSectionHeading";
 import { SettingsSection } from "../../shared/SettingsSection";
 import { getManageDeviceUrl } from "../../../../../utils/oidc/urls.ts";
+import { getScrollBehavior } from "../../../../../utils/scrollBehavior";
 import { SDKContext } from "../../../../../contexts/SDKContext";
 import Spinner from "../../../elements/Spinner";
 
@@ -185,7 +186,7 @@ const SessionManagerTab: React.FC<{
                 // align element to top of scrollbox
                 block: "start",
                 inline: "nearest",
-                behavior: "smooth",
+                behavior: getScrollBehavior(),
             }),
         );
     };

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -2829,6 +2829,7 @@
             "composer_heading": "Composer",
             "default_timezone": "Browser default (%(timezone)s)",
             "dialog_title": "<strong>Settings:</strong> Preferences",
+            "disable_smooth_scrolling": "Disable smooth scrolling (reduces motion)",
             "enable_content_protection": "Enable content protection",
             "enable_hardware_acceleration": "Enable hardware acceleration",
             "enable_tray_icon": "Show tray icon and minimise window to it on close",

--- a/apps/web/src/settings/Settings.tsx
+++ b/apps/web/src/settings/Settings.tsx
@@ -344,6 +344,7 @@ export interface Settings {
     "layout": IBaseSetting<Layout>;
     "Images.size": IBaseSetting<ImageSize>;
     "showChatEffects": IBaseSetting<boolean>;
+    "Accessibility.disableSmoothScrolling": IBaseSetting<boolean>;
     "Performance.addSendMessageTimingMetadata": IBaseSetting<boolean>;
     "Widgets.pinned": IBaseSetting<{ [widgetId: string]: boolean }>;
     "Widgets.layout": IBaseSetting<ILayoutSettings | null>;
@@ -1310,6 +1311,11 @@ export const SETTINGS: Settings = {
         displayName: _td("settings|show_chat_effects"),
         default: true,
         controller: new ReducedMotionController(),
+    },
+    "Accessibility.disableSmoothScrolling": {
+        supportedLevels: LEVELS_ACCOUNT_SETTINGS,
+        displayName: _td("settings|preferences|disable_smooth_scrolling"),
+        default: false,
     },
     "Performance.addSendMessageTimingMetadata": {
         supportedLevels: [SettingLevel.CONFIG],

--- a/apps/web/src/utils/scrollBehavior.ts
+++ b/apps/web/src/utils/scrollBehavior.ts
@@ -1,0 +1,26 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import SettingsStore from "../settings/SettingsStore";
+
+/** Whether the operating system requests reduced motion via the prefers-reduced-motion media query. */
+export function prefersReducedMotion(): boolean {
+    return globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+}
+
+/**
+ * Whether smooth scrolling should be suppressed, honouring both the explicit user setting and
+ * the operating system's reduced-motion preference.
+ */
+export function smoothScrollingDisabled(): boolean {
+    return SettingsStore.getValue("Accessibility.disableSmoothScrolling") || prefersReducedMotion();
+}
+
+/** Returns the ScrollBehavior to use, honoring the user setting + OS reduced-motion preference. */
+export function getScrollBehavior(preferred: ScrollBehavior = "smooth"): ScrollBehavior {
+    return smoothScrollingDisabled() ? "auto" : preferred;
+}

--- a/apps/web/test/unit-tests/components/views/settings/tabs/user/__snapshots__/PreferencesUserSettingsTab-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/settings/tabs/user/__snapshots__/PreferencesUserSettingsTab-test.tsx.snap
@@ -1297,7 +1297,6 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       class="_container_udcm8_10"
                     >
                       <input
-                        checked=""
                         class="_input_udcm8_24"
                         disabled=""
                         id="mx_SettingsFlag_gs5uWEzYzZrS"
@@ -1316,7 +1315,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       class="_label_1o4d9_60"
                       for="mx_SettingsFlag_gs5uWEzYzZrS"
                     >
-                      Show profile picture changes
+                      Disable smooth scrolling (reduces motion)
                     </label>
                   </div>
                 </div>
@@ -1349,7 +1348,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       class="_label_1o4d9_60"
                       for="mx_SettingsFlag_qWg7OgID1yRR"
                     >
-                      Show avatars in user, room and event mentions
+                      Show profile picture changes
                     </label>
                   </div>
                 </div>
@@ -1382,7 +1381,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       class="_label_1o4d9_60"
                       for="mx_SettingsFlag_pOPewl7rtMbV"
                     >
-                      Enable big emoji in chat
+                      Show avatars in user, room and event mentions
                     </label>
                   </div>
                 </div>
@@ -1415,7 +1414,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       class="_label_1o4d9_60"
                       for="mx_SettingsFlag_cmt3PZSyNp3v"
                     >
-                      Jump to the bottom of the timeline when you send a message
+                      Enable big emoji in chat
                     </label>
                   </div>
                 </div>
@@ -1447,6 +1446,39 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                     <label
                       class="_label_1o4d9_60"
                       for="mx_SettingsFlag_dJJz3lHUv9XX"
+                    >
+                      Jump to the bottom of the timeline when you send a message
+                    </label>
+                  </div>
+                </div>
+                <div
+                  class="_inline-field_1o4d9_33"
+                >
+                  <div
+                    class="_inline-field-control_1o4d9_45"
+                  >
+                    <div
+                      class="_container_udcm8_10"
+                    >
+                      <input
+                        checked=""
+                        class="_input_udcm8_24"
+                        disabled=""
+                        id="mx_SettingsFlag_SBSSOZDRlzlA"
+                        role="switch"
+                        type="checkbox"
+                      />
+                      <div
+                        class="_ui_udcm8_34"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="_inline-field-body_1o4d9_39"
+                  >
+                    <label
+                      class="_label_1o4d9_60"
+                      for="mx_SettingsFlag_SBSSOZDRlzlA"
                     >
                       Show current profile picture and name for users in message history
                     </label>
@@ -1696,7 +1728,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       <input
                         class="_input_udcm8_24"
                         disabled=""
-                        id="mx_SettingsFlag_SBSSOZDRlzlA"
+                        id="mx_SettingsFlag_FLEpLCb0jpp6"
                         role="switch"
                         type="checkbox"
                       />
@@ -1710,7 +1742,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   >
                     <label
                       class="_label_1o4d9_60"
-                      for="mx_SettingsFlag_SBSSOZDRlzlA"
+                      for="mx_SettingsFlag_FLEpLCb0jpp6"
                     >
                       Show NSFW content
                     </label>
@@ -1750,7 +1782,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                         checked=""
                         class="_input_udcm8_24"
                         disabled=""
-                        id="mx_SettingsFlag_FLEpLCb0jpp6"
+                        id="mx_SettingsFlag_NQFWldEwbV3q"
                         role="switch"
                         type="checkbox"
                       />
@@ -1764,7 +1796,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   >
                     <label
                       class="_label_1o4d9_60"
-                      for="mx_SettingsFlag_FLEpLCb0jpp6"
+                      for="mx_SettingsFlag_NQFWldEwbV3q"
                     >
                       Prompt before sending invites to potentially invalid matrix IDs
                     </label>

--- a/apps/web/test/unit-tests/utils/scrollBehavior-test.ts
+++ b/apps/web/test/unit-tests/utils/scrollBehavior-test.ts
@@ -1,0 +1,93 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import SettingsStore from "../../../src/settings/SettingsStore";
+import { getScrollBehavior, prefersReducedMotion, smoothScrollingDisabled } from "../../../src/utils/scrollBehavior";
+
+jest.mock("../../../src/settings/SettingsStore");
+
+describe("scrollBehavior", () => {
+    const mockedGetValue = jest.mocked(SettingsStore.getValue);
+
+    /** Set up matchMedia so that (prefers-reduced-motion: reduce) returns `matches`. */
+    const mockMatchMedia = (matches: boolean): void => {
+        globalThis.matchMedia = jest.fn().mockReturnValue({ matches }) as unknown as typeof globalThis.matchMedia;
+    };
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        mockedGetValue.mockReturnValue(false);
+        mockMatchMedia(false);
+    });
+
+    describe("prefersReducedMotion", () => {
+        it("returns true when the OS prefers reduced motion", () => {
+            mockMatchMedia(true);
+            expect(prefersReducedMotion()).toBe(true);
+        });
+
+        it("returns false when the OS does not prefer reduced motion", () => {
+            mockMatchMedia(false);
+            expect(prefersReducedMotion()).toBe(false);
+        });
+
+        it("returns false (and does not throw) when matchMedia is undefined", () => {
+            // @ts-ignore deliberately removing matchMedia to emulate an environment without it
+            delete globalThis.matchMedia;
+            expect(() => prefersReducedMotion()).not.toThrow();
+            expect(prefersReducedMotion()).toBe(false);
+        });
+    });
+
+    describe("smoothScrollingDisabled", () => {
+        it.each([
+            { setting: false, reduce: false, expected: false },
+            { setting: true, reduce: false, expected: true },
+            { setting: false, reduce: true, expected: true },
+            { setting: true, reduce: true, expected: true },
+        ])(
+            "is the OR of the setting ($setting) and OS reduced-motion ($reduce) => $expected",
+            ({ setting, reduce, expected }) => {
+                mockedGetValue.mockReturnValue(setting);
+                mockMatchMedia(reduce);
+                expect(smoothScrollingDisabled()).toBe(expected);
+            },
+        );
+
+        it("reads the Accessibility.disableSmoothScrolling setting", () => {
+            mockedGetValue.mockReturnValue(false);
+            smoothScrollingDisabled();
+            expect(mockedGetValue).toHaveBeenCalledWith("Accessibility.disableSmoothScrolling");
+        });
+    });
+
+    describe("getScrollBehavior", () => {
+        it("returns 'smooth' when the setting is off and the OS does not prefer reduced motion", () => {
+            mockedGetValue.mockReturnValue(false);
+            mockMatchMedia(false);
+            expect(getScrollBehavior()).toBe("smooth");
+        });
+
+        it("returns 'auto' when the user has disabled smooth scrolling (OS query off)", () => {
+            mockedGetValue.mockReturnValue(true);
+            mockMatchMedia(false);
+            expect(getScrollBehavior()).toBe("auto");
+        });
+
+        it("returns 'auto' when the OS prefers reduced motion (setting off)", () => {
+            mockedGetValue.mockReturnValue(false);
+            mockMatchMedia(true);
+            expect(getScrollBehavior()).toBe("auto");
+        });
+
+        it("honours a custom preferred behavior when smooth scrolling is enabled", () => {
+            mockedGetValue.mockReturnValue(false);
+            mockMatchMedia(false);
+            expect(getScrollBehavior("instant")).toBe("instant");
+        });
+    });
+});


### PR DESCRIPTION
### Problem

Programmatic scrolls — jumping to a room sublist, scrolling a filtered session into view — were
hard-coded to `behavior: "smooth"`, with no way to turn the animation off. That's an
accessibility/motion concern for users who find the animation uncomfortable, and it ignores users
who have reduced motion enabled at the OS level (#32315).

### Fix

- Add an `Accessibility.disableSmoothScrolling` account setting, surfaced in **Preferences**
  (default off).
- Add a small `scrollBehavior` util that resolves the `ScrollBehavior` to use: it returns `"auto"`
  when **either** the setting is enabled **or** the OS reports `prefers-reduced-motion: reduce`,
  and otherwise the preferred behaviour (`"smooth"`).
- Route the existing `scrollIntoView` calls in `RoomSublist` and `SessionManagerTab` through
  `getScrollBehavior()` so they respect both signals.

### Tests

- `scrollBehavior-test.ts` (Jest, 12 passing) — covers `prefersReducedMotion`,
  `smoothScrollingDisabled`, and `getScrollBehavior` for the setting × OS-preference matrix.
- `PreferencesUserSettingsTab` snapshot updated for the new toggle.

Fixes #32315

Notes: Adds an accessibility setting to disable smooth scrolling, which also turns off automatically when the OS requests reduced motion.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
