### PR TITLE
Remove outdated references to MSC2697

### DIFF
--- a/apps/web/playwright/e2e/crypto/dehydration-mas.spec.ts
+++ b/apps/web/playwright/e2e/crypto/dehydration-mas.spec.ts
@@ -21,7 +21,6 @@ test.use({
     ...masHomeserver,
     synapseConfig: {
         experimental_features: {
-            msc2697_enabled: false,
             msc3814_enabled: true,
         },
     },

--- a/apps/web/playwright/e2e/crypto/dehydration.spec.ts
+++ b/apps/web/playwright/e2e/crypto/dehydration.spec.ts
@@ -26,7 +26,6 @@ test.use({
     displayName: NAME,
     synapseConfig: {
         experimental_features: {
-            msc2697_enabled: false,
             msc3814_enabled: true,
         },
     },


### PR DESCRIPTION
As of https://github.com/element-hq/synapse/pull/19346, Synapse no longer attempts to support MSC2697, so that bit of config is not needed.