### PR TITLE
Default the Ctrl/Cmd+F search shortcut to in-room search on desktop

### DIFF
--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -3030,6 +3030,7 @@
         "use_12_hour_format": "Show timestamps in 12 hour format (e.g. 2:30pm)",
         "use_command_enter_send_message": "Use Command + Enter to send a message",
         "use_command_f_search": "Use Command + F to search timeline",
+        "use_command_f_search_description": "When enabled, the search shortcut opens in-room message search instead of your browser's find-on-page. Searching encrypted rooms requires the desktop app with message search enabled.",
         "use_control_enter_send_message": "Use Ctrl + Enter to send a message",
         "use_control_f_search": "Use Ctrl + F to search timeline",
         "voip": {

--- a/apps/web/src/settings/Settings.tsx
+++ b/apps/web/src/settings/Settings.tsx
@@ -25,7 +25,7 @@ import FontSizeController from "./controllers/FontSizeController";
 import SystemFontController from "./controllers/SystemFontController";
 import { SettingLevel } from "./SettingLevel";
 import type SettingController from "./controllers/SettingController";
-import { IS_MAC } from "../Keyboard";
+import { IS_MAC, IS_ELECTRON } from "../Keyboard";
 import UIFeatureController from "./controllers/UIFeatureController";
 import { UIFeature } from "./UIFeature";
 import { Layout } from "./enums/Layout";
@@ -952,7 +952,11 @@ export const SETTINGS: Settings = {
     "ctrlFForSearch": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         displayName: IS_MAC ? _td("settings|use_command_f_search") : _td("settings|use_control_f_search"),
-        default: false,
+        description: _td("settings|use_command_f_search_description"),
+        // Default the in-room search shortcut on for the desktop app, where Seshat makes
+        // encrypted-room search work and there is no browser "find on page" to override. Web
+        // stays opt-in so the browser's native find bar is preserved (see element-web #24359/#33360).
+        default: !!IS_ELECTRON,
     },
     "MessageComposerInput.ctrlEnterToSend": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,

--- a/apps/web/test/unit-tests/KeyBindingsDefaults-test.ts
+++ b/apps/web/test/unit-tests/KeyBindingsDefaults-test.ts
@@ -1,0 +1,36 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { defaultBindingsProvider } from "../../src/KeyBindingsDefaults";
+import SettingsStore from "../../src/settings/SettingsStore";
+import { KeyBindingAction } from "../../src/accessibility/KeyboardShortcuts";
+import { type KeyBinding } from "../../src/KeyBindingsManager";
+import { Key } from "../../src/Keyboard";
+
+const searchBinding = (bindings: KeyBinding[]): KeyBinding | undefined =>
+    bindings.find((b) => b.action === KeyBindingAction.SearchInRoom);
+
+describe("defaultBindingsProvider.getRoomBindings", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("registers the Ctrl/Cmd+F room-search binding when ctrlFForSearch is enabled", () => {
+        jest.spyOn(SettingsStore, "getValue").mockImplementation((name) => name === "ctrlFForSearch");
+
+        const binding = searchBinding(defaultBindingsProvider.getRoomBindings());
+
+        expect(binding).toBeDefined();
+        expect(binding!.keyCombo).toEqual({ key: Key.F, ctrlOrCmdKey: true });
+    });
+
+    it("omits the room-search binding when ctrlFForSearch is disabled", () => {
+        jest.spyOn(SettingsStore, "getValue").mockReturnValue(false);
+
+        expect(searchBinding(defaultBindingsProvider.getRoomBindings())).toBeUndefined();
+    });
+});

--- a/apps/web/test/unit-tests/components/views/settings/tabs/user/__snapshots__/PreferencesUserSettingsTab-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/settings/tabs/user/__snapshots__/PreferencesUserSettingsTab-test.tsx.snap
@@ -246,6 +246,12 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                     >
                       Use Ctrl + F to search timeline
                     </label>
+                    <span
+                      class="_message_1o4d9_86 _help-message_1o4d9_92"
+                      id="radix-react-use-id-2"
+                    >
+                      When enabled, the search shortcut opens in-room message search instead of your browser's find-on-page. Searching encrypted rooms requires the desktop app with message search enabled.
+                    </span>
                   </div>
                 </div>
               </div>
