### PR TITLE
Clear the composer preview after sending a message.

### DIFF
--- a/apps/web/playwright/e2e/links/composer-url-preview.spec.ts
+++ b/apps/web/playwright/e2e/links/composer-url-preview.spec.ts
@@ -36,10 +36,14 @@ test.describe("Composer URL preview", () => {
                 );
 
                 await page.goto(`#/room/${room.roomId}`);
-                const composer = page.getByRole("textbox", { name: "Send an unencrypted message…" });
+                const composerRegion = page.getByRole("region", { name: "Message composer" });
+                const composer = composerRegion.getByRole("textbox", { name: "Send an unencrypted message…" });
                 await composer.pressSequentially("https://example.org/");
-
-                await expect(page.getByRole("link", { name: "Example Site" })).toBeVisible();
+                const preview = composerRegion.getByRole("link", { name: "Example Site" });
+                await expect(preview).toBeVisible();
+                await composer.press("Enter");
+                await expect(composer).toBeEmpty();
+                await expect(preview).toBeHidden();
             });
 
             test("does not show a preview when the server returns a 404", async ({ page, app, room }) => {

--- a/apps/web/src/components/views/rooms/MessageComposer.tsx
+++ b/apps/web/src/components/views/rooms/MessageComposer.tsx
@@ -395,6 +395,7 @@ export class MessageComposer extends React.Component<IProps, IState> {
     };
 
     private sendMessage = async (): Promise<void> => {
+        this.setState({ urlPreviewComposerContent: "" });
         if (this.state.haveRecording && this.voiceRecordingButton.current) {
             // There shouldn't be any text message to send when a voice recording is active, so
             // just send out the voice recording.

--- a/apps/web/src/components/views/rooms/MessageComposerUrlPreview.tsx
+++ b/apps/web/src/components/views/rooms/MessageComposerUrlPreview.tsx
@@ -34,7 +34,8 @@ export function MessageComposerUrlPreviewWrapper({ content }: { content: string 
             void vm.updateWithText(content);
         },
         [vm, content],
-        DEBOUNCE_REQUEST_TIMEOUT_MS,
+        // Update instantly if content is empty (e.g. sent message or cleared input)
+        !!content ? DEBOUNCE_REQUEST_TIMEOUT_MS : 0,
     );
 
     useEffect(() => {

--- a/apps/web/src/components/views/rooms/MessageComposerUrlPreview.tsx
+++ b/apps/web/src/components/views/rooms/MessageComposerUrlPreview.tsx
@@ -35,7 +35,7 @@ export function MessageComposerUrlPreviewWrapper({ content }: { content: string 
         },
         [vm, content],
         // Update instantly if content is empty (e.g. sent message or cleared input)
-        !!content ? DEBOUNCE_REQUEST_TIMEOUT_MS : 0,
+        content ? DEBOUNCE_REQUEST_TIMEOUT_MS : 0,
     );
 
     useEffect(() => {


### PR DESCRIPTION
Fixing a bug introduced in https://github.com/element-hq/element-web/pull/33964 where the composer preview is not hidden after sending a message.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
