### PR TITLE
Correct incorect hard-coded string in test mock

### DIFF
--- a/apps/web/test/unit-tests/submit-rageshake-test.ts
+++ b/apps/web/test/unit-tests/submit-rageshake-test.ts
@@ -15,6 +15,7 @@ import {
     TypedEventEmitter,
     MatrixHttpApi,
 } from "matrix-js-sdk/src/matrix";
+import { CrossSigningKey } from "matrix-js-sdk/src/crypto-api";
 import fetchMock from "@fetch-mock/jest";
 
 import { getMockClientWithEventEmitter, mockClientMethodsCrypto, mockPlatformPeg } from "../test-utils";
@@ -193,7 +194,7 @@ describe("Rageshakes", () => {
                 const crossSigningPubKey = "crossSigningPubKey";
                 mocked(mockClient.getCrypto()!.getCrossSigningKeyId).mockImplementation(
                     async (type): Promise<string | null> => {
-                        if (!type || type === "master") {
+                        if (!type || type === CrossSigningKey.Master) {
                             return crossSigningPubKey;
                         }
                         return null;


### PR DESCRIPTION
Pulled out of https://github.com/element-hq/element-web/pull/33977 to avoid a chicken/egg problem. https://github.com/matrix-org/matrix-js-sdk/pull/5389 changes the values of the enum keys in `CrossSigningKey`, which will break this mock implementation of `getCrossSigningKeyId` which hardcodes the old value.