### PR TITLE
Fix ToastContext test flake

### DIFF
--- a/packages/shared-components/src/core/utils/ToastContext.test.tsx
+++ b/packages/shared-components/src/core/utils/ToastContext.test.tsx
@@ -7,7 +7,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { describe, it, expect, vitest } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { Toast } from "@vector-im/compound-web";
 import React, { type JSX } from "react";
 

--- a/packages/shared-components/src/core/utils/ToastContext.test.tsx
+++ b/packages/shared-components/src/core/utils/ToastContext.test.tsx
@@ -61,8 +61,6 @@ describe("useToastContext", () => {
                 <HappyComponent />
             </ToastContext>,
         );
-        await waitFor(() => {
-            expect(getByText("Toast!")).toBeInViewport();
-        });
+        expect(getByText("Toast!")).toBeVisible();
     });
 });


### PR DESCRIPTION
We don't need to waitFor and we shouldn't check the viewport. This was causing flakes.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
