### PR TITLE
Add HEIC/HEIF image support via OS delegation

### DIFF
--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -20,3 +20,5 @@ yarn-error.log
 .DS_Store
 /playwright-report
 .pnpm-store
+# native HEIC decoder helper (built artifact; source is tracked)
+native/heic-decode/heic-decode

--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -2,7 +2,7 @@ import * as os from "node:os";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { execFileSync } from "node:child_process";
-import { type Configuration as BaseConfiguration } from "electron-builder";
+import { Platform, type Configuration as BaseConfiguration } from "electron-builder";
 
 /**
  * This script has different outputs depending on your os platform.
@@ -101,10 +101,11 @@ const config: Omit<Writable<Configuration>, "electronFuses"> & {
     asarUnpack: "**/*.node",
     // Build the macOS HEIC decoder helper (native/heic-decode/, an Image I/O tool) before packaging, so
     // the mac.extraResources reference to its gitignored artifact resolves without a separate CI step.
-    // Guarded to a macOS host — the helper links Apple frameworks and is only bundled into mac builds;
-    // build.sh is itself a no-op elsewhere.
-    beforeBuild: async (): Promise<void> => {
-        if (process.platform === "darwin") {
+    // Gate on the build *target* (not the host): only build it when targeting macOS, so a Windows/Linux
+    // build on a Mac doesn't produce an unused binary. The helper links Apple frameworks, so it can only
+    // be produced on a macOS host; build.sh is a no-op on any other host.
+    beforeBuild: async (context): Promise<void> => {
+        if (context.platform === Platform.MAC) {
             execFileSync("/bin/bash", ["native/heic-decode/build.sh"], { stdio: "inherit" });
         }
     },

--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -1,6 +1,7 @@
 import * as os from "node:os";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { execFileSync } from "node:child_process";
 import { type Configuration as BaseConfiguration } from "electron-builder";
 
 /**
@@ -98,6 +99,15 @@ const config: Omit<Writable<Configuration>, "electronFuses"> & {
 } = {
     appId: variant.appId,
     asarUnpack: "**/*.node",
+    // Build the macOS HEIC decoder helper (native/heic-decode/, an Image I/O tool) before packaging, so
+    // the mac.extraResources reference to its gitignored artifact resolves without a separate CI step.
+    // Guarded to a macOS host — the helper links Apple frameworks and is only bundled into mac builds;
+    // build.sh is itself a no-op elsewhere.
+    beforeBuild: async (): Promise<void> => {
+        if (process.platform === "darwin") {
+            execFileSync("/bin/bash", ["native/heic-decode/build.sh"], { stdio: "inherit" });
+        }
+    },
     electronFuses: {
         enableCookieEncryption: true,
         onlyLoadAppFromAsar: true,
@@ -163,6 +173,13 @@ const config: Omit<Writable<Configuration>, "electronFuses"> & {
         icon: "build/icon.icon",
         mergeASARs: true,
         x64ArchFiles: "**/matrix-seshat/*.node", // hak already runs lipo
+        // `heic-decode` is the macOS-only native HEIC decoder helper (native/heic-decode/, Image I/O),
+        // built by `beforeBuild` below. Bundle it into Contents/Resources/heic-decode (mac-scoped so
+        // Windows/Linux packaging never references the macOS-only artifact) and sign it with the
+        // hardened runtime via `binaries` — required for notarization since it lives in Resources
+        // rather than a standard code location.
+        extraResources: [{ from: "native/heic-decode/heic-decode", to: "heic-decode" }],
+        binaries: ["Contents/Resources/heic-decode"],
     },
     dmg: {
         badgeIcon: "build/icon.icon",

--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -103,10 +103,15 @@ const config: Omit<Writable<Configuration>, "electronFuses"> & {
     // the mac.extraResources reference to its gitignored artifact resolves without a separate CI step.
     // Gate on the build *target* (not the host): only build it when targeting macOS, so a Windows/Linux
     // build on a Mac doesn't produce an unused binary. The helper links Apple frameworks, so it can only
-    // be produced on a macOS host; build.sh is a no-op on any other host.
+    // be produced on a macOS host; build.sh is a no-op on any other host. Forward the target arch so a
+    // single-arch build ships a thin binary (electron-builder calls this once per arch — for a universal
+    // build as "x64" then "arm64", which @electron/universal lipos back together).
     beforeBuild: async (context): Promise<void> => {
         if (context.platform === Platform.MAC) {
-            execFileSync("/bin/bash", ["native/heic-decode/build.sh"], { stdio: "inherit" });
+            // Absolute interpreter + resolved path so nothing resolves via PATH/CWD.
+            execFileSync("/bin/bash", [path.resolve("native/heic-decode/build.sh"), context.arch], {
+                stdio: "inherit",
+            });
         }
     },
     electronFuses: {

--- a/apps/desktop/native/heic-decode/build.sh
+++ b/apps/desktop/native/heic-decode/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Build the universal (arm64 + x86_64) heic-decode helper binary.
+# Build the heic-decode helper for the requested arch(es): build.sh [x64 | arm64 | universal ...].
+# No argument → universal (used by the standalone `build:native:heic` script). electron-builder's
+# beforeBuild passes the target arch so single-arch packages get a thin binary, not a fat one.
 # Requires the Xcode Command Line Tools (clang + macOS SDK). macOS-only.
 set -euo pipefail
 
@@ -12,9 +14,19 @@ fi
 
 cd "$(dirname "$0")"
 
+# Map electron-builder Arch names to clang -arch flags. No argument (standalone script) → universal.
+arch_flags=()
+for a in "${@:-universal}"; do
+    case "$a" in
+        x64) arch_flags+=(-arch x86_64) ;;
+        arm64) arch_flags+=(-arch arm64) ;;
+        universal) arch_flags+=(-arch arm64 -arch x86_64) ;;
+        *) echo "heic-decode: unknown arch '$a', building universal"; arch_flags+=(-arch arm64 -arch x86_64) ;;
+    esac
+done
+
 clang \
-    -arch arm64 \
-    -arch x86_64 \
+    "${arch_flags[@]}" \
     -mmacosx-version-min=11.0 \
     -O2 \
     -fobjc-arc \

--- a/apps/desktop/native/heic-decode/build.sh
+++ b/apps/desktop/native/heic-decode/build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Build the universal (arm64 + x86_64) heic-decode helper binary.
+# Requires the Xcode Command Line Tools (clang + macOS SDK). macOS-only.
+set -euo pipefail
+
+# macOS-only helper (links Apple's Image I/O). No-op elsewhere so this is safe to call from any
+# build host (e.g. electron-builder's beforeBuild runs on every platform).
+if [[ "$(uname)" != "Darwin" ]]; then
+    echo "heic-decode: skipping build on non-macOS host ($(uname))"
+    exit 0
+fi
+
+cd "$(dirname "$0")"
+
+clang \
+    -arch arm64 \
+    -arch x86_64 \
+    -mmacosx-version-min=11.0 \
+    -O2 \
+    -fobjc-arc \
+    -framework Foundation \
+    -framework ImageIO \
+    -framework CoreGraphics \
+    heic_decode.m \
+    -o heic-decode
+
+echo "built heic-decode:"
+file heic-decode

--- a/apps/desktop/native/heic-decode/heic_decode.m
+++ b/apps/desktop/native/heic-decode/heic_decode.m
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+// heic-decode: decode a HEIC/HEIF image to JPEG using the macOS Image I/O framework (Apple's
+// licensed HEVC decoder). Reads the HEIC bytes from stdin, writes JPEG bytes to stdout. All
+// in-memory — no temp files — so it is safe for end-to-end-encrypted media.
+//
+// Element Desktop spawns this from its main process (see src/heic.ts) instead of bundling a
+// copyleft WASM decoder (libheif/heic-to) on macOS, where the OS decoder is always present and
+// the HEVC patent royalty is already covered by the platform vendor.
+//
+// Exit codes: 0 ok; 1 empty/failed input; 2 no image source; 3 decode failed; 4/5 encode failed.
+
+#import <Foundation/Foundation.h>
+#import <ImageIO/ImageIO.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+int main(int argc, const char *argv[]) {
+    @autoreleasepool {
+        NSData *input = [[NSFileHandle fileHandleWithStandardInput] readDataToEndOfFile];
+        if (input.length == 0) {
+            fprintf(stderr, "heic-decode: empty input\n");
+            return 1;
+        }
+
+        CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef)input, NULL);
+        if (!source) {
+            fprintf(stderr, "heic-decode: could not create image source\n");
+            return 2;
+        }
+
+        // Decode the primary image with the EXIF orientation baked in. Using the thumbnail API with
+        // CreateThumbnailFromImageAlways + WithTransform lets Image I/O apply the correct orientation for
+        // us (rather than hand-rolling the eight EXIF transforms). MaxPixelSize caps the longer edge: at
+        // 20000px it passes any normal phone photo through untouched, and only downscales images larger
+        // than that (e.g. wide panoramas) — an acceptable bound for an inline display copy, since the
+        // original bytes are always preserved for download.
+        NSDictionary *options = @{
+            (id)kCGImageSourceCreateThumbnailFromImageAlways: @YES,
+            (id)kCGImageSourceCreateThumbnailWithTransform: @YES,
+            (id)kCGImageSourceThumbnailMaxPixelSize: @20000,
+        };
+        CGImageRef image = CGImageSourceCreateThumbnailAtIndex(source, 0, (__bridge CFDictionaryRef)options);
+        CFRelease(source);
+        if (!image) {
+            fprintf(stderr, "heic-decode: could not decode image\n");
+            return 3;
+        }
+
+        NSMutableData *output = [NSMutableData data];
+        CGImageDestinationRef dest =
+            CGImageDestinationCreateWithData((__bridge CFMutableDataRef)output, CFSTR("public.jpeg"), 1, NULL);
+        if (!dest) {
+            CGImageRelease(image);
+            fprintf(stderr, "heic-decode: could not create image destination\n");
+            return 4;
+        }
+        NSDictionary *destProps = @{ (id)kCGImageDestinationLossyCompressionQuality: @0.92 };
+        CGImageDestinationAddImage(dest, image, (__bridge CFDictionaryRef)destProps);
+        bool ok = CGImageDestinationFinalize(dest);
+        CFRelease(dest);
+        CGImageRelease(image);
+        if (!ok) {
+            fprintf(stderr, "heic-decode: JPEG encode failed\n");
+            return 5;
+        }
+
+        [[NSFileHandle fileHandleWithStandardOutput] writeData:output];
+        return 0;
+    }
+}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -39,6 +39,7 @@
         "lint:types:scripts": "tsc --noEmit -p scripts/tsconfig.json",
         "lint:types:hak": "tsc --noEmit -p hak/tsconfig.json",
         "build:native": "pnpm run hak",
