### PR TITLE
Restore the window size/position reliably and stop auto-starting fullscreen

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -63,7 +63,6 @@
         "auto-launch": "^5.0.5",
         "counterpart": "^0.18.6",
         "electron-store": "^11.0.0",
-        "electron-window-state": "^5.0.3",
         "minimist": "^1.2.6",
         "png-to-ico": "^3.0.0",
         "uuid": "^14.0.0"

--- a/apps/desktop/src/electron-main.ts
+++ b/apps/desktop/src/electron-main.ts
@@ -21,11 +21,11 @@ import {
     session,
     protocol,
     desktopCapturer,
+    screen,
 } from "electron";
 // eslint-disable-next-line n/file-extension-in-import
 import * as Sentry from "@sentry/electron/main";
 import path, { dirname } from "node:path";
-import windowStateKeeper from "electron-window-state";
 import { URL, fileURLToPath } from "node:url";
 
 import "./ipc.js";
@@ -40,6 +40,7 @@ import * as updater from "./updater.js";
 import ProtocolHandler from "./protocol.js";
 import { _t, AppLocalization } from "./language-helper.js";
 import { setDisplayMediaCallback } from "./displayMediaCallback.js";
+import { WindowStateManager } from "./window-state.js";
 import { setupMacosTitleBar } from "./macos-titlebar.js";
 import { setupMediaAuth } from "./media-auth.js";
 import { getBuildConfig } from "./build-config.js";
@@ -237,11 +238,10 @@ app.on("ready", async () => {
         store,
     });
 
-    // Load the previous window state with fallback to defaults
-    const mainWindowState = windowStateKeeper({
-        defaultWidth: 1024,
-        defaultHeight: 768,
-    });
+    // Load the previous window state (size/position/maximized) with fallback to defaults, clamped to
+    // the displays currently connected. See window-state.ts (#32228 / #32360).
+    const windowState = new WindowStateManager();
+    const restoreState = windowState.getRestoreState(screen.getAllDisplays());
 
     console.debug("Opening main window");
     const preloadScript = path.normalize(`${__dirname}/preload.cjs`);
