### PR TITLE
Sort in-room message search by relevance or recency

### DIFF
--- a/apps/web/res/css/views/right_panel/_RoomSummaryCard.pcss
+++ b/apps/web/res/css/views/right_panel/_RoomSummaryCard.pcss
@@ -97,6 +97,11 @@ Please see LICENSE files in the repository root for full details.
     }
 }
 
+/* Let the search input keep shrinking when the sender-filter button sits beside it in the search header. */
+.mx_RoomSummaryCard_searchInput {
+    min-width: 0;
+}
+
 .mx_RoomSummaryCard_roomName {
     margin: $spacing-12 0 $spacing-4;
 }

--- a/apps/web/res/css/views/rooms/_EventBubbleTile.pcss
+++ b/apps/web/res/css/views/rooms/_EventBubbleTile.pcss
@@ -95,7 +95,10 @@ Please see LICENSE files in the repository root for full details.
     }
 
     &:hover,
-    &.mx_EventTile_selected {
+    &.mx_EventTile_selected,
+    /* Focused search-stepping match: give the bubble the same subtle band as the
+       selected/hover state so the active match is distinguishable in bubble layout too. */
+    &.mx_EventTile_searchHighlightActive {
         &::before {
             background: $eventbubble-bg-hover;
         }

--- a/apps/web/res/css/views/rooms/_EventTile.pcss
+++ b/apps/web/res/css/views/rooms/_EventTile.pcss
@@ -196,7 +196,11 @@ $left-gutter: 64px;
         &:focus-visible:focus-within,
         &.mx_EventTile_actionBarFocused,
         &.mx_EventTile_isEditing,
-        &.mx_EventTile_selected {
+        &.mx_EventTile_selected,
+        /* The live tile currently focused while stepping search matches reuses the
+           subtle "selected" background + the accent stroke below, so it stands out from a hovered tile
+           and from the mention/keyword highlight while the match stays focused. */
+        &.mx_EventTile_searchHighlightActive {
             .mx_EventTile_line {
                 background-color: $event-selected-color;
             }
@@ -204,7 +208,8 @@ $left-gutter: 64px;
 
         /* this is used for the tile for the event which is selected via the URL. */
         &.mx_EventTile_isEditing,
-        &.mx_EventTile_selected {
+        &.mx_EventTile_selected,
+        &.mx_EventTile_searchHighlightActive {
             > .mx_EventTile_line {
                 /* TODO: ultimately we probably want some transition on here. */
                 box-shadow: inset var(--EventTile-box-shadow-offset-x) 0 0 var(--EventTile-box-shadow-spread-radius)

--- a/apps/web/src/Searching.ts
+++ b/apps/web/src/Searching.ts
@@ -25,17 +25,50 @@ import { isNotUndefined } from "./Typeguards";
 
 const SEARCH_LIMIT = 10;
 
+// When a `from:`/sender filter is active the Seshat (local) leg cannot filter by sender at query time
+// (its ISearchArgs has no sender field), so we post-filter the returned page client-side. A page of only
+// SEARCH_LIMIT raw results could shrink to zero after dropping other senders, so we over-fetch from Seshat
+// to give the post-filter enough candidates to still fill a page. The homeserver leg filters natively via
+// IRoomEventFilter.senders and needs no over-fetch.
+const SESHAT_SENDER_OVERFETCH_LIMIT = SEARCH_LIMIT * 5;
+
+/**
+ * Drop Seshat results whose matched event was not sent by one of the selected senders, in place.
+ *
+ * The homeserver `/search` leg filters by sender natively (IRoomEventFilter.senders); the local Seshat
+ * leg cannot, so we filter the raw response client-side before it is merged/paginated. Filtering at the
+ * raw `IResultRoomEvents` level (matching `result.result.sender`, a full MXID) keeps the merge math in one
+ * place. A no-op when `senders` is empty.
+ *
+ * `localResult.count` is deliberately left untouched: Seshat reports it as the term-only match total across all
+ * pages, whereas the post-filter only sees the current (over-fetched) page, so it cannot be turned into an exact
+ * sender-filtered total here. The header summary already treats this count as a backend estimate distinct from the
+ * exact "k of N loaded" stepper, so the Seshat leg keeps that same estimate semantics.
+ */
+function filterSeshatResultsBySender(localResult: IResultRoomEvents | undefined, senders?: string[]): void {
+    if (!localResult?.results || !senders || senders.length === 0) return;
+    const allowed = new Set(senders);
+    localResult.results = localResult.results.filter((r) => allowed.has(r.result.sender));
+}
+
 async function serverSideSearch(
     client: MatrixClient,
     term: string,
     roomId?: string,
     abortSignal?: AbortSignal,
+    senders?: string[],
 ): Promise<{ response: ISearchResponse; query: ISearchRequestBody }> {
     const filter: IRoomEventFilter = {
         limit: SEARCH_LIMIT,
     };
 
     if (roomId !== undefined) filter.rooms = [roomId];
+
+    // Scope to the given senders (the `from:` filter). The homeserver applies this natively; it is independent of
+    // `rooms`, so an all-rooms search narrows by sender alone. The filter rides inside `body` below, which is stored
+    // as `_query` and replayed on every paginated request, so server-side pagination keeps the sender scope with no
+    // extra work.
+    if (senders && senders.length > 0) filter.senders = senders;
 
     const body: ISearchRequestBody = {
         search_categories: {
@@ -62,8 +95,9 @@ async function serverSideSearchProcess(
     term: string,
     roomId?: string,
     abortSignal?: AbortSignal,
+    senders?: string[],
 ): Promise<ISearchResults> {
-    const result = await serverSideSearch(client, term, roomId, abortSignal);
+    const result = await serverSideSearch(client, term, roomId, abortSignal, senders);
 
     // The js-sdk method backPaginateRoomEventsSearch() uses _query internally
     // so we're reusing the concept here since we want to delegate the
@@ -92,11 +126,12 @@ async function combinedSearch(
     client: MatrixClient,
     searchTerm: string,
     abortSignal?: AbortSignal,
+    senders?: string[],
 ): Promise<ISearchResults> {
     // Create two promises, one for the local search, one for the
     // server-side search.
-    const serverSidePromise = serverSideSearch(client, searchTerm, undefined, abortSignal);
-    const localPromise = localSearch(searchTerm);
+    const serverSidePromise = serverSideSearch(client, searchTerm, undefined, abortSignal, senders);
+    const localPromise = localSearch(searchTerm, undefined, senders);
 
     // Wait for both promises to resolve.
     await Promise.all([serverSidePromise, localPromise]);
@@ -130,6 +165,9 @@ async function combinedSearch(
         oldestEventFrom: "server",
         results: [],
         highlights: [],
+        // Remember the sender filter so combinedPagination can re-apply the post-filter to later Seshat pages
+        // (the server leg keeps it via the stored _query).
+        senderFilter: senders,
     };
 
     // Combine our results.
@@ -153,15 +191,18 @@ async function combinedSearch(
 async function localSearch(
     searchTerm: string,
     roomId?: string,
-    processResult = true,
+    senders?: string[],
 ): Promise<{ response: IResultRoomEvents; query: ISearchArgs }> {
     const eventIndex = EventIndexPeg.get();
 
+    const hasSenderFilter = !!senders && senders.length > 0;
     const searchArgs: ISearchArgs = {
         search_term: searchTerm,
         before_limit: 1,
         after_limit: 1,
-        limit: SEARCH_LIMIT,
+        // Over-fetch when a sender filter is active so the client-side post-filter still has enough candidates to
+        // fill a page; Seshat has no native sender filter.
+        limit: hasSenderFilter ? SESHAT_SENDER_OVERFETCH_LIMIT : SEARCH_LIMIT,
         order_by_recency: true,
         room_id: undefined,
     };
@@ -195,6 +236,9 @@ async function localSearch(
         }
     }
 
+    // Apply the `from:`/sender filter Seshat cannot do at query time.
+    filterSeshatResultsBySender(localResult, senders);
+
     searchArgs.next_batch = localResult.next_batch;
 
     const result = {
@@ -210,21 +254,27 @@ export interface ISeshatSearchResults extends ISearchResults {
     cachedEvents?: ISearchResult[];
     oldestEventFrom?: "local" | "server";
     serverSideNextBatch?: string;
+    // The active `from:`/sender filter (full MXIDs), carried so each Seshat pagination page can re-apply the
+    // client-side post-filter Seshat cannot do at query time. The homeserver leg keeps the filter via the stored
+    // `_query` body and needs no carry here.
+    senderFilter?: string[];
 }
 
 async function localSearchProcess(
     client: MatrixClient,
     searchTerm: string,
     roomId?: string,
+    senders?: string[],
 ): Promise<ISeshatSearchResults> {
     const emptyResult = {
         results: [],
         highlights: [],
+        senderFilter: senders,
     } as ISeshatSearchResults;
 
     if (searchTerm === "") return emptyResult;
 
-    const result = await localSearch(searchTerm, roomId);
+    const result = await localSearch(searchTerm, roomId, senders);
 
     emptyResult.seshatQuery = result.query;
 
@@ -255,6 +305,10 @@ async function localPagination(
     if (!localResult) {
         throw new Error("Local search pagination failed");
     }
+
+    // Re-apply the `from:`/sender post-filter to this page; the over-fetch limit is already baked into the stored
+    // seshatQuery.
+    filterSeshatResultsBySender(localResult, searchResult.senderFilter);
 
     searchResult.seshatQuery.next_batch = localResult.next_batch;
 
@@ -581,6 +635,9 @@ async function combinedPagination(
     // the local indexes turn or the server has exhausted its results.
     if (searchArgs?.next_batch && (!searchResult.serverSideNextBatch || oldestEventFrom === "server")) {
         localResult = await eventIndex!.search(searchArgs);
+        // Re-apply the `from:`/sender post-filter to this Seshat page; the server leg keeps the filter natively
+        // via the stored _query body.
+        filterSeshatResultsBySender(localResult, searchResult.senderFilter);
     }
 
     // Fetch events from the server if we have a token for it and if it's the
@@ -621,6 +678,7 @@ async function eventIndexSearch(
     term: string,
     roomId?: string,
     abortSignal?: AbortSignal,
+    senders?: string[],
 ): Promise<ISearchResults> {
     let searchPromise: Promise<ISearchResults>;
 
@@ -628,16 +686,16 @@ async function eventIndexSearch(
         if (await client.getCrypto()?.isEncryptionEnabledInRoom(roomId)) {
             // The search is for a single encrypted room, use our local
             // search method.
-            searchPromise = localSearchProcess(client, term, roomId);
+            searchPromise = localSearchProcess(client, term, roomId, senders);
         } else {
             // The search is for a single non-encrypted room, use the
             // server-side search.
-            searchPromise = serverSideSearchProcess(client, term, roomId, abortSignal);
+            searchPromise = serverSideSearchProcess(client, term, roomId, abortSignal, senders);
         }
     } else {
         // Search across all rooms, combine a server side search and a
         // local search.
-        searchPromise = combinedSearch(client, term, abortSignal);
+        searchPromise = combinedSearch(client, term, abortSignal, senders);
     }
 
     return searchPromise;
@@ -684,13 +742,14 @@ export default function eventSearch(
     term: string,
     roomId?: string,
     abortSignal?: AbortSignal,
+    senders?: string[],
 ): Promise<ISearchResults> {
     const eventIndex = EventIndexPeg.get();
 
     if (eventIndex === null) {
-        return serverSideSearchProcess(client, term, roomId, abortSignal);
+        return serverSideSearchProcess(client, term, roomId, abortSignal, senders);
     } else {
-        return eventIndexSearch(client, term, roomId, abortSignal);
+        return eventIndexSearch(client, term, roomId, abortSignal, senders);
     }
 }
 
@@ -820,6 +879,11 @@ export interface SearchInfo {
      * The scope of the search.
      */
     scope: SearchScope;
+    /**
+     * The active `from:`/sender filter (full MXIDs), or undefined/empty for no sender filter. Mirrors
+     * {@link SearchSessionParams.senders} into the per-room-view render state.
+     */
+    senders?: string[];
     /**
      * The promise for the search results.
      */

--- a/apps/web/src/Searching.ts
+++ b/apps/web/src/Searching.ts
@@ -703,6 +703,104 @@ export enum SearchScope {
 }
 
 /**
+ * The location of a single search match, used for stepping through matches in the live timeline.
+ */
+export interface SearchMatch {
+    /**
+     * The room the matched event belongs to.
+     */
+    roomId: string;
+    /**
+     * The id of the matched event.
+     */
+    eventId: string;
+}
+
+/**
+ * Build a chronologically ordered list of match locations from a set of search results, for in-timeline
+ * stepping.
+ *
+ * Matches are ordered newest-first by event timestamp so that the up/down arrows mean a consistent
+ * "newer/older" independent of how the backend happened to order the raw results. This explicit client-side
+ * sort guarantees a single chronological order on the merged stepping list regardless of the backend's
+ * ordering, so stepping stays "newer/older" in every case.
+ * `Array.prototype.sort` is stable, so matches sharing a timestamp keep their backend order; a match whose
+ * event has no timestamp sinks to the end (treated as oldest). Results whose matched event is missing an event
+ * id or room id are skipped — they cannot be jumped to in the timeline.
+ */
+export function extractSearchMatches(results: ISearchResults): SearchMatch[] {
+    const matches: Array<SearchMatch & { ts: number }> = [];
+    for (const result of results.results ?? []) {
+        const event = result.context.getEvent();
+        const eventId = event.getId();
+        const roomId = event.getRoomId();
+        if (eventId && roomId) {
+            // getTs() is typed as number but masks a possibly-absent origin_server_ts with a non-null
+            // assertion; default to 0 so an undated match can never produce a NaN comparison and corrupt order.
+            matches.push({ roomId, eventId, ts: event.getTs() ?? 0 });
+        }
+    }
+    matches.sort((a, b) => b.ts - a.ts);
+    return matches.map(({ roomId, eventId }) => ({ roomId, eventId }));
+}
+
+/**
+ * A single search result enriched for the Telegram-style results dropdown: the jumpable location
+ * ({@link SearchMatch}) plus the data a compact row needs — sender MXID, the matched message body and timestamp.
+ */
+export interface SearchResultPreview extends SearchMatch {
+    /** The MXID of the matched event's sender. */
+    sender: string;
+    /** The matched message body (plain text) shown as the row preview. */
+    body: string;
+    /** The matched event's origin-server timestamp (ms), used to render the row date. */
+    ts: number;
+}
+
+/**
+ * Build the ordered list of result previews for the search results dropdown.
+ *
+ * Ordered identically to {@link extractSearchMatches} (newest-first by timestamp, stable, undated last, results
+ * missing an event/room id skipped) so that preview row index `i` maps to match `i` — letting a row click reuse the
+ * existing {@link SearchMatch}-based live-timeline stepping. Pure: the backend results are not mutated.
+ */
+export function extractSearchResultPreviews(results: ISearchResults): SearchResultPreview[] {
+    const previews: SearchResultPreview[] = [];
+    for (const result of results.results ?? []) {
+        const event = result.context.getEvent();
+        const eventId = event.getId();
+        const roomId = event.getRoomId();
+        if (eventId && roomId) {
+            previews.push({
+                roomId,
+                eventId,
+                sender: event.getSender() ?? "",
+                body: event.getContent().body ?? "",
+                // Default an absent timestamp to 0 so it sorts last and never produces a NaN comparison.
+                ts: event.getTs() ?? 0,
+            });
+        }
+    }
+    previews.sort((a, b) => b.ts - a.ts);
+    return previews;
+}
+
+/**
+ * Build the ordered list of terms to highlight in matched message bodies for a set of search results.
+ *
+ * Mirrors the enrichment the results list applies (see RoomSearchView): the literal search term is always
+ * highlighted even if the backend (Synapse/Seshat) did not echo it back, and terms are ordered longest-first so
+ * that overlapping highlights favour the more specific term. Pure — the backend `highlights` array is not mutated.
+ */
+export function extractSearchHighlights(results: ISearchResults, term: string): string[] {
+    const highlights = [...(results.highlights ?? [])];
+    if (!highlights.includes(term)) {
+        highlights.push(term);
+    }
+    return highlights.sort((a, b) => b.length - a.length);
+}
+
+/**
  * Information about a message search in progress.
  */
 export interface SearchInfo {

--- a/apps/web/src/Searching.ts
+++ b/apps/web/src/Searching.ts
@@ -57,6 +57,7 @@ async function serverSideSearch(
     roomId?: string,
     abortSignal?: AbortSignal,
     senders?: string[],
+    order: SearchOrderBy = SearchOrderBy.Recent,
 ): Promise<{ response: ISearchResponse; query: ISearchRequestBody }> {
     const filter: IRoomEventFilter = {
         limit: SEARCH_LIMIT,
@@ -75,7 +76,9 @@ async function serverSideSearch(
             room_events: {
                 search_term: term,
                 filter: filter,
-                order_by: SearchOrderBy.Recent,
+                // Recency by default; the search header's order toggle can request relevance. The order rides
+                // inside `body` (stored as `_query`) so server-side pagination replays it.
+                order_by: order,
                 event_context: {
                     before_limit: 1,
                     after_limit: 1,
@@ -96,8 +99,9 @@ async function serverSideSearchProcess(
     roomId?: string,
     abortSignal?: AbortSignal,
     senders?: string[],
+    order: SearchOrderBy = SearchOrderBy.Recent,
 ): Promise<ISearchResults> {
-    const result = await serverSideSearch(client, term, roomId, abortSignal, senders);
+    const result = await serverSideSearch(client, term, roomId, abortSignal, senders, order);
 
     // The js-sdk method backPaginateRoomEventsSearch() uses _query internally
     // so we're reusing the concept here since we want to delegate the
@@ -128,8 +132,14 @@ async function combinedSearch(
     abortSignal?: AbortSignal,
     senders?: string[],
 ): Promise<ISearchResults> {
-    // Create two promises, one for the local search, one for the
-    // server-side search.
+    // Create two promises, one for the local search, one for the server-side search.
+    //
+    // Both legs are intentionally left on the recency default (no order param): the sliding-window merge below
+    // (combineEvents/compareOldestEvents, which pages the next leg by oldest timestamp) only preserves global order
+    // when both sources are recency-sorted, so the search header's relevance order is NOT honoured on this combined
+    // (local index + homeserver) all-rooms path — it would corrupt cross-page order. (A homeserver-only all-rooms
+    // search has a single source and does honour relevance — see eventSearch's no-index branch.) Honouring relevance
+    // in the merge needs a merge-by-rank redesign (deferred).
     const serverSidePromise = serverSideSearch(client, searchTerm, undefined, abortSignal, senders);
     const localPromise = localSearch(searchTerm, undefined, senders);
 
@@ -192,6 +202,7 @@ async function localSearch(
     searchTerm: string,
     roomId?: string,
     senders?: string[],
+    order: SearchOrderBy = SearchOrderBy.Recent,
 ): Promise<{ response: IResultRoomEvents; query: ISearchArgs }> {
     const eventIndex = EventIndexPeg.get();
 
@@ -203,7 +214,9 @@ async function localSearch(
         // Over-fetch when a sender filter is active so the client-side post-filter still has enough candidates to
         // fill a page; Seshat has no native sender filter.
         limit: hasSenderFilter ? SESHAT_SENDER_OVERFETCH_LIMIT : SEARCH_LIMIT,
-        order_by_recency: true,
+        // Recency unless the order toggle requested relevance: with order_by_recency false, Seshat/tantivy orders
+        // results by its full-text relevance (BM25) score instead of timestamp.
+        order_by_recency: order !== SearchOrderBy.Rank,
         room_id: undefined,
     };
 
@@ -265,6 +278,7 @@ async function localSearchProcess(
     searchTerm: string,
     roomId?: string,
     senders?: string[],
+    order: SearchOrderBy = SearchOrderBy.Recent,
 ): Promise<ISeshatSearchResults> {
     const emptyResult = {
         results: [],
@@ -274,7 +288,7 @@ async function localSearchProcess(
 
     if (searchTerm === "") return emptyResult;
 
-    const result = await localSearch(searchTerm, roomId, senders);
+    const result = await localSearch(searchTerm, roomId, senders, order);
 
     emptyResult.seshatQuery = result.query;
 
@@ -679,22 +693,23 @@ async function eventIndexSearch(
     roomId?: string,
     abortSignal?: AbortSignal,
     senders?: string[],
+    order: SearchOrderBy = SearchOrderBy.Recent,
 ): Promise<ISearchResults> {
     let searchPromise: Promise<ISearchResults>;
 
     if (roomId !== undefined) {
         if (await client.getCrypto()?.isEncryptionEnabledInRoom(roomId)) {
-            // The search is for a single encrypted room, use our local
-            // search method.
-            searchPromise = localSearchProcess(client, term, roomId, senders);
+            // The search is for a single encrypted room, use our local search method. Single Seshat source, so the
+            // requested order is honoured (recency vs Seshat relevance).
+            searchPromise = localSearchProcess(client, term, roomId, senders, order);
         } else {
-            // The search is for a single non-encrypted room, use the
-            // server-side search.
-            searchPromise = serverSideSearchProcess(client, term, roomId, abortSignal, senders);
+            // The search is for a single non-encrypted room, use the server-side search. Single source, so the
+            // backend order is honoured verbatim — thread the requested order through.
+            searchPromise = serverSideSearchProcess(client, term, roomId, abortSignal, senders, order);
         }
     } else {
-        // Search across all rooms, combine a server side search and a
-        // local search.
+        // Search across all rooms, combine a server side search and a local search. The combined merge re-sorts by
+        // recency, so `order` is intentionally NOT threaded here (forced recency, see combinedSearch).
         searchPromise = combinedSearch(client, term, abortSignal, senders);
     }
 
@@ -743,13 +758,14 @@ export default function eventSearch(
     roomId?: string,
     abortSignal?: AbortSignal,
     senders?: string[],
+    order: SearchOrderBy = SearchOrderBy.Recent,
 ): Promise<ISearchResults> {
     const eventIndex = EventIndexPeg.get();
 
     if (eventIndex === null) {
-        return serverSideSearchProcess(client, term, roomId, abortSignal, senders);
+        return serverSideSearchProcess(client, term, roomId, abortSignal, senders, order);
     } else {
-        return eventIndexSearch(client, term, roomId, abortSignal, senders);
+        return eventIndexSearch(client, term, roomId, abortSignal, senders, order);
     }
 }
 
@@ -884,6 +900,12 @@ export interface SearchInfo {
      * {@link SearchSessionParams.senders} into the per-room-view render state.
      */
     senders?: string[];
+    /**
+     * The requested result ordering — {@link SearchOrderBy.Recent} (default) or {@link SearchOrderBy.Rank}
+     * (relevance). Mirrors {@link SearchSessionParams.order} into the per-room-view render state. Honoured by
+     * single-backend searches; an all-rooms search that merges a local index (combinedSearch) stays recency.
+     */
+    order?: SearchOrderBy;
     /**
      * The promise for the search results.
      */

--- a/apps/web/src/components/structures/MessagePanel.tsx
+++ b/apps/web/src/components/structures/MessagePanel.tsx
@@ -148,6 +148,13 @@ interface IProps {
     // ID of an event to highlight. If undefined, no event will be highlighted.
     highlightedEventId?: string;
 
+    // Terms to highlight in the body of the focused search match while stepping through search results in the
+    // live timeline. Only applied to the tile whose id matches `searchHighlightEventId`.
+    searchHighlights?: string[];
+
+    // Id of the event whose body should have `searchHighlights` applied. If undefined, no body is highlighted.
+    searchHighlightEventId?: string;
+
     // The room these events are all in together, if any.
     // (The notification panel won't have a room here, for example.)
     room?: Room;
@@ -801,6 +808,13 @@ export default class MessagePanel extends React.Component<IProps, IState> {
         const eventId = mxEv.getId()!;
         const highlight = eventId === this.props.highlightedEventId;
 
+        // While stepping through search matches in the live timeline, highlight the matched terms in the body of
+        // the focused match only (the same `mx_EventTile_searchHighlight` styling used in the results list), and
+        // mark that whole tile as the active stepping match so it stands out (`mx_EventTile_searchHighlightActive`).
+        const isSearchHighlightMatch =
+            this.props.searchHighlightEventId !== undefined && eventId === this.props.searchHighlightEventId;
+        const searchHighlights = isSearchHighlightMatch ? this.props.searchHighlights : undefined;
+
         const readReceipts = this.readReceiptsByEvent.get(eventId);
 
         const callEventGrouper = this.props.callEventGroupers.get(mxEv.getContent().call_id);
@@ -828,6 +842,8 @@ export default class MessagePanel extends React.Component<IProps, IState> {
                 lastInSection={lastInSection}
                 lastSuccessful={wrappedEvent.lastSuccessfulWeSent}
                 isSelectedEvent={highlight}
+                highlights={searchHighlights}
+                isSearchHighlightMatch={isSearchHighlightMatch}
                 getRelationsForEvent={this.props.getRelationsForEvent}
                 showReactions={this.props.showReactions}
                 layout={this.props.layout}

--- a/apps/web/src/components/structures/RightPanel.tsx
+++ b/apps/web/src/components/structures/RightPanel.tsx
@@ -8,7 +8,14 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import React from "react";
-import { type Room, type RoomState, RoomStateEvent, RoomMember, type MatrixEvent } from "matrix-js-sdk/src/matrix";
+import {
+    type Room,
+    type RoomState,
+    RoomStateEvent,
+    RoomMember,
+    type MatrixEvent,
+    type SearchOrderBy,
+} from "matrix-js-sdk/src/matrix";
 import { throttle } from "lodash";
 
 import dis from "../../dispatcher/dispatcher";
@@ -52,8 +59,10 @@ interface RoomProps extends BaseProps {
     onSearchChange?: (term: string) => void;
     onSearchCancel?: () => void;
     onSearchSendersChange?: (senders: string[]) => void;
+    onSearchOrderChange?: (order: SearchOrderBy) => void;
     searchTerm?: string;
     searchSenders?: string[];
+    searchOrder?: SearchOrderBy;
 }
 
 type Props = XOR<RoomlessProps, RoomProps>;
@@ -262,8 +271,10 @@ export default class RightPanel extends React.Component<Props, IState> {
                             onSearchChange={this.props.onSearchChange}
                             onSearchCancel={this.props.onSearchCancel}
                             onSearchSendersChange={this.props.onSearchSendersChange}
+                            onSearchOrderChange={this.props.onSearchOrderChange}
                             searchTerm={this.props.searchTerm}
                             searchSenders={this.props.searchSenders}
+                            searchOrder={this.props.searchOrder}
                             focusRoomSearch={cardState?.focusRoomSearch}
                         />
                     );

--- a/apps/web/src/components/structures/RightPanel.tsx
+++ b/apps/web/src/components/structures/RightPanel.tsx
@@ -51,7 +51,9 @@ interface RoomProps extends BaseProps {
     permalinkCreator: RoomPermalinkCreator;
     onSearchChange?: (term: string) => void;
     onSearchCancel?: () => void;
+    onSearchSendersChange?: (senders: string[]) => void;
     searchTerm?: string;
+    searchSenders?: string[];
 }
 
 type Props = XOR<RoomlessProps, RoomProps>;
@@ -259,7 +261,9 @@ export default class RightPanel extends React.Component<Props, IState> {
                             permalinkCreator={this.props.permalinkCreator!}
                             onSearchChange={this.props.onSearchChange}
                             onSearchCancel={this.props.onSearchCancel}
+                            onSearchSendersChange={this.props.onSearchSendersChange}
                             searchTerm={this.props.searchTerm}
+                            searchSenders={this.props.searchSenders}
                             focusRoomSearch={cardState?.focusRoomSearch}
                         />
                     );

--- a/apps/web/src/components/structures/RoomView.tsx
+++ b/apps/web/src/components/structures/RoomView.tsx
@@ -1862,16 +1862,18 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             });
     }
 
-    private onSearch = (term: string, scope = SearchScope.Room): void => {
+    // `senders` defaults to the current session's filter so a term change (onSearchChange) or scope change
+    // (onSearchScopeChange) preserves the active `from:` filter; the sender-filter control passes it explicitly.
+    private onSearch = (term: string, scope = SearchScope.Room, senders = this.state.search?.senders): void => {
         const roomId = scope === SearchScope.Room ? this.getRoomId() : undefined;
         debuglog("sending search request");
         const abortController = new AbortController();
-        const promise = eventSearch(this.context.client!, term, roomId, abortController.signal);
+        const promise = eventSearch(this.context.client!, term, roomId, abortController.signal, senders);
         // make sure that we don't end up showing results from an aborted search by keeping a unique id.
         const searchId = new Date().getTime();
 
         // The search session lives in the SearchSessionStore so the shared stepper and clear gates read one source.
-        SearchSessionStore.instance.start({ searchId, roomId, term, scope, promise, abortController });
+        SearchSessionStore.instance.start({ searchId, roomId, term, scope, senders, promise, abortController });
 
         this.setState({
             timelineRenderingType: TimelineRenderingType.Search,
@@ -1880,6 +1882,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                 roomId,
                 term,
                 scope,
+                senders,
                 promise,
                 abortController,
             },
@@ -1888,6 +1891,12 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
 
     private onSearchScopeChange = (scope: SearchScope): void => {
         this.onSearch(this.state.search?.term ?? "", scope);
+    };
+
+    // Re-run the active search with a new `from:`/sender filter, keeping the current term and scope. An empty array
+    // clears the filter.
+    private onSearchSendersChange = (senders: string[]): void => {
+        this.onSearch(this.state.search?.term ?? "", this.state.search?.scope ?? SearchScope.Room, senders);
     };
 
     private onSearchUpdate = (inProgress: boolean, searchResults: ISearchResults | null, error: Error | null): void => {
@@ -2791,7 +2800,9 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                 e2eStatus={this.state.e2eStatus}
                 onSearchChange={this.onSearchChange}
                 onSearchCancel={this.onCancelSearchClick}
+                onSearchSendersChange={this.onSearchSendersChange}
                 searchTerm={this.state.search?.term ?? ""}
+                searchSenders={this.state.search?.senders ?? []}
             />
         ) : undefined;
 

--- a/apps/web/src/components/structures/RoomView.tsx
+++ b/apps/web/src/components/structures/RoomView.tsx
@@ -1891,18 +1891,14 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
     };
 
     private onSearchUpdate = (inProgress: boolean, searchResults: ISearchResults | null, error: Error | null): void => {
-        // In-timeline match stepping is enabled only for completed, single-room searches in this PR. All-rooms and
-        // cross-room stepping are deliberately left to PR-24.
-        const canStep = !inProgress && searchResults !== null && this.state.search?.scope === SearchScope.Room;
-        const currentRoomId = this.getRoomId();
-        const freshMatches =
-            canStep && searchResults
-                ? extractSearchMatches(searchResults).filter((match) => match.roomId === currentRoomId)
-                : undefined;
-        const freshPreviews =
-            canStep && searchResults
-                ? extractSearchResultPreviews(searchResults).filter((preview) => preview.roomId === currentRoomId)
-                : undefined;
+        // In-timeline match stepping is enabled for any completed search. Matches can span rooms — an all-rooms search
+        // spans rooms, and a room-scoped search of an upgraded room also covers its predecessor chain (#32258) — and
+        // stepping into a different room re-mounts this room-id-keyed RoomView, which re-hydrates the live stepper from
+        // the SearchSessionStore. So there is no current-room filter and no scope restriction; the store holds the
+        // full, ordered cross-room match list. (Stepping through pages beyond the loaded results is still deferred.)
+        const canStep = !inProgress && searchResults !== null;
+        const freshMatches = canStep && searchResults ? extractSearchMatches(searchResults) : undefined;
+        const freshPreviews = canStep && searchResults ? extractSearchResultPreviews(searchResults) : undefined;
         const freshHighlights =
             canStep && searchResults ? extractSearchHighlights(searchResults, this.state.search!.term) : undefined;
         const count = searchResults?.count ?? this.state.search?.count;
@@ -1919,8 +1915,8 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         this.setState({
             search: {
                 ...this.state.search!,
-                // NB: `count` (the backend's full estimate) and `matches.length` (this loaded page, filtered to the
-                // current room, capped at SEARCH_LIMIT) are intentionally different denominators.
+                // NB: `count` (the backend's full estimate across all matching rooms) and `matches.length` (this
+                // loaded page, capped at SEARCH_LIMIT) are intentionally different denominators.
                 count,
                 highlights: freshHighlights,
                 currentMatchIndex:

--- a/apps/web/src/components/structures/RoomView.tsx
+++ b/apps/web/src/components/structures/RoomView.tsx
@@ -122,7 +122,15 @@ import { LargeLoader } from "./LargeLoader";
 import { isVideoRoom } from "../../utils/video-rooms";
 import { SDKContext } from "../../contexts/SDKContext";
 import { RoomSearchView } from "./RoomSearchView";
-import eventSearch, { type SearchInfo, SearchScope } from "../../Searching";
+import eventSearch, {
+    extractSearchHighlights,
+    extractSearchMatches,
+    extractSearchResultPreviews,
+    type SearchInfo,
+    type SearchMatch,
+    SearchScope,
+} from "../../Searching";
+import { RoomSearchNavigationViewModel } from "../../viewmodels/search/RoomSearchNavigationViewModel";
 import { WidgetType } from "../../widgets/WidgetType";
 import WidgetUtils from "../../utils/WidgetUtils";
 import { shouldEncryptRoomWithSingle3rdPartyInvite } from "../../utils/room/shouldEncryptRoomWithSingle3rdPartyInvite";
@@ -137,6 +145,7 @@ import { PinnedMessageBanner } from "../views/rooms/PinnedMessageBanner";
 import { ScopedRoomContextProvider, useScopedRoomContext } from "../../contexts/ScopedRoomContext";
 import { DeclineAndBlockInviteDialog } from "../views/dialogs/DeclineAndBlockInviteDialog";
 import { type FocusMessageSearchPayload } from "../../dispatcher/payloads/FocusMessageSearchPayload.ts";
+import { type SearchMatchStepPayload } from "../../dispatcher/payloads/SearchMatchStepPayload.ts";
 import { isRoomEncrypted } from "../../hooks/useIsEncrypted";
 import { type RoomViewStore } from "../../stores/RoomViewStore.tsx";
 import { RoomStatusBarViewModel } from "../../viewmodels/room/RoomStatusBar.ts";
@@ -144,6 +153,8 @@ import { EncryptionEventViewModel } from "../../viewmodels/room/timeline/event-t
 import { ModuleApi } from "../../modules/Api.ts";
 import { RoomUploadContextProvider } from "../../viewmodels/room/RoomUploadViewModel.tsx";
 import { EventPresentationContextProvider } from "../../utils/EventPresentationContextProvider";
+import { SearchSessionStore } from "../../stores/SearchSessionStore";
+import { Key } from "../../Keyboard";
 
 const DEBUG = false;
 const PREVENT_MULTIPLE_JITSI_WITHIN = 30_000;
@@ -209,6 +220,17 @@ interface IRoomProps extends RoomViewProps {
 
 export { MainSplitContentType };
 
+interface RoomSearchInfo extends SearchInfo {
+    /**
+     * Index of the currently-focused in-room match, mirrored from SearchSessionStore for render-only state.
+     */
+    currentMatchIndex?: number;
+    /**
+     * Terms to highlight in the live tile while stepping through in-room matches.
+     */
+    highlights?: string[];
+}
+
 export interface IRoomState {
     room?: Room;
     roomId?: string;
@@ -232,7 +254,7 @@ export interface IRoomState {
     /**
      * The state of an ongoing search if there is one.
      */
-    search?: SearchInfo;
+    search?: RoomSearchInfo;
     callState?: CallState;
     canPeek: boolean;
     canSelfRedact: boolean;
@@ -441,6 +463,10 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
     private roomView = createRef<HTMLDivElement>();
     private searchResultsPanel = createRef<ScrollPanel>();
     private messagePanel: TimelinePanel | null = null;
+    // Drives the in-timeline "k of N" search match stepper. Always present; renders nothing until it has matches.
+    public readonly searchNavVm = new RoomSearchNavigationViewModel({
+        onActivateMatch: (match: SearchMatch, index: number): void => this.onActivateSearchMatch(match, index),
+    });
     private roomViewBody = createRef<HTMLDivElement>();
 
     private roomViewStore: RoomViewStore;
@@ -677,8 +703,19 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             newState.showRightPanel = false;
         }
 
+        // Consume the stepping-jump flag exactly once per store update. A stepping jump (set by the match stepper
+        // just before its ViewRoom dispatch) must not be treated as a user navigation by the clear gate below.
+        const wasSteppingJump = SearchSessionStore.instance.consumeSteppingJump();
+        // While the results list is shown (a search is active but no match is focused), keep the live timeline
+        // anchored to the last-viewed match. The durable anchor is the event our last internal navigation pinned.
+        const searchResultsListShown =
+            this.state.search !== undefined && SearchSessionStore.instance.focusedMatch === null;
+        const searchAnchorEventId = SearchSessionStore.instance.steppingTarget ?? undefined;
         const initialEventId = this.roomViewStore.getInitialEventId() ?? this.state.initialEventId;
-        if (initialEventId) {
+        if (searchResultsListShown) {
+            newState.initialEventId = searchAnchorEventId;
+            newState.isInitialEventHighlighted = false;
+        } else if (initialEventId) {
             let initialEvent = room?.findEventById(initialEventId);
             // The event does not exist in the current sync data
             // We need to fetch it to know whether to route this request
@@ -777,14 +814,17 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             }
         }
 
-        // Clear the search results when clicking a search result (which changes the
-        // currently scrolled to event, this.state.initialEventId).
+        // Clear the search results when clicking a search result (which changes the currently scrolled-to event),
+        // but leave the session alive for our own stepping/back-to-results ViewRoom dispatches.
+        const focusedEventId = this.roomViewStore.getInitialEventId();
         if (
             this.state.timelineRenderingType === TimelineRenderingType.Search &&
-            this.state.initialEventId !== newState.initialEventId
+            !wasSteppingJump &&
+            focusedEventId &&
+            focusedEventId !== SearchSessionStore.instance.steppingTarget
         ) {
             newState.timelineRenderingType = TimelineRenderingType.Room;
-            this.state.search?.abortController?.abort();
+            SearchSessionStore.instance.clear({ abort: true });
             newState.search = undefined;
         }
 
@@ -1065,6 +1105,8 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         // (We could use isMounted, but facebook have deprecated that.)
         this.unmounted = true;
 
+        this.searchNavVm.dispose();
+
         this.context.legacyCallHandler.removeListener(LegacyCallHandlerEvent.CallState, this.onCallState);
 
         // update the scroll map before we get unmounted
@@ -1145,6 +1187,19 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
 
     private onReactKeyDown = (ev: React.KeyboardEvent): void => {
         let handled = false;
+
+        if (
+            this.state.search &&
+            ev.target instanceof HTMLInputElement &&
+            ev.key === Key.ENTER &&
+            !ev.nativeEvent?.isComposing
+        ) {
+            defaultDispatcher.dispatch<SearchMatchStepPayload>({
+                action: Action.SearchMatchStep,
+                direction: ev.shiftKey ? "previous" : "next",
+            });
+            handled = true;
+        }
 
         const action = getKeyBindingsManager().getRoomAction(ev);
         switch (action) {
@@ -1276,13 +1331,19 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                 }
 
                 const editState = payload.event ? new EditorStateTransfer(payload.event) : undefined;
+                // If a search is active (implying that the "edit" button has been pressed on one of the events in
+                // the search result), we need to close that search, because RoomSearchView doesn't handle editing
+                // and won't render the composer. Skip this while a stepping jump is in flight so a racing edit
+                // dispatch cannot tear down the surviving session; a genuine edit (no jump) still clears it.
+                const closeSearchForEdit =
+                    this.state.search !== undefined && !SearchSessionStore.instance.isSteppingJump();
+                if (closeSearchForEdit) {
+                    SearchSessionStore.instance.clear({ abort: true });
+                }
                 this.setState(
                     {
                         editState,
-                        // If a search is active (implying that the "edit" button has been pressed on one of the
-                        // events in the search result), we need to close that search, because RoomSearchView
-                        // doesn't handle editing and won't render the composer.
-                        search: undefined,
+                        ...(closeSearchForEdit ? { search: undefined } : {}),
                     },
                     () => {
                         if (payload.event) {
@@ -1356,6 +1417,15 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             case Action.FocusMessageSearch:
                 if ((payload as FocusMessageSearchPayload).initialText) {
                     this.onSearch(payload.initialText);
+                }
+                break;
+            case Action.SearchMatchStep:
+                // Step the in-room search match cursor in response to Enter / Shift+Enter in the search box.
+                // The view model no-ops when there is nothing to step (e.g. no matches loaded).
+                if ((payload as SearchMatchStepPayload).direction === "previous") {
+                    this.searchNavVm.previous();
+                } else {
+                    this.searchNavVm.next();
                 }
                 break;
         }
@@ -1797,13 +1867,16 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         debuglog("sending search request");
         const abortController = new AbortController();
         const promise = eventSearch(this.context.client!, term, roomId, abortController.signal);
+        // make sure that we don't end up showing results from an aborted search by keeping a unique id.
+        const searchId = new Date().getTime();
+
+        // The search session lives in the SearchSessionStore so the shared stepper and clear gates read one source.
+        SearchSessionStore.instance.start({ searchId, roomId, term, scope, promise, abortController });
 
         this.setState({
             timelineRenderingType: TimelineRenderingType.Search,
             search: {
-                // make sure that we don't end up showing results from
-                // an aborted search by keeping a unique id.
-                searchId: new Date().getTime(),
+                searchId,
                 roomId,
                 term,
                 scope,
@@ -1818,13 +1891,66 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
     };
 
     private onSearchUpdate = (inProgress: boolean, searchResults: ISearchResults | null, error: Error | null): void => {
+        // In-timeline match stepping is enabled only for completed, single-room searches in this PR. All-rooms and
+        // cross-room stepping are deliberately left to PR-24.
+        const canStep = !inProgress && searchResults !== null && this.state.search?.scope === SearchScope.Room;
+        const currentRoomId = this.getRoomId();
+        const freshMatches =
+            canStep && searchResults
+                ? extractSearchMatches(searchResults).filter((match) => match.roomId === currentRoomId)
+                : undefined;
+        const freshPreviews =
+            canStep && searchResults
+                ? extractSearchResultPreviews(searchResults).filter((preview) => preview.roomId === currentRoomId)
+                : undefined;
+        const freshHighlights =
+            canStep && searchResults ? extractSearchHighlights(searchResults, this.state.search!.term) : undefined;
+        const count = searchResults?.count ?? this.state.search?.count;
+
+        SearchSessionStore.instance.updateResults({
+            inProgress,
+            matches: freshMatches ?? [],
+            previews: freshPreviews ?? [],
+            highlights: freshHighlights,
+            count,
+            error: error ?? undefined,
+        });
+
         this.setState({
             search: {
                 ...this.state.search!,
-                count: searchResults?.count,
+                // NB: `count` (the backend's full estimate) and `matches.length` (this loaded page, filtered to the
+                // current room, capped at SEARCH_LIMIT) are intentionally different denominators.
+                count,
+                highlights: freshHighlights,
+                currentMatchIndex:
+                    SearchSessionStore.instance.focusedMatch !== null
+                        ? SearchSessionStore.instance.currentMatchIndex
+                        : undefined,
                 error: error ?? undefined,
                 inProgress,
             },
+        });
+    };
+
+    /**
+     * Step the live timeline to a search match. Switches back to the room timeline so the match is shown in context
+     * and reuses the existing ViewRoom jump-and-highlight path, while keeping the search session alive.
+     */
+    private onActivateSearchMatch = (match: SearchMatch, index: number): void => {
+        SearchSessionStore.instance.beginSteppingJump(match.eventId);
+        SearchSessionStore.instance.setCurrentMatchIndex(index);
+        this.setState((state) => ({
+            timelineRenderingType: TimelineRenderingType.Room,
+            search: state.search ? { ...state.search, currentMatchIndex: index } : undefined,
+        }));
+        defaultDispatcher.dispatch<ViewRoomPayload>({
+            action: Action.ViewRoom,
+            room_id: match.roomId,
+            event_id: match.eventId,
+            highlighted: true,
+            scroll_into_view: true,
+            metricsTrigger: undefined,
         });
     };
 
@@ -1953,6 +2079,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
     }, 300);
 
     private onCancelSearchClick = (): Promise<void> => {
+        SearchSessionStore.instance.clear({ abort: true });
         return new Promise<void>((resolve) => {
             this.setState(
                 {
@@ -1963,6 +2090,36 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             );
         });
     };
+
+    private onBackToSearchResults = (): void => {
+        // Return from live-timeline match stepping to the results list while keeping the search session alive.
+        SearchSessionStore.instance.setCurrentMatchIndex(-1);
+        this.setState((state) => ({
+            timelineRenderingType: TimelineRenderingType.Search,
+            search: state.search ? { ...state.search, currentMatchIndex: undefined } : undefined,
+            // Anchor the hidden live timeline to the last-viewed match while the results list is showing.
+            initialEventId: SearchSessionStore.instance.steppingTarget ?? undefined,
+            isInitialEventHighlighted: false,
+        }));
+        this.resetFocusedEvent();
+    };
+
+    /**
+     * While a search is active, clear any event the live timeline is pinned to by dispatching a stepping-guarded
+     * ViewRoom with no event_id. No-op if nothing is focused.
+     */
+    private resetFocusedEvent(): void {
+        const roomId = this.getRoomId();
+        const focusedEventId = this.roomViewStore.getInitialEventId();
+        if (roomId && focusedEventId) {
+            SearchSessionStore.instance.beginSteppingJump(focusedEventId);
+            defaultDispatcher.dispatch<ViewRoomPayload>({
+                action: Action.ViewRoom,
+                room_id: roomId,
+                metricsTrigger: undefined,
+            });
+        }
+    }
 
     // jump down to the bottom of this room, where new events are arriving
     private jumpToLiveTimeline = (): void => {
@@ -2424,14 +2581,24 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
 
         const hiddenHighlightCount = this.getHiddenHighlightCount();
 
+        // While stepping a match in the live timeline, show the live MessagePanel instead of the results list.
+        // The durable store signal survives result updates that may reset the local index mirror.
+        const isSteppingSearchMatch =
+            this.state.search !== undefined && SearchSessionStore.instance.focusedMatch !== null;
+
         let aux: JSX.Element | undefined;
         let previewBar;
-        if (this.state.timelineRenderingType === TimelineRenderingType.Search) {
+        if (
+            this.state.search &&
+            (this.state.timelineRenderingType === TimelineRenderingType.Search || isSteppingSearchMatch)
+        ) {
             if (!isRoomEncryptionLoading) {
                 aux = (
                     <RoomSearchAuxPanel
                         searchInfo={this.state.search}
+                        navigationVm={this.searchNavVm}
                         onCancelClick={this.onCancelSearchClick}
+                        onBackToResults={this.onBackToSearchResults}
                         onSearchScopeChange={this.onSearchScopeChange}
                         isRoomEncrypted={isRoomEncrypted}
                     />
@@ -2533,7 +2700,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         let searchResultsPanel;
         let hideMessagePanel = false;
 
-        if (this.state.search) {
+        if (this.state.search && !isSteppingSearchMatch) {
             searchResultsPanel = (
                 <RoomSearchView
                     key={this.state.search.searchId}
@@ -2554,6 +2721,14 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             highlightedEventId = this.state.initialEventId;
         }
 
+        // While stepping through search matches, highlight the matched terms in the focused match's live tile.
+        let searchHighlightEventId: string | undefined;
+        let searchHighlights: string[] | undefined;
+        if (isSteppingSearchMatch && this.state.search) {
+            searchHighlightEventId = SearchSessionStore.instance.focusedMatch ?? undefined;
+            searchHighlights = this.state.search.highlights;
+        }
+
         let messagePanel: JSX.Element | undefined;
         if (!isRoomEncryptionLoading) {
             messagePanel = (
@@ -2569,6 +2744,8 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                         manageReadMarkers={!this.state.isPeeking}
                         hidden={hideMessagePanel}
                         highlightedEventId={highlightedEventId}
+                        searchHighlights={searchHighlights}
+                        searchHighlightEventId={searchHighlightEventId}
                         eventId={this.state.initialEventId}
                         eventScrollIntoView={this.state.initialEventScrollIntoView}
                         eventPixelOffset={this.state.initialEventPixelOffset}

--- a/apps/web/src/components/structures/RoomView.tsx
+++ b/apps/web/src/components/structures/RoomView.tsx
@@ -36,6 +36,7 @@ import {
     ClientEvent,
     type MatrixError,
     type ISearchResults,
+    SearchOrderBy,
     THREAD_RELATION_TYPE,
     type MatrixClient,
 } from "matrix-js-sdk/src/matrix";
@@ -1862,18 +1863,24 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             });
     }
 
-    // `senders` defaults to the current session's filter so a term change (onSearchChange) or scope change
-    // (onSearchScopeChange) preserves the active `from:` filter; the sender-filter control passes it explicitly.
-    private onSearch = (term: string, scope = SearchScope.Room, senders = this.state.search?.senders): void => {
+    // `senders` and `order` default to the current session's values so a term change (onSearchChange) or scope
+    // change (onSearchScopeChange) preserves the active `from:` filter and chosen order; the dedicated controls pass
+    // their axis explicitly.
+    private onSearch = (
+        term: string,
+        scope = SearchScope.Room,
+        senders = this.state.search?.senders,
+        order = this.state.search?.order ?? SearchOrderBy.Recent,
+    ): void => {
         const roomId = scope === SearchScope.Room ? this.getRoomId() : undefined;
         debuglog("sending search request");
         const abortController = new AbortController();
-        const promise = eventSearch(this.context.client!, term, roomId, abortController.signal, senders);
+        const promise = eventSearch(this.context.client!, term, roomId, abortController.signal, senders, order);
         // make sure that we don't end up showing results from an aborted search by keeping a unique id.
         const searchId = new Date().getTime();
 
         // The search session lives in the SearchSessionStore so the shared stepper and clear gates read one source.
-        SearchSessionStore.instance.start({ searchId, roomId, term, scope, senders, promise, abortController });
+        SearchSessionStore.instance.start({ searchId, roomId, term, scope, senders, order, promise, abortController });
 
         this.setState({
             timelineRenderingType: TimelineRenderingType.Search,
@@ -1883,6 +1890,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                 term,
                 scope,
                 senders,
+                order,
                 promise,
                 abortController,
             },
@@ -1897,6 +1905,17 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
     // clears the filter.
     private onSearchSendersChange = (senders: string[]): void => {
         this.onSearch(this.state.search?.term ?? "", this.state.search?.scope ?? SearchScope.Room, senders);
+    };
+
+    // Re-run the active search with a new result order (recent/relevant), keeping the current term, scope and
+    // sender filter.
+    private onSearchOrderChange = (order: SearchOrderBy): void => {
+        this.onSearch(
+            this.state.search?.term ?? "",
+            this.state.search?.scope ?? SearchScope.Room,
+            this.state.search?.senders,
+            order,
+        );
     };
 
     private onSearchUpdate = (inProgress: boolean, searchResults: ISearchResults | null, error: Error | null): void => {
@@ -2801,8 +2820,10 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                 onSearchChange={this.onSearchChange}
                 onSearchCancel={this.onCancelSearchClick}
                 onSearchSendersChange={this.onSearchSendersChange}
+                onSearchOrderChange={this.onSearchOrderChange}
                 searchTerm={this.state.search?.term ?? ""}
                 searchSenders={this.state.search?.senders ?? []}
+                searchOrder={this.state.search?.order ?? SearchOrderBy.Recent}
             />
         ) : undefined;
 

--- a/apps/web/src/components/structures/TimelinePanel.tsx
+++ b/apps/web/src/components/structures/TimelinePanel.tsx
@@ -92,6 +92,13 @@ interface IProps {
     // typically this will be either 'eventId' or undefined.
     highlightedEventId?: string;
 
+    // Terms to highlight in the body of the focused search match (`searchHighlightEventId`) while stepping
+    // through search results in the live timeline. Undefined when not stepping.
+    searchHighlights?: string[];
+
+    // Id of the event whose body should have `searchHighlights` applied while stepping through search matches.
+    searchHighlightEventId?: string;
+
     // id of an event to jump to. If not given, will go to the end of the live timeline.
     eventId?: string;
 
@@ -1853,6 +1860,8 @@ class TimelinePanel extends React.Component<IProps, IState> {
                 forwardPaginating={forwardPaginating}
                 events={events}
                 highlightedEventId={this.props.highlightedEventId}
+                searchHighlights={this.props.searchHighlights}
+                searchHighlightEventId={this.props.searchHighlightEventId}
                 readMarkerEventId={this.state.readMarkerEventId}
                 readMarkerVisible={this.state.readMarkerVisible}
                 canBackPaginate={this.state.canBackPaginate}

--- a/apps/web/src/components/views/right_panel/RoomSearchOrderToggle.tsx
+++ b/apps/web/src/components/views/right_panel/RoomSearchOrderToggle.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import React, { type JSX, useState } from "react";
+import { SearchOrderBy } from "matrix-js-sdk/src/matrix";
+import { IconButton, Menu, RadioMenuItem } from "@vector-im/compound-web";
+import ChevronUpDownIcon from "@vector-im/compound-design-tokens/assets/web/icons/chevron-up-down";
+
+import { _t } from "../../../languageHandler";
+
+interface Props {
+    /** The active result order, owned upstream by the SearchSessionStore and threaded down as a prop. */
+    order: SearchOrderBy;
+    /** Re-run the active search with the chosen result order (recent vs relevant). */
+    onSearchOrderChange: (order: SearchOrderBy) => void;
+}
+
+/**
+ * Result-order toggle for the in-room search header (Telegram-style "sort" control), sitting beside the search
+ * input and the `from:`/sender filter.
+ *
+ * A Compound {@link Menu} of two mutually-exclusive {@link RadioMenuItem}s — **Most recent** ({@link
+ * SearchOrderBy.Recent}, the default) and **Most relevant** ({@link SearchOrderBy.Rank}). Picking one re-runs the
+ * active search asking the backend to order results accordingly. The selected order is owned by RoomView's search
+ * session and threaded down as the `order` prop; this control is stateless and toggles it through the callback.
+ *
+ * NB: relevance ordering takes effect on single-backend searches (a single room — encrypted via Seshat relevance,
+ * or non-encrypted via the homeserver — and a homeserver-only all-rooms search). An all-rooms search that merges a
+ * local Seshat index stays recency-ordered (its client-side merge only preserves order for recency-sorted sources)
+ * — see Searching.ts.
+ */
+export function RoomSearchOrderToggle({ order, onSearchOrderChange }: Props): JSX.Element {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <Menu
+            title={_t("room|search|order_toggle_label")}
+            open={open}
+            onOpenChange={setOpen}
+            trigger={
+                <IconButton
+                    size="28px"
+                    // The visual indicator dot is invisible to screen readers, so fold the active (relevance)
+                    // state into the accessible name when the order is non-default (mirrors the sender filter).
+                    aria-label={
+                        order !== SearchOrderBy.Recent
+                            ? _t("room|search|order_toggle_button_active")
+                            : _t("room|search|order_toggle_button")
+                    }
+                    data-testid="search-order-toggle-button"
+                    // A dot signals that a non-default (relevance) order is active without opening the menu.
+                    indicator={order !== SearchOrderBy.Recent ? "default" : undefined}
+                >
+                    <ChevronUpDownIcon width="20px" height="20px" />
+                </IconButton>
+            }
+        >
+            <RadioMenuItem
+                label={_t("room|search|order_recent")}
+                checked={order === SearchOrderBy.Recent}
+                onSelect={() => onSearchOrderChange(SearchOrderBy.Recent)}
+            />
+            <RadioMenuItem
+                label={_t("room|search|order_relevant")}
+                checked={order === SearchOrderBy.Rank}
+                onSelect={() => onSearchOrderChange(SearchOrderBy.Rank)}
+            />
+        </Menu>
+    );
+}

--- a/apps/web/src/components/views/right_panel/RoomSearchSenderFilter.tsx
+++ b/apps/web/src/components/views/right_panel/RoomSearchSenderFilter.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import React, { type JSX, useState } from "react";
+import { type Room } from "matrix-js-sdk/src/matrix";
+import { CheckboxMenuItem, IconButton, Menu, MenuItem } from "@vector-im/compound-web";
+import UserProfileIcon from "@vector-im/compound-design-tokens/assets/web/icons/user-profile";
+import CloseIcon from "@vector-im/compound-design-tokens/assets/web/icons/close";
+import { useCreateAutoDisposedViewModel, useViewModel } from "@element-hq/web-shared-components";
+
+import { _t } from "../../../languageHandler";
+import { RoomSearchSenderFilterViewModel } from "../../../viewmodels/search/RoomSearchSenderFilterViewModel";
+
+interface Props {
+    /** The room whose members can be picked as `from:` filters. Key this control by room id (see the VM). */
+    room: Room;
+    /** The currently-selected sender MXIDs (owned by the SearchSessionStore, threaded down as a prop). */
+    senders: string[];
+    /** Re-run the search with the updated sender filter (empty array clears it). */
+    onSearchSendersChange: (senders: string[]) => void;
+}
+
+/**
+ * `from:`/sender filter control for the in-room search header (Telegram-style member picker), sitting beside the
+ * search input.
+ *
+ * A Compound {@link Menu} of the room's members as multi-select checkboxes; toggling a member re-runs the active
+ * search narrowed to that sender (homeserver `IRoomEventFilter.senders` natively, Seshat via a client-side
+ * post-filter). The selected senders are owned by RoomView's search session and threaded down as the `senders`
+ * prop; this control is stateless and toggles them through the injected callback. Renders nothing when the room
+ * has no other members (nobody to filter by).
+ */
+export function RoomSearchSenderFilter({ room, senders, onSearchSendersChange }: Props): JSX.Element | null {
+    const vm = useCreateAutoDisposedViewModel(() => new RoomSearchSenderFilterViewModel({ room }));
+    const { members } = useViewModel(vm);
+    const [open, setOpen] = useState(false);
+
+    if (members.length === 0) return null;
+
+    const selected = new Set(senders);
+    const toggle = (userId: string): void => {
+        onSearchSendersChange(selected.has(userId) ? senders.filter((s) => s !== userId) : [...senders, userId]);
+    };
+
+    return (
+        <Menu
+            title={_t("room|search|sender_filter_label")}
+            open={open}
+            onOpenChange={setOpen}
+            trigger={
+                <IconButton
+                    size="28px"
+                    // The visual indicator dot is invisible to screen readers, so fold the active count into the
+                    // accessible name when a filter is set.
+                    aria-label={
+                        senders.length > 0
+                            ? _t("room|search|sender_filter_button_active", { count: senders.length })
+                            : _t("room|search|sender_filter_button")
+                    }
+                    data-testid="search-sender-filter-button"
+                    // A dot signals that a sender filter is active without opening the menu.
+                    indicator={senders.length > 0 ? "default" : undefined}
+                >
+                    <UserProfileIcon width="20px" height="20px" />
+                </IconButton>
+            }
+        >
+            {members.map((m) => (
+                <CheckboxMenuItem
+                    key={m.userId}
+                    label={m.name}
+                    checked={selected.has(m.userId)}
+                    onSelect={(e) => {
+                        // Keep the menu open so several senders can be toggled in one pass (multi-select).
+                        e.preventDefault();
+                        toggle(m.userId);
+                    }}
+                />
+            ))}
+            {senders.length > 0 && (
+                <MenuItem
+                    kind="critical"
+                    Icon={CloseIcon}
+                    label={_t("room|search|sender_filter_clear")}
+                    data-testid="search-sender-filter-clear"
+                    onSelect={() => onSearchSendersChange([])}
+                />
+            )}
+        </Menu>
+    );
+}

--- a/apps/web/src/components/views/right_panel/RoomSummaryCardView.tsx
+++ b/apps/web/src/components/views/right_panel/RoomSummaryCardView.tsx
@@ -38,7 +38,7 @@ import PublicIcon from "@vector-im/compound-design-tokens/assets/web/icons/publi
 import ErrorIcon from "@vector-im/compound-design-tokens/assets/web/icons/error";
 import ErrorSolidIcon from "@vector-im/compound-design-tokens/assets/web/icons/error-solid";
 import ChevronDownIcon from "@vector-im/compound-design-tokens/assets/web/icons/chevron-down";
-import { JoinRule, type Room } from "matrix-js-sdk/src/matrix";
+import { JoinRule, type Room, SearchOrderBy } from "matrix-js-sdk/src/matrix";
 import { Box, Flex, HistoryVisibilityBadge, LinkedText } from "@element-hq/web-shared-components";
 
 import BaseCard from "./BaseCard.tsx";
@@ -51,6 +51,7 @@ import { useRoomSummaryCardViewModel } from "../../viewmodels/right_panel/RoomSu
 import { useRoomTopicViewModel } from "../../viewmodels/right_panel/RoomSummaryCardTopicViewModel.tsx";
 import { useRoomName } from "../../../hooks/useRoomName.ts";
 import { RoomSearchSenderFilter } from "./RoomSearchSenderFilter.tsx";
+import { RoomSearchOrderToggle } from "./RoomSearchOrderToggle.tsx";
 
 interface IProps {
     room: Room;
@@ -58,9 +59,11 @@ interface IProps {
     onSearchChange?: (term: string) => void;
     onSearchCancel?: () => void;
     onSearchSendersChange?: (senders: string[]) => void;
+    onSearchOrderChange?: (order: SearchOrderBy) => void;
     focusRoomSearch?: boolean;
     searchTerm?: string;
     searchSenders?: string[];
+    searchOrder?: SearchOrderBy;
 }
 
 const RoomTopic: React.FC<Pick<IProps, "room">> = ({ room }): JSX.Element | null => {
@@ -131,9 +134,11 @@ const RoomSummaryCardView: React.FC<IProps> = ({
     onSearchChange,
     onSearchCancel,
     onSearchSendersChange,
+    onSearchOrderChange,
     focusRoomSearch,
     searchTerm = "",
     searchSenders = [],
+    searchOrder = SearchOrderBy.Recent,
 }) => {
     const vm = useRoomSummaryCardViewModel(room, permalinkCreator, onSearchCancel);
     // XXX: this name should be part of the view model
@@ -235,6 +240,14 @@ const RoomSummaryCardView: React.FC<IProps> = ({
                         room={room}
                         senders={searchSenders}
                         onSearchSendersChange={onSearchSendersChange}
+                    />
+                )}
+                {/* Recent/Relevant result-order toggle. */}
+                {onSearchOrderChange && (
+                    <RoomSearchOrderToggle
+                        key={room.roomId}
+                        order={searchOrder}
+                        onSearchOrderChange={onSearchOrderChange}
                     />
                 )}
             </Flex>

--- a/apps/web/src/components/views/right_panel/RoomSummaryCardView.tsx
+++ b/apps/web/src/components/views/right_panel/RoomSummaryCardView.tsx
@@ -50,14 +50,17 @@ import { topicToHtml } from "../../../HtmlUtils.tsx";
 import { useRoomSummaryCardViewModel } from "../../viewmodels/right_panel/RoomSummaryCardViewModel.tsx";
 import { useRoomTopicViewModel } from "../../viewmodels/right_panel/RoomSummaryCardTopicViewModel.tsx";
 import { useRoomName } from "../../../hooks/useRoomName.ts";
+import { RoomSearchSenderFilter } from "./RoomSearchSenderFilter.tsx";
 
 interface IProps {
     room: Room;
     permalinkCreator: RoomPermalinkCreator;
     onSearchChange?: (term: string) => void;
     onSearchCancel?: () => void;
+    onSearchSendersChange?: (senders: string[]) => void;
     focusRoomSearch?: boolean;
     searchTerm?: string;
+    searchSenders?: string[];
 }
 
 const RoomTopic: React.FC<Pick<IProps, "room">> = ({ room }): JSX.Element | null => {
@@ -127,8 +130,10 @@ const RoomSummaryCardView: React.FC<IProps> = ({
     permalinkCreator,
     onSearchChange,
     onSearchCancel,
+    onSearchSendersChange,
     focusRoomSearch,
     searchTerm = "",
+    searchSenders = [],
 }) => {
     const vm = useRoomSummaryCardViewModel(room, permalinkCreator, onSearchCancel);
     // XXX: this name should be part of the view model
@@ -207,19 +212,32 @@ const RoomSummaryCardView: React.FC<IProps> = ({
 
     const header = onSearchChange && (
         <Form.Root className="mx_RoomSummaryCard_search" onSubmit={(e) => e.preventDefault()}>
-            <Search
-                placeholder={_t("room|search|placeholder")}
-                name="room_message_search"
-                onChange={(e) => {
-                    setSearchValue(e.currentTarget.value);
-                    onSearchChange(e.currentTarget.value);
-                }}
-                value={searchValue}
-                className="mx_no_textinput"
-                ref={vm.searchInputRef}
-                autoFocus={focusRoomSearch}
-                onKeyDown={vm.onUpdateSearchInput}
-            />
+            <Flex align="center" gap="var(--cpd-space-2x)">
+                <Box flex="1" className="mx_RoomSummaryCard_searchInput">
+                    <Search
+                        placeholder={_t("room|search|placeholder")}
+                        name="room_message_search"
+                        onChange={(e) => {
+                            setSearchValue(e.currentTarget.value);
+                            onSearchChange(e.currentTarget.value);
+                        }}
+                        value={searchValue}
+                        className="mx_no_textinput"
+                        ref={vm.searchInputRef}
+                        autoFocus={focusRoomSearch}
+                        onKeyDown={vm.onUpdateSearchInput}
+                    />
+                </Box>
+                {/* "from:"/sender filter; renders only when the room has other members to filter by. */}
+                {onSearchSendersChange && (
+                    <RoomSearchSenderFilter
+                        key={room.roomId}
+                        room={room}
+                        senders={searchSenders}
+                        onSearchSendersChange={onSearchSendersChange}
+                    />
+                )}
+            </Flex>
         </Form.Root>
     );
 

--- a/apps/web/src/components/views/rooms/EventTile.tsx
+++ b/apps/web/src/components/views/rooms/EventTile.tsx
@@ -191,6 +191,12 @@ export interface EventTileProps {
     /** Whether this is the currently selected event. */
     isSelectedEvent?: boolean;
 
+    /**
+     * Whether this tile is the search match currently focused while stepping through results in the live
+     * timeline. Drives the `mx_EventTile_searchHighlightActive` class. See Searching.ts / RoomView search stepping.
+     */
+    isSearchHighlightMatch?: boolean;
+
     /** Resize observer used by the parent timeline, if any. */
     resizeObserver?: ResizeObserver;
 
@@ -903,6 +909,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                     isRedacted: this.props.isRedacted,
                 }),
                 isSelected: this.props.isSelectedEvent || !!this.state.interaction.contextMenu,
+                isSearchHighlightMatch: this.props.isSearchHighlightMatch,
                 isLast: this.props.last,
                 isLastInSection: this.props.lastInSection,
                 isContextual: this.props.contextual,

--- a/apps/web/src/components/views/rooms/RoomSearchAuxPanel.tsx
+++ b/apps/web/src/components/views/rooms/RoomSearchAuxPanel.tsx
@@ -9,7 +9,9 @@ Please see LICENSE files in the repository root for full details.
 import React from "react";
 import SearchIcon from "@vector-im/compound-design-tokens/assets/web/icons/search";
 import CloseIcon from "@vector-im/compound-design-tokens/assets/web/icons/close";
+import ListIcon from "@vector-im/compound-design-tokens/assets/web/icons/list-view";
 import { IconButton, Link } from "@vector-im/compound-web";
+import { SearchMatchNavigation, type SearchMatchNavigationViewModel } from "@element-hq/web-shared-components";
 
 import { _t } from "../../../languageHandler";
 import { PosthogScreenTracker } from "../../../PosthogTrackers";
@@ -17,15 +19,39 @@ import SearchWarning, { WarningKind } from "../elements/SearchWarning";
 import { type SearchInfo, SearchScope } from "../../../Searching";
 import InlineSpinner from "../elements/InlineSpinner";
 
-interface Props {
-    searchInfo?: SearchInfo;
-    isRoomEncrypted: boolean;
-    onSearchScopeChange(this: void, scope: SearchScope): void;
-    onCancelClick(this: void): void;
+interface SearchInfoWithStepping extends SearchInfo {
+    currentMatchIndex?: number;
 }
 
-const RoomSearchAuxPanel: React.FC<Props> = ({ searchInfo, isRoomEncrypted, onSearchScopeChange, onCancelClick }) => {
+interface Props {
+    searchInfo?: SearchInfoWithStepping;
+    isRoomEncrypted: boolean;
+    /**
+     * View model driving the in-timeline "k of N" match stepper. When provided and it has matches, the
+     * counter and up/down arrows are shown in the header.
+     */
+    navigationVm?: SearchMatchNavigationViewModel;
+    onSearchScopeChange(this: void, scope: SearchScope): void;
+    onCancelClick(this: void): void;
+    /**
+     * Return from live-timeline match stepping to the search results list, keeping the search session alive.
+     * Only surfaced (as a button) while a match is focused; distinct from {@link onCancelClick}, which ends the
+     * search entirely.
+     */
+    onBackToResults?(this: void): void;
+}
+
+const RoomSearchAuxPanel: React.FC<Props> = ({
+    searchInfo,
+    isRoomEncrypted,
+    navigationVm,
+    onSearchScopeChange,
+    onCancelClick,
+    onBackToResults,
+}) => {
     const scope = searchInfo?.scope ?? SearchScope.Room;
+    // True while a match is focused in the live timeline (stepping). Used to surface the "back to results" affordance.
+    const isSteppingMatch = (searchInfo?.currentMatchIndex ?? -1) >= 0;
 
     return (
         <>
@@ -34,6 +60,9 @@ const RoomSearchAuxPanel: React.FC<Props> = ({ searchInfo, isRoomEncrypted, onSe
                 <div className="mx_RoomSearchAuxPanel_summary">
                     <SearchIcon width="24px" height="24px" />
                     <div className="mx_RoomSearchAuxPanel_summary_text">
+                        {/* We keep the backend "N results found" summary visible alongside the "k of N loaded"
+                            stepper; the stepper's "loaded" label disambiguates the two (differently-counted)
+                            denominators (backend estimate vs. locally-loaded steppable matches). */}
                         {searchInfo?.count !== undefined ? (
                             _t(
                                 "room|search|summary",
@@ -49,6 +78,16 @@ const RoomSearchAuxPanel: React.FC<Props> = ({ searchInfo, isRoomEncrypted, onSe
                     </div>
                 </div>
                 <div className="mx_RoomSearchAuxPanel_buttons">
+                    {isSteppingMatch && onBackToResults && (
+                        <IconButton
+                            onClick={onBackToResults}
+                            tooltip={_t("room|search|back_to_results")}
+                            aria-label={_t("room|search|back_to_results")}
+                        >
+                            <ListIcon width="20px" height="20px" />
+                        </IconButton>
+                    )}
+                    {navigationVm && <SearchMatchNavigation vm={navigationVm} />}
                     <Link
                         onClick={() =>
                             onSearchScopeChange(scope === SearchScope.Room ? SearchScope.All : SearchScope.Room)

--- a/apps/web/src/dispatcher/actions.ts
+++ b/apps/web/src/dispatcher/actions.ts
@@ -399,6 +399,13 @@ export enum Action {
     FocusMessageSearch = "focus_search",
 
     /**
+     * Step the in-room search match cursor to the next or previous match in the live timeline. Dispatched from
+     * the focused search input (Enter / Shift+Enter) and handled by the room being searched. Use with a
+     * SearchMatchStepPayload.
+     */
+    SearchMatchStep = "search_match_step",
+
+    /**
      * Open the direct message dialog
      */
     CreateChat = "view_create_chat",

--- a/apps/web/src/dispatcher/payloads/SearchMatchStepPayload.ts
+++ b/apps/web/src/dispatcher/payloads/SearchMatchStepPayload.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import { type Action } from "../actions";
+import { type ActionPayload } from "../payloads";
+
+export interface SearchMatchStepPayload extends ActionPayload {
+    action: Action.SearchMatchStep;
+
+    /**
+     * Which way to step the search match cursor: "next" advances to the older match, "previous" goes back to
+     * the newer match. Both wrap around the ends of the match list.
+     */
+    direction: "next" | "previous";
+}

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -2114,6 +2114,11 @@
         "search": {
             "all_rooms_button": "Search all rooms",
             "back_to_results": "Back to results",
+            "order_recent": "Most recent",
+            "order_relevant": "Most relevant",
+            "order_toggle_button": "Sort results",
+            "order_toggle_button_active": "Sort results (by relevance)",
+            "order_toggle_label": "Sort search results",
             "placeholder": "Search messages…",
             "sender_filter_button": "Filter by sender",
             "sender_filter_button_active": "Filter by sender (%(count)s selected)",

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -2113,6 +2113,7 @@
         "room_is_low_priority": "This is a low priority room",
         "search": {
             "all_rooms_button": "Search all rooms",
+            "back_to_results": "Back to results",
             "placeholder": "Search messages…",
             "summary": {
                 "one": "1 result found for “<query/>”",

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -2115,6 +2115,10 @@
             "all_rooms_button": "Search all rooms",
             "back_to_results": "Back to results",
             "placeholder": "Search messages…",
+            "sender_filter_button": "Filter by sender",
+            "sender_filter_button_active": "Filter by sender (%(count)s selected)",
+            "sender_filter_clear": "Clear sender filter",
+            "sender_filter_label": "Messages from",
             "summary": {
                 "one": "1 result found for “<query/>”",
                 "other": "%(count)s results found for “<query/>”"

--- a/apps/web/src/stores/SearchSessionStore.ts
+++ b/apps/web/src/stores/SearchSessionStore.ts
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import EventEmitter from "events";
+import { type ISearchResults, type SearchOrderBy } from "matrix-js-sdk/src/matrix";
+
+import { type SearchMatch, type SearchResultPreview, type SearchScope } from "../Searching";
+import defaultDispatcher from "../dispatcher/dispatcher";
+import { Action } from "../dispatcher/actions";
+import { type ActionPayload } from "../dispatcher/payloads";
+
+export enum SearchSessionStoreEvent {
+    Update = "update",
+}
+
+/**
+ * The immutable identity of a search session — mirrors the start-time fields of a {@link SearchInfo}.
+ */
+export interface SearchSessionParams {
+    searchId: number;
+    term: string;
+    scope: SearchScope;
+    /** The room the search was started from, or undefined for an all-rooms search. */
+    roomId?: string;
+    /**
+     * The active `from:`/sender filter (full MXIDs), or undefined/empty for no sender filter. Part of the
+     * session identity: it survives RoomView remounts during cross-room stepping and
+     * is preserved verbatim by {@link SearchSessionStore.updateResults}, so a re-search keeps the filter.
+     */
+    senders?: string[];
+    /**
+     * The requested result ordering — {@link SearchOrderBy.Recent} (default) or {@link SearchOrderBy.Rank}
+     * (relevance). Part of the session identity: it survives RoomView remounts during
+     * cross-room stepping and is preserved verbatim by {@link SearchSessionStore.updateResults}, so a re-search
+     * keeps the chosen order.
+     */
+    order?: SearchOrderBy;
+    promise: Promise<ISearchResults>;
+    abortController?: AbortController;
+}
+
+/**
+ * The results applied to the live session as the backend settles. `matches`/`highlights` are omitted while the
+ * search is still in progress.
+ */
+export interface SearchSessionResults {
+    inProgress: boolean;
+    matches?: SearchMatch[];
+    /** Result preview rows for the dropdown (parallel to {@link matches}) — see {@link extractSearchResultPreviews}. */
+    previews?: SearchResultPreview[];
+    highlights?: string[];
+    count?: number;
+    /** Whether more result pages remain to be paginated in. */
+    hasMore?: boolean;
+    error?: Error;
+}
+
+/**
+ * A snapshot of the active search session.
+ */
+export interface SearchSession extends SearchSessionParams {
+    /** Ordered (newest-first), cross-room and unfiltered — see {@link extractSearchMatches}. */
+    matches: SearchMatch[];
+    /** Result preview rows for the dropdown, parallel to {@link matches} (see {@link extractSearchResultPreviews}). */
+    previews: SearchResultPreview[];
+    /** Index into {@link matches} of the focused match, or -1 when no match is focused (viewing the results list). */
+    currentMatchIndex: number;
+    highlights: string[];
+    count?: number;
+    /** Whether more result pages remain to be paginated into the results dropdown. */
+    hasMore?: boolean;
+    inProgress: boolean;
+    error?: Error;
+}
+
+/**
+ * Owns the live message-search session independently of any RoomView instance.
+ *
+ * RoomView is keyed by room id (see LoggedInView), so it unmounts/remounts on any cross-room navigation. Stepping
+ * through search matches in the live timeline crosses rooms — an all-rooms search spans rooms, and even a
+ * room-scoped search also searches upgraded predecessor rooms (#32258) — so the session (the ordered cross-room
+ * match list, the focused index, the highlight terms and the search promise/abort controller) must outlive the
+ * component. This singleton is that owner: {@link RoomView} mirrors it into its render state and re-hydrates from it
+ * after a remount, while {@link RoomSearchNavigationViewModel} reads/writes the cursor here.
+ */
+export class SearchSessionStore extends EventEmitter {
+    private static _instance: SearchSessionStore | null = null;
+
+    private session: SearchSession | null = null;
+    // Transient (not view state, so never emitted): set immediately before a stepping-driven ViewRoom dispatch so
+    // RoomView's "edited an event" clear gate can tell a stepping jump apart from a genuine user navigation and not
+    // tear the session down. Consumed exactly once; auto-reset whenever fresh results arrive or the session is
+    // cleared.
+    private steppingJump = false;
+    // Durable companion to {@link steppingJump}: the event id the in-flight internal navigation pins the live
+    // timeline to — the match we are stepping to, or the event we are clearing on the way back to the results list.
+    // The result-click clear gate compares it against the LIVE focused event id rather than consuming the one-shot
+    // flag, so it is immune to the race the flag has: any unrelated RoomViewStore emission landing between
+    // {@link beginSteppingJump} and our own ViewRoom being processed used to consume the flag early, so the real
+    // stepping/return update then saw it already false and the gate wrongly tore the session down (the packaged-build
+    // "search resets itself" bug). Persisted — not consumed — and reset ONLY by start()/clear(); deliberately kept
+    // across updateResults() and across returns to the results list so a transient un-pinned frame can never unguard
+    // the clear gate mid-jump.
+    private steppingTargetEventId: string | null = null;
+    // Durable marker of the focused match's event id (or null when viewing the results list), set by
+    // {@link setCurrentMatchIndex}, reset by start()/clear() and (only) when the focused match drops out of a fresh
+    // result set in {@link updateResults}. Unlike {@link SearchSession.currentMatchIndex}
+    // — which updateResults invalidates to -1 on every fresh/in-progress result set — this survives a result update,
+    // so it is the robust "are we stepping a match, and which one" signal. RoomView derives its stepping render +
+    // the result-click clear gate's "results list shown" test from this rather than from the volatile cursor: a
+    // settled search update (or a "load more" page) landing while a match is focused used to null the cursor, and a
+    // background RoomViewStore emission then treated the focused jump as the results list and clobbered the live
+    // flash + in-bubble highlight + centered scroll on the packaged build (the result-click regression).
+    private focusedMatchEventId: string | null = null;
+
+    public constructor() {
+        super();
+        defaultDispatcher.register(this.onAction);
+    }
+
+    public static get instance(): SearchSessionStore {
+        if (!SearchSessionStore._instance) {
+            SearchSessionStore._instance = new SearchSessionStore();
+        }
+        return SearchSessionStore._instance;
+    }
+
+    private onAction = (payload: ActionPayload): void => {
+        if (payload.action === Action.OnLoggedOut) {
+            this.clear({ abort: true });
+        }
+    };
+
+    /**
+     * Begin a new search session, replacing and aborting any previous one. Matches/highlights stay empty until
+     * {@link updateResults} is called once the backend settles.
+     */
+    public start(params: SearchSessionParams): void {
+        // A new term replaces the previous session; abort its in-flight request so we never adopt stale results.
+        this.session?.abortController?.abort();
+        this.session = {
+            ...params,
+            matches: [],
+            previews: [],
+            currentMatchIndex: -1,
+            highlights: [],
+            hasMore: false,
+            inProgress: true,
+        };
+        this.steppingJump = false;
+        this.steppingTargetEventId = null;
+        this.focusedMatchEventId = null;
+        this.emit(SearchSessionStoreEvent.Update);
+    }
+
+    /**
+     * Apply settled (or in-progress) results to the live session. No-op if there is no active session.
+     */
+    public updateResults(results: SearchSessionResults): void {
+        if (!this.session) return;
+        const matches = results.matches ?? this.session.matches;
+        // A fresh result set invalidates the index-based cursor, BUT if a match is still focused (durable
+        // {@link focusedMatchEventId}, e.g. a settled search/"load more" landed mid-step) re-derive the cursor onto
+        // that same match by event id so stepping and the "k of N" counter stay put — instead of snapping back to
+        // "no match" (-1) and collapsing the live highlight. No focus → -1 (viewing the list).
+        const refocusedIndex = this.focusedMatchEventId
+            ? matches.findIndex((m) => m.eventId === this.focusedMatchEventId)
+            : -1;
+        // If the focused match dropped out of the new result set entirely, stop treating it as focused too, so the
+        // UI falls back to the results list coherently instead of stranding on a hidden live timeline with a
+        // "0 of N" counter and no back-to-results affordance.
+        if (refocusedIndex < 0) {
+            this.focusedMatchEventId = null;
+        }
+        this.session = {
+            ...this.session,
+            inProgress: results.inProgress,
+            matches,
+            previews: results.previews ?? this.session.previews,
+            highlights: results.highlights ?? this.session.highlights,
+            count: results.count,
+            hasMore: results.hasMore ?? this.session.hasMore,
+            error: results.error,
+            currentMatchIndex: refocusedIndex,
+        };
+        // Fresh results end any in-flight one-shot stepping jump. NB: deliberately do NOT clear steppingTargetEventId
+        // here — returning from stepping to the results list re-mounts RoomView's hidden RoomSearchView data engine,
+        // which re-resolves the (already-settled) promise and calls updateResults again; clearing the durable target
+        // here would unguard the clear gate for exactly that return-to-list window and let an unrelated emission tear
+        // the session down (the "search resets itself" bug). The target is reset only by start()/clear().
+        this.steppingJump = false;
+        this.emit(SearchSessionStoreEvent.Update);
+    }
+
+    /**
+     * Move the focused-match cursor. `-1` means "no match focused" (viewing the results list).
+     */
+    public setCurrentMatchIndex(index: number): void {
+        // Record the durable focused-match marker BEFORE the no-op guard below, so returning to the list
+        // (setCurrentMatchIndex(-1)) always clears it even when the cursor was already -1 (e.g. a prior
+        // updateResults left it there). A focused index maps to that match's event id; -1 clears the focus.
+        this.focusedMatchEventId = index >= 0 ? (this.session?.matches[index]?.eventId ?? null) : null;
+        if (!this.session || this.session.currentMatchIndex === index) return;
+        this.session = { ...this.session, currentMatchIndex: index };
+        this.emit(SearchSessionStoreEvent.Update);
+    }
+
+    /**
+     * Mark that the next ViewRoom dispatch is an internal search navigation (stepping to a match, or clearing the
+     * focused event on return to the results list), not a user navigating away. `eventId` is the event the live
+     * timeline is/was pinned to for this navigation — a match's event id when stepping, or the event being cleared
+     * when returning to the list. The result-click clear gate treats a focused event equal to it as ours (durable —
+     * {@link steppingTarget}), so it never tears the session down even if an unrelated emission consumed the one-shot
+     * {@link steppingJump} flag first.
+     */
+    public beginSteppingJump(eventId: string | null): void {
+        this.steppingJump = true;
+        this.steppingTargetEventId = eventId;
+    }
+
+    /** Read and reset the one-shot stepping-jump flag. Used by the edit clear gate (exactly-once). */
+    public consumeSteppingJump(): boolean {
+        const value = this.steppingJump;
+        this.steppingJump = false;
+        return value;
+    }
+
+    /** Read the one-shot stepping-jump flag without resetting it. Used by the edit clear gate. */
+    public isSteppingJump(): boolean {
+        return this.steppingJump;
+    }
+
+    /**
+     * The event id the in-flight internal navigation pins the live timeline to, or null if none. The result-click
+     * clear gate leaves the session alive while the focused event equals this — robust against the one-shot
+     * {@link steppingJump} flag being consumed early by an unrelated RoomViewStore emission.
+     */
+    public get steppingTarget(): string | null {
+        return this.steppingTargetEventId;
+    }
+
+    /**
+     * The focused match's event id, or null when viewing the results list. Durable: survives {@link updateResults}
+     * (reset only by start()/clear()), so it is the race-free "stepping a match?" signal RoomView renders from —
+     * see {@link focusedMatchEventId}.
+     */
+    public get focusedMatch(): string | null {
+        return this.focusedMatchEventId;
+    }
+
+    /**
+     * End the session. Aborts the in-flight request unless `abort` is false (the session is never cleared on a
+     * remount, so the surviving promise is never rejected by a room switch).
+     */
+    public clear({ abort = true }: { abort?: boolean } = {}): void {
+        if (abort) {
+            this.session?.abortController?.abort();
+        }
+        this.session = null;
+        this.steppingJump = false;
+        this.steppingTargetEventId = null;
+        this.focusedMatchEventId = null;
+        this.emit(SearchSessionStoreEvent.Update);
+    }
+
+    public hasActiveSession(): boolean {
+        return this.session !== null;
+    }
+
+    public getSnapshot(): SearchSession | null {
+        return this.session;
+    }
+
+    public get matches(): SearchMatch[] {
+        return this.session?.matches ?? [];
+    }
+
+    public get currentMatchIndex(): number {
+        return this.session?.currentMatchIndex ?? -1;
+    }
+}

--- a/apps/web/src/viewmodels/room/timeline/event-tile/EventTileDerivedState.ts
+++ b/apps/web/src/viewmodels/room/timeline/event-tile/EventTileDerivedState.ts
@@ -417,6 +417,8 @@ export interface EventTileClassState {
     isHighlighted: boolean;
     /** Whether the tile is selected or has an open context menu. */
     isSelected: boolean;
+    /** Whether the tile is the search match currently focused while stepping in the live timeline. */
+    isSearchHighlightMatch?: boolean;
     /** Whether the tile is a continuation of the previous event. */
     isContinuation?: boolean;
     /** The Matrix event type for event-type class derivation. */
@@ -456,6 +458,7 @@ export function getEventTileClassState({
     isSending,
     isHighlighted,
     isSelected,
+    isSearchHighlightMatch,
     isContinuation,
     eventType,
     isCallInvite,
@@ -482,6 +485,7 @@ export function getEventTileClassState({
         mx_EventTile_sending: !isEditing && isSending,
         mx_EventTile_highlight: isHighlighted,
         mx_EventTile_selected: isSelected,
+        mx_EventTile_searchHighlightActive: isSearchHighlightMatch,
         mx_EventTile_continuation: isContinuation || isCallInvite || ElementCallEventType.matches(eventType),
         mx_EventTile_last: isLast,
         mx_EventTile_lastInSection: isLastInSection,

--- a/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
+++ b/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
@@ -104,6 +104,8 @@ export interface EventTileDisplayInput {
     isHighlighted: boolean;
     /** Whether the tile is selected or has an open context menu. */
     isSelected: boolean;
+    /** Whether the tile is the search match currently focused while stepping in the live timeline. */
+    isSearchHighlightMatch?: boolean;
     /** Whether the tile is the last event in the timeline. */
     isLast?: boolean;
     /** Whether the tile is the last event in its section. */
@@ -621,6 +623,7 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
             isSending,
             isHighlighted: display.isHighlighted,
             isSelected: display.isSelected,
+            isSearchHighlightMatch: display.isSearchHighlightMatch,
             isContinuation,
             eventType,
             isCallInvite,

--- a/apps/web/src/viewmodels/search/RoomSearchNavigationViewModel.ts
+++ b/apps/web/src/viewmodels/search/RoomSearchNavigationViewModel.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import { BaseViewModel } from "@element-hq/web-shared-components";
+
+import { type SearchMatch } from "../../Searching";
+import { SearchSessionStore, SearchSessionStoreEvent } from "../../stores/SearchSessionStore";
+
+interface SearchMatchNavigationViewSnapshot {
+    current: number;
+    total: number;
+    canPrevious: boolean;
+    canNext: boolean;
+}
+
+interface SearchMatchNavigationViewActions {
+    previous(): void;
+    next(): void;
+}
+
+/**
+ * Constructor props for {@link RoomSearchNavigationViewModel}.
+ */
+export interface RoomSearchNavigationProps {
+    /**
+     * Invoked when a match becomes the focused one (via next/previous). The owner is responsible for driving
+     * the live timeline to the match (e.g. dispatching a ViewRoom action) and recording the active index.
+     */
+    onActivateMatch(this: void, match: SearchMatch, index: number): void;
+}
+
+function computeSnapshot(store: SearchSessionStore): SearchMatchNavigationViewSnapshot {
+    const total = store.matches.length;
+    const index = store.currentMatchIndex;
+    return {
+        current: index < 0 ? 0 : index + 1,
+        total,
+        // Stepping wraps around, so both arrows are available whenever there is at least one match.
+        canPrevious: total > 0,
+        canNext: total > 0,
+    };
+}
+
+/**
+ * MVVM-v2 view model owning the in-room search match cursor.
+ *
+ * The match list and focused index live in the {@link SearchSessionStore}; this view model is a thin reactive
+ * projection of that store onto the "k of N" counter, and drives the live timeline through the injected
+ * {@link RoomSearchNavigationProps.onActivateMatch} callback when the user steps with the up/down arrows.
+ */
+export class RoomSearchNavigationViewModel
+    extends BaseViewModel<SearchMatchNavigationViewSnapshot, RoomSearchNavigationProps>
+    implements SearchMatchNavigationViewActions
+{
+    private readonly store = SearchSessionStore.instance;
+
+    public constructor(props: RoomSearchNavigationProps) {
+        super(props, computeSnapshot(SearchSessionStore.instance));
+        this.disposables.trackListener(this.store, SearchSessionStoreEvent.Update, this.onStoreUpdate);
+    }
+
+    private onStoreUpdate = (): void => {
+        this.snapshot.set(computeSnapshot(this.store));
+    };
+
+    /**
+     * Step to the next (older) match. From the empty cursor this activates the first (newest) match; from the
+     * last match it wraps around to the first.
+     */
+    public readonly next = (): void => {
+        const total = this.store.matches.length;
+        if (total === 0) return;
+        const index = this.store.currentMatchIndex;
+        const nextIndex = index < 0 ? 0 : (index + 1) % total;
+        this.activate(nextIndex);
+    };
+
+    /**
+     * Step to the previous (newer) match. From the empty cursor or the first match this wraps around to the
+     * last (oldest) match.
+     */
+    public readonly previous = (): void => {
+        const total = this.store.matches.length;
+        if (total === 0) return;
+        const index = this.store.currentMatchIndex;
+        const prevIndex = index <= 0 ? total - 1 : index - 1;
+        this.activate(prevIndex);
+    };
+
+    private activate(index: number): void {
+        // Flag the upcoming ViewRoom dispatch as a stepping jump to this match's event so RoomView's clear gates leave
+        // the session alone, then move the cursor (which emits Update -> recomputes this snapshot via onStoreUpdate).
+        this.store.beginSteppingJump(this.store.matches[index].eventId);
+        this.store.setCurrentMatchIndex(index);
+        this.props.onActivateMatch(this.store.matches[index], index);
+    }
+}

--- a/apps/web/src/viewmodels/search/RoomSearchSenderFilterViewModel.ts
+++ b/apps/web/src/viewmodels/search/RoomSearchSenderFilterViewModel.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import { type Room } from "matrix-js-sdk/src/matrix";
+import { BaseViewModel } from "@element-hq/web-shared-components";
+
+/**
+ * A selectable sender option for the search `from:` filter.
+ */
+export interface SenderOption {
+    /** Full MXID, matched against {@link IRoomEventFilter.senders} / a result's `sender`. */
+    userId: string;
+    /** Display name to show in the picker. */
+    name: string;
+}
+
+/**
+ * Reactive state for the search sender-filter picker.
+ */
+export interface RoomSearchSenderFilterSnapshot {
+    /** The room's joined members (excluding the current user), sorted by display name, offered as `from:` options. */
+    members: SenderOption[];
+}
+
+/**
+ * Constructor props for {@link RoomSearchSenderFilterViewModel}.
+ */
+export interface RoomSearchSenderFilterProps {
+    /** The room whose members can be picked as `from:` filters. */
+    room: Room;
+}
+
+function computeMembers(room: Room): SenderOption[] {
+    const myUserId = room.myUserId;
+    return room
+        .getJoinedMembers()
+        .filter((m) => m.userId !== myUserId)
+        .map((m) => ({ userId: m.userId, name: m.name }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * MVVM-v2 view model backing the search `from:`/sender filter picker.
+ *
+ * Owns the candidate sender catalogue — the room's joined members, minus the current user, sorted by display
+ * name — so the View stays dumb. The selected senders are NOT held here: they are owned by RoomView's search
+ * session and threaded down to the View as a prop; the View toggles them through an injected callback.
+ */
+export class RoomSearchSenderFilterViewModel extends BaseViewModel<
+    RoomSearchSenderFilterSnapshot,
+    RoomSearchSenderFilterProps
+> {
+    public constructor(props: RoomSearchSenderFilterProps) {
+        super(props, { members: computeMembers(props.room) });
+    }
+}

--- a/apps/web/test/unit-tests/Searching-test.ts
+++ b/apps/web/test/unit-tests/Searching-test.ts
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { type IResultRoomEvents } from "matrix-js-sdk/src/matrix";
+import { type IResultRoomEvents, SearchOrderBy } from "matrix-js-sdk/src/matrix";
 
 import eventSearch, { searchPagination } from "../../src/Searching";
 import EventIndexPeg from "../../src/indexing/EventIndexPeg";
@@ -458,6 +458,108 @@ describe("Searching", () => {
             expect(mockEventIndex.search.mock.calls[0][0].limit).toBe(10);
             const senders = processed.get().search_categories.room_events.results.map((r: any) => r.result.sender);
             expect(senders).toEqual(["@alice:example.org", "@bob:example.org"]);
+        });
+    });
+
+    describe("relevance-vs-recency order", () => {
+        // Pretend the searched room is encrypted so eventSearch takes the local (Seshat) path.
+        const mockEncryptedRoom = (): void => {
+            jest.spyOn(mockClient, "getCrypto").mockReturnValue({
+                isEncryptionEnabledInRoom: jest.fn().mockResolvedValue(true),
+            } as any);
+        };
+
+        it("sets order_by: Rank on the homeserver body when relevance order is requested", async () => {
+            jest.spyOn(EventIndexPeg, "get").mockReturnValue(null); // no local index -> server-side path
+            const searchSpy = jest.spyOn(mockClient, "search").mockResolvedValue({
+                search_categories: { room_events: { results: [], count: 0, highlights: [] } },
+            } as any);
+
+            await eventSearch(mockClient, "hello", "!room:example.org", undefined, undefined, SearchOrderBy.Rank);
+
+            const body = (searchSpy.mock.calls[0][0] as any).body;
+            expect(body.search_categories.room_events.order_by).toBe(SearchOrderBy.Rank);
+        });
+
+        it("defaults the homeserver body to Recent order", async () => {
+            jest.spyOn(EventIndexPeg, "get").mockReturnValue(null);
+            const searchSpy = jest.spyOn(mockClient, "search").mockResolvedValue({
+                search_categories: { room_events: { results: [], count: 0, highlights: [] } },
+            } as any);
+
+            await eventSearch(mockClient, "hello", "!room:example.org");
+
+            const body = (searchSpy.mock.calls[0][0] as any).body;
+            expect(body.search_categories.room_events.order_by).toBe(SearchOrderBy.Recent);
+        });
+
+        it("carries order_by into the stored _query so server-side pagination keeps the order", async () => {
+            jest.spyOn(EventIndexPeg, "get").mockReturnValue(null);
+            jest.spyOn(mockClient, "search").mockResolvedValue({
+                search_categories: { room_events: { results: [], count: 0, highlights: [] } },
+            } as any);
+            jest.spyOn(mockClient, "processRoomEventsSearch").mockImplementation(((sr: any) => sr) as any);
+
+            const result: any = await eventSearch(
+                mockClient,
+                "hello",
+                "!room:example.org",
+                undefined,
+                undefined,
+                SearchOrderBy.Rank,
+            );
+
+            expect(result._query.search_categories.room_events.order_by).toBe(SearchOrderBy.Rank);
+        });
+
+        it("orders a single encrypted room by Seshat relevance (order_by_recency false) under relevance order", async () => {
+            const mockEventIndex = {
+                search: jest.fn().mockResolvedValue({ count: 0, results: [], highlights: [] } as IResultRoomEvents),
+            };
+            jest.spyOn(EventIndexPeg, "get").mockReturnValue(mockEventIndex as any);
+            mockEncryptedRoom();
+
+            await eventSearch(mockClient, "hello", "!room:example.org", undefined, undefined, SearchOrderBy.Rank);
+
+            expect(mockEventIndex.search.mock.calls[0][0].order_by_recency).toBe(false);
+        });
+
+        it("keeps a single encrypted room ordered by recency (order_by_recency true) by default", async () => {
+            const mockEventIndex = {
+                search: jest.fn().mockResolvedValue({ count: 0, results: [], highlights: [] } as IResultRoomEvents),
+            };
+            jest.spyOn(EventIndexPeg, "get").mockReturnValue(mockEventIndex as any);
+            mockEncryptedRoom();
+
+            await eventSearch(mockClient, "hello", "!room:example.org");
+
+            expect(mockEventIndex.search.mock.calls[0][0].order_by_recency).toBe(true);
+        });
+
+        it("keeps recency order on both legs of an all-rooms search even when relevance is requested", async () => {
+            // The combined (All-rooms) path merges the two legs with a sliding-window cache that only preserves
+            // global order when both legs are recency-sorted, so a relevance order must NOT propagate to either leg
+            // (deferred until the merge is redesigned). The single-source paths above honour it; the merged path
+            // stays recency by construction.
+            const mockEventIndex = {
+                search: jest.fn().mockResolvedValue({ count: 0, results: [], highlights: [] } as IResultRoomEvents),
+            };
+            jest.spyOn(EventIndexPeg, "get").mockReturnValue(mockEventIndex as any);
+            const searchSpy = jest.spyOn(mockClient, "search").mockResolvedValue({
+                search_categories: { room_events: { results: [], count: 0, highlights: [] } },
+            } as any);
+            jest.spyOn(mockClient, "processRoomEventsSearch").mockImplementation(((sr: any) => ({
+                ...sr,
+                results: [],
+                highlights: [],
+            })) as any);
+
+            // roomId undefined => All Rooms => combinedSearch.
+            await eventSearch(mockClient, "hello", undefined, undefined, undefined, SearchOrderBy.Rank);
+
+            const body = (searchSpy.mock.calls[0][0] as any).body;
+            expect(body.search_categories.room_events.order_by).toBe(SearchOrderBy.Recent);
+            expect(mockEventIndex.search.mock.calls[0][0].order_by_recency).toBe(true);
         });
     });
 });

--- a/apps/web/test/unit-tests/Searching-test.ts
+++ b/apps/web/test/unit-tests/Searching-test.ts
@@ -7,7 +7,7 @@ Please see LICENSE files in the repository root for full details.
 
 import { type IResultRoomEvents } from "matrix-js-sdk/src/matrix";
 
-import eventSearch from "../../src/Searching";
+import eventSearch, { searchPagination } from "../../src/Searching";
 import EventIndexPeg from "../../src/indexing/EventIndexPeg";
 import { createTestClient } from "../test-utils";
 
@@ -257,6 +257,207 @@ describe("Searching", () => {
 
             const thirdMainEvent = mockSearchResults.results![2].result as unknown as Record<string, unknown>;
             expect(thirdMainEvent.state_key).toBeUndefined();
+        });
+    });
+
+    describe("from:/sender filter", () => {
+        const rawResult = (sender: string, eventId: string, ts: number): any => ({
+            rank: 1,
+            result: {
+                event_id: eventId,
+                room_id: "!room:example.org",
+                sender,
+                type: "m.room.message",
+                origin_server_ts: ts,
+                content: { body: "hello", msgtype: "m.text" },
+            },
+            context: { events_before: [], events_after: [], profile_info: {} },
+        });
+
+        // Pretend the searched room is encrypted so eventSearch takes the local (Seshat) path.
+        const mockEncryptedRoom = (): void => {
+            jest.spyOn(mockClient, "getCrypto").mockReturnValue({
+                isEncryptionEnabledInRoom: jest.fn().mockResolvedValue(true),
+            } as any);
+        };
+
+        const captureProcessed = (): { get: () => any } => {
+            let captured: any;
+            jest.spyOn(mockClient, "processRoomEventsSearch").mockImplementation(((sr: any, response: any) => {
+                captured = response;
+                return { ...sr, results: [], highlights: [] };
+            }) as any);
+            return { get: () => captured };
+        };
+
+        it("sets filter.senders on the homeserver search body when senders are given", async () => {
+            jest.spyOn(EventIndexPeg, "get").mockReturnValue(null); // no local index -> server-side path
+            const searchSpy = jest.spyOn(mockClient, "search").mockResolvedValue({
+                search_categories: { room_events: { results: [], count: 0, highlights: [] } },
+            } as any);
+
+            await eventSearch(mockClient, "hello", "!room:example.org", undefined, ["@alice:example.org"]);
+
+            const body = (searchSpy.mock.calls[0][0] as any).body;
+            expect(body.search_categories.room_events.filter.senders).toEqual(["@alice:example.org"]);
+            // The room scope is preserved alongside the new sender scope.
+            expect(body.search_categories.room_events.filter.rooms).toEqual(["!room:example.org"]);
+        });
+
+        it("carries filter.senders into the stored _query so server-side pagination keeps it", async () => {
+            jest.spyOn(EventIndexPeg, "get").mockReturnValue(null);
+            jest.spyOn(mockClient, "search").mockResolvedValue({
+                search_categories: { room_events: { results: [], count: 0, highlights: [] } },
+            } as any);
+            jest.spyOn(mockClient, "processRoomEventsSearch").mockImplementation(((sr: any) => sr) as any);
+
+            const result: any = await eventSearch(mockClient, "hello", "!room:example.org", undefined, [
+                "@alice:example.org",
+            ]);
+
+            expect(result._query.search_categories.room_events.filter.senders).toEqual(["@alice:example.org"]);
+        });
+
+        it("over-fetches the Seshat limit when a sender filter is active", async () => {
+            const mockEventIndex = {
+                search: jest.fn().mockResolvedValue({ count: 0, results: [], highlights: [] } as IResultRoomEvents),
+            };
+            jest.spyOn(EventIndexPeg, "get").mockReturnValue(mockEventIndex as any);
+            mockEncryptedRoom();
+
+            await eventSearch(mockClient, "hello", "!room:example.org", undefined, ["@bob:example.org"]);
+
+            expect(mockEventIndex.search.mock.calls[0][0].limit).toBeGreaterThan(10);
+        });
+
+        it("keeps the default Seshat limit when no sender filter is given", async () => {
+            const mockEventIndex = {
+                search: jest.fn().mockResolvedValue({ count: 0, results: [], highlights: [] } as IResultRoomEvents),
+            };
+            jest.spyOn(EventIndexPeg, "get").mockReturnValue(mockEventIndex as any);
+            mockEncryptedRoom();
+
+            await eventSearch(mockClient, "hello", "!room:example.org");
+
+            expect(mockEventIndex.search.mock.calls[0][0].limit).toBe(10);
+        });
+
+        it("post-filters Seshat results to the selected sender", async () => {
+            const mockEventIndex = {
+                search: jest.fn().mockResolvedValue({
+                    count: 2,
+                    results: [rawResult("@alice:example.org", "$a", 200), rawResult("@bob:example.org", "$b", 100)],
+                    highlights: [],
+                } as IResultRoomEvents),
+            };
+            jest.spyOn(EventIndexPeg, "get").mockReturnValue(mockEventIndex as any);
+            mockEncryptedRoom();
+            const processed = captureProcessed();
+
+            await eventSearch(mockClient, "hello", "!room:example.org", undefined, ["@bob:example.org"]);
+
+            const senders = processed.get().search_categories.room_events.results.map((r: any) => r.result.sender);
+            expect(senders).toEqual(["@bob:example.org"]);
+        });
+
+        it("returns an empty result without throwing when the sender has no matches", async () => {
+            const mockEventIndex = {
+                search: jest.fn().mockResolvedValue({
+                    count: 1,
+                    results: [rawResult("@alice:example.org", "$a", 200)],
+                    highlights: [],
+                } as IResultRoomEvents),
+            };
+            jest.spyOn(EventIndexPeg, "get").mockReturnValue(mockEventIndex as any);
+            mockEncryptedRoom();
+            const processed = captureProcessed();
+
+            await expect(
+                eventSearch(mockClient, "hello", "!room:example.org", undefined, ["@nobody:example.org"]),
+            ).resolves.toBeDefined();
+
+            expect(processed.get().search_categories.room_events.results).toEqual([]);
+        });
+
+        it("re-applies the sender post-filter on Seshat pagination", async () => {
+            const mockEventIndex = {
+                search: jest.fn().mockResolvedValue({
+                    count: 2,
+                    results: [rawResult("@alice:example.org", "$a2", 80), rawResult("@bob:example.org", "$b2", 70)],
+                    highlights: [],
+                } as IResultRoomEvents),
+            };
+            jest.spyOn(EventIndexPeg, "get").mockReturnValue(mockEventIndex as any);
+            const processed = captureProcessed();
+
+            const searchResult: any = {
+                results: [],
+                highlights: [],
+                seshatQuery: { search_term: "hello", room_id: "!room:example.org", limit: 50, next_batch: "n1" },
+                senderFilter: ["@bob:example.org"],
+            };
+
+            await searchPagination(mockClient, searchResult);
+
+            const senders = processed.get().search_categories.room_events.results.map((r: any) => r.result.sender);
+            expect(senders).toEqual(["@bob:example.org"]);
+        });
+
+        it("filters both the homeserver and Seshat legs for an all-rooms search", async () => {
+            const mockEventIndex = {
+                search: jest.fn().mockResolvedValue({
+                    count: 2,
+                    results: [rawResult("@alice:example.org", "$e", 90), rawResult("@bob:example.org", "$f", 80)],
+                    highlights: [],
+                } as IResultRoomEvents),
+            };
+            jest.spyOn(EventIndexPeg, "get").mockReturnValue(mockEventIndex as any);
+            const searchSpy = jest.spyOn(mockClient, "search").mockResolvedValue({
+                search_categories: { room_events: { results: [], count: 0, highlights: [] } },
+            } as any);
+            const processed = captureProcessed();
+
+            // roomId undefined => All Rooms => combinedSearch
+            await eventSearch(mockClient, "hello", undefined, undefined, ["@bob:example.org"]);
+
+            const body = (searchSpy.mock.calls[0][0] as any).body;
+            expect(body.search_categories.room_events.filter.senders).toEqual(["@bob:example.org"]);
+            const senders = processed.get().search_categories.room_events.results.map((r: any) => r.result.sender);
+            expect(senders).toEqual(["@bob:example.org"]);
+        });
+
+        it("does not set filter.senders on the homeserver body when no sender filter is given", async () => {
+            jest.spyOn(EventIndexPeg, "get").mockReturnValue(null);
+            const searchSpy = jest.spyOn(mockClient, "search").mockResolvedValue({
+                search_categories: { room_events: { results: [], count: 0, highlights: [] } },
+            } as any);
+
+            await eventSearch(mockClient, "hello", "!room:example.org");
+
+            const body = (searchSpy.mock.calls[0][0] as any).body;
+            expect(body.search_categories.room_events.filter.senders).toBeUndefined();
+        });
+
+        it("treats an empty senders array as no filter (the cleared-filter case)", async () => {
+            // The Clear action passes []; it must behave exactly like undefined — no homeserver filter, no Seshat
+            // over-fetch, no post-filter dropping results.
+            const mockEventIndex = {
+                search: jest.fn().mockResolvedValue({
+                    count: 2,
+                    results: [rawResult("@alice:example.org", "$a", 200), rawResult("@bob:example.org", "$b", 100)],
+                    highlights: [],
+                } as IResultRoomEvents),
+            };
+            jest.spyOn(EventIndexPeg, "get").mockReturnValue(mockEventIndex as any);
+            mockEncryptedRoom();
+            const processed = captureProcessed();
+
+            await eventSearch(mockClient, "hello", "!room:example.org", undefined, []);
+
+            // Default Seshat limit (no over-fetch) and every sender preserved (no post-filter).
+            expect(mockEventIndex.search.mock.calls[0][0].limit).toBe(10);
+            const senders = processed.get().search_categories.room_events.results.map((r: any) => r.result.sender);
+            expect(senders).toEqual(["@alice:example.org", "@bob:example.org"]);
         });
     });
 });

--- a/apps/web/test/unit-tests/components/structures/MessagePanel-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/MessagePanel-test.tsx
@@ -833,6 +833,70 @@ describe("MessagePanel", function () {
         expect(within(tiles[0] as HTMLElement).queryByRole("status")).not.toBeInTheDocument();
         expect(within(tiles[1] as HTMLElement).queryByRole("status")).not.toBeInTheDocument();
     });
+
+    describe("search match highlighting", () => {
+        const mkHighlightEvents = (): MatrixEvent[] => [
+            TestUtilsMatrix.mkMessage({
+                event: true,
+                room: roomId,
+                user: "@user:id",
+                ts: 1000,
+                id: "$match0",
+                msg: "find the boat please",
+            }),
+            TestUtilsMatrix.mkMessage({
+                event: true,
+                room: roomId,
+                user: "@user:id",
+                ts: 2000,
+                id: "$match1",
+                msg: "another boat over here",
+            }),
+        ];
+
+        it("highlights the search term only in the focused match's live tile", () => {
+            const events = mkHighlightEvents();
+            const { container } = render(
+                getComponent({ events, searchHighlightEventId: "$match0", searchHighlights: ["boat"] }),
+                clientAndSDKContextRenderOptions(client, sdkContext),
+            );
+
+            const highlights = container.getElementsByClassName("mx_EventTile_searchHighlight");
+            expect(highlights.length).toEqual(1);
+            expect(highlights[0].textContent).toEqual("boat");
+        });
+
+        it("does not highlight anything when no search highlight props are supplied", () => {
+            const events = mkHighlightEvents();
+            const { container } = render(
+                getComponent({ events }),
+                clientAndSDKContextRenderOptions(client, sdkContext),
+            );
+
+            expect(container.getElementsByClassName("mx_EventTile_searchHighlight").length).toEqual(0);
+        });
+
+        it("marks only the focused match's tile as the active stepping match", () => {
+            const events = mkHighlightEvents();
+            const { container } = render(
+                getComponent({ events, searchHighlightEventId: "$match0" }),
+                clientAndSDKContextRenderOptions(client, sdkContext),
+            );
+
+            const active = container.getElementsByClassName("mx_EventTile_searchHighlightActive");
+            expect(active.length).toEqual(1);
+        });
+
+        it("marks no tile active when not stepping", () => {
+            const events = mkHighlightEvents();
+            const { container } = render(
+                getComponent({ events }),
+                clientAndSDKContextRenderOptions(client, sdkContext),
+            );
+
+            expect(container.getElementsByClassName("mx_EventTile_searchHighlightActive").length).toEqual(0);
+        });
+    });
 });
 
 describe("shouldFormContinuation", () => {

--- a/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
@@ -60,7 +60,8 @@ import WidgetUtils from "../../../../src/utils/WidgetUtils";
 import { WidgetType } from "../../../../src/widgets/WidgetType";
 import WidgetStore from "../../../../src/stores/WidgetStore";
 import { type ViewRoomErrorPayload } from "../../../../src/dispatcher/payloads/ViewRoomErrorPayload";
-import { SearchScope } from "../../../../src/Searching";
+import { type SearchInfo, SearchScope } from "../../../../src/Searching";
+import { SearchSessionStore } from "../../../../src/stores/SearchSessionStore";
 import { MEGOLM_ENCRYPTION_ALGORITHM } from "../../../../src/utils/crypto";
 import MatrixClientContext from "../../../../src/contexts/MatrixClientContext";
 import { type ViewUserPayload } from "../../../../src/dispatcher/payloads/ViewUserPayload.ts";
@@ -116,6 +117,10 @@ describe("RoomView", () => {
 
         crypto = cli.getCrypto()!;
         jest.spyOn(cli, "getCrypto").mockReturnValue(undefined);
+
+        // The SearchSessionStore is a singleton that outlives each test; reset it so a search session never leaks
+        // into the next test (abort:false so we don't reject a still-pending mock promise).
+        SearchSessionStore.instance.clear({ abort: false });
     });
 
     afterEach(() => {
@@ -218,6 +223,170 @@ describe("RoomView", () => {
         await mountRoomView(ref);
         return ref.current!;
     };
+
+    // Seed a completed search the way RoomView.onSearch would: the session lives in the SearchSessionStore, so a
+    // directly-setState'd `search` no longer populates the store-backed match stepper on its own. RoomSearchView then
+    // resolves the promise and onSearchUpdate fills in the matches. This mirrors onSearch INCLUDING its
+    // resetFocusedEvent step — a flag-guarded no-event ViewRoom that drops any event the timeline was pinned to — so
+    // the result-click clear gate behaves the same as in production.
+    const startSearch = (ref: RefObject<RoomView | null>, search: SearchInfo): void => {
+        act(() => {
+            SearchSessionStore.instance.start({
+                searchId: search.searchId,
+                roomId: search.roomId,
+                term: search.term,
+                scope: search.scope,
+                promise: search.promise,
+                abortController: search.abortController ?? new AbortController(),
+            });
+            ref.current!.setState({ timelineRenderingType: TimelineRenderingType.Search, search });
+            const focusedEventId = stores.roomViewStore.getInitialEventId();
+            if (focusedEventId) {
+                SearchSessionStore.instance.beginSteppingJump(focusedEventId);
+                defaultDispatcher.dispatch<ViewRoomPayload>({
+                    action: Action.ViewRoom,
+                    room_id: room.roomId,
+                    metricsTrigger: undefined,
+                });
+            }
+        });
+    };
+
+    describe("all-rooms / cross-room search match stepping", () => {
+        // These heavier mount-based stepping tests live in an early describe rather than alongside the later
+        // "message search" tests: a pre-existing cross-test isolation leak in this large suite leaves a client-less
+        // RoomView re-rendering (and crashing) for whichever mount-heavy test runs last among the later describes.
+        // Running early keeps state clean.
+        it("steps into a predecessor-room match (cross-room) via the SearchSessionStore", async () => {
+            room.getMyMembership = jest.fn().mockReturnValue(KnownMembership.Join);
+
+            // A room-scoped search of an upgraded room also searches its predecessor chain (#32258), so the completed
+            // result set can contain matches that live in a *different* room. The session lives in the
+            // SearchSessionStore, which survives RoomView being re-mounted for the predecessor room — so these
+            // cross-room matches ARE steppable (there is no current-room filter): stepping into one dispatches
+            // ViewRoom for the predecessor room.
+            const predRoom = new Room("!predecessor:example.org", cli, "@alice:example.org");
+            rooms.set(predRoom.roomId, predRoom);
+
+            const eventMapper = (obj: Partial<IEvent>) => new MatrixEvent(obj);
+            const makeResult = (roomId: string, eventId: string, body: string, ts: number) =>
+                SearchResult.fromJson(
+                    {
+                        rank: 1,
+                        result: {
+                            room_id: roomId,
+                            event_id: eventId,
+                            sender: cli.getSafeUserId(),
+                            origin_server_ts: ts,
+                            content: { body, msgtype: "m.text" },
+                            type: EventType.RoomMessage,
+                        },
+                        context: { profile_info: {}, events_before: [], events_after: [] },
+                    },
+                    eventMapper,
+                );
+
+            const roomViewRef = createRef<RoomView>();
+            await mountRoomView(roomViewRef);
+            await waitFor(() => expect(roomViewRef.current).toBeTruthy());
+
+            startSearch(roomViewRef, {
+                searchId: 1,
+                roomId: room.roomId,
+                term: "match",
+                scope: SearchScope.Room,
+                promise: Promise.resolve({
+                    results: [
+                        makeResult(room.roomId, "$current", "current match", 2),
+                        makeResult(predRoom.roomId, "$predecessor", "predecessor match", 1),
+                    ],
+                    highlights: [],
+                    count: 2,
+                }),
+            });
+
+            // Both matches are now steppable; the store holds the full, unfiltered cross-room match list.
+            await screen.findByText("0 of 2", { exact: false });
+            expect(SearchSessionStore.instance.matches).toHaveLength(2);
+
+            const dispatchSpy = jest.spyOn(defaultDispatcher, "dispatch");
+            // Step to the newest ($current, this room) then the older ($predecessor, the predecessor room).
+            await userEvent.click(screen.getByRole("button", { name: "Next match" }));
+            await screen.findByText("1 of 2", { exact: false });
+            await userEvent.click(screen.getByRole("button", { name: "Next match" }));
+            await screen.findByText("2 of 2", { exact: false });
+
+            // Stepping into the predecessor match dispatches ViewRoom for the *predecessor* room — in the real app
+            // this re-mounts the room-id-keyed RoomView, which re-hydrates the stepper from the store.
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    action: Action.ViewRoom,
+                    room_id: predRoom.roomId,
+                    event_id: "$predecessor",
+                    highlighted: true,
+                    scroll_into_view: true,
+                }),
+            );
+        });
+
+        it("enables the match stepper for all-rooms searches and steps across rooms", async () => {
+            room.getMyMembership = jest.fn().mockReturnValue(KnownMembership.Join);
+
+            // All-rooms matches span rooms; the SearchSessionStore survives the cross-room re-mount, so the stepper is
+            // enabled for scope=All too (there is no scope===Room gate).
+            const otherRoom = new Room("!other:example.org", cli, "@alice:example.org");
+            rooms.set(otherRoom.roomId, otherRoom);
+
+            const eventMapper = (obj: Partial<IEvent>) => new MatrixEvent(obj);
+            const makeResult = (roomId: string, eventId: string, ts: number) =>
+                SearchResult.fromJson(
+                    {
+                        rank: 1,
+                        result: {
+                            room_id: roomId,
+                            event_id: eventId,
+                            sender: cli.getSafeUserId(),
+                            origin_server_ts: ts,
+                            content: { body: "a match", msgtype: "m.text" },
+                            type: EventType.RoomMessage,
+                        },
+                        context: { profile_info: {}, events_before: [], events_after: [] },
+                    },
+                    eventMapper,
+                );
+
+            const roomViewRef = createRef<RoomView>();
+            await mountRoomView(roomViewRef);
+            await waitFor(() => expect(roomViewRef.current).toBeTruthy());
+
+            startSearch(roomViewRef, {
+                searchId: 1,
+                roomId: undefined, // all-rooms search
+                term: "match",
+                scope: SearchScope.All,
+                promise: Promise.resolve({
+                    results: [makeResult(room.roomId, "$here", 2), makeResult(otherRoom.roomId, "$there", 1)],
+                    highlights: [],
+                    count: 2,
+                }),
+            });
+
+            // The stepper IS enabled for all-rooms searches now, with the full cross-room match list.
+            await screen.findByText("0 of 2", { exact: false });
+            expect(screen.getByRole("button", { name: "Next match" })).toBeInTheDocument();
+
+            const dispatchSpy = jest.spyOn(defaultDispatcher, "dispatch");
+            await userEvent.click(screen.getByRole("button", { name: "Next match" })); // $here (this room)
+            await screen.findByText("1 of 2", { exact: false });
+            await userEvent.click(screen.getByRole("button", { name: "Next match" })); // $there (the other room)
+            await screen.findByText("2 of 2", { exact: false });
+
+            // Stepping reaches a match in a different room, dispatching ViewRoom for that room.
+            expect(dispatchSpy).toHaveBeenCalledWith(
+                expect.objectContaining({ action: Action.ViewRoom, room_id: otherRoom.roomId, event_id: "$there" }),
+            );
+        });
+    });
 
     it("gets a room view store from MultiRoomViewStore when given a room ID", async () => {
         stores.multiRoomViewStore.getRoomViewStoreForRoom = jest.fn().mockReturnValue(stores.roomViewStore);

--- a/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
@@ -329,6 +329,38 @@ describe("RoomView", () => {
             );
         });
 
+        it("re-runs the active search with the from:/sender filter, preserving term and scope", async () => {
+            room.getMyMembership = jest.fn().mockReturnValue(KnownMembership.Join);
+
+            const roomViewRef = createRef<RoomView>();
+            await mountRoomView(roomViewRef);
+            await waitFor(() => expect(roomViewRef.current).toBeTruthy());
+
+            startSearch(roomViewRef, {
+                searchId: 1,
+                roomId: room.roomId,
+                term: "match",
+                scope: SearchScope.Room,
+                promise: Promise.resolve({ results: [], highlights: [], count: 0 } as any),
+            });
+
+            // The sender-filter control calls onSearchSendersChange; it must re-run the search keeping the current
+            // term + scope, and record the senders on both the session store and the render-state mirror. We invoke
+            // the (private) handler directly via the ref — driving it through the full RightPanel UI would add a heavy
+            // member-list render for no extra coverage; the store spy + state assertion below prove the wiring.
+            const startSpy = jest.spyOn(SearchSessionStore.instance, "start");
+            act(() => {
+                (
+                    roomViewRef.current as unknown as { onSearchSendersChange: (senders: string[]) => void }
+                ).onSearchSendersChange(["@bob:example.org"]);
+            });
+
+            expect(startSpy).toHaveBeenCalledWith(
+                expect.objectContaining({ term: "match", scope: SearchScope.Room, senders: ["@bob:example.org"] }),
+            );
+            expect(roomViewRef.current!.state.search!.senders).toEqual(["@bob:example.org"]);
+        });
+
         it("enables the match stepper for all-rooms searches and steps across rooms", async () => {
             room.getMyMembership = jest.fn().mockReturnValue(KnownMembership.Join);
 

--- a/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
@@ -20,6 +20,7 @@ import {
     RoomEvent,
     RoomMember,
     RoomStateEvent,
+    SearchOrderBy,
     SearchResult,
 } from "matrix-js-sdk/src/matrix";
 import { type CryptoApi, CryptoEvent, UserVerificationStatus } from "matrix-js-sdk/src/crypto-api";
@@ -359,6 +360,72 @@ describe("RoomView", () => {
                 expect.objectContaining({ term: "match", scope: SearchScope.Room, senders: ["@bob:example.org"] }),
             );
             expect(roomViewRef.current!.state.search!.senders).toEqual(["@bob:example.org"]);
+        });
+
+        it("re-runs the active search with the chosen order, preserving term, scope and senders", async () => {
+            room.getMyMembership = jest.fn().mockReturnValue(KnownMembership.Join);
+
+            const roomViewRef = createRef<RoomView>();
+            await mountRoomView(roomViewRef);
+            await waitFor(() => expect(roomViewRef.current).toBeTruthy());
+
+            startSearch(roomViewRef, {
+                searchId: 1,
+                roomId: room.roomId,
+                term: "match",
+                scope: SearchScope.Room,
+                senders: ["@bob:example.org"],
+                promise: Promise.resolve({ results: [], highlights: [], count: 0 } as any),
+            });
+
+            // The order toggle calls onSearchOrderChange; it must re-run the search keeping the current term, scope
+            // and sender filter, and record the order on both the session store and the render-state mirror.
+            const startSpy = jest.spyOn(SearchSessionStore.instance, "start");
+            act(() => {
+                (
+                    roomViewRef.current as unknown as { onSearchOrderChange: (order: SearchOrderBy) => void }
+                ).onSearchOrderChange(SearchOrderBy.Rank);
+            });
+
+            expect(startSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    term: "match",
+                    scope: SearchScope.Room,
+                    senders: ["@bob:example.org"],
+                    order: SearchOrderBy.Rank,
+                }),
+            );
+            expect(roomViewRef.current!.state.search!.order).toBe(SearchOrderBy.Rank);
+        });
+
+        it("preserves an already-active relevance order across a sender-filter change", async () => {
+            room.getMyMembership = jest.fn().mockReturnValue(KnownMembership.Join);
+
+            const roomViewRef = createRef<RoomView>();
+            await mountRoomView(roomViewRef);
+            await waitFor(() => expect(roomViewRef.current).toBeTruthy());
+
+            // Relevance order is already active on the render state.
+            startSearch(roomViewRef, {
+                searchId: 1,
+                roomId: room.roomId,
+                term: "match",
+                scope: SearchScope.Room,
+                order: SearchOrderBy.Rank,
+                promise: Promise.resolve({ results: [], highlights: [], count: 0 } as any),
+            });
+
+            // Changing the sender filter must NOT reset the order: onSearch defaults `order` from the current
+            // session, so the chosen relevance order is carried through (the point of making order session identity).
+            const startSpy = jest.spyOn(SearchSessionStore.instance, "start");
+            act(() => {
+                (
+                    roomViewRef.current as unknown as { onSearchSendersChange: (senders: string[]) => void }
+                ).onSearchSendersChange(["@bob:example.org"]);
+            });
+
+            expect(startSpy).toHaveBeenCalledWith(expect.objectContaining({ order: SearchOrderBy.Rank }));
+            expect(roomViewRef.current!.state.search!.order).toBe(SearchOrderBy.Rank);
         });
 
         it("enables the match stepper for all-rooms searches and steps across rooms", async () => {

--- a/apps/web/test/unit-tests/components/views/right_panel/RoomSearchOrderToggle-test.tsx
+++ b/apps/web/test/unit-tests/components/views/right_panel/RoomSearchOrderToggle-test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import React from "react";
+import { render, screen } from "jest-matrix-react";
+import userEvent from "@testing-library/user-event";
+import { SearchOrderBy } from "matrix-js-sdk/src/matrix";
+
+import { RoomSearchOrderToggle } from "../../../../../src/components/views/right_panel/RoomSearchOrderToggle";
+
+describe("RoomSearchOrderToggle", () => {
+    it("renders the order toggle trigger", () => {
+        render(<RoomSearchOrderToggle order={SearchOrderBy.Recent} onSearchOrderChange={jest.fn()} />);
+        expect(screen.getByTestId("search-order-toggle-button")).toBeInTheDocument();
+    });
+
+    it("selecting Most relevant requests relevance (Rank) order", async () => {
+        const onChange = jest.fn();
+        render(<RoomSearchOrderToggle order={SearchOrderBy.Recent} onSearchOrderChange={onChange} />);
+
+        await userEvent.click(screen.getByTestId("search-order-toggle-button"));
+        await userEvent.click(await screen.findByRole("menuitemradio", { name: "Most relevant" }));
+
+        expect(onChange).toHaveBeenCalledWith(SearchOrderBy.Rank);
+    });
+
+    it("selecting Most recent requests recency (Recent) order", async () => {
+        const onChange = jest.fn();
+        render(<RoomSearchOrderToggle order={SearchOrderBy.Rank} onSearchOrderChange={onChange} />);
+
+        await userEvent.click(screen.getByTestId("search-order-toggle-button"));
+        await userEvent.click(await screen.findByRole("menuitemradio", { name: "Most recent" }));
+
+        expect(onChange).toHaveBeenCalledWith(SearchOrderBy.Recent);
+    });
+
+    it("checks the radio matching the active order (controlled)", async () => {
+        render(<RoomSearchOrderToggle order={SearchOrderBy.Rank} onSearchOrderChange={jest.fn()} />);
+
+        await userEvent.click(screen.getByTestId("search-order-toggle-button"));
+
+        expect(await screen.findByRole("menuitemradio", { name: "Most relevant" })).toBeChecked();
+        expect(screen.getByRole("menuitemradio", { name: "Most recent" })).not.toBeChecked();
+    });
+
+    it("shows the active-order indicator only for a non-default (relevance) order", () => {
+        const { rerender } = render(
+            <RoomSearchOrderToggle order={SearchOrderBy.Recent} onSearchOrderChange={jest.fn()} />,
+        );
+        // Default (recency): no indicator dot, and the accessible name is the neutral label.
+        expect(screen.getByTestId("search-order-toggle-button")).not.toHaveAttribute("data-indicator");
+        expect(screen.getByTestId("search-order-toggle-button")).toHaveAccessibleName("Sort results");
+
+        rerender(<RoomSearchOrderToggle order={SearchOrderBy.Rank} onSearchOrderChange={jest.fn()} />);
+        // Relevance: the indicator dot is shown and the active state is folded into the accessible name.
+        expect(screen.getByTestId("search-order-toggle-button")).toHaveAttribute("data-indicator", "default");
+        expect(screen.getByTestId("search-order-toggle-button")).toHaveAccessibleName("Sort results (by relevance)");
+    });
+});

--- a/apps/web/test/unit-tests/components/views/right_panel/RoomSearchSenderFilter-test.tsx
+++ b/apps/web/test/unit-tests/components/views/right_panel/RoomSearchSenderFilter-test.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import React from "react";
+import { mocked } from "jest-mock";
+import { render, screen } from "jest-matrix-react";
+import userEvent from "@testing-library/user-event";
+import { Room, type RoomMember } from "matrix-js-sdk/src/matrix";
+
+import { RoomSearchSenderFilter } from "../../../../../src/components/views/right_panel/RoomSearchSenderFilter";
+import { stubClient } from "../../../../test-utils";
+
+const member = (userId: string, name: string): RoomMember => ({ userId, name }) as RoomMember;
+
+describe("RoomSearchSenderFilter", () => {
+    const buildRoom = (members: RoomMember[]): Room => {
+        const client = mocked(stubClient());
+        const room = new Room("!r:server", client, "@me:server");
+        jest.spyOn(room, "getJoinedMembers").mockReturnValue(members);
+        return room;
+    };
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("renders the filter trigger when the room has other members", () => {
+        render(
+            <RoomSearchSenderFilter
+                room={buildRoom([member("@alice:server", "Alice")])}
+                senders={[]}
+                onSearchSendersChange={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId("search-sender-filter-button")).toBeInTheDocument();
+    });
+
+    it("renders nothing when the room has no other members", () => {
+        const { container } = render(
+            <RoomSearchSenderFilter
+                room={buildRoom([member("@me:server", "Me")])}
+                senders={[]}
+                onSearchSendersChange={jest.fn()}
+            />,
+        );
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it("selecting a member adds them to the sender filter", async () => {
+        const onChange = jest.fn();
+        render(
+            <RoomSearchSenderFilter
+                room={buildRoom([member("@alice:server", "Alice"), member("@bob:server", "Bob")])}
+                senders={[]}
+                onSearchSendersChange={onChange}
+            />,
+        );
+
+        await userEvent.click(screen.getByTestId("search-sender-filter-button"));
+        await userEvent.click(await screen.findByRole("menuitemcheckbox", { name: "Alice" }));
+
+        expect(onChange).toHaveBeenCalledWith(["@alice:server"]);
+    });
+
+    it("toggling an already-selected member off removes them", async () => {
+        const onChange = jest.fn();
+        render(
+            <RoomSearchSenderFilter
+                room={buildRoom([member("@alice:server", "Alice"), member("@bob:server", "Bob")])}
+                senders={["@alice:server", "@bob:server"]}
+                onSearchSendersChange={onChange}
+            />,
+        );
+
+        await userEvent.click(screen.getByTestId("search-sender-filter-button"));
+        await userEvent.click(await screen.findByRole("menuitemcheckbox", { name: "Alice" }));
+
+        expect(onChange).toHaveBeenCalledWith(["@bob:server"]);
+    });
+
+    it("accumulates multiple senders when toggled in one pass (controlled usage)", async () => {
+        // The real parent (RoomView) is controlled: onSearchSendersChange updates the senders prop. Mirror that with
+        // a stateful wrapper to prove rapid multi-select accumulates rather than replacing the previous selection.
+        const Wrapper = (): React.JSX.Element => {
+            const [senders, setSenders] = React.useState<string[]>([]);
+            return (
+                <RoomSearchSenderFilter
+                    room={buildRoom([member("@alice:server", "Alice"), member("@bob:server", "Bob")])}
+                    senders={senders}
+                    onSearchSendersChange={setSenders}
+                />
+            );
+        };
+        render(<Wrapper />);
+
+        await userEvent.click(screen.getByTestId("search-sender-filter-button"));
+        await userEvent.click(await screen.findByRole("menuitemcheckbox", { name: "Alice" }));
+        await userEvent.click(await screen.findByRole("menuitemcheckbox", { name: "Bob" }));
+
+        // Both checkboxes remain checked (menu stays open via preventDefault); neither selection was lost.
+        expect(screen.getByRole("menuitemcheckbox", { name: "Alice" })).toBeChecked();
+        expect(screen.getByRole("menuitemcheckbox", { name: "Bob" })).toBeChecked();
+    });
+
+    it("announces the active sender count on the trigger for screen readers", () => {
+        render(
+            <RoomSearchSenderFilter
+                room={buildRoom([member("@alice:server", "Alice"), member("@bob:server", "Bob")])}
+                senders={["@alice:server", "@bob:server"]}
+                onSearchSendersChange={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId("search-sender-filter-button")).toHaveAccessibleName(/2/);
+    });
+
+    it("clears all selected senders via the clear action", async () => {
+        const onChange = jest.fn();
+        render(
+            <RoomSearchSenderFilter
+                room={buildRoom([member("@alice:server", "Alice")])}
+                senders={["@alice:server"]}
+                onSearchSendersChange={onChange}
+            />,
+        );
+
+        await userEvent.click(screen.getByTestId("search-sender-filter-button"));
+        await userEvent.click(await screen.findByTestId("search-sender-filter-clear"));
+
+        expect(onChange).toHaveBeenCalledWith([]);
+    });
+});

--- a/apps/web/test/unit-tests/stores/SearchSessionStore-test.ts
+++ b/apps/web/test/unit-tests/stores/SearchSessionStore-test.ts
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import { type ISearchResults, SearchOrderBy } from "matrix-js-sdk/src/matrix";
+
+import { SearchSessionStore, SearchSessionStoreEvent } from "../../../src/stores/SearchSessionStore";
+import { type SearchMatch, SearchScope } from "../../../src/Searching";
+import defaultDispatcher from "../../../src/dispatcher/dispatcher";
+import { Action } from "../../../src/dispatcher/actions";
+
+const match = (roomId: string, eventId: string): SearchMatch => ({ roomId, eventId });
+
+describe("SearchSessionStore", () => {
+    let store: SearchSessionStore;
+    const promise = Promise.resolve({ results: [], highlights: [], count: 0 } as unknown as ISearchResults);
+
+    const start = (overrides: Partial<Parameters<SearchSessionStore["start"]>[0]> = {}): AbortController => {
+        const abortController = new AbortController();
+        store.start({
+            searchId: 1,
+            term: "hello",
+            scope: SearchScope.Room,
+            roomId: "!a:server",
+            promise,
+            abortController,
+            ...overrides,
+        });
+        return abortController;
+    };
+
+    beforeEach(() => {
+        store = SearchSessionStore.instance;
+        // Start each test from a clean singleton (the store survives the whole file, like UIStore).
+        store.clear({ abort: false });
+    });
+
+    afterEach(() => {
+        store.clear({ abort: false });
+    });
+
+    describe("start", () => {
+        it("creates an active session with an empty cursor and matches", () => {
+            start();
+            expect(store.hasActiveSession()).toBe(true);
+            const snapshot = store.getSnapshot();
+            expect(snapshot).toMatchObject({
+                searchId: 1,
+                term: "hello",
+                scope: SearchScope.Room,
+                roomId: "!a:server",
+                matches: [],
+                highlights: [],
+                currentMatchIndex: -1,
+                inProgress: true,
+            });
+            expect(store.matches).toEqual([]);
+            expect(store.currentMatchIndex).toBe(-1);
+        });
+
+        it("emits Update when a session starts", () => {
+            const listener = jest.fn();
+            store.on(SearchSessionStoreEvent.Update, listener);
+            start();
+            expect(listener).toHaveBeenCalledTimes(1);
+            store.off(SearchSessionStoreEvent.Update, listener);
+        });
+
+        it("replaces and aborts the previous session when a new term starts", () => {
+            const first = start({ searchId: 1, term: "first" });
+            const second = start({ searchId: 2, term: "second" });
+            expect(first.signal.aborted).toBe(true);
+            expect(second.signal.aborted).toBe(false);
+            expect(store.getSnapshot()?.term).toBe("second");
+        });
+    });
+
+    describe("updateResults", () => {
+        it("applies cross-room matches/highlights/count and resets the cursor", () => {
+            start();
+            const matches = [match("!a:server", "$1"), match("!predecessor:server", "$2")];
+            store.setCurrentMatchIndex(1);
+            store.updateResults({ inProgress: false, matches, highlights: ["hello"], count: 7 });
+            const snapshot = store.getSnapshot();
+            expect(snapshot?.matches).toEqual(matches);
+            expect(snapshot?.highlights).toEqual(["hello"]);
+            expect(snapshot?.count).toBe(7);
+            expect(snapshot?.inProgress).toBe(false);
+            // A fresh result set invalidates the cursor.
+            expect(snapshot?.currentMatchIndex).toBe(-1);
+        });
+
+        it("is a no-op when there is no active session", () => {
+            const listener = jest.fn();
+            store.on(SearchSessionStoreEvent.Update, listener);
+            store.updateResults({ inProgress: false, matches: [match("!a:server", "$1")] });
+            expect(store.hasActiveSession()).toBe(false);
+            expect(listener).not.toHaveBeenCalled();
+            store.off(SearchSessionStoreEvent.Update, listener);
+        });
+
+        it("records an error", () => {
+            start();
+            const error = new Error("boom");
+            store.updateResults({ inProgress: false, error });
+            expect(store.getSnapshot()?.error).toBe(error);
+        });
+
+        it("preserves the senders (from:) filter across result updates", () => {
+            start({ senders: ["@alice:server"] });
+            expect(store.getSnapshot()?.senders).toEqual(["@alice:server"]);
+            store.updateResults({ inProgress: false, matches: [match("!a:server", "$1")], count: 1 });
+            // The sender filter is session identity, not per-result state: it must survive updateResults.
+            expect(store.getSnapshot()?.senders).toEqual(["@alice:server"]);
+        });
+
+        it("preserves the result order (recent/relevant) across result updates", () => {
+            start({ order: SearchOrderBy.Rank });
+            expect(store.getSnapshot()?.order).toBe(SearchOrderBy.Rank);
+            store.updateResults({ inProgress: false, matches: [match("!a:server", "$1")], count: 1 });
+            // The chosen order is session identity, not per-result state: it must survive updateResults.
+            expect(store.getSnapshot()?.order).toBe(SearchOrderBy.Rank);
+        });
+    });
+
+    describe("setCurrentMatchIndex", () => {
+        it("moves the cursor and emits Update", () => {
+            start();
+            store.updateResults({ inProgress: false, matches: [match("!a:server", "$1"), match("!b:server", "$2")] });
+            const listener = jest.fn();
+            store.on(SearchSessionStoreEvent.Update, listener);
+            store.setCurrentMatchIndex(1);
+            expect(store.currentMatchIndex).toBe(1);
+            expect(listener).toHaveBeenCalledTimes(1);
+            store.off(SearchSessionStoreEvent.Update, listener);
+        });
+
+        it("accepts -1 to clear the focus (back to the list)", () => {
+            start();
+            store.setCurrentMatchIndex(0);
+            store.setCurrentMatchIndex(-1);
+            expect(store.currentMatchIndex).toBe(-1);
+        });
+
+        it("is a no-op when there is no active session", () => {
+            store.setCurrentMatchIndex(2);
+            expect(store.currentMatchIndex).toBe(-1);
+        });
+    });
+
+    describe("clear", () => {
+        it("aborts the in-flight request by default and drops the session", () => {
+            const abortController = start();
+            store.clear();
+            expect(abortController.signal.aborted).toBe(true);
+            expect(store.hasActiveSession()).toBe(false);
+            expect(store.getSnapshot()).toBeNull();
+        });
+
+        it("does not abort when abort:false", () => {
+            const abortController = start();
+            store.clear({ abort: false });
+            expect(abortController.signal.aborted).toBe(false);
+            expect(store.hasActiveSession()).toBe(false);
+        });
+    });
+
+    describe("steppingJump flag", () => {
+        it("defaults to false", () => {
+            start();
+            expect(store.isSteppingJump()).toBe(false);
+        });
+
+        it("begin sets it; isSteppingJump reads it non-destructively", () => {
+            start();
+            store.beginSteppingJump("$e");
+            expect(store.isSteppingJump()).toBe(true);
+            expect(store.isSteppingJump()).toBe(true);
+        });
+
+        it("consume returns true once then false", () => {
+            start();
+            store.beginSteppingJump("$e");
+            expect(store.consumeSteppingJump()).toBe(true);
+            expect(store.consumeSteppingJump()).toBe(false);
+        });
+
+        it("does not emit Update when toggled (it is not view state)", () => {
+            start();
+            const listener = jest.fn();
+            store.on(SearchSessionStoreEvent.Update, listener);
+            store.beginSteppingJump("$e");
+            store.consumeSteppingJump();
+            expect(listener).not.toHaveBeenCalled();
+            store.off(SearchSessionStoreEvent.Update, listener);
+        });
+
+        it("auto-resets when fresh results arrive", () => {
+            start();
+            store.beginSteppingJump("$e");
+            store.updateResults({ inProgress: false, matches: [] });
+            expect(store.isSteppingJump()).toBe(false);
+        });
+
+        it("is cleared when the session is cleared", () => {
+            start();
+            store.beginSteppingJump("$e");
+            store.clear();
+            expect(store.isSteppingJump()).toBe(false);
+        });
+    });
+
+    describe("steppingTarget (durable navigation guard)", () => {
+        it("defaults to null", () => {
+            start();
+            expect(store.steppingTarget).toBeNull();
+        });
+
+        it("begin records the event id and survives the one-shot flag being consumed", () => {
+            start();
+            store.beginSteppingJump("$hit");
+            expect(store.steppingTarget).toBe("$hit");
+            // Consuming the flag (an unrelated update would) must NOT clear the durable target — that is the whole
+            // point: the result-click clear gate still recognises our own navigation after the flag is gone.
+            store.consumeSteppingJump();
+            expect(store.steppingTarget).toBe("$hit");
+        });
+
+        it("persists across fresh results (so the return-to-results re-render does not unguard the clear gate)", () => {
+            start();
+            store.beginSteppingJump("$hit");
+            // Returning from stepping re-mounts the hidden RoomSearchView, which re-resolves the promise and calls
+            // updateResults again — the durable target must survive that so the clear gate stays guarded for the
+            // return-to-list window. (The one-shot flag still resets here.)
+            store.updateResults({ inProgress: false, matches: [] });
+            expect(store.steppingTarget).toBe("$hit");
+            expect(store.isSteppingJump()).toBe(false);
+        });
+
+        it("resets to null on a new search session (start)", () => {
+            start();
+            store.beginSteppingJump("$hit");
+            start();
+            expect(store.steppingTarget).toBeNull();
+        });
+
+        it("resets to null when the session is cleared", () => {
+            start();
+            store.beginSteppingJump("$hit");
+            store.clear();
+            expect(store.steppingTarget).toBeNull();
+        });
+    });
+
+    describe("focusedMatch (durable stepping marker)", () => {
+        const matches = [match("!a:server", "$1"), match("!b:server", "$2"), match("!c:server", "$3")];
+
+        it("defaults to null", () => {
+            start();
+            expect(store.focusedMatch).toBeNull();
+        });
+
+        it("tracks the focused match's event id when the cursor moves to it", () => {
+            start();
+            store.updateResults({ inProgress: false, matches });
+            store.setCurrentMatchIndex(1);
+            expect(store.focusedMatch).toBe("$2");
+        });
+
+        it("clears to null when the cursor returns to the results list (-1)", () => {
+            start();
+            store.updateResults({ inProgress: false, matches });
+            store.setCurrentMatchIndex(1);
+            store.setCurrentMatchIndex(-1);
+            expect(store.focusedMatch).toBeNull();
+        });
+
+        it("survives a fresh result set so a settled search update mid-step cannot collapse stepping", () => {
+            start();
+            store.updateResults({ inProgress: false, matches });
+            store.setCurrentMatchIndex(1);
+            // The async search settles again / a "load more" page lands WHILE a match is focused. Unlike the
+            // volatile cursor (which updateResults resets), the durable focus must survive — otherwise a background
+            // RoomViewStore emission makes RoomView treat the focused jump as "results list shown" and clobbers the
+            // live flash + in-bubble highlight + centered scroll (the packaged-build result-click regression).
+            store.updateResults({ inProgress: false, matches });
+            expect(store.focusedMatch).toBe("$2");
+            // The cursor is re-derived back onto the focused match (not reset to -1), so the "k of N" counter stays.
+            expect(store.currentMatchIndex).toBe(1);
+        });
+
+        it("re-derives the cursor onto the focused match when its index shifts in new results", () => {
+            start();
+            store.updateResults({ inProgress: false, matches });
+            store.setCurrentMatchIndex(2); // focus $3
+            // A new result set where $3 is now at index 0.
+            store.updateResults({
+                inProgress: false,
+                matches: [match("!c:server", "$3"), match("!a:server", "$1")],
+            });
+            expect(store.focusedMatch).toBe("$3");
+            expect(store.currentMatchIndex).toBe(0);
+        });
+
+        it("clears the focus when the focused match drops out of a fresh result set", () => {
+            start();
+            store.updateResults({ inProgress: false, matches });
+            store.setCurrentMatchIndex(1); // focus $2
+            // A new result set that no longer contains $2 — the focus must drop so the UI falls back to the list
+            // coherently (not strand on a hidden timeline with a "0 of N" counter).
+            store.updateResults({ inProgress: false, matches: [match("!a:server", "$1")] });
+            expect(store.focusedMatch).toBeNull();
+            expect(store.currentMatchIndex).toBe(-1);
+        });
+
+        it("resets to null on a new search (start) and on clear", () => {
+            start();
+            store.updateResults({ inProgress: false, matches });
+            store.setCurrentMatchIndex(1);
+            start();
+            expect(store.focusedMatch).toBeNull();
+
+            store.updateResults({ inProgress: false, matches });
+            store.setCurrentMatchIndex(1);
+            store.clear();
+            expect(store.focusedMatch).toBeNull();
+        });
+    });
+
+    describe("logout reset", () => {
+        it("clears the session and aborts on Action.OnLoggedOut", () => {
+            const abortController = start();
+            defaultDispatcher.dispatch({ action: Action.OnLoggedOut }, true);
+            expect(store.hasActiveSession()).toBe(false);
+            expect(abortController.signal.aborted).toBe(true);
+        });
+    });
+});

--- a/apps/web/test/unit-tests/viewmodels/search/RoomSearchSenderFilterViewModel-test.ts
+++ b/apps/web/test/unit-tests/viewmodels/search/RoomSearchSenderFilterViewModel-test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import { mocked } from "jest-mock";
+import { Room, type RoomMember } from "matrix-js-sdk/src/matrix";
+
+import { RoomSearchSenderFilterViewModel } from "../../../../src/viewmodels/search/RoomSearchSenderFilterViewModel";
+import { stubClient } from "../../../test-utils";
+
+const member = (userId: string, name: string): RoomMember => ({ userId, name }) as RoomMember;
+
+describe("RoomSearchSenderFilterViewModel", () => {
+    const myUserId = "@me:server";
+
+    const buildRoom = (members: RoomMember[]): Room => {
+        const client = mocked(stubClient());
+        const room = new Room("!r:server", client, myUserId);
+        jest.spyOn(room, "getJoinedMembers").mockReturnValue(members);
+        return room;
+    };
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("lists joined members excluding the current user, sorted by display name", () => {
+        const room = buildRoom([
+            member("@me:server", "Me"),
+            member("@bob:server", "Bob"),
+            member("@alice:server", "Alice"),
+        ]);
+
+        const vm = new RoomSearchSenderFilterViewModel({ room });
+
+        expect(vm.getSnapshot().members).toEqual([
+            { userId: "@alice:server", name: "Alice" },
+            { userId: "@bob:server", name: "Bob" },
+        ]);
+    });
+
+    it("exposes an empty member list when the room only contains the current user", () => {
+        const room = buildRoom([member("@me:server", "Me")]);
+
+        const vm = new RoomSearchSenderFilterViewModel({ room });
+
+        expect(vm.getSnapshot().members).toEqual([]);
+    });
+});

--- a/apps/web/test/viewmodels/search/RoomSearchNavigationViewModel-test.ts
+++ b/apps/web/test/viewmodels/search/RoomSearchNavigationViewModel-test.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import { type ISearchResults } from "matrix-js-sdk/src/matrix";
+
+import {
+    RoomSearchNavigationViewModel,
+    type RoomSearchNavigationProps,
+} from "../../../src/viewmodels/search/RoomSearchNavigationViewModel";
+import { type SearchMatch, SearchScope } from "../../../src/Searching";
+import { SearchSessionStore } from "../../../src/stores/SearchSessionStore";
+
+describe("RoomSearchNavigationViewModel", () => {
+    const matchA: SearchMatch = { roomId: "!r:e", eventId: "$a" };
+    const matchB: SearchMatch = { roomId: "!r:e", eventId: "$b" };
+    const matchC: SearchMatch = { roomId: "!r:e", eventId: "$c" };
+    const promise = Promise.resolve({ results: [], highlights: [], count: 0 } as unknown as ISearchResults);
+
+    let store: SearchSessionStore;
+    let vms: RoomSearchNavigationViewModel[];
+
+    const setMatches = (matches: SearchMatch[]): void => {
+        store.start({
+            searchId: 1,
+            term: "x",
+            scope: SearchScope.Room,
+            promise,
+            abortController: new AbortController(),
+        });
+        store.updateResults({ inProgress: false, matches });
+    };
+
+    const makeVm = (props: RoomSearchNavigationProps): RoomSearchNavigationViewModel => {
+        const vm = new RoomSearchNavigationViewModel(props);
+        vms.push(vm);
+        return vm;
+    };
+
+    beforeEach(() => {
+        store = SearchSessionStore.instance;
+        store.clear({ abort: false });
+        vms = [];
+    });
+
+    afterEach(() => {
+        vms.forEach((vm) => {
+            if (!vm.isDisposed) vm.dispose();
+        });
+        store.clear({ abort: false });
+    });
+
+    it("starts empty with both arrows disabled", () => {
+        const vm = makeVm({ onActivateMatch: jest.fn() });
+        expect(vm.getSnapshot()).toEqual({ current: 0, total: 0, canPrevious: false, canNext: false });
+    });
+
+    it("reflects the store's total and enables both arrows once matches are set", () => {
+        const vm = makeVm({ onActivateMatch: jest.fn() });
+        setMatches([matchA, matchB, matchC]);
+        expect(vm.getSnapshot()).toEqual({ current: 0, total: 3, canPrevious: true, canNext: true });
+    });
+
+    it("hydrates its snapshot from an already-populated store on construction", () => {
+        setMatches([matchA, matchB, matchC]);
+        store.setCurrentMatchIndex(1);
+        const vm = makeVm({ onActivateMatch: jest.fn() });
+        expect(vm.getSnapshot()).toEqual({ current: 2, total: 3, canPrevious: true, canNext: true });
+    });
+
+    it("activates the first match on next() from the empty cursor and marks a stepping jump", () => {
+        const onActivateMatch = jest.fn();
+        const vm = makeVm({ onActivateMatch });
+        setMatches([matchA, matchB, matchC]);
+        vm.next();
+        expect(onActivateMatch).toHaveBeenCalledWith(matchA, 0);
+        expect(store.currentMatchIndex).toBe(0);
+        expect(store.isSteppingJump()).toBe(true);
+        expect(vm.getSnapshot()).toEqual({ current: 1, total: 3, canPrevious: true, canNext: true });
+    });
+
+    it("steps forward through every match", () => {
+        const onActivateMatch = jest.fn();
+        const vm = makeVm({ onActivateMatch });
+        setMatches([matchA, matchB, matchC]);
+        vm.next();
+        vm.next();
+        vm.next();
+        expect(onActivateMatch).toHaveBeenNthCalledWith(3, matchC, 2);
+        expect(vm.getSnapshot()).toEqual({ current: 3, total: 3, canPrevious: true, canNext: true });
+    });
+
+    it("wraps from the last match back to the first on next()", () => {
+        const onActivateMatch = jest.fn();
+        const vm = makeVm({ onActivateMatch });
+        setMatches([matchA, matchB, matchC]);
+        vm.next();
+        vm.next();
+        vm.next();
+        onActivateMatch.mockClear();
+        vm.next();
+        expect(onActivateMatch).toHaveBeenCalledWith(matchA, 0);
+        expect(vm.getSnapshot()).toEqual({ current: 1, total: 3, canPrevious: true, canNext: true });
+    });
+
+    it("wraps to the last match on previous() from the empty cursor", () => {
+        const onActivateMatch = jest.fn();
+        const vm = makeVm({ onActivateMatch });
+        setMatches([matchA, matchB]);
+        vm.previous();
+        expect(onActivateMatch).toHaveBeenCalledWith(matchB, 1);
+        expect(vm.getSnapshot()).toEqual({ current: 2, total: 2, canPrevious: true, canNext: true });
+    });
+
+    it("wraps from the first match to the last on previous()", () => {
+        const onActivateMatch = jest.fn();
+        const vm = makeVm({ onActivateMatch });
+        setMatches([matchA, matchB, matchC]);
+        vm.next();
+        onActivateMatch.mockClear();
+        vm.previous();
+        expect(onActivateMatch).toHaveBeenCalledWith(matchC, 2);
+        expect(vm.getSnapshot()).toEqual({ current: 3, total: 3, canPrevious: true, canNext: true });
+    });
+
+    it("resets the cursor when the store gets a fresh result set", () => {
+        const vm = makeVm({ onActivateMatch: jest.fn() });
+        setMatches([matchA, matchB, matchC]);
+        vm.next();
+        vm.next();
+        setMatches([matchA]);
+        expect(vm.getSnapshot()).toEqual({ current: 0, total: 1, canPrevious: true, canNext: true });
+    });
+
+    it("does nothing when stepping with no matches", () => {
+        const onActivateMatch = jest.fn();
+        const vm = makeVm({ onActivateMatch });
+        vm.next();
+        vm.previous();
+        expect(onActivateMatch).not.toHaveBeenCalled();
+        expect(vm.getSnapshot()).toEqual({ current: 0, total: 0, canPrevious: false, canNext: false });
+    });
+
+    it("reacts to an external store cursor change", () => {
+        const vm = makeVm({ onActivateMatch: jest.fn() });
+        setMatches([matchA, matchB, matchC]);
+        store.setCurrentMatchIndex(2);
+        expect(vm.getSnapshot()).toEqual({ current: 3, total: 3, canPrevious: true, canNext: true });
+    });
+
+    it("stops reacting to the store once disposed", () => {
+        const vm = makeVm({ onActivateMatch: jest.fn() });
+        setMatches([matchA, matchB]);
+        vm.dispose();
+        store.setCurrentMatchIndex(1);
+        expect(vm.getSnapshot()).toEqual({ current: 0, total: 2, canPrevious: true, canNext: true });
+    });
+});

--- a/packages/shared-components/src/i18n/strings/en_EN.json
+++ b/packages/shared-components/src/i18n/strings/en_EN.json
@@ -85,6 +85,11 @@
         "jump_to_date_beginning": "The beginning of the room",
         "jump_to_date_prompt": "Pick a date to jump to",
         "pinned_message_badge": "Pinned message",
+        "search": {
+            "match_position": "%(current)s of %(total)s loaded",
+            "next_match": "Next match",
+            "previous_match": "Previous match"
+        },
         "status_bar": {
             "delete_all": "Delete all",
             "exceeded_resource_limit_description": "Please contact your service administrator to continue using the service.",

--- a/packages/shared-components/src/index.ts
+++ b/packages/shared-components/src/index.ts
@@ -14,6 +14,7 @@ export * from "./core/AvatarWithDetails";
 export * from "./core/roving";
 export * from "./room/composer/Banner";
 export * from "./room/composer/UploadButton";
+export * from "./room/search/SearchMatchNavigation";
 export * from "./crypto/SasEmoji";
 export * from "./menus/UserMenu";
 export * from "./notifications/NotificationBadgeView";

--- a/packages/shared-components/src/room/search/SearchMatchNavigation/SearchMatchNavigation.module.css
+++ b/packages/shared-components/src/room/search/SearchMatchNavigation/SearchMatchNavigation.module.css
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+.navigation {
+    flex-shrink: 0;
+}
+
+.counter {
+    color: var(--cpd-color-text-secondary);
+    font: var(--cpd-font-body-sm-medium);
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+}

--- a/packages/shared-components/src/room/search/SearchMatchNavigation/SearchMatchNavigation.test.tsx
+++ b/packages/shared-components/src/room/search/SearchMatchNavigation/SearchMatchNavigation.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import { render, screen } from "@test-utils";
+import React from "react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, vi, afterEach, expect } from "vitest";
+
+import {
+    SearchMatchNavigation,
+    type SearchMatchNavigationViewActions,
+    type SearchMatchNavigationViewSnapshot,
+} from "./SearchMatchNavigation";
+import { MockViewModel } from "../../../core/viewmodel/MockViewModel";
+
+describe("SearchMatchNavigation", () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const previous = vi.fn();
+    const next = vi.fn();
+
+    class TestViewModel
+        extends MockViewModel<SearchMatchNavigationViewSnapshot>
+        implements SearchMatchNavigationViewActions
+    {
+        public previous = previous;
+        public next = next;
+    }
+
+    const renderNav = (snapshot: SearchMatchNavigationViewSnapshot): void => {
+        render(<SearchMatchNavigation vm={new TestViewModel(snapshot)} />);
+    };
+
+    it("renders the k-of-N counter and enabled arrows", () => {
+        renderNav({ current: 2, total: 5, canPrevious: true, canNext: true });
+        expect(screen.getByText("2 of 5 loaded")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Previous match" })).toBeEnabled();
+        expect(screen.getByRole("button", { name: "Next match" })).toBeEnabled();
+    });
+
+    it("invokes previous when the up arrow is clicked", async () => {
+        const user = userEvent.setup();
+        renderNav({ current: 2, total: 5, canPrevious: true, canNext: true });
+        await user.click(screen.getByRole("button", { name: "Previous match" }));
+        expect(previous).toHaveBeenCalledTimes(1);
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it("invokes next when the down arrow is clicked", async () => {
+        const user = userEvent.setup();
+        renderNav({ current: 2, total: 5, canPrevious: true, canNext: true });
+        await user.click(screen.getByRole("button", { name: "Next match" }));
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(previous).not.toHaveBeenCalled();
+    });
+
+    it("disables an arrow when its snapshot flag is false", () => {
+        renderNav({ current: 1, total: 5, canPrevious: false, canNext: true });
+        expect(screen.getByRole("button", { name: "Previous match" })).toBeDisabled();
+        expect(screen.getByRole("button", { name: "Next match" })).toBeEnabled();
+    });
+
+    it("renders nothing when there are no matches", () => {
+        const { container } = render(
+            <SearchMatchNavigation
+                vm={new TestViewModel({ current: 0, total: 0, canPrevious: false, canNext: false })}
+            />,
+        );
+        expect(container).toBeEmptyDOMElement();
+    });
+});

--- a/packages/shared-components/src/room/search/SearchMatchNavigation/SearchMatchNavigation.tsx
+++ b/packages/shared-components/src/room/search/SearchMatchNavigation/SearchMatchNavigation.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import React, { type JSX } from "react";
+import { IconButton } from "@vector-im/compound-web";
+import ChevronUpIcon from "@vector-im/compound-design-tokens/assets/web/icons/chevron-up";
+import ChevronDownIcon from "@vector-im/compound-design-tokens/assets/web/icons/chevron-down";
+
+import styles from "./SearchMatchNavigation.module.css";
+import { type ViewModel, useViewModel } from "../../../core/viewmodel";
+import { Flex } from "../../../core/utils/Flex";
+import { useI18n } from "../../../core/i18n/i18nContext";
+
+export interface SearchMatchNavigationViewSnapshot {
+    /**
+     * The 1-based position of the currently-focused match, or 0 when no match is active.
+     */
+    current: number;
+    /**
+     * The total number of matches that can be stepped through.
+     */
+    total: number;
+    /**
+     * Whether stepping to the previous (newer) match is possible.
+     */
+    canPrevious: boolean;
+    /**
+     * Whether stepping to the next (older) match is possible.
+     */
+    canNext: boolean;
+}
+
+export interface SearchMatchNavigationViewActions {
+    /**
+     * Step to the previous (newer) match in the timeline.
+     */
+    previous(): void;
+    /**
+     * Step to the next (older) match in the timeline.
+     */
+    next(): void;
+}
+
+/**
+ * The view model for the in-room search match navigation component.
+ */
+export type SearchMatchNavigationViewModel = ViewModel<
+    SearchMatchNavigationViewSnapshot,
+    SearchMatchNavigationViewActions
+>;
+
+interface SearchMatchNavigationProps {
+    /**
+     * The view model for the in-room search match navigation component.
+     */
+    vm: SearchMatchNavigationViewModel;
+}
+
+/**
+ * A compact "k of N" counter flanked by up/down arrows for stepping through in-room search matches in the
+ * live timeline. Renders nothing when there are no matches to step through.
+ *
+ * @example
+ * ```tsx
+ * <SearchMatchNavigation vm={roomSearchNavigationViewModel} />
+ * ```
+ */
+export function SearchMatchNavigation({ vm }: Readonly<SearchMatchNavigationProps>): JSX.Element | null {
+    const { translate: _t } = useI18n();
+    const { current, total, canPrevious, canNext } = useViewModel(vm);
+
+    if (total === 0) return null;
+
+    return (
+        <Flex
+            className={styles.navigation}
+            align="center"
+            gap="var(--cpd-space-1x)"
+            data-testid="search-match-navigation"
+        >
+            <span className={styles.counter}>{_t("room|search|match_position", { current, total })}</span>
+            <IconButton
+                size="28px"
+                disabled={!canPrevious}
+                onClick={() => vm.previous()}
+                tooltip={_t("room|search|previous_match")}
+                aria-label={_t("room|search|previous_match")}
+            >
+                <ChevronUpIcon width="20px" height="20px" />
+            </IconButton>
+            <IconButton
+                size="28px"
+                disabled={!canNext}
+                onClick={() => vm.next()}
+                tooltip={_t("room|search|next_match")}
+                aria-label={_t("room|search|next_match")}
+            >
+                <ChevronDownIcon width="20px" height="20px" />
+            </IconButton>
+        </Flex>
+    );
+}

--- a/packages/shared-components/src/room/search/SearchMatchNavigation/index.ts
+++ b/packages/shared-components/src/room/search/SearchMatchNavigation/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+export type {
+    SearchMatchNavigationViewModel,
+    SearchMatchNavigationViewSnapshot,
+    SearchMatchNavigationViewActions,
+} from "./SearchMatchNavigation";
+export { SearchMatchNavigation } from "./SearchMatchNavigation";

--- a/packages/shared-components/tsconfig.json
+++ b/packages/shared-components/tsconfig.json
@@ -1,6 +1,10 @@
 {
     "compilerOptions": {
         "allowImportingTsExtensions": true,
+        // Type-checking only: this package is bundled by Vite and `lint:types` always runs `tsc --noEmit`, so tsc
+        // never emits here. Setting noEmit in-file keeps editors (which read tsconfig.json directly, without the CLI
+        // flag) from flagging TS5096 for allowImportingTsExtensions without noEmit/emitDeclarationOnly.
+        "noEmit": true,
         "experimentalDecorators": false,
         "emitDecoratorMetadata": false,
         "resolveJsonModule": true,


### PR DESCRIPTION
### What

Adds a **relevance / recency sort toggle** to in-room message search: a small "sort" menu in the search header with
two options — **Most recent** (`SearchOrderBy.Recent`, the default) and **Most relevant** (`SearchOrderBy.Rank`).
Picking one re-runs the active search asking the backend to order results accordingly.

- The homeserver leg sets `order_by` on the search body (and it rides in the stored `_query`, so server-side
  pagination keeps the order).
- The Seshat leg sets `order_by_recency: false` for relevance, letting tantivy order by its full-text (BM25) score.
- Relevance is honoured on the **single-source** search paths (a single room — encrypted via Seshat, or non-encrypted
  via the homeserver). An **all-rooms** search stays recency-ordered regardless: its two legs are merged with a
  sliding-window cache that only preserves global order when both sources are recency-sorted, so propagating relevance
  there would corrupt cross-page order. That's deferred and documented in `Searching.ts`.

The chosen order is part of the search session, so changing the term or the sender filter keeps it.

### Why

Part of the search-operators / discoverability work — relates to element-hq/element-web#21640 and #2434.

### Notes for reviewers

Stacked on #34010 (sender filter) → #34009 (all-rooms) → #34008 (match stepping); the reviewable delta is the final
commit. The `SearchSessionStore` already carries the `order` field (added in #34008), so this PR contains no store
change.

### Tests

- `RoomSearchOrderToggle` component (radio interactions, active-order indicator, a11y) unit tests.
- `Searching` unit tests: homeserver `order_by`, Seshat `order_by_recency`, order carried into `_query` for
  pagination, and the all-rooms path staying recency under a relevance request.
- `RoomView` tests for re-run-on-order-change and order preservation across a sender-filter change.


## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
