### PR TITLE
Don't re-export MainSplitContentType enum

### DIFF
--- a/apps/web/src/components/structures/RoomView.tsx
+++ b/apps/web/src/components/structures/RoomView.tsx
@@ -207,8 +207,6 @@ interface IRoomProps extends RoomViewProps {
     enableReadReceiptsAndMarkersOnActivity?: boolean;
 }
 
-export { MainSplitContentType };
-
 export interface IRoomState {
     room?: Room;
     roomId?: string;

--- a/apps/web/src/components/views/rooms/RoomHeader/RoomHeader.tsx
+++ b/apps/web/src/components/views/rooms/RoomHeader/RoomHeader.tsx
@@ -49,7 +49,7 @@ import { CallGuestLinkButton } from "./CallGuestLinkButton.tsx";
 import { type ButtonEvent } from "../../elements/AccessibleButton.tsx";
 import WithPresenceIndicator, { useDmMember } from "../../avatars/WithPresenceIndicator.tsx";
 import { type IOOBData } from "../../../../stores/ThreepidInviteStore.ts";
-import { MainSplitContentType } from "../../../../contexts/RoomContext.tsx";
+import { MainSplitContentType } from "../../../../contexts/RoomContext.ts";
 import defaultDispatcher from "../../../../dispatcher/dispatcher.ts";
 import { RoomSettingsTab } from "../../dialogs/RoomSettingsDialog.tsx";
 import { useScopedRoomContext } from "../../../../contexts/ScopedRoomContext.tsx";

--- a/apps/web/src/components/views/rooms/RoomHeader/RoomHeader.tsx
+++ b/apps/web/src/components/views/rooms/RoomHeader/RoomHeader.tsx
@@ -49,7 +49,7 @@ import { CallGuestLinkButton } from "./CallGuestLinkButton.tsx";
 import { type ButtonEvent } from "../../elements/AccessibleButton.tsx";
 import WithPresenceIndicator, { useDmMember } from "../../avatars/WithPresenceIndicator.tsx";
 import { type IOOBData } from "../../../../stores/ThreepidInviteStore.ts";
-import { MainSplitContentType } from "../../../structures/RoomView.tsx";
+import { MainSplitContentType } from "../../../../contexts/RoomContext.tsx";
 import defaultDispatcher from "../../../../dispatcher/dispatcher.ts";
 import { RoomSettingsTab } from "../../dialogs/RoomSettingsDialog.tsx";
 import { useScopedRoomContext } from "../../../../contexts/ScopedRoomContext.tsx";

--- a/apps/web/src/settings/handlers/AbstractLocalStorageSettingsHandler.ts
+++ b/apps/web/src/settings/handlers/AbstractLocalStorageSettingsHandler.ts
@@ -38,8 +38,7 @@ export default abstract class AbstractLocalStorageSettingsHandler extends Settin
         if (!AbstractLocalStorageSettingsHandler.storageListenerBound) {
             AbstractLocalStorageSettingsHandler.storageListenerBound = true;
             // Listen for storage changes from other tabs to bust the cache
-            // Ignore if the function doesn't exist so it doesn't error when run in tests
-            globalThis.addEventListener?.("storage", AbstractLocalStorageSettingsHandler.onStorageEvent);
+            window.addEventListener("storage", AbstractLocalStorageSettingsHandler.onStorageEvent);
         }
     }
 

--- a/apps/web/src/settings/handlers/AbstractLocalStorageSettingsHandler.ts
+++ b/apps/web/src/settings/handlers/AbstractLocalStorageSettingsHandler.ts
@@ -38,7 +38,8 @@ export default abstract class AbstractLocalStorageSettingsHandler extends Settin
         if (!AbstractLocalStorageSettingsHandler.storageListenerBound) {
             AbstractLocalStorageSettingsHandler.storageListenerBound = true;
             // Listen for storage changes from other tabs to bust the cache
-            window.addEventListener("storage", AbstractLocalStorageSettingsHandler.onStorageEvent);
+            // Ignore if the function doesn't exist so it doesn't error when run in tests
+            globalThis.addEventListener?.("storage", AbstractLocalStorageSettingsHandler.onStorageEvent);
         }
     }
 

--- a/apps/web/test/test-utils/room.ts
+++ b/apps/web/test/test-utils/room.ts
@@ -10,7 +10,7 @@ import { type MockedObject } from "jest-mock-vitest-adapter";
 import { type EventTimeline, EventType, type MatrixClient, type MatrixEvent, Room } from "matrix-js-sdk/src/matrix";
 import { KnownMembership } from "matrix-js-sdk/src/types";
 
-import { MainSplitContentType } from "../../src/components/structures/RoomView";
+import { MainSplitContentType } from "../../src/contexts/RoomContext";
 import { type RoomContextType, TimelineRenderingType } from "../../src/contexts/RoomContext";
 import { Layout } from "../../src/settings/enums/Layout";
 import { mkEvent } from "./test-utils";

--- a/apps/web/test/unit-tests/components/views/rooms/SendMessageComposer-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/SendMessageComposer-test.tsx
@@ -25,7 +25,7 @@ import { MatrixClientPeg } from "../../../../../src/MatrixClientPeg";
 import defaultDispatcher from "../../../../../src/dispatcher/dispatcher";
 import DocumentOffset from "../../../../../src/editor/offset";
 import { Layout } from "../../../../../src/settings/enums/Layout";
-import { MainSplitContentType } from "../../../../../src/components/structures/RoomView";
+import { MainSplitContentType } from "../../../../../src/contexts/RoomContext";
 import { mockPlatformPeg } from "../../../../test-utils/platform";
 import { doMaybeLocalRoomAction } from "../../../../../src/utils/local-room";
 import { addTextToComposer } from "../../../../test-utils/composer";


### PR DESCRIPTION
I don't see why this was necessary, importing RoomView pulls in all sort of stuff, whereas RoomContext is much smaller.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
