### PR TITLE
Document incompatibility between playwright fixtures and MAS

### DIFF
--- a/packages/playwright-common/src/fixtures/user.ts
+++ b/packages/playwright-common/src/fixtures/user.ts
@@ -31,6 +31,14 @@ export async function populateLocalStorageWithCredentials(page: Page, credential
             window.localStorage.setItem("mx_has_pickle_key", "false");
             window.localStorage.setItem("mx_has_access_token", "true");
 
+            // XXX: If the homeserver is using MAS, then Element uses additional localstorage settings to store more
+            // data. The fact that we don't populate them means that, for example, when you hit "Remove this device" in
+            // the app, it attempts to hit the legacy `/logout` endpoint, which returns a 40x error, which is silently
+            // ignored.
+            //
+            // If you fix this, (1) yay! (2) please remember to update the warning on the doc-comments of this method
+            // and its callers.
+
             window.localStorage.setItem(
                 "mx_local_settings",
                 JSON.stringify({

--- a/packages/playwright-common/src/fixtures/user.ts
+++ b/packages/playwright-common/src/fixtures/user.ts
@@ -15,7 +15,11 @@ import { sample, uniqueId } from "lodash-es";
 import { test as base } from "./panel.js";
 import { type Credentials } from "../utils/api.js";
 
-/** Adds an initScript to the given page which will populate localStorage appropriately so that Element will use the given credentials. */
+/**
+ * Adds an initScript to the given page which will populate localStorage appropriately so that Element will use the given credentials.
+ *
+ * Warning: this is an incomplete implementation, particularly in MAS environments: for example, a logout operation will not work correctly.
+ */
 export async function populateLocalStorageWithCredentials(page: Page, credentials: Credentials) {
     await page.addInitScript(
         ({ credentials }) => {
@@ -61,6 +65,9 @@ export const test = base.extend<{
      * but adds an initScript which will populate localStorage with the user's details from
      * {@link #credentials} and {@link #homeserver}.
      *
+     * Warning: this is an incomplete implementation, particularly in MAS environments: for example, a logout operation
+     * will not work correctly.
+     *
      * Similar to {@link #user}, but doesn't load the app.
      */
     pageWithCredentials: Page;
@@ -69,6 +76,9 @@ export const test = base.extend<{
      * A (rather poorly-named) test fixture which registers a user per {@link #credentials}, stores
      * the credentials into localStorage per {@link #pageWithCredentials}, and then loads the front page of the
      * app.
+     *
+     * Warning: the user credentials are an incomplete implementation, particularly in MAS environments: for example, a logout operation
+     * will not work correctly.
      */
     user: Credentials;
 }>({

--- a/packages/playwright-common/src/utils/context.ts
+++ b/packages/playwright-common/src/utils/context.ts
@@ -15,6 +15,8 @@ import { populateLocalStorageWithCredentials } from "../fixtures/user.js";
 
 /** Create a new instance of the application, in a separate browser context, using the given credentials.
  *
+ * Warning: `populateLocalStorageWithCredentials` is an incomplete implementation, particularly in MAS environments: for example, a logout operation will not work correctly.
+ *
  * @param browser - the browser to use
  * @param credentials - the credentials to use for the new instance
  * @param additionalConfig - additional config for the `config.json` for the new instance


### PR DESCRIPTION
Last night I discovered the hard way that if you are using a MAS-backed homeserver, and create a user with the `user` fixture, then the `logout` button ... doesn't.

In an attempt to save someone else from losing two hours of their life, add some warnings.