@@ -256,10 +256,10 @@ app.on("ready", async () => {
         show: false,
         autoHideMenuBar: store.get("autoHideMenuBar"),
 
-        x: mainWindowState.x,
-        y: mainWindowState.y,
-        width: mainWindowState.width,
-        height: mainWindowState.height,
+        x: restoreState.bounds.x,
+        y: restoreState.bounds.y,
+        width: restoreState.bounds.width,
+        height: restoreState.bounds.height,
         webPreferences: {
             preload: preloadScript,
             nodeIntegration: false,
@@ -298,12 +298,16 @@ app.on("ready", async () => {
 
     global.mainWindow.once("ready-to-show", () => {
         if (!global.mainWindow) return;
-        mainWindowState.manage(global.mainWindow);
+
+        // Now the window exists, restore the maximized state and start tracking changes. Fullscreen
+        // is deliberately not restored so the app never auto-starts fullscreen (#32360).
+        if (restoreState.isMaximized) global.mainWindow.maximize();
+        windowState.monitor(global.mainWindow);
 
         if (!args.hidden) {
             global.mainWindow.show();
         } else {
-            // hide here explicitly because window manage above sometimes shows it
+            // hide here explicitly because maximize() above can show the window
             global.mainWindow.hide();
         }
     });
@@ -337,6 +341,10 @@ app.on("ready", async () => {
             if (shouldCancelCloseRequest) return;
         }
 
+        // Persist the window geometry before exiting: app.exit() terminates immediately and fires no
+        // `close` event, so the close-handler flush below would otherwise be skipped on this path.
+        windowState.persist(global.mainWindow);
+
         // Exit the app
         app.exit();
     });
@@ -345,6 +353,11 @@ app.on("ready", async () => {
         global.mainWindow = null;
     });
     global.mainWindow.on("close", async (e) => {
+        // Capture the final geometry synchronously while the window is still alive — this is the only
+        // reliable flush on the macOS hide-on-close path (where `closed` never fires) and also picks up
+        // any geometry change still sitting in the debounce when the user quits. See window-state.ts.
+        windowState.persist(global.mainWindow!);
+
         // If we are not quitting and have a tray icon then minimize to tray
         if (!global.appQuitting && (tray.hasTray() || process.platform === "darwin")) {
             // On Mac, closing the window just hides it

--- a/apps/desktop/src/store.ts
+++ b/apps/desktop/src/store.ts
@@ -63,6 +63,27 @@ export async function clearDataAndRelaunch(electronSession: Session): Promise<vo
     relaunchApp();
 }
 
+/** A window rectangle in screen coordinates (x/y may be negative on a secondary display). */
+export interface WindowBounds {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+/**
+ * The persisted size/position/maximized state of the main window, restored on the next launch.
+ *
+ * `bounds` is always the last *normal* (non-maximized, non-fullscreen) rectangle so that
+ * un-maximizing lands at a sane size. Fullscreen is intentionally not persisted (see window-state.ts
+ * and element-web#32360). See element-web#32228. This replaces the unmaintained
+ * `electron-window-state` package.
+ */
+export interface PersistedWindowState {
+    bounds?: WindowBounds;
+    isMaximized?: boolean;
+}
+
 interface StoreData {
     warnBeforeExit: boolean;
     minimizeToTray: boolean;
@@ -80,6 +101,8 @@ interface StoreData {
     safeStorageBackendMigrate?: boolean;
     /** whether to open the app at login minimised, only valid when app.openAtLogin is true */
     openAtLoginMinimised: boolean;
+    /** the persisted main-window geometry restored on the next launch (#32228 / #32360) */
+    windowState?: PersistedWindowState;
 }
 
 /**
@@ -226,6 +249,24 @@ class Store extends ElectronStore<StoreData> {
                 openAtLoginMinimised: {
                     type: "boolean",
                     default: true,
+                },
+                windowState: {
+                    type: "object",
+                    properties: {
+                        bounds: {
+                            type: "object",
+                            properties: {
+                                x: { type: "number" },
+                                y: { type: "number" },
+                                width: { type: "number" },
+                                height: { type: "number" },
+                            },
+                            required: ["x", "y", "width", "height"],
+                            additionalProperties: false,
+                        },
+                        isMaximized: { type: "boolean" },
+                    },
+                    additionalProperties: false,
                 },
             },
         });

--- a/apps/desktop/src/window-state.test.ts
+++ b/apps/desktop/src/window-state.test.ts
@@ -1,0 +1,365 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { type BrowserWindow, type Display } from "electron";
+
+import {
+    boundsAreValid,
+    captureState,
+    DEFAULT_HEIGHT,
+    DEFAULT_WIDTH,
+    isVisibleOnSomeDisplay,
+    PERSIST_DEBOUNCE_MS,
+    resolveRestoreState,
+    WindowStateManager,
+    type WindowStateSource,
+} from "./window-state.js";
+import Store, { type PersistedWindowState } from "./store.js";
+
+vi.mock("./store.js", () => ({
+    default: { instance: { get: vi.fn(), set: vi.fn() } },
+}));
+
+// Build a fake Electron Display exposing just the workArea our helpers read.
+const display = (x: number, y: number, width: number, height: number): Display =>
+    ({ workArea: { x, y, width, height } }) as unknown as Display;
+
+// A single 1440x900 macOS-style display whose work area is inset 23px for the menu bar.
+const PRIMARY = display(0, 23, 1440, 877);
+
+// Build a fake window source for captureState / persist.
+const fakeWin = (opts: {
+    maximized?: boolean;
+    fullscreen?: boolean;
+    minimized?: boolean;
+    bounds?: { x: number; y: number; width: number; height: number };
+}): WindowStateSource => ({
+    isMaximized: () => opts.maximized ?? false,
+    isFullScreen: () => opts.fullscreen ?? false,
+    isMinimized: () => opts.minimized ?? false,
+    getBounds: () => opts.bounds ?? { x: 0, y: 0, width: 0, height: 0 },
+});
+
+describe("boundsAreValid", () => {
+    it("accepts an integer rectangle with positive dimensions (incl. negative x/y for a left-hand display)", () => {
+        expect(boundsAreValid({ x: 0, y: 0, width: 1024, height: 768 })).toBe(true);
+        expect(boundsAreValid({ x: -1920, y: -200, width: 800, height: 600 })).toBe(true);
+    });
+
+    it.each([
+        { x: 0, y: 0, width: 0, height: 768 },
+        { x: 0, y: 0, width: 1024, height: -1 },
+        { x: 0, y: 0, width: 800.5, height: 600 },
+        { x: 1.5, y: 0, width: 800, height: 600 },
+        { x: Number.NaN, y: 0, width: 800, height: 600 },
+        { x: 0, y: 0, width: Number.POSITIVE_INFINITY, height: 600 },
+    ])("rejects the non-integer / non-finite / non-positive rectangle %o", (bounds) => {
+        expect(boundsAreValid(bounds)).toBe(false);
+    });
+
+    it.each([undefined, null, {}, { x: 0, y: 0 }, "1024x768", 5, { x: "0", y: 0, width: 1, height: 1 }])(
+        "rejects the malformed value %o",
+        (value) => {
+            expect(boundsAreValid(value)).toBe(false);
+        },
+    );
+});
+
+describe("isVisibleOnSomeDisplay", () => {
+    it("accepts a window fully inside the primary work area", () => {
+        expect(isVisibleOnSomeDisplay({ x: 100, y: 100, width: 800, height: 600 }, [PRIMARY])).toBe(true);
+    });
+
+    it("accepts a window whose top sits under the menu bar (overlaps work area, not fully contained)", () => {
+        // y:0 is above the work area (which starts at 23) — the old strict-containment check reset this.
+        expect(isVisibleOnSomeDisplay({ x: 0, y: 0, width: 1440, height: 900 }, [PRIMARY])).toBe(true);
+    });
+
+    it("rejects a window entirely off-screen", () => {
+        expect(isVisibleOnSomeDisplay({ x: 5000, y: 5000, width: 800, height: 600 }, [PRIMARY])).toBe(false);
+    });
+
+    it("accepts a window dragged partly off the right edge while a usable chunk stays visible", () => {
+        // 300px of the 800px-wide window remains over the work area — comfortably grabbable.
+        expect(isVisibleOnSomeDisplay({ x: 1140, y: 100, width: 800, height: 600 }, [PRIMARY])).toBe(true);
+    });
+
+    it("rejects a window with only a sliver visible (less than the grabbable minimum)", () => {
+        // Only 40px peeks over the left edge — below the visibility threshold.
+        expect(isVisibleOnSomeDisplay({ x: -760, y: 100, width: 800, height: 600 }, [PRIMARY])).toBe(false);
+    });
+
+    // Pin the exact MIN_VISIBLE_PX = 100 threshold (workArea.x of PRIMARY is 0), so an off-by-one
+    // (>= vs >) or a moved constant is caught.
+    it("accepts a window with exactly the minimum horizontal overlap (100px)", () => {
+        // x:-700, width:800 -> overlap = (-700+800) - 0 = 100px exactly.
+        expect(isVisibleOnSomeDisplay({ x: -700, y: 100, width: 800, height: 600 }, [PRIMARY])).toBe(true);
+    });
+
+    it("rejects a window one pixel below the minimum horizontal overlap (99px)", () => {
+        expect(isVisibleOnSomeDisplay({ x: -701, y: 100, width: 800, height: 600 }, [PRIMARY])).toBe(false);
+    });
+
+    it("rejects a window one pixel below the minimum vertical overlap (99px)", () => {
+        // workArea.y is 23; a window ending at y=122 overlaps the work area by 99px vertically.
+        expect(isVisibleOnSomeDisplay({ x: 100, y: -478, width: 800, height: 600 }, [PRIMARY])).toBe(false);
+    });
+
+    it("accepts a window living on a secondary display to the left of the primary", () => {
+        const secondary = display(-1920, 0, 1920, 1080);
+        expect(isVisibleOnSomeDisplay({ x: -1800, y: 100, width: 800, height: 600 }, [PRIMARY, secondary])).toBe(true);
+    });
+
+    it("rejects when there are no displays at all", () => {
+        expect(isVisibleOnSomeDisplay({ x: 0, y: 23, width: 800, height: 600 }, [])).toBe(false);
+    });
+});
+
+describe("resolveRestoreState", () => {
+    it("restores valid, on-screen persisted bounds and the maximized flag verbatim", () => {
+        const persisted: PersistedWindowState = {
+            bounds: { x: 100, y: 100, width: 900, height: 700 },
+            isMaximized: true,
+        };
+        expect(resolveRestoreState(persisted, [PRIMARY])).toEqual({
+            bounds: { x: 100, y: 100, width: 900, height: 700 },
+            isMaximized: true,
+        });
+    });
+
+    it("falls back to the centred default size (no x/y) when nothing is persisted", () => {
+        const restore = resolveRestoreState(undefined, [PRIMARY]);
+        expect(restore.bounds).toEqual({ width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT });
+        expect(restore.bounds.x).toBeUndefined();
+        expect(restore.bounds.y).toBeUndefined();
+        expect(restore.isMaximized).toBe(false);
+    });
+
+    it("drops off-screen persisted bounds but preserves the maximized intent", () => {
+        const persisted: PersistedWindowState = {
+            bounds: { x: 6000, y: 6000, width: 900, height: 700 },
+            isMaximized: true,
+        };
+        const restore = resolveRestoreState(persisted, [PRIMARY]);
+        expect(restore.bounds).toEqual({ width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT });
+        expect(restore.isMaximized).toBe(true);
+    });
+
+    it("ignores corrupt bounds (zero width) and uses the default size", () => {
+        const persisted: PersistedWindowState = { bounds: { x: 0, y: 0, width: 0, height: 700 } };
+        expect(resolveRestoreState(persisted, [PRIMARY]).bounds).toEqual({
+            width: DEFAULT_WIDTH,
+            height: DEFAULT_HEIGHT,
+        });
+    });
+
+    it("never carries a fullscreen flag, so the app can never auto-start fullscreen (#32360)", () => {
+        // Capturing a fullscreen window must not produce anything that re-enters fullscreen on launch.
+        const captured = captureState(fakeWin({ fullscreen: true, bounds: { x: 0, y: 0, width: 1440, height: 900 } }), {
+            bounds: { x: 50, y: 50, width: 800, height: 600 },
+        });
+        expect(captured).not.toHaveProperty("isFullScreen");
+
+        const restore = resolveRestoreState(captured, [PRIMARY]);
+        expect(restore).not.toHaveProperty("isFullScreen");
+    });
+});
+
+describe("captureState", () => {
+    const previous: PersistedWindowState = { bounds: { x: 10, y: 20, width: 800, height: 600 }, isMaximized: false };
+
+    it("records the live bounds and clears maximized for a normal window", () => {
+        const win = fakeWin({ bounds: { x: 30, y: 40, width: 1000, height: 700 } });
+        expect(captureState(win, previous)).toEqual({
+            bounds: { x: 30, y: 40, width: 1000, height: 700 },
+            isMaximized: false,
+        });
+    });
+
+    it("keeps the previous normal bounds when the window is maximized", () => {
+        const win = fakeWin({ maximized: true, bounds: { x: 0, y: 0, width: 1440, height: 900 } });
+        expect(captureState(win, previous)).toEqual({
+            bounds: { x: 10, y: 20, width: 800, height: 600 },
+            isMaximized: true,
+        });
+    });
+
+    it("keeps the previous normal bounds when the window is fullscreen and does not remember fullscreen", () => {
+        const win = fakeWin({ fullscreen: true, bounds: { x: 0, y: 0, width: 1440, height: 900 } });
+        expect(captureState(win, previous)).toEqual({
+            bounds: { x: 10, y: 20, width: 800, height: 600 },
+            isMaximized: false,
+        });
+    });
+
+    it("returns the previous state untouched while minimized (geometry is unreliable)", () => {
+        const win = fakeWin({ minimized: true, bounds: { x: -8, y: -8, width: 0, height: 0 } });
+        expect(captureState(win, previous)).toBe(previous);
+    });
+
+    it("leaves bounds undefined when maximized on first run with no previous bounds", () => {
+        const win = fakeWin({ maximized: true, bounds: { x: 0, y: 0, width: 1440, height: 900 } });
+        expect(captureState(win, {})).toEqual({ bounds: undefined, isMaximized: true });
+    });
+});
+
+describe("WindowStateManager", () => {
+    const storeGet = vi.mocked(Store.instance!.get);
+    const storeSet = vi.mocked(Store.instance!.set);
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        storeGet.mockReturnValue(undefined);
+    });
+
+    it("reads the persisted window state from the store on construction", () => {
+        const saved: PersistedWindowState = { bounds: { x: 1, y: 2, width: 800, height: 600 } };
+        storeGet.mockReturnValue(saved);
+
+        const manager = new WindowStateManager();
+        expect(storeGet).toHaveBeenCalledWith("windowState");
+        expect(manager.getRestoreState([PRIMARY]).bounds).toEqual({ x: 1, y: 2, width: 800, height: 600 });
+    });
+
+    it("falls back to defaults when the store is empty", () => {
+        const manager = new WindowStateManager();
+        expect(manager.getRestoreState([PRIMARY]).bounds).toEqual({ width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT });
+    });
+
+    it("persists the captured state through the store", () => {
+        const manager = new WindowStateManager();
+        manager.persist(fakeWin({ bounds: { x: 30, y: 40, width: 1000, height: 700 } }));
+
+        expect(storeSet).toHaveBeenCalledWith("windowState", {
+            bounds: { x: 30, y: 40, width: 1000, height: 700 },
+            isMaximized: false,
+        });
+    });
+
+    it("retains the last normal bounds across a later maximized capture", () => {
+        const manager = new WindowStateManager();
+        manager.persist(fakeWin({ bounds: { x: 30, y: 40, width: 1000, height: 700 } }));
+        manager.persist(fakeWin({ maximized: true, bounds: { x: 0, y: 0, width: 1440, height: 900 } }));
+
+        expect(storeSet).toHaveBeenLastCalledWith("windowState", {
+            bounds: { x: 30, y: 40, width: 1000, height: 700 },
+            isMaximized: true,
+        });
+    });
+
+    it("does not throw or persist when capturing a window that has already been destroyed", () => {
+        const manager = new WindowStateManager();
+        const thrower = (): never => {
+            throw new Error("Object has been destroyed");
+        };
+        const destroyed = {
+            isMinimized: thrower,
+            isMaximized: thrower,
+            isFullScreen: thrower,
+            getBounds: thrower,
+        } as unknown as WindowStateSource;
+
+        expect(() => manager.persist(destroyed)).not.toThrow();
+        expect(storeSet).not.toHaveBeenCalled();
+    });
+
+    describe("monitor", () => {
+        const buildWin = (): {
+            win: BrowserWindow;
+            handlers: Record<string, () => void>;
+            setFullscreen: (v: boolean) => void;
+            setBounds: (b: { x: number; y: number; width: number; height: number }) => void;
+        } => {
+            const handlers: Record<string, () => void> = {};
+            let fullscreen = false;
+            let bounds = { x: 1, y: 2, width: 800, height: 600 };
+            const win = {
+                on: vi.fn((event: string, cb: () => void) => {
+                    handlers[event] = cb;
+                }),
+                isMaximized: () => false,
+                isFullScreen: () => fullscreen,
+                isMinimized: () => false,
+                getBounds: () => bounds,
+            } as unknown as BrowserWindow;
+            return {
+                win,
+                handlers,
+                setFullscreen: (v): void => {
+                    fullscreen = v;
+                },
+                setBounds: (b): void => {
+                    bounds = b;
+                },
+            };
+        };
+
+        it("subscribes to every geometry/state transition plus window teardown", () => {
+            const { win } = buildWin();
+            new WindowStateManager().monitor(win);
+            for (const event of ["resize", "move", "maximize", "unmaximize", "leave-full-screen", "closed"]) {
+                expect(win.on).toHaveBeenCalledWith(event, expect.any(Function));
+            }
+        });
+
+        it("persists the restored windowed bounds when leaving fullscreen (reads the live window)", () => {
+            const { win, handlers, setFullscreen, setBounds } = buildWin();
+            new WindowStateManager().monitor(win);
+
+            // Leaving fullscreen returns the window to its windowed bounds; the handler must read those.
+            setFullscreen(false);
+            setBounds({ x: 7, y: 8, width: 900, height: 650 });
+            handlers["leave-full-screen"]();
+
+            expect(storeSet).toHaveBeenLastCalledWith("windowState", {
+                bounds: { x: 7, y: 8, width: 900, height: 650 },
+                isMaximized: false,
+            });
+        });
+
+        it("coalesces a burst of resize/move events into a single persist, then re-arms", () => {
+            vi.useFakeTimers();
+            try {
+                const { win, handlers } = buildWin();
+                new WindowStateManager().monitor(win);
+
+                handlers["move"]();
+                vi.advanceTimersByTime(PERSIST_DEBOUNCE_MS - 1);
+                handlers["resize"](); // resets the timer — proves clearTimeout coalescing
+                handlers["move"]();
+                vi.advanceTimersByTime(PERSIST_DEBOUNCE_MS - 1);
+                expect(storeSet).not.toHaveBeenCalled(); // still within the debounce of the last event
+
+                vi.advanceTimersByTime(1);
+                expect(storeSet).toHaveBeenCalledTimes(1); // ONE write for the whole burst
+
+                handlers["move"](); // re-arm after a flush
+                vi.advanceTimersByTime(PERSIST_DEBOUNCE_MS);
+                expect(storeSet).toHaveBeenCalledTimes(2);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("cancels a pending debounced persist once the window is closed", () => {
+            vi.useFakeTimers();
+            try {
+                const { win, handlers } = buildWin();
+                new WindowStateManager().monitor(win);
+
+                handlers["move"](); // schedule a debounced persist
+                handlers["closed"](); // window torn down — must cancel it
+                vi.advanceTimersByTime(PERSIST_DEBOUNCE_MS * 2);
+
+                expect(storeSet).not.toHaveBeenCalled();
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+    });
+});

--- a/apps/desktop/src/window-state.ts
+++ b/apps/desktop/src/window-state.ts
@@ -1,0 +1,185 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { type BrowserWindow, type Display } from "electron";
+
+import Store, { type PersistedWindowState, type WindowBounds } from "./store.js";
+
+/**
+ * Remembers the main window's size, position, and maximized state across launches.
+ *
+ * This is an in-repo replacement for the unmaintained `electron-window-state` package (last
+ * released 2018), which on macOS only ever flushed state on the BrowserWindow `closed` event.
+ * Element hides-on-close on macOS (`event.preventDefault()` — the window is never destroyed), so
+ * `closed` never fires and geometry was lost on any crash/force-quit (element-web#32228). The
+ * replacement instead persists through the existing `electron-store`-backed {@link Store} (atomic,
+ * durable writes) on every relevant window event, so the saved state always reflects reality.
+ *
+ * Fullscreen is deliberately **not** restored. The old library re-applied a persisted
+ * `isFullScreen` flag on launch, which became sticky (Element quits without un-fullscreening, and
+ * on Linux tiling WMs `isFullScreen()` is a false positive) and is the "always starts in
+ * fullscreen" bug (element-web#32360). Like VS Code (`window.restoreFullscreen` defaults to false)
+ * we only restore size/position/maximized, so the app never auto-enters fullscreen on launch.
+ */
+
+/** The default window size used on first launch and when persisted bounds are unusable. */
+export const DEFAULT_WIDTH = 1024;
+export const DEFAULT_HEIGHT = 768;
+
+/** How much of the window (in px, each axis) must overlap a display's work area to count as visible. */
+const MIN_VISIBLE_PX = 100;
+
+/** Debounce applied to the high-frequency `resize`/`move` events before persisting. */
+export const PERSIST_DEBOUNCE_MS = 250;
+
+/** The subset of {@link BrowserWindow} we read when capturing state (also satisfied by test fakes). */
+export interface WindowStateSource {
+    isMaximized(): boolean;
+    isFullScreen(): boolean;
+    isMinimized(): boolean;
+    getBounds(): WindowBounds;
+}
+
+/** The state handed to the {@link BrowserWindow} constructor and applied on `ready-to-show`. */
+export interface RestoreState {
+    /** `x`/`y` are omitted when there is nothing valid to restore, so Electron centres the window. */
+    bounds: { x?: number; y?: number; width: number; height: number };
+    isMaximized: boolean;
+}
+
+/** Validates that an untrusted value is a usable window rectangle (finite integers, positive dimensions). */
+export function boundsAreValid(bounds: unknown): bounds is WindowBounds {
+    if (typeof bounds !== "object" || bounds === null) return false;
+    const { x, y, width, height } = bounds as Record<string, unknown>;
+    return (
+        Number.isInteger(x) &&
+        Number.isInteger(y) &&
+        Number.isInteger(width) &&
+        Number.isInteger(height) &&
+        (width as number) > 0 &&
+        (height as number) > 0
+    );
+}
+
+/**
+ * Whether a usable chunk of the rectangle overlaps the *work area* of at least one display.
+ *
+ * Uses work area (not full display bounds) and an overlap test (not full containment) so a window
+ * tucked under the macOS menu bar/notch, or dragged a little off an edge, is preserved rather than
+ * reset — while a window stranded on a now-disconnected monitor still falls back to defaults.
+ */
+export function isVisibleOnSomeDisplay(bounds: WindowBounds, displays: Display[]): boolean {
+    return displays.some((display) => {
+        const { workArea } = display;
+        const overlapWidth =
+            Math.min(bounds.x + bounds.width, workArea.x + workArea.width) - Math.max(bounds.x, workArea.x);
+        const overlapHeight =
+            Math.min(bounds.y + bounds.height, workArea.y + workArea.height) - Math.max(bounds.y, workArea.y);
+        return overlapWidth >= MIN_VISIBLE_PX && overlapHeight >= MIN_VISIBLE_PX;
+    });
+}
+
+/**
+ * Resolves the persisted state into the geometry to create the window with.
+ *
+ * Valid, on-screen bounds are restored verbatim; otherwise the default size is used (centred, by
+ * omitting x/y). The maximized intent is always preserved — even when the normal bounds have to be
+ * dropped — so the window restores maximized with a sane underlying size.
+ */
+export function resolveRestoreState(persisted: PersistedWindowState | undefined, displays: Display[]): RestoreState {
+    const isMaximized = persisted?.isMaximized === true;
+
+    const saved = persisted?.bounds;
+    if (saved && boundsAreValid(saved) && isVisibleOnSomeDisplay(saved, displays)) {
+        return { bounds: { x: saved.x, y: saved.y, width: saved.width, height: saved.height }, isMaximized };
+    }
+    return { bounds: { width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT }, isMaximized };
+}
+
+/**
+ * Captures the current window state for persistence.
+ *
+ * The normal (windowed) bounds are only overwritten when the window is in a normal state, so the
+ * last sensible size survives a capture taken while maximized or fullscreen. Fullscreen is detected
+ * only to avoid persisting the fullscreen rectangle as the windowed size — it is never itself
+ * persisted (see the module docstring / #32360). While minimized the geometry is unreliable, so the
+ * previous state is returned untouched.
+ */
+export function captureState(win: WindowStateSource, previous: PersistedWindowState): PersistedWindowState {
+    if (win.isMinimized()) return previous;
+
+    const isMaximized = win.isMaximized();
+    let bounds = previous.bounds;
+    if (!isMaximized && !win.isFullScreen()) {
+        const live = win.getBounds();
+        bounds = { x: live.x, y: live.y, width: live.width, height: live.height };
+    }
+    return { bounds, isMaximized };
+}
+
+/**
+ * Tracks and persists the main window's geometry. Mirrors the {@link import('./auto-launch.js')}
+ * pattern: a thin class over a pure core plus the {@link Store} seam, so the logic is unit-testable
+ * without a live window.
+ */
+export class WindowStateManager {
+    private state: PersistedWindowState;
+    private persistTimer?: ReturnType<typeof setTimeout>;
+
+    public constructor() {
+        this.state = Store.instance?.get("windowState") ?? {};
+    }
+
+    /** The geometry to create the window with, clamped to the currently-connected displays. */
+    public getRestoreState(displays: Display[]): RestoreState {
+        return resolveRestoreState(this.state, displays);
+    }
+
+    /**
+     * Capture the window's current state and persist it durably through the store. Reading a
+     * window that has already been torn down throws ("Object has been destroyed"); that is
+     * swallowed so a late timer or a teardown-time flush is a no-op rather than a crash.
+     */
+    public persist(win: WindowStateSource): void {
+        let next: PersistedWindowState;
+        try {
+            next = captureState(win, this.state);
+        } catch {
+            return;
+        }
+        this.state = next;
+        Store.instance?.set("windowState", this.state);
+    }
+
+    private cancelPendingPersist(): void {
+        if (this.persistTimer) {
+            clearTimeout(this.persistTimer);
+            this.persistTimer = undefined;
+        }
+    }
+
+    /**
+     * Subscribe to the window events that change persisted state. High-frequency `resize`/`move`
+     * are debounced (coalesced into one write); discrete maximize/un-maximize and the return from
+     * fullscreen persist immediately. The pending debounce is cancelled on `closed` so a stale
+     * timer never fires against a destroyed window.
+     */
+    public monitor(win: BrowserWindow): void {
+        const schedule = (): void => {
+            this.cancelPendingPersist();
+            this.persistTimer = setTimeout(() => this.persist(win), PERSIST_DEBOUNCE_MS);
+        };
+        const persistNow = (): void => this.persist(win);
+
+        win.on("resize", schedule);
+        win.on("move", schedule);
+        win.on("maximize", persistNow);
+        win.on("unmaximize", persistNow);
+        win.on("leave-full-screen", persistNow);
+        win.on("closed", () => this.cancelPendingPersist());
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,9 +380,6 @@ importers:
       electron-store:
         specifier: ^11.0.0
         version: 11.0.2
-      electron-window-state:
-        specifier: ^5.0.3
-        version: 5.0.3
       minimist:
         specifier: ^1.2.6
         version: 1.2.8
@@ -8509,10 +8506,6 @@ packages:
 
   electron-to-chromium@1.5.332:
     resolution: {integrity: sha512-7OOtytmh/rINMLwaFTbcMVvYXO3AUm029X0LcyfYk0B557RlPkdpTpnH9+htMlfu5dKwOmT0+Zs2Aw+lnn6TeQ==}
-
-  electron-window-state@5.0.3:
-    resolution: {integrity: sha512-1mNTwCfkolXl3kMf50yW3vE2lZj0y92P/HYWFBrb+v2S/pCka5mdwN3cagKm458A7NjndSwijynXgcLWRodsVg==}
-    engines: {node: '>=8.0.0'}
 
   electron-winstaller@5.4.0:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
@@ -21858,11 +21851,6 @@ snapshots:
       type-fest: 5.5.0
 
   electron-to-chromium@1.5.332: {}
-
-  electron-window-state@5.0.3:
-    dependencies:
-      jsonfile: 4.0.0
-      mkdirp: 0.5.6
 
   electron-winstaller@5.4.0:
     dependencies:


### PR DESCRIPTION
### Problem

The desktop window did not reliably restore its previous size and position, and could relaunch
into **fullscreen** even when the user had left it windowed (#32228, #32360). This was handled by
the unmaintained `electron-window-state` package, which persists to its own JSON file and re-applies
a stored fullscreen rectangle on launch.

### Fix

Replace `electron-window-state` with an in-repo `WindowStateManager`:

- Persists size / position / **maximized** state durably through the existing `electron-store`-backed
  `Store` (atomic, alongside the rest of the app's state) instead of a separate JSON file.
- **Clamps** restored bounds to the displays currently connected, so a window stranded on a
  now-disconnected monitor falls back to sensible defaults instead of opening off-screen.
- Deliberately **never restores fullscreen** (only the last *normal* rectangle is persisted), so the
  app never auto-starts fullscreen (#32360).
- Flushes geometry on `close` and before `app.exit()` — including the macOS hide-on-close path where
  `closed` never fires — and debounces high-frequency `resize`/`move` events.

This drops the `electron-window-state` dependency.

### Tests

`window-state.test.ts` (Vitest, 43 passing) covers bounds persistence, restore + display clamping
(including disconnected-monitor fallback), the maximized round-trip, the no-fullscreen rule, and the
debounce/flush behaviour.

Fixes #32228
Fixes #32360

Notes: Reliably restores the desktop window's size/position/maximized state (clamped to connected displays) and no longer auto-starts fullscreen, replacing the unmaintained electron-window-state package.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