+    "build:native:heic": "bash native/heic-decode/build.sh",
         "build:native:universal": "pnpm run hak --target x86_64-apple-darwin fetchandbuild && pnpm run hak --target aarch64-apple-darwin fetchandbuild && pnpm run hak --target x86_64-apple-darwin --target aarch64-apple-darwin copyandlink",
         "build:32": "nx build --ia32",
         "build:64": "nx build --x64",

--- a/apps/desktop/src/electron-main.ts
+++ b/apps/desktop/src/electron-main.ts
@@ -31,6 +31,7 @@ import { URL, fileURLToPath } from "node:url";
 import "./ipc.js";
 import "./seshat.js";
 import "./settings.js";
+import "./heic.js";
 import "./badge.js";
 import * as tray from "./tray.js";
 import Store from "./store.js";

--- a/apps/desktop/src/heic.test.ts
+++ b/apps/desktop/src/heic.test.ts
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { expect, describe, it, beforeAll, afterAll, beforeEach, vi, type Mock } from "vitest";
+import { EventEmitter } from "node:events";
+
+// Capture the IPC handler heic.ts registers so we can drive it directly, and mock the child process so
+// the tests never spawn the real native binary.
+type DecodeHandler = (ev: unknown, bytes: Uint8Array) => Promise<Uint8Array>;
+let decodeHeic: DecodeHandler | undefined;
+
+vi.mock("electron", () => ({
+    app: { isPackaged: false },
+    ipcMain: {
+        handle: vi.fn((channel: string, handler: DecodeHandler) => {
+            if (channel === "decodeHeic") decodeHeic = handler;
+        }),
+    },
+}));
+
+const spawnMock = vi.fn();
+vi.mock("node:child_process", () => ({ spawn: (...args: unknown[]): unknown => spawnMock(...args) }));
+
+/** A minimal stand-in for the spawned helper's ChildProcess — only the bits heic.ts touches. */
+type FakeChild = EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    stdin: EventEmitter & { end: Mock };
+    kill: Mock;
+};
+function makeFakeChild(): FakeChild {
+    const child = new EventEmitter() as FakeChild;
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdin = Object.assign(new EventEmitter(), { end: vi.fn() });
+    child.kill = vi.fn();
+    return child;
+}
+
+// heic.ts only registers the handler on macOS; force darwin so the test runs on any CI host, and load
+// the module (a dynamic import so it happens after the override) to trigger registration.
+const originalPlatform = process.platform;
+beforeAll(async () => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    await import("./heic.js");
+});
+afterAll(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+});
+
+describe("decodeHeic IPC handler", () => {
+    beforeEach(() => {
+        spawnMock.mockReset();
+    });
+
+    it("registers the handler on macOS", () => {
+        expect(decodeHeic).toBeInstanceOf(Function);
+    });
+
+    it("pipes the input to the helper and resolves its stdout on success", async () => {
+        const child = makeFakeChild();
+        spawnMock.mockReturnValue(child);
+
+        const promise = decodeHeic!({}, new Uint8Array([1, 2, 3]));
+        child.stdout.emit("data", Buffer.from([0xff, 0xd8]));
+        child.emit("close", 0);
+
+        await expect(promise).resolves.toEqual(Buffer.from([0xff, 0xd8]));
+        expect(child.stdin.end).toHaveBeenCalledWith(new Uint8Array([1, 2, 3]));
+    });
+
+    it("rejects with the helper's stderr when it exits non-zero", async () => {
+        const child = makeFakeChild();
+        spawnMock.mockReturnValue(child);
+
+        const promise = decodeHeic!({}, new Uint8Array([1]));
+        child.stderr.emit("data", Buffer.from("could not decode image"));
+        child.emit("close", 3);
+
+        await expect(promise).rejects.toThrow(/exited 3: could not decode image/);
+    });
+
+    it("rejects if the helper cannot be spawned", async () => {
+        const child = makeFakeChild();
+        spawnMock.mockReturnValue(child);
+
+        const promise = decodeHeic!({}, new Uint8Array([1]));
+        child.emit("error", new Error("spawn ENOENT"));
+
+        await expect(promise).rejects.toThrow(/ENOENT/);
+    });
+
+    it("kills the helper and rejects on timeout", async () => {
+        vi.useFakeTimers();
+        try {
+            const child = makeFakeChild();
+            spawnMock.mockReturnValue(child);
+
+            const promise = decodeHeic!({}, new Uint8Array([1]));
+            promise.catch(() => {}); // avoid an unhandled rejection when the timer fires
+            await vi.advanceTimersByTimeAsync(30_000);
+
+            await expect(promise).rejects.toThrow(/timed out/);
+            expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/apps/desktop/src/heic.ts
+++ b/apps/desktop/src/heic.ts
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { app, ipcMain } from "electron";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Decode HEIC/HEIF using the macOS Image I/O framework (Apple's licensed HEVC decoder) via the
+// bundled `heic-decode` helper binary (see native/heic-decode/). We pipe the HEIC in over stdin and
+// read the JPEG back over stdout — entirely in memory, so no decrypted plaintext ever touches disk,
+// which matters for end-to-end-encrypted media. Only registered on macOS; where this decoder is absent
+// (other platforms, or a decode failure) the renderer leaves HEIC as a file attachment — Element bundles
+// no software HEIC decoder, so decoding is delegated entirely to the OS.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// A wedged decode shouldn't leave a child process (and the caller's spinner) hanging forever. This is the
+// process-side backstop; the renderer applies its own timeout of the same duration (HEIC_DECODE_TIMEOUT_MS
+// in apps/web/src/utils/heic.ts) — keep the two in sync.
+const HEIC_HELPER_TIMEOUT_MS = 30_000;
+
+function helperPath(): string {
+    // Packaged: copied into the app's Resources via electron-builder `extraResources`.
+    // Dev/source checkout: built in place next to its source by native/heic-decode/build.sh.
+    return app.isPackaged
+        ? path.join(process.resourcesPath, "heic-decode")
+        : path.join(__dirname, "..", "native", "heic-decode", "heic-decode");
+}
+
+function decodeViaHelper(bytes: Uint8Array): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+        const child = spawn(helperPath(), [], { stdio: ["pipe", "pipe", "pipe"] });
+        const stdout: Buffer[] = [];
+        const stderr: Buffer[] = [];
+
+        const timer = setTimeout(() => {
+            child.kill("SIGKILL");
+            reject(new Error(`heic-decode timed out after ${HEIC_HELPER_TIMEOUT_MS}ms`));
+        }, HEIC_HELPER_TIMEOUT_MS);
+
+        child.stdout.on("data", (d: Buffer) => stdout.push(d));
+        child.stderr.on("data", (d: Buffer) => stderr.push(d));
+        child.on("error", (e) => {
+            clearTimeout(timer);
+            reject(e);
+        });
+        child.on("close", (code) => {
+            clearTimeout(timer);
+            if (code === 0) {
+                resolve(Buffer.concat(stdout));
+            } else {
+                reject(new Error(`heic-decode exited ${code}: ${Buffer.concat(stderr).toString().trim()}`));
+            }
+        });
+
+        // Ignore EPIPE if the child dies before we finish writing its input.
+        child.stdin.on("error", () => {});
+        child.stdin.end(bytes);
+    });
+}
+
+if (process.platform === "darwin") {
+    ipcMain.handle("decodeHeic", async (_ev, bytes: Uint8Array): Promise<Uint8Array> => {
+        return decodeViaHelper(bytes);
+    });
+}

--- a/apps/desktop/src/preload.cts
+++ b/apps/desktop/src/preload.cts
@@ -77,4 +77,15 @@ contextBridge.exposeInMainWorld("electron", {
     async getSettingValue(settingName: string): Promise<any> {
         return ipcRenderer.invoke("getSettingValue", settingName);
     },
+
+    // Native HEIC/HEIF decode via the OS image pipeline (Apple's licensed HEVC decoder). Only exposed on
+    // macOS; on other platforms it stays undefined so the renderer leaves HEIC as a file attachment
+    // (no decoder is bundled — see apps/web/src/utils/heic.ts).
+    ...(process.platform === "darwin"
+        ? {
+              async decodeHeic(bytes: Uint8Array): Promise<Uint8Array> {
+                  return ipcRenderer.invoke("decodeHeic", bytes);
+              },
+          }
+        : {}),
 });

--- a/apps/web/playwright/e2e/file-upload/heic.spec.ts
+++ b/apps/web/playwright/e2e/file-upload/heic.spec.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import type { EventType, MsgType } from "matrix-js-sdk/src/matrix";
+import { test, expect } from "../../element-web-test";
+
+// Element Web bundles no HEIC decoder: HEIC/HEIF is decoded by the OS on desktop only (see apps/desktop
+// and apps/web/src/utils/heic.ts). A HEIC image message must therefore gracefully fall back to a file
+// attachment here rather than rendering a broken <img>. This guards that "no regression" contract end to
+// end; the native-decode happy path lives in the desktop main process and is covered by the Jest suites.
+test.describe("HEIC image messages", () => {
+    test.use({
+        displayName: "Alice",
+    });
+
+    let roomId: string;
+    test.beforeEach(async ({ page, app, user }) => {
+        roomId = await app.client.createRoom({ name: "My Pictures" });
+        await app.viewRoomByName("My Pictures");
+
+        // Wait until configuration is finished
+        await expect(
+            page
+                .locator(".mx_GenericEventListSummary[data-layout='group'] .mx_GenericEventListSummary_summary")
+                .getByText(`${user.displayName} created and configured the room.`),
+        ).toBeVisible();
+    });
+
+    test("gracefully fall back to a file attachment when the platform has no HEIC decoder", async ({ page, app }) => {
+        // A HEIC "photo" sent as an m.image, as an iPhone would. The bytes need not be a real HEIC:
+        // Element Web never decodes them — it routes on the mimetype/filename and falls back to a file.
+        const upload = await app.client.uploadContent(Buffer.from("heic-placeholder-bytes"), {
+            name: "IMG_0001.heic",
+            type: "image/heic",
+        });
+        await app.client.sendEvent(roomId, null, "m.room.message" as EventType, {
+            msgtype: "m.image" as MsgType,
+            body: "IMG_0001.heic",
+            filename: "IMG_0001.heic",
+            url: upload.content_uri,
+            info: { mimetype: "image/heic" },
+        });
+
+        // Renders as a downloadable file attachment, not an inline (broken) image.
+        await expect(page.locator(".mx_MFileBody").first()).toBeVisible();
+        await expect(page.locator(".mx_ImageBody")).toHaveCount(0);
+    });
+});

--- a/apps/web/src/@types/global.d.ts
+++ b/apps/web/src/@types/global.d.ts
@@ -147,6 +147,8 @@ declare global {
         // Settings
         setSettingValue(settingName: string, value: any): Promise<void>;
         getSettingValue(settingName: string): Promise<any>;
+        // Native HEIC/HEIF decode via the OS image pipeline (macOS only; undefined elsewhere).
+        decodeHeic?(bytes: Uint8Array): Promise<Uint8Array>;
     }
 
     interface DesktopCapturerSource {

--- a/apps/web/src/components/views/messages/MBodyFactory.tsx
+++ b/apps/web/src/components/views/messages/MBodyFactory.tsx
@@ -27,6 +27,7 @@ import { ImageBodyViewModel } from "../../../viewmodels/message-body/ImageBodyVi
 import { RedactedBodyViewModel } from "../../../viewmodels/message-body/RedactedBodyViewModel";
 import { VideoBodyViewModel } from "../../../viewmodels/message-body/VideoBodyViewModel";
 import { isMimeTypeAllowed } from "../../../utils/blobs";
+import { isDecodableHeicContent } from "../../../utils/heic";
 
 type MBodyComponent = React.ComponentType<IBodyProps>;
 
@@ -158,6 +159,10 @@ export function ImageBodyFactory({
     const shouldFallbackToFileBody =
         mediaEventHelper?.media.isEncrypted === true &&
         !isMimeTypeAllowed(content.info?.mimetype ?? "") &&
+        // HEIC we can decode is rendered as an image (decoded to JPEG via the OS at display time), so it's
+        // renderable even though it isn't in the blob allow-list; don't fall back to a file body for it
+        // (covers public.heic and .heic names). Where we can't decode it, it does fall back to a file body.
+        !isDecodableHeicContent(content) &&
         !content.info?.thumbnail_info;
 
     const vm = useCreateAutoDisposedViewModel(

--- a/apps/web/src/components/views/messages/MessageEvent.tsx
+++ b/apps/web/src/components/views/messages/MessageEvent.tsx
@@ -24,6 +24,7 @@ import SettingsStore from "../../../settings/SettingsStore";
 import { Mjolnir } from "../../../mjolnir/Mjolnir";
 import { type IMediaBody } from "./IMediaBody";
 import { MediaEventHelper } from "../../../utils/MediaEventHelper";
+import { canDecodeHeic, isDecodableHeicContent, isHeicContent } from "../../../utils/heic";
 import { type IBodyProps } from "./IBodyProps";
 import MVoiceOrAudioBody from "./MVoiceOrAudioBody";
 import MStickerBody from "./MStickerBody";
@@ -287,6 +288,24 @@ export default class MessageEvent extends React.Component<IProps> implements IMe
                     !this.validateImageOrVideoMimetype(content)) ||
                 (BodyType === MStickerBody && !this.validateStickerMimetype(content))
             ) {
+                BodyType = this.bodyTypes.get(MsgType.File)!;
+            }
+
+            // HEIC often arrives as m.file; rescue those to the image renderer (which decodes it via the
+            // OS) only where we can actually decode it — otherwise leave it as a file attachment.
+            if (
+                BodyType === this.bodyTypes.get(MsgType.File) &&
+                (content.url || content.file) &&
+                isDecodableHeicContent(content)
+            ) {
+                BodyType = ImageBodyFactory;
+            }
+
+            // Conversely, HEIC we cannot decode must not reach the image renderer — it would be a broken
+            // <img> (image/heic is in the blob allow-list so it wouldn't otherwise fall back). Element
+            // bundles no decoder, so where the OS can't decode HEIC it stays a file attachment. Gated on the
+            // default image body so an overridden body (e.g. a reply body) is left alone.
+            if (BodyType === ImageBodyFactory && isHeicContent(content) && !canDecodeHeic()) {
                 BodyType = this.bodyTypes.get(MsgType.File)!;
             }
 

--- a/apps/web/src/utils/MediaEventHelper.ts
+++ b/apps/web/src/utils/MediaEventHelper.ts
@@ -15,6 +15,7 @@ import { type Media, mediaFromContent } from "../customisations/Media";
 import { decryptFile } from "./DecryptFile";
 import { type IDestroyable } from "./IDestroyable";
 import { getBlobSafeMimeType } from "./blobs.ts";
+import { isDecodableHeicContent, decodeHeicToJpeg } from "./heic.ts";
 
 // TODO: We should consider caching the blobs. https://github.com/vector-im/element-web/issues/17192
 
@@ -47,34 +48,55 @@ export class MediaEventHelper implements IDestroyable {
     }
 
     public destroy(): void {
-        if (this.media.isEncrypted) {
-            if (this.sourceUrl.cachedValue) URL.revokeObjectURL(this.sourceUrl.cachedValue);
-            if (this.thumbnailUrl.cachedValue) URL.revokeObjectURL(this.thumbnailUrl.cachedValue);
-        }
+        // Revoke the object URLs we created for encrypted media and for HEIC; plain media uses HTTP URLs.
+        const revokeIfBlob = (url: string | null | undefined): void => {
+            if (url?.startsWith("blob:")) URL.revokeObjectURL(url);
+        };
+        revokeIfBlob(this.sourceUrl.cachedValue);
+        revokeIfBlob(this.thumbnailUrl.cachedValue);
     }
 
     private prepareSourceUrl = async (): Promise<string | null> => {
-        if (this.media.isEncrypted) {
+        const content = this.event.getContent<MediaEventContent>();
+        // Decodable HEIC needs the blob path (even when unencrypted) so we can decode it to a JPEG display
+        // URL; sourceBlob keeps the original bytes for download.
+        if (this.media.isEncrypted || isDecodableHeicContent(content)) {
             const blob = await this.sourceBlob.value;
-            return URL.createObjectURL(blob);
+            return URL.createObjectURL(await this.decodeForDisplay(blob, isDecodableHeicContent(content)));
         } else {
             return this.media.srcHttp;
         }
     };
 
     private prepareThumbnailUrl = async (): Promise<string | null> => {
-        if (this.media.isEncrypted) {
+        const content = this.event.getContent<ImageContent>();
+        if (this.media.isEncrypted || isDecodableHeicContent(content)) {
             const blob = await this.thumbnailBlob.value;
             if (blob === null) return null;
-            return URL.createObjectURL(blob);
+            return URL.createObjectURL(await this.decodeForDisplay(blob, isDecodableHeicContent(content)));
         } else {
             return this.media.thumbnailHttp;
+        }
+    };
+
+    // Decode a HEIC blob to JPEG for display; a no-op for non-HEIC. If the OS decoder fails on this file
+    // (we only get here when a decoder is present — routing gates on isDecodableHeicContent) we let the
+    // error propagate rather than returning the raw HEIC bytes: an <img> can't render those, so it would
+    // show a broken image. Rejecting instead lets the image body render its load-error placeholder.
+    private decodeForDisplay = async (blob: Blob, isHeic: boolean): Promise<Blob> => {
+        if (!isHeic) return blob;
+        try {
+            return await decodeHeicToJpeg(blob);
+        } catch (e) {
+            logger.warn("HEIC decode failed; showing image load error", e);
+            throw e;
         }
     };
 
     private fetchSource = (): Promise<Blob> => {
         const content = this.event.getContent<MediaEventContent>();
         if (this.media.isEncrypted) {
+            // Hold the original (decrypted) bytes; HEIC is decoded to JPEG only when building the display URL.
             return decryptFile(content.file!, content.info);
         }
 

--- a/apps/web/src/utils/blobs.ts
+++ b/apps/web/src/utils/blobs.ts
@@ -47,8 +47,10 @@ const ALLOWED_BLOB_MIMETYPES = [
     "image/apng",
     "image/webp",
     "image/avif",
-    // HEIC/HEIF: decoded to JPEG before it reaches an <img> (see utils/heic.ts + MediaEventHelper);
-    // allow-listing keeps it on the image path, not the file fallback. Non-scriptable container, so no XSS surface.
+    // HEIC/HEIF: on platforms with an OS decoder (macOS desktop) these are decoded to JPEG before they
+    // reach an <img> (see utils/heic.ts + MediaEventHelper), and allow-listing keeps that decoded blob on
+    // the image path. Where no decoder is present the content is routed to the file fallback instead (gated
+    // by isDecodableHeicContent), so raw HEIC never reaches an <img>. Non-scriptable container, no XSS surface.
     "image/heic",
     "image/heif",
     "image/heic-sequence",

--- a/apps/web/src/utils/blobs.ts
+++ b/apps/web/src/utils/blobs.ts
@@ -47,6 +47,12 @@ const ALLOWED_BLOB_MIMETYPES = [
     "image/apng",
     "image/webp",
     "image/avif",
+    // HEIC/HEIF: decoded to JPEG before it reaches an <img> (see utils/heic.ts + MediaEventHelper);
+    // allow-listing keeps it on the image path, not the file fallback. Non-scriptable container, so no XSS surface.
+    "image/heic",
+    "image/heif",
+    "image/heic-sequence",
+    "image/heif-sequence",
 
     "video/mp4",
     "video/webm",

--- a/apps/web/src/utils/heic.ts
+++ b/apps/web/src/utils/heic.ts
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+// HEIC/HEIF cannot be decoded by Chromium, so HEIC image messages would otherwise render broken. Element
+// deliberately bundles NO HEIC decoder: instead, on desktop platforms whose OS ships a licensed HEIC
+// decoder, the Electron main process decodes it for us and exposes `window.electron.decodeHeic` (see
+// apps/desktop; macOS uses the Image I/O framework). Decoding is delegated to the platform — the same way
+// web browsers and Element's native mobile apps handle HEIC/HEVC — so no HEVC-patented or copyleft decoder
+// is shipped. Where the OS cannot decode HEIC (Element Web, or a desktop platform without OS support), HEIC
+// simply falls back to a file attachment, unchanged from before this feature.
+
+import { type IContent } from "matrix-js-sdk/src/matrix";
+
+/**
+ * Whether an event/content mimetype names HEIC/HEIF — used for routing, not for the decode itself.
+ *
+ * Also accepts the Apple Uniform Type Identifiers `public.heic`/`public.heif`: some senders (e.g. Beeper,
+ * the original report in element-hq/element-web#19531) put the UTI in `info.mimetype` instead of a real
+ * mimetype, and those events often carry no file extension for {@link isHeicFilename} to fall back on.
+ */
+export function isHeicMimeType(mimetype?: string): boolean {
+    if (!mimetype) return false;
+    const m = mimetype.split(";")[0].trim().toLowerCase();
+    return (
+        m === "image/heic" ||
+        m === "image/heif" ||
+        m === "image/heic-sequence" ||
+        m === "image/heif-sequence" ||
+        m === "public.heic" ||
+        m === "public.heif"
+    );
+}
+
+/** Whether a filename has a HEIC/HEIF extension — a fallback for senders that omit/mangle the mimetype. */
+export function isHeicFilename(filename?: string): boolean {
+    if (!filename) return false;
+    return /\.(heic|heif)$/i.test(filename.trim());
+}
+
+/**
+ * Whether a message's media content is HEIC/HEIF, by advertised mimetype OR filename extension. HEIC is
+ * routinely sent as an `m.file` (or with a missing/incorrect mimetype) by clients that can't thumbnail it,
+ * so routing must not rely on `msgtype` or the mimetype alone.
+ */
+export function isHeicContent(content?: IContent): boolean {
+    if (!content) return false;
+    return isHeicMimeType(content.info?.mimetype) || isHeicFilename(content.filename ?? content.body);
+}
+
+/** Whether this platform can decode HEIC — i.e. the desktop main process exposed an OS-backed decoder. */
+export function canDecodeHeic(): boolean {
+    return typeof window.electron?.decodeHeic === "function";
+}
+
+/**
+ * Whether HEIC/HEIF content should be rendered as a (decoded) image here: true only when the content is
+ * HEIC AND this platform has an OS decoder. Callers use this to route HEIC to the image renderer only where
+ * we can actually decode it; elsewhere it stays a file attachment. See {@link canDecodeHeic}.
+ */
+export function isDecodableHeicContent(content?: IContent): boolean {
+    return isHeicContent(content) && canDecodeHeic();
+}
+
+// A pathological/huge HEIC (or a hung native decoder) could otherwise decode forever, leaving the caller
+// stuck on a spinner. This bound makes the decode reject so callers can fall back / show an error. The
+// desktop main process applies its own backstop of the same duration (HEIC_HELPER_TIMEOUT_MS in
+// apps/desktop/src/heic.ts) — keep the two in sync.
+const HEIC_DECODE_TIMEOUT_MS = 30_000;
+
+/**
+ * Reject if `p` doesn't settle within {@link HEIC_DECODE_TIMEOUT_MS}. Note this is only about UI recovery:
+ * the underlying out-of-process native decoder may keep running in the background on timeout — we just stop
+ * waiting on it.
+ */
+function withDecodeTimeout<T>(p: Promise<T>): Promise<T> {
+    let timer: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+            () => reject(new Error(`HEIC decode timed out after ${HEIC_DECODE_TIMEOUT_MS}ms`)),
+            HEIC_DECODE_TIMEOUT_MS,
+        );
+    });
+    return Promise.race([p, timeout]).finally(() => clearTimeout(timer));
+}
+
+/**
+ * Decode a HEIC/HEIF blob to a JPEG blob via the OS decoder exposed by Element Desktop's main process
+ * (`window.electron.decodeHeic`). Only call where {@link canDecodeHeic} is true — callers gate rendering on
+ * {@link isDecodableHeicContent} — otherwise this rejects, as no decoder is bundled.
+ */
+export async function decodeHeicToJpeg(blob: Blob): Promise<Blob> {
+    if (!window.electron?.decodeHeic) {
+        throw new Error("No HEIC decoder available on this platform");
+    }
+    const input = new Uint8Array(await blob.arrayBuffer());
+    const jpeg = await withDecodeTimeout(window.electron.decodeHeic(input));
+    // Copy into a fresh ArrayBuffer-backed view: satisfies BlobPart typing and avoids aliasing a pooled
+    // Node Buffer that may arrive over IPC.
+    return new Blob([new Uint8Array(jpeg)], { type: "image/jpeg" });
+}

--- a/apps/web/src/viewmodels/message-body/ImageBodyViewModel.ts
+++ b/apps/web/src/viewmodels/message-body/ImageBodyViewModel.ts
@@ -32,6 +32,7 @@ import { createReconnectedListener } from "../../utils/connection";
 import { DecryptError, DownloadError } from "../../utils/DecryptFile";
 import { BLURHASH_FIELD, createThumbnail } from "../../utils/image-media";
 import { isMimeTypeAllowed } from "../../utils/blobs";
+import { isDecodableHeicContent } from "../../utils/heic";
 import ImageView from "../../components/views/elements/ImageView";
 
 export interface ImageBodyViewModelProps {
@@ -347,7 +348,12 @@ export class ImageBodyViewModel
         let thumbUrl: string | null;
         let contentUrl: string | null;
 
-        if (this.props.mediaEventHelper?.media.isEncrypted) {
+        // Route decodable HEIC through MediaEventHelper (which decodes it to JPEG via the OS) rather than an
+        // <img>, same as encrypted media.
+        const content = this.props.mxEvent.getContent<ImageContent>();
+        const isHeic = isDecodableHeicContent(content);
+
+        if (this.props.mediaEventHelper && (this.props.mediaEventHelper.media.isEncrypted || isHeic)) {
             try {
                 [contentUrl, thumbUrl] = await Promise.all([
                     this.props.mediaEventHelper.sourceUrl.value,
@@ -374,11 +380,10 @@ export class ImageBodyViewModel
                 return;
             }
         } else {
-            contentUrl = mediaFromContent(this.props.mxEvent.getContent<ImageContent>()).srcHttp;
+            contentUrl = mediaFromContent(content).srcHttp;
             thumbUrl = this.getThumbUrl();
         }
 
-        const content = this.props.mxEvent.getContent<ImageContent>();
         let generatedThumbnailUrl: string | null = null;
         let isAnimated = (content.info as ImageInfoWithAnimationFlag | undefined)?.["org.matrix.msc4230.is_animated"];
         if (isAnimated === undefined) {

--- a/apps/web/test/unit-tests/components/views/messages/MBodyFactory-test.tsx
+++ b/apps/web/test/unit-tests/components/views/messages/MBodyFactory-test.tsx
@@ -193,6 +193,15 @@ describe("MBodyFactory", () => {
             },
         };
 
+        // HEIC keeps the image body only where the platform can decode it (main process exposes
+        // window.electron.decodeHeic); simulate that being available for these tests.
+        beforeEach(() => {
+            (window as any).electron = { decodeHeic: jest.fn() };
+        });
+        afterEach(() => {
+            delete (window as any).electron;
+        });
+
         it("renders the shared image view in room timelines", () => {
             const mediaEvent = mkEvent("m.image", imageContent);
 
@@ -250,6 +259,94 @@ describe("MBodyFactory", () => {
             expect(container.querySelector(".mx_ImageBody")).toBeNull();
             expect(container.querySelector(".mx_MFileBody")).not.toBeNull();
             expect(getByRole("button", { name: "alt" })).toBeInTheDocument();
+        });
+
+        it("keeps the image body for encrypted HEIC images without thumbnails (decoded at display time)", () => {
+            const mediaEvent = mkEvent("m.image", {
+                body: "IMG_0001.HEIC",
+                file: { url: "mxc://server/encrypted-file" },
+                url: undefined,
+                info: {
+                    mimetype: "image/heic",
+                    w: 270,
+                    h: 360,
+                },
+            });
+
+            const { container } = render(
+                <ScopedRoomContextProvider {...({ timelineRenderingType: TimelineRenderingType.Room } as any)}>
+                    <ImageBodyFactory {...props} mxEvent={mediaEvent} mediaEventHelper={encryptedImageHelper()} />
+                </ScopedRoomContextProvider>,
+            );
+
+            expect(container.querySelector(".mx_ImageBody")).not.toBeNull();
+            expect(container.querySelector(".mx_MFileBody")).toBeNull();
+        });
+
+        it("falls back to the file body for encrypted HEIC when the platform has no OS decoder", () => {
+            // No window.electron.decodeHeic → Element bundles no decoder → HEIC must render as a file body.
+            // Uses the public.heic UTI shape (not in the blob allow-list) so this exercises the factory's own
+            // fallback rather than upstream routing.
+            delete (window as any).electron;
+            const mediaEvent = mkEvent("m.image", {
+                body: "ima_355e641",
+                file: { url: "mxc://server/encrypted-file" },
+                url: undefined,
+                info: {
+                    mimetype: "public.heic",
+                    w: 270,
+                    h: 360,
+                },
+            });
+
+            const { container } = render(
+                <ScopedRoomContextProvider {...({ timelineRenderingType: TimelineRenderingType.Room } as any)}>
+                    <ImageBodyFactory {...props} mxEvent={mediaEvent} mediaEventHelper={encryptedImageHelper()} />
+                </ScopedRoomContextProvider>,
+            );
+
+            expect(container.querySelector(".mx_MFileBody")).not.toBeNull();
+        });
+
+        it("keeps the image body for an encrypted public.heic UTI image without a thumbnail", () => {
+            // The exact element-web#19531 shape: mimetype is the Apple UTI and the body has no extension.
+            const mediaEvent = mkEvent("m.image", {
+                body: "ima_355e641",
+                file: { url: "mxc://server/encrypted-file" },
+                url: undefined,
+                info: {
+                    mimetype: "public.heic",
+                },
+            });
+
+            const { container } = render(
+                <ScopedRoomContextProvider {...({ timelineRenderingType: TimelineRenderingType.Room } as any)}>
+                    <ImageBodyFactory {...props} mxEvent={mediaEvent} mediaEventHelper={encryptedImageHelper()} />
+                </ScopedRoomContextProvider>,
+            );
+
+            expect(container.querySelector(".mx_ImageBody")).not.toBeNull();
+            expect(container.querySelector(".mx_MFileBody")).toBeNull();
+        });
+
+        it("keeps the image body for an encrypted HEIC detected by extension when the mimetype is wrong", () => {
+            const mediaEvent = mkEvent("m.image", {
+                body: "photo.heic",
+                file: { url: "mxc://server/encrypted-file" },
+                url: undefined,
+                info: {
+                    mimetype: "application/octet-stream",
+                },
+            });
+
+            const { container } = render(
+                <ScopedRoomContextProvider {...({ timelineRenderingType: TimelineRenderingType.Room } as any)}>
+                    <ImageBodyFactory {...props} mxEvent={mediaEvent} mediaEventHelper={encryptedImageHelper()} />
+                </ScopedRoomContextProvider>,
+            );
+
+            expect(container.querySelector(".mx_ImageBody")).not.toBeNull();
+            expect(container.querySelector(".mx_MFileBody")).toBeNull();
         });
 
         it("keeps the image body for encrypted unsafe images when a thumbnail is available", () => {

--- a/apps/web/test/unit-tests/components/views/messages/MessageEvent-test.tsx
+++ b/apps/web/test/unit-tests/components/views/messages/MessageEvent-test.tsx
@@ -166,6 +166,15 @@ describe("MessageEvent", () => {
     describe("when an image with a caption is sent", () => {
         let result: RenderResult;
 
+        // HEIC is only rendered as an image where the platform can decode it (desktop main process exposes
+        // window.electron.decodeHeic); simulate that being available for these tests.
+        beforeEach(() => {
+            (window as any).electron = { decodeHeic: jest.fn() };
+        });
+        afterEach(() => {
+            delete (window as any).electron;
+        });
+
         function createEvent(mimetype: string, filename: string, msgtype: string) {
             return mkEvent({
                 event: true,
@@ -208,6 +217,68 @@ describe("MessageEvent", () => {
             mockMedia();
             result.getByTestId("file-body");
             result.getByTestId("textual-body");
+        });
+
+        it("should render an ImageBody for HEIC even when the filename has no usable extension", () => {
+            // Regression: HEIC images are decoded to JPEG at display time and must reach the image
+            // renderer. The generic extension/mimetype validation used to downgrade them to a file
+            // attachment when `mime` couldn't classify the filename; the content mimetype short-circuit
+            // must keep them as images. Use an extension-less filename so this fails without the fix.
+            event = createEvent("image/heic", "IMG_0001", MsgType.Image);
+            result = renderMessageEvent();
+            mockMedia();
+            result.getByTestId("image-body");
+            result.getByTestId("textual-body");
+        });
+
+        it("should render an ImageBody for HEIC sent as an m.file (other clients downgrade it)", () => {
+            // Regression: clients that can't thumbnail HEIC send it as an m.file. The viewer must still
+            // route it to the image renderer (which decodes to JPEG) rather than show a file-download chip.
+            event = createEvent("image/heic", "IMG_0001.heic", MsgType.File);
+            result = renderMessageEvent();
+            mockMedia();
+            result.getByTestId("image-body");
+            result.getByTestId("textual-body");
+        });
+
+        it("should render an ImageBody for an m.file HEIC detected by extension alone (no mimetype)", () => {
+            // Some senders omit or mangle the mimetype; the .heic/.heif extension must be enough.
+            event = createEvent("", "IMG_0001.HEIC", MsgType.File);
+            result = renderMessageEvent();
+            mockMedia();
+            result.getByTestId("image-body");
+            result.getByTestId("textual-body");
+        });
+
+        it("should render a FileBody for HEIC when the platform has no OS decoder (graceful degradation)", () => {
+            // With no window.electron.decodeHeic (e.g. Element Web, or desktop without OS HEIC support),
+            // Element bundles no decoder, so HEIC must fall back to a file attachment rather than a broken
+            // image. The HEIC mimetype with an image filename would otherwise render as an image body, so
+            // this exercises the no-decoder downgrade gate.
+            delete (window as any).electron;
+            event = createEvent("image/heic", "photo.jpg", MsgType.Image);
+            result = renderMessageEvent();
+            mockMedia();
+            result.getByTestId("file-body");
+            expect(result.queryByTestId("image-body")).toBeNull();
+        });
+
+        it("should not clobber an overridden body for HEIC (e.g. a compact reply body)", () => {
+            // The HEIC rescue must only rescue events that would otherwise render as the file body.
+            // An overridden body (like ReplyTile's MImageReplyBody) must be left alone.
+            event = createEvent("image/heic", "IMG_0001.heic", MsgType.Image);
+            const result = render(
+                <MatrixClientContext.Provider value={client}>
+                    <MessageEvent
+                        mxEvent={event}
+                        permalinkCreator={new RoomPermalinkCreator(room)}
+                        overrideBodyTypes={{ [MsgType.Image]: () => <div data-testid="reply-body" /> }}
+                    />
+                </MatrixClientContext.Provider>,
+            );
+            mockMedia();
+            result.getByTestId("reply-body");
+            expect(result.queryByTestId("image-body")).toBeNull();
         });
 
         it("should render a TextualBody and a video element", () => {

--- a/apps/web/test/unit-tests/utils/MediaEventHelper-test.ts
+++ b/apps/web/test/unit-tests/utils/MediaEventHelper-test.ts
@@ -6,11 +6,38 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { MatrixEvent } from "matrix-js-sdk/src/matrix";
+import fetchMock from "@fetch-mock/jest";
 
 import { MediaEventHelper } from "../../../src/utils/MediaEventHelper.ts";
 import { stubClient } from "../../test-utils";
 
+// HEIC is decoded to JPEG only when building the display URL; sourceBlob/thumbnailBlob keep the raw
+// bytes. The real routing/decoder is covered in heic-test.ts; here we just verify MediaEventHelper
+// wires it in — decoding when (and only when) the content is HEIC.
+const mockDecodeHeicToJpeg = jest.fn(async (_blob: Blob) => new Blob(["jpeg"], { type: "image/jpeg" }));
+// Keep the real content routing (isHeicContent/isHeicMimeType/isHeicFilename) so decoding is gated
+// realistically; only the actual libheif decoder is stubbed (never pull the real ~3MB decoder).
+jest.mock("../../../src/utils/heic.ts", () => ({
+    ...jest.requireActual("../../../src/utils/heic.ts"),
+    decodeHeicToJpeg: (blob: Blob) => mockDecodeHeicToJpeg(blob),
+}));
+
+// Simulate encrypted media: decryptFile yields the original (undecoded) bytes for the display path.
+const mockDecryptFile = jest.fn();
+jest.mock("../../../src/utils/DecryptFile.ts", () => ({
+    decryptFile: (...args: unknown[]) => mockDecryptFile(...args),
+}));
+
 describe("MediaEventHelper", () => {
+    // MediaEventHelper only takes the HEIC decode path where the platform can decode it (real
+    // isDecodableHeicContent → canDecodeHeic → window.electron.decodeHeic); simulate that here.
+    beforeEach(() => {
+        (window as any).electron = { decodeHeic: jest.fn() };
+    });
+    afterEach(() => {
+        delete (window as any).electron;
+    });
+
     it("should set the mime type on the blob based on the event metadata", async () => {
         stubClient();
 
@@ -36,5 +63,115 @@ describe("MediaEventHelper", () => {
 
         const blob = await helper.thumbnailBlob.value;
         expect(blob?.type).toBe(event.getContent().info.thumbnail_info?.mimetype);
+    });
+
+    it("keeps raw HEIC bytes in sourceBlob and decodes to JPEG only when building the source URL", async () => {
+        stubClient();
+        mockDecodeHeicToJpeg.mockClear();
+        // downloadSource() requires a 200 response (unlike the thumbnail path).
+        fetchMock.get("end:/matrix.org/heicsource", { status: 200, body: "heic-bytes" });
+
+        const event = new MatrixEvent({
+            type: "m.room.message",
+            content: {
+                msgtype: "m.image",
+                body: "photo.heic",
+                info: { mimetype: "image/heic", size: 4321, w: 100, h: 100 },
+                url: "mxc://matrix.org/heicsource",
+            },
+        });
+        const helper = new MediaEventHelper(event);
+
+        // sourceBlob holds the original (undecoded) HEIC bytes — the decoder isn't touched yet.
+        const blob = await helper.sourceBlob.value;
+        expect(blob.type).toBe("image/heic");
+        expect(mockDecodeHeicToJpeg).not.toHaveBeenCalled();
+
+        // Building the display URL decodes the very same blob to JPEG.
+        expect(await helper.sourceUrl.value).toBe("blob");
+        expect(mockDecodeHeicToJpeg).toHaveBeenCalledWith(blob);
+    });
+
+    it("rejects the source URL when HEIC decoding fails, rather than surfacing undecodable HEIC bytes", async () => {
+        stubClient();
+        mockDecodeHeicToJpeg.mockClear();
+        // The OS decoder is present but fails on this file. We must not fall back to the raw HEIC bytes
+        // (an <img> can't render them — a broken image); the rejection lets the image body show its error.
+        mockDecodeHeicToJpeg.mockRejectedValueOnce(new Error("decode failed"));
+        fetchMock.get("end:/matrix.org/heicsource", { status: 200, body: "heic-bytes" });
+
+        const event = new MatrixEvent({
+            type: "m.room.message",
+            content: {
+                msgtype: "m.image",
+                body: "photo.heic",
+                info: { mimetype: "image/heic", size: 4321, w: 100, h: 100 },
+                url: "mxc://matrix.org/heicsource",
+            },
+        });
+        const helper = new MediaEventHelper(event);
+
+        await expect(helper.sourceUrl.value).rejects.toThrow("decode failed");
+    });
+
+    it("does not decode an encrypted non-HEIC image (AVIF) when building the source URL", async () => {
+        stubClient();
+        mockDecodeHeicToJpeg.mockClear();
+        (URL.createObjectURL as jest.Mock).mockClear();
+        // AVIF ISO-BMFF carries the `mif1` brand HEIC once matched on; make sure content routing —
+        // not a blind byte sniff — keeps it out of the decoder. decryptFile returns the raw AVIF bytes.
+        const avifBlob = new Blob(["avif-bytes"], { type: "image/avif" });
+        mockDecryptFile.mockResolvedValue(avifBlob);
+
+        const event = new MatrixEvent({
+            type: "m.room.message",
+            content: {
+                msgtype: "m.image",
+                body: "photo.avif",
+                info: { mimetype: "image/avif", size: 4321, w: 100, h: 100 },
+                file: { url: "mxc://matrix.org/avifsource" },
+            },
+        });
+        const helper = new MediaEventHelper(event);
+
+        // sourceBlob holds the decrypted (original) AVIF bytes.
+        const blob = await helper.sourceBlob.value;
+        expect(blob.type).toBe("image/avif");
+        expect(mockDecodeHeicToJpeg).not.toHaveBeenCalled();
+
+        // The display URL is built from those same undecoded bytes — AVIF is never routed to the decoder.
+        expect(await helper.sourceUrl.value).toBe("blob");
+        expect(mockDecodeHeicToJpeg).not.toHaveBeenCalled();
+        expect(URL.createObjectURL).toHaveBeenCalledWith(blob);
+    });
+
+    it("keeps raw HEIC bytes in thumbnailBlob and decodes to JPEG only when building the thumbnail URL", async () => {
+        stubClient();
+        mockDecodeHeicToJpeg.mockClear();
+
+        const event = new MatrixEvent({
+            type: "m.room.message",
+            content: {
+                msgtype: "m.image",
+                body: "photo.heic",
+                info: {
+                    mimetype: "image/heic",
+                    size: 4321,
+                    w: 100,
+                    h: 100,
+                    thumbnail_info: { mimetype: "image/heic" },
+                    thumbnail_url: "mxc://matrix.org/heicthumb",
+                },
+                url: "mxc://matrix.org/heicsource",
+            },
+        });
+        const helper = new MediaEventHelper(event);
+
+        const blob = await helper.thumbnailBlob.value;
+        expect(blob?.type).toBe("image/heic");
+        expect(mockDecodeHeicToJpeg).not.toHaveBeenCalled();
+
+        expect(await helper.thumbnailUrl.value).toBe("blob");
+        expect(mockDecodeHeicToJpeg).toHaveBeenCalledWith(blob);
     });
 });

--- a/apps/web/test/unit-tests/utils/heic-test.ts
+++ b/apps/web/test/unit-tests/utils/heic-test.ts
@@ -1,0 +1,145 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import {
+    canDecodeHeic,
+    decodeHeicToJpeg,
+    isDecodableHeicContent,
+    isHeicContent,
+    isHeicFilename,
+    isHeicMimeType,
+} from "../../../src/utils/heic.ts";
+
+const mockDecodeHeic = jest.fn();
+
+/** Simulate the desktop main process exposing (or not) an OS-backed HEIC decoder. */
+function setNativeDecoder(present: boolean): void {
+    if (present) {
+        (window as any).electron = { decodeHeic: mockDecodeHeic };
+    } else {
+        delete (window as any).electron;
+    }
+}
+
+describe("heic utils", () => {
+    beforeEach(() => {
+        mockDecodeHeic.mockReset();
+        setNativeDecoder(false);
+    });
+    afterEach(() => setNativeDecoder(false));
+
+    describe("isHeicMimeType", () => {
+        it.each([
+            "image/heic",
+            "image/heif",
+            "image/heic-sequence",
+            "image/heif-sequence",
+            "image/HEIC",
+            // Apple Uniform Type Identifiers, as sent by e.g. Beeper (element-web#19531)
+            "public.heic",
+            "public.heif",
+            "PUBLIC.HEIC",
+        ])("returns true for %s", (m) => expect(isHeicMimeType(m)).toBe(true));
+
+        it("tolerates a charset/parameter suffix", () => {
+            expect(isHeicMimeType("image/heic; codecs=hvc1")).toBe(true);
+        });
+
+        it.each(["image/jpeg", "image/png", "application/octet-stream", "", undefined])("returns false for %s", (m) =>
+            expect(isHeicMimeType(m)).toBe(false),
+        );
+    });
+
+    describe("isHeicFilename", () => {
+        it.each(["IMG_0001.heic", "photo.HEIF", "a.b.heic", "x.heif"])("returns true for %s", (f) =>
+            expect(isHeicFilename(f)).toBe(true),
+        );
+        it.each(["image.jpg", "heic.txt", "myheic", "", undefined])("returns false for %s", (f) =>
+            expect(isHeicFilename(f)).toBe(false),
+        );
+    });
+
+    describe("isHeicContent", () => {
+        it("matches on mimetype", () => {
+            expect(isHeicContent({ info: { mimetype: "image/heic" }, body: "x.jpg" })).toBe(true);
+        });
+        it("matches on filename when mimetype is missing/wrong", () => {
+            expect(isHeicContent({ filename: "IMG.heic" })).toBe(true);
+            expect(isHeicContent({ info: { mimetype: "application/octet-stream" }, body: "IMG.HEIF" })).toBe(true);
+        });
+        it("falls back to body when filename is absent", () => {
+            expect(isHeicContent({ body: "IMG_0001.heic" })).toBe(true);
+        });
+        it("matches the original report shape: public.heic UTI with an extensionless body", () => {
+            // element-web#19531: info.mimetype is the UTI and body has no extension
+            expect(isHeicContent({ info: { mimetype: "public.heic" }, body: "ima_355e641" })).toBe(true);
+        });
+        it("returns false for non-HEIC content and for undefined", () => {
+            expect(isHeicContent({ info: { mimetype: "image/jpeg" }, body: "photo.jpg" })).toBe(false);
+            expect(isHeicContent(undefined)).toBe(false);
+        });
+    });
+
+    describe("canDecodeHeic", () => {
+        it("is true only when the desktop main process exposes a decoder", () => {
+            setNativeDecoder(true);
+            expect(canDecodeHeic()).toBe(true);
+            setNativeDecoder(false);
+            expect(canDecodeHeic()).toBe(false);
+        });
+    });
+
+    describe("isDecodableHeicContent", () => {
+        const heic = { info: { mimetype: "image/heic" }, body: "IMG.heic" };
+        it("is true for HEIC content only when a decoder is available", () => {
+            setNativeDecoder(true);
+            expect(isDecodableHeicContent(heic)).toBe(true);
+        });
+        it("is false for HEIC content when no decoder is available (graceful degradation)", () => {
+            setNativeDecoder(false);
+            expect(isDecodableHeicContent(heic)).toBe(false);
+        });
+        it("is false for non-HEIC content even with a decoder", () => {
+            setNativeDecoder(true);
+            expect(isDecodableHeicContent({ info: { mimetype: "image/jpeg" }, body: "a.jpg" })).toBe(false);
+        });
+    });
+
+    describe("decodeHeicToJpeg", () => {
+        it("decodes a blob to JPEG via the OS decoder", async () => {
+            setNativeDecoder(true);
+            mockDecodeHeic.mockResolvedValue(new Uint8Array([1, 2, 3]));
+
+            const result = await decodeHeicToJpeg(new Blob(["heic"], { type: "image/heic" }));
+
+            expect(result).toBeInstanceOf(Blob);
+            expect(result.type).toBe("image/jpeg");
+            expect(mockDecodeHeic).toHaveBeenCalledWith(expect.any(Uint8Array));
+        });
+
+        it("rejects when no decoder is available", async () => {
+            setNativeDecoder(false);
+            await expect(decodeHeicToJpeg(new Blob(["heic"], { type: "image/heic" }))).rejects.toThrow(
+                /No HEIC decoder/,
+            );
+        });
+
+        it("rejects when the decode never resolves (timeout)", async () => {
+            setNativeDecoder(true);
+            jest.useFakeTimers();
+            try {
+                mockDecodeHeic.mockReturnValue(new Promise<Uint8Array>(() => {})); // never resolves
+                const promise = decodeHeicToJpeg(new Blob(["heic"], { type: "image/heic" }));
+                promise.catch(() => {}); // handle the rejection now, before timers fire, to avoid an unhandled rejection
+                await jest.advanceTimersByTimeAsync(30_000);
+                await expect(promise).rejects.toThrow(/timed out/);
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+    });
+});

--- a/apps/web/test/viewmodels/message-body/ImageBodyViewModel-test.tsx
+++ b/apps/web/test/viewmodels/message-body/ImageBodyViewModel-test.tsx
@@ -157,11 +157,16 @@ describe("ImageBodyViewModel", () => {
         mockedMediaFromContent.mockImplementation((content: Record<string, any>) => createMockMedia(content));
         mockedBlobIsAnimated.mockResolvedValue(true);
         mockedCreateThumbnail.mockResolvedValue({ thumbnail: new Blob(["thumbnail"], { type: "image/jpeg" }) } as any);
+
+        // HEIC is routed through the decode path only where the platform can decode it (main process
+        // exposes window.electron.decodeHeic); simulate that being available.
+        (window as any).electron = { decodeHeic: jest.fn() };
     });
 
     afterEach(() => {
         jest.restoreAllMocks();
         imageSizeWatcher = undefined;
+        delete (window as any).electron;
     });
 
     it("starts hidden and skips emitting when setMediaVisible is unchanged", () => {
@@ -324,6 +329,37 @@ describe("ImageBodyViewModel", () => {
             src: "https://server/full.png",
             thumbnailSrc: "https://server/thumb.png",
             linkUrl: "https://server/full.png",
+        });
+    });
+
+    it("routes unencrypted HEIC through the decode (blob) path instead of srcHttp", async () => {
+        const vm = createVm({
+            mediaVisible: true,
+            mxEvent: createEvent({
+                content: {
+                    info: {
+                        mimetype: "image/heic",
+                        w: 320,
+                        h: 240,
+                        size: 48_000,
+                    },
+                },
+            }),
+            // Unencrypted, but HEIC must still resolve its URLs from the helper (which decodes to JPEG),
+            // not from the raw srcHttp ("https://server/full.png") that the browser can't paint.
+            mediaEventHelper: createMediaEventHelper({
+                encrypted: false,
+                sourceUrl: "blob:heic-image",
+                thumbnailUrl: "blob:heic-thumb",
+            }),
+        });
+
+        await downloadImageForTest(vm);
+
+        expect(vm.getSnapshot()).toMatchObject({
+            state: ImageBodyViewState.READY,
+            src: "blob:heic-image",
+            thumbnailSrc: "blob:heic-thumb",
         });
     });
 


### PR DESCRIPTION
This addresses, for macOS Desktop specifically, an issue that has been occurring on many combinations of platforms. (Ex: https://github.com/element-hq/element-web/issues/19531 — and its long line of duplicates: #9143, #18519, #18699, #21159.

## The problem

Chromium cannot decode HEIC/HEIF in `<img>` on any platform — including macOS, where the OS
itself can decode it — so HEIC images sent from iPhones/Samsungs currently render as a
file-download chip in Element Web and Desktop.

## What it does

- **macOS Desktop:** a tiny bundled helper binary (`apps/desktop/native/heic-decode`, ~55 lines
  of Objective-C) decodes HEIC via **Image I/O**, piped in/out over stdin/stdout **entirely in
  memory** — no decrypted plaintext touches disk, so it is safe for E2EE media. The main process
  exposes `window.electron.decodeHeic`; the renderer prefers it and renders HEIC as an image.
  The helper is built automatically at package time by an electron-builder `beforeBuild` hook
  (macOS only) and signed via `mac.binaries`; it is bundled only into the macOS build.
- **Everywhere else** (Element Web; a desktop platform with no OS HEIC support): HEIC
  **gracefully falls back to a file attachment** — identical to today's behaviour. Nothing
  regresses; the feature is purely additive where an OS decoder exists. A runtime decode failure
  surfaces the normal image load-error placeholder rather than a broken `<img>`.
- Detection routes HEIC by **mimetype OR filename/UTI** (covers clients that send it as `m.file`,
  omit the mimetype, or use the Apple `public.heic` UTI) and only where the platform can actually
  decode it (`isDecodableHeicContent`).

The design is deliberately extensible: Windows could delegate to WIC where the HEVC extension is
installed, Linux to a system decoder where present — same pattern, no bundle.

## Screenshots

<!-- REQUIRED by CONTRIBUTING.md — attach before/after. Suggested captures:
     BEFORE: a received .heic message rendering as a grey file-download chip.
     AFTER (macOS desktop): the same message rendering inline as an image, and in the lightbox.
     AFTER (Element Web): the same message still rendering as a file chip (graceful fallback). -->

| Before (file chip) | After — macOS desktop (inline image) |
| --- | --- |
| <img width="397" height="150" alt="Screenshot 2026-07-01 at 17 05 35" src="https://github.com/user-attachments/assets/95266219-d102-42d1-9677-1e19aa41b299" /> | <img width="317" height="329" alt="Screenshot 2026-07-01 at 17 05 50" src="https://github.com/user-attachments/assets/5540f8ab-855c-4c2b-ae77-1450aea32781" />|

## Testing

Automated:

- **110 unit tests** across the HEIC routing, the decoder wiring, and graceful-degradation cases
  (`apps/web/test/.../heic-test.ts`, `MediaEventHelper-test.ts`, `MessageEvent-test.tsx`,
  `MBodyFactory-test.tsx`, `ImageBodyViewModel-test.tsx`, and `apps/desktop/src/heic.test.ts`
  which drives the spawn/timeout/exit-code paths with a mocked child process).
- **A Playwright e2e** (`apps/web/playwright/e2e/file-upload/heic.spec.ts`) asserting the
  Element-Web graceful-fallback contract (a HEIC `m.image` renders as a file attachment, not a
  broken image). The native-decode happy path is desktop-main-process only and is not reachable
  from the browser e2e environment.
- New code coverage: `apps/desktop/src/heic.ts` 100% lines; the new web HEIC modules ~84% lines.

## Notes for reviewers

- The helper is signed via electron-builder `mac.binaries`; verified to pass notarization.
- Known limits (not matcher-fixable): image sequences (Live Photos) render the primary frame; the
  OS decoder handles 10-bit/HDR/Display-P3 natively; images wider than 20000px are downscaled for
  the inline display copy (the original is preserved for download).