@@ -403,7 +409,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                     </label>
                     <span
                       class="_message_1o4d9_86 _help-message_1o4d9_92"
-                      id="radix-react-use-id-2"
+                      id="radix-react-use-id-3"
                     >
                       Requires your server to support MSC4133
                     </span>
@@ -472,7 +478,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                     </label>
                     <span
                       class="_message_1o4d9_86 _help-message_1o4d9_92"
-                      id="radix-react-use-id-3"
+                      id="radix-react-use-id-4"
                     >
                       Your server doesn't support disabling sending read receipts.
                     </span>
@@ -597,7 +603,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                     </label>
                     <span
                       class="_message_1o4d9_86 _help-message_1o4d9_92"
-                      id="radix-react-use-id-4"
+                      id="radix-react-use-id-5"
                     >
                       <span>
                         Start messages with 
@@ -1484,7 +1490,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                     >
                       <input
                         class="_input_udcm8_24"
-                        id="react-use-id-5"
+                        id="react-use-id-6"
                         role="switch"
                         type="checkbox"
                       />
@@ -1498,7 +1504,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   >
                     <label
                       class="_label_1o4d9_60"
-                      for="react-use-id-5"
+                      for="react-use-id-6"
                     >
                       Hide avatars of room and inviter
                     </label>
@@ -1512,13 +1518,13 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                 >
                   <label
                     class="_label_1o4d9_60"
-                    for="radix-react-use-id-6"
+                    for="radix-react-use-id-7"
                   >
                     Show media in timeline
                   </label>
                   <span
                     class="_message_1o4d9_86 _help-message_1o4d9_92 mx_MediaPreviewAccountSetting_RadioHelp"
-                    id="radix-react-use-id-7"
+                    id="radix-react-use-id-8"
                   >
                     A hidden media can always be shown by tapping on it
                   </span>
@@ -1631,7 +1637,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                         checked=""
                         class="_input_udcm8_24"
                         disabled=""
-                        id="react-use-id-8"
+                        id="react-use-id-9"
                         role="switch"
                         type="checkbox"
                       />
@@ -1645,13 +1651,13 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   >
                     <label
                       class="_label_1o4d9_60"
-                      for="react-use-id-8"
+                      for="react-use-id-9"
                     >
                       Allow users to invite you to rooms
                     </label>
                     <span
                       class="_message_1o4d9_86 _help-message_1o4d9_92"
-                      id="radix-react-use-id-9"
+                      id="radix-react-use-id-10"
                     >
                       Your server does not implement this feature.
                     </span>


### PR DESCRIPTION
### Problem

The `ctrlFForSearch` setting (Ctrl/Cmd+F opens in-room message search instead of the
browser's find-on-page) shipped **off by default for everyone** and with no description,
so the shortcut most users expect to search the conversation did nothing useful out of the
box. On the desktop app there is no browser "find on page" for it to clash with, and Seshat
makes encrypted-room search work, so defaulting it off there is a missed default. On web the
opposite is true — overriding the browser's native Ctrl+F is surprising. The setting therefore
wants different defaults on the two platforms (#24359), and a description so users understand
what it does (#22888).

### Fix

- Default `ctrlFForSearch` to **on for the desktop app** (`!!IS_ELECTRON`) and keep it **off on
  web**, so the desktop app searches the room by default while web preserves the browser's
  native find bar.
- Add a `description` to the setting explaining what the shortcut does and that encrypted-room
  search needs the desktop app with message search enabled.

No new UI surface — this is a default + copy change on the existing setting, confined to
`Settings.tsx` and the i18n string. The settings-tab snapshot is regenerated to include the
new description.

### Tests

- New `KeyBindingsDefaults-test.ts`: the Ctrl/Cmd+F room-search keybinding is registered when
  `ctrlFForSearch` is enabled and omitted when it is disabled.
- `PreferencesUserSettingsTab` snapshot updated for the added description.

Fixes #22888
Relates to #24359

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
