### PR TITLE
Handle SDKContextClass `client` initialisation internally

### DIFF
--- a/apps/web/src/Lifecycle.ts
+++ b/apps/web/src/Lifecycle.ts
@@ -81,6 +81,7 @@ import {
 import { TokenRefresher } from "./utils/oidc/TokenRefresher";
 import { checkBrowserSupport } from "./SupportedBrowser";
 import { type URLParams } from "./vector/url_utils.ts";
+import { type OnLoggedInPayload } from "./dispatcher/payloads/OnLoggedInPayload.ts";
 
 const HOMESERVER_URL_KEY = "mx_hs_url";
 const ID_SERVER_URL_KEY = "mx_is_url";
@@ -906,9 +907,9 @@ async function doSetLoggedIn(
     }
     checkSessionLock();
 
-    // We are now logged in, so fire this. We have yet to start the client but the
-    // client_started dispatch is for that.
-    dis.fire(Action.OnLoggedIn);
+    // We are now logged in, so fire this. We have yet to start the client but the client_started dispatch is for that.
+    // Dispatch this synchronously so SDKContextClass can set the client for other modules to consume.
+    dis.dispatch<OnLoggedInPayload>({ action: Action.OnLoggedIn, client }, true);
 
     const clientPegOpts: MatrixClientPegAssignOpts = {};
     if (credentials.pickleKey) {

--- a/apps/web/src/components/structures/MatrixChat.tsx
+++ b/apps/web/src/components/structures/MatrixChat.tsx
@@ -1521,7 +1521,6 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
      * Handle an {@link Action.OnLoggedIn} action (i.e, we now have a client with working credentials).
      */
     private onLoggedIn(): void {
-        this.stores.client = MatrixClientPeg.safeGet();
         StorageManager.tryPersistStorage();
 
         // If we're loading the app for the first time, we can now transition to a splash screen while we wait for the

--- a/apps/web/src/contexts/SDKContextClass.ts
+++ b/apps/web/src/contexts/SDKContextClass.ts
@@ -26,6 +26,9 @@ import { OidcClientStore } from "../stores/oidc/OidcClientStore";
 import WidgetStore from "../stores/WidgetStore";
 import ResizeNotifier from "../utils/ResizeNotifier";
 import { MultiRoomViewStore } from "../stores/MultiRoomViewStore";
+import { type ActionPayload, isAction } from "../dispatcher/payloads.ts";
+import { Action } from "../dispatcher/actions.ts";
+import { type OnLoggedInPayload } from "../dispatcher/payloads/OnLoggedInPayload.ts";
 
 /**
  * A class which (mostly) lazily initialises stores as and when they are requested, ensuring they remain
@@ -43,11 +46,13 @@ export class SDKContextClass {
      */
     public static readonly instance = new SDKContextClass();
 
-    // Optional as we don't have a client on initial load if unregistered. This should be set
-    // when the MatrixClient is first acquired in the dispatcher event Action.OnLoggedIn.
+    // Optional as we don't have a client on initial load if unregistered.
     // It is only safe to set this once, as updating this value will NOT notify components using
     // this Context.
-    public client?: MatrixClient;
+    protected _client?: MatrixClient;
+    public get client(): MatrixClient | undefined {
+        return this._client;
+    }
 
     // All protected fields to make it easier to derive test stores
     protected _WidgetPermissionStore?: WidgetPermissionStore;
@@ -66,6 +71,16 @@ export class SDKContextClass {
     protected _OidcClientStore?: OidcClientStore;
     protected _ResizeNotifier?: ResizeNotifier;
     protected _MultiRoomViewStore?: MultiRoomViewStore;
+
+    public constructor() {
+        defaultDispatcher.register(this.onDispatch);
+    }
+
+    private onDispatch = (payload: ActionPayload): void => {
+        if (isAction<OnLoggedInPayload>(payload, Action.OnLoggedIn)) {
+            this._client = payload.client;
+        }
+    };
 
     /**
      * Automatically construct stores which need to be created eagerly so they can register with
@@ -193,5 +208,6 @@ export class SDKContextClass {
     public onLoggedOut(): void {
         this._UserProfilesStore = undefined;
         this._OidcClientStore = undefined;
+        this._client = undefined;
     }
 }

--- a/apps/web/src/dispatcher/actions.ts
+++ b/apps/web/src/dispatcher/actions.ts
@@ -335,7 +335,7 @@ export enum Action {
      * access token from local storage). Note that this does not necessarily mean that a login action has happened,
      * just that authentication creds have been set up.
      *
-     * No additional payload information required.
+     * Use with a OnLoggedInPayload.
      */
     OnLoggedIn = "on_logged_in",
 

--- a/apps/web/src/dispatcher/payloads.ts
+++ b/apps/web/src/dispatcher/payloads.ts
@@ -17,6 +17,15 @@ export interface ActionPayload {
 }
 
 /**
+ * Type guard to check if a payload is of a specific action type.
+ * @param payload - the incoming payload to check
+ * @param action - the action to return true for
+ */
+export function isAction<P extends ActionPayload>(payload: ActionPayload, action: P["action"]): payload is P {
+    return payload.action === action;
+}
+
+/**
  * The function the dispatcher calls when ready for an AsyncActionPayload. The
  * single argument is used to start a dispatch. First the dispatcher calls the
  * outer function, then when the called function is ready it calls the cb

--- a/apps/web/src/dispatcher/payloads/OnLoggedInPayload.ts
+++ b/apps/web/src/dispatcher/payloads/OnLoggedInPayload.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { type MatrixClient } from "matrix-js-sdk/src/matrix";
+
+import { type ActionPayload } from "../payloads";
+import { type Action } from "../actions";
+
+export interface OnLoggedInPayload extends ActionPayload {
+    action: Action.OnLoggedIn;
+
+    client: MatrixClient;
+}

--- a/apps/web/test/unit-tests/TestSDKContext.ts
+++ b/apps/web/test/unit-tests/TestSDKContext.ts
@@ -6,6 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { type MatrixClient } from "matrix-js-sdk/src/matrix";
+
 import { SDKContextClass } from "../../src/contexts/SDKContextClass";
 import { type PosthogAnalytics } from "../../src/PosthogAnalytics";
 import { type SlidingSyncManager } from "../../src/SlidingSyncManager";
@@ -22,6 +24,7 @@ import type WidgetStore from "../../src/stores/WidgetStore";
  * replace individual stores. This is useful for tests which need to mock out stores.
  */
 export class TestSDKContext extends SDKContextClass {
+    declare public _client?: MatrixClient;
     declare public _RightPanelStore?: RightPanelStore;
     declare public _RoomNotificationStateStore?: RoomNotificationStateStore;
     declare public _RoomViewStore?: RoomViewStore;

--- a/apps/web/test/unit-tests/components/structures/LoggedInView-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/LoggedInView-test.tsx
@@ -85,7 +85,7 @@ describe("<LoggedInView />", () => {
         mockClient.setPushRuleActions.mockReset().mockResolvedValue({});
         // @ts-expect-error
         mockClient.pushProcessor = new PushProcessor(mockClient);
-        mockSdkContext.client = mockClient;
+        mockSdkContext._client = mockClient;
     });
 
     describe("synced push rules", () => {

--- a/apps/web/test/unit-tests/components/structures/PipContainer-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/PipContainer-test.tsx
@@ -112,7 +112,7 @@ describe("PipContainer", () => {
         sdkContext = new TestSDKContext();
         // @ts-ignore PipContainer uses SDKContext in the constructor
         SDKContextClass.instance = sdkContext;
-        sdkContext.client = client;
+        sdkContext._client = client;
     });
 
     afterEach(async () => {

--- a/apps/web/test/unit-tests/components/structures/RightPanel-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/RightPanel-test.tsx
@@ -23,8 +23,8 @@ import { RightPanelPhases } from "../../../../src/stores/right-panel/RightPanelS
 import RightPanelStore from "../../../../src/stores/right-panel/RightPanelStore";
 import { UPDATE_EVENT } from "../../../../src/stores/AsyncStore";
 import { WidgetLayoutStore } from "../../../../src/stores/widgets/WidgetLayoutStore";
-import { SDKContextClass } from "../../../../src/contexts/SDKContextClass";
 import { RoomPermalinkCreator } from "../../../../src/utils/permalinks/Permalinks";
+import { TestSDKContext } from "../../TestSDKContext.ts";
 
 const RightPanelBase = wrapInMatrixClientContext(_RightPanel);
 
@@ -32,14 +32,14 @@ describe("RightPanel", () => {
     const resizeNotifier = new ResizeNotifier();
 
     let cli: MockedObject<MatrixClient>;
-    let context: SDKContextClass;
+    let context: TestSDKContext;
     let RightPanel: React.ComponentType<React.ComponentProps<typeof RightPanelBase>>;
     beforeEach(() => {
         stubClient();
         cli = mocked(MatrixClientPeg.safeGet());
         DMRoomMap.makeShared(cli);
-        context = new SDKContextClass();
-        context.client = cli;
+        context = new TestSDKContext();
+        context._client = cli;
         RightPanel = wrapInSdkContext(RightPanelBase, context);
     });
 

--- a/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
@@ -56,7 +56,7 @@ import { DirectoryMember } from "../../../../src/utils/direct-messages";
 import { createDmLocalRoom } from "../../../../src/utils/dm/createDmLocalRoom";
 import { UPDATE_EVENT } from "../../../../src/stores/AsyncStore";
 import { SDKContext } from "../../../../src/contexts/SDKContext";
-import { SDKContextClass } from "../../../../src/contexts/SDKContextClass";
+import { TestSDKContext } from "../../TestSDKContext.ts";
 import WidgetUtils from "../../../../src/utils/WidgetUtils";
 import { WidgetType } from "../../../../src/widgets/WidgetType";
 import WidgetStore from "../../../../src/stores/WidgetStore";
@@ -86,7 +86,7 @@ describe("RoomView", () => {
     let cli: MockedObject<MatrixClient>;
     let room: Room;
     let rooms: Map<string, Room>;
-    let stores: SDKContextClass;
+    let stores: TestSDKContext;
     let crypto: CryptoApi;
 
     // mute some noise
@@ -111,8 +111,8 @@ describe("RoomView", () => {
         room.on(RoomEvent.TimelineReset, (...args) => cli.emit(RoomEvent.TimelineReset, ...args));
 
         DMRoomMap.makeShared(cli);
-        stores = new SDKContextClass();
-        stores.client = cli;
+        stores = new TestSDKContext();
+        stores._client = cli;
         stores.rightPanelStore.useUnitTestClient(cli);
 
         crypto = cli.getCrypto()!;

--- a/apps/web/test/unit-tests/components/views/dialogs/InviteDialog-test.tsx
+++ b/apps/web/test/unit-tests/components/views/dialogs/InviteDialog-test.tsx
@@ -33,6 +33,7 @@ import { type IConfigOptions } from "../../../../../src/IConfigOptions";
 import { SDKContextClass } from "../../../../../src/contexts/SDKContextClass";
 import { type IProfileInfo } from "../../../../../src/hooks/useProfileInfo";
 import { DirectoryMember, startDmOnFirstMessage } from "../../../../../src/utils/direct-messages";
+import { TestSDKContext } from "../../../TestSDKContext.ts";
 
 const mockGetAccessToken = jest.fn().mockResolvedValue("getAccessToken");
 jest.mock("../../../../../src/IdentityAuthClient", () =>
@@ -94,6 +95,7 @@ const bobProfileInfo: IProfileInfo = {
 describe("InviteDialog", () => {
     let mockClient: Mocked<MatrixClient>;
     let room: Room;
+    let sdkContext: TestSDKContext;
 
     filterConsole(
         "Error retrieving profile for userId @carol:example.com",
@@ -178,13 +180,15 @@ describe("InviteDialog", () => {
         mockClient.getRooms.mockReturnValue([room]);
         mockClient.getRoom.mockReturnValue(room);
 
-        SDKContextClass.instance.client = mockClient;
+        sdkContext = new TestSDKContext();
+        // @ts-ignore UserMenuViewModel uses SDKContext in the constructor
+        SDKContextClass.instance = sdkContext;
+        sdkContext._client = mockClient;
     });
 
     afterEach(async () => {
         await clearAllModals();
         SDKContextClass.instance.onLoggedOut();
-        SDKContextClass.instance.client = undefined;
     });
 
     afterAll(() => {

--- a/apps/web/test/unit-tests/components/views/dialogs/RoomSettingsDialog-test.tsx
+++ b/apps/web/test/unit-tests/components/views/dialogs/RoomSettingsDialog-test.tsx
@@ -24,7 +24,7 @@ import MatrixClientContext from "../../../../../src/contexts/MatrixClientContext
 import SettingsStore from "../../../../../src/settings/SettingsStore";
 import { UIFeature } from "../../../../../src/settings/UIFeature";
 import DMRoomMap from "../../../../../src/utils/DMRoomMap";
-import { SDKContextClass } from "../../../../../src/contexts/SDKContextClass";
+import { TestSDKContext } from "../../../TestSDKContext.ts";
 
 describe("<RoomSettingsDialog />", () => {
     const userId = "@alice:server.org";
@@ -44,7 +44,7 @@ describe("<RoomSettingsDialog />", () => {
     const room2 = new Room("!room2:server.org", mockClient, userId);
     room2.name = "Another Room";
 
-    let sdkContext: SDKContextClass;
+    let sdkContext: TestSDKContext;
 
     jest.spyOn(SettingsStore, "getValue");
 
@@ -57,8 +57,8 @@ describe("<RoomSettingsDialog />", () => {
             return null;
         });
 
-        sdkContext = new SDKContextClass();
-        sdkContext.client = mockClient;
+        sdkContext = new TestSDKContext();
+        sdkContext._client = mockClient;
 
         jest.spyOn(SettingsStore, "getValue").mockReset().mockReturnValue(false);
 

--- a/apps/web/test/unit-tests/components/views/dialogs/UserSettingsDialog-test.tsx
+++ b/apps/web/test/unit-tests/components/views/dialogs/UserSettingsDialog-test.tsx
@@ -26,7 +26,7 @@ import {
 } from "../../../../test-utils";
 import { UIFeature } from "../../../../../src/settings/UIFeature";
 import { SettingLevel } from "../../../../../src/settings/SettingLevel";
-import { SDKContextClass } from "../../../../../src/contexts/SDKContextClass";
+import { TestSDKContext } from "../../../TestSDKContext.ts";
 import { type FeatureSettingKey } from "../../../../../src/settings/Settings.tsx";
 import { mockOpenIdConfiguration } from "../../../../test-utils/oidc.ts";
 
@@ -57,7 +57,7 @@ describe("<UserSettingsDialog />", () => {
     const mockSettingsStore = mocked(SettingsStore);
     let mockClient!: MockedObject<MatrixClient>;
 
-    let sdkContext: SDKContextClass;
+    let sdkContext: TestSDKContext;
     const defaultProps = { onFinished: jest.fn() };
     const getComponent = (
         props: Partial<typeof defaultProps & { initialTabId?: UserTab; props: Record<string, any> }> = {},
@@ -76,8 +76,8 @@ describe("<UserSettingsDialog />", () => {
             getMediaConfig: jest.fn(),
             getAuthMetadata: jest.fn().mockResolvedValue(mockOpenIdConfiguration()),
         });
-        sdkContext = new SDKContextClass();
-        sdkContext.client = mockClient;
+        sdkContext = new TestSDKContext();
+        sdkContext._client = mockClient;
         mockSettingsStore.getValue.mockReturnValue(false);
         mockSettingsStore.getValueAt.mockReturnValue(false);
         mockSettingsStore.getFeatureSettingNames.mockReturnValue([]);

--- a/apps/web/test/unit-tests/components/views/elements/Pill-test.tsx
+++ b/apps/web/test/unit-tests/components/views/elements/Pill-test.tsx
@@ -48,11 +48,12 @@ describe("<Pill>", () => {
     const user3Id = "@user3:example.com";
     let renderResult: RenderResult;
     let pillParentClickHandler: (e: ButtonEvent) => void;
+    let sdkContext: TestSDKContext;
 
     const renderPill = (props: PillProps): void => {
         const cli = MatrixClientPeg.safeGet();
         const mockSdkContext = new TestSDKContext();
-        mockSdkContext.client = cli;
+        mockSdkContext._client = cli;
 
         const withDefault = {
             inMessage: true,
@@ -79,7 +80,10 @@ describe("<Pill>", () => {
 
     beforeEach(() => {
         client = mocked(stubClient());
-        SDKContextClass.instance.client = client;
+        sdkContext = new TestSDKContext();
+        // @ts-ignore Pill uses the SDKContext global
+        SDKContextClass.instance = sdkContext;
+        sdkContext._client = client;
         DMRoomMap.makeShared(client);
         room1 = new Room(room1Id, client, user1Id);
         room1.name = "Room 1";

--- a/apps/web/test/unit-tests/components/views/rooms/RoomHeader/CallGuestLinkButton-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/RoomHeader/CallGuestLinkButton-test.tsx
@@ -12,7 +12,7 @@ import { type EventTimeline, JoinRule, Room } from "matrix-js-sdk/src/matrix";
 import { KnownMembership } from "matrix-js-sdk/src/types";
 
 import { SDKContext } from "../../../../../../src/contexts/SDKContext";
-import { SDKContextClass } from "../../../../../../src/contexts/SDKContextClass";
+import { TestSDKContext } from "../../../../TestSDKContext.ts";
 import { getMockClientWithEventEmitter, mockClientMethodsUser } from "../../../../../test-utils";
 import {
     CallGuestLinkButton,
@@ -26,7 +26,7 @@ import SettingsStore from "../../../../../../src/settings/SettingsStore";
 
 describe("<CallGuestLinkButton />", () => {
     const roomId = "!room:server.org";
-    let sdkContext!: SDKContextClass;
+    let sdkContext!: TestSDKContext;
     let modalSpy: jest.SpyInstance;
     let modalResolve: (value: unknown[] | PromiseLike<unknown[]>) => void;
     let room: Room;
@@ -78,8 +78,8 @@ describe("<CallGuestLinkButton />", () => {
             ...mockClientMethodsUser(),
             sendStateEvent: jest.fn(),
         });
-        sdkContext = new SDKContextClass();
-        sdkContext.client = client;
+        sdkContext = new TestSDKContext();
+        sdkContext._client = client;
         const modalPromise = new Promise<unknown[]>((resolve) => {
             modalResolve = resolve;
         });
@@ -94,7 +94,7 @@ describe("<CallGuestLinkButton />", () => {
             return oldGet(key);
         });
         jest.spyOn(room, "hasEncryptionStateEvent").mockReturnValue(true);
-        jest.spyOn(SDKContextClass.instance.roomViewStore, "isViewingCall").mockReturnValue(true);
+        jest.spyOn(sdkContext.roomViewStore, "isViewingCall").mockReturnValue(true);
     });
     afterEach(() => {
         jest.restoreAllMocks();
@@ -152,7 +152,7 @@ describe("<CallGuestLinkButton />", () => {
 
     it("don't show external conference button if now guest spa link is configured", () => {
         jest.spyOn(room, "getJoinRule").mockReturnValue(JoinRule.Public);
-        jest.spyOn(SDKContextClass.instance.roomViewStore, "isViewingCall").mockReturnValue(true);
+        jest.spyOn(sdkContext.roomViewStore, "isViewingCall").mockReturnValue(true);
 
         jest.spyOn(SdkConfig, "get").mockImplementation((key) => {
             if (key === "element_call") {
@@ -179,7 +179,7 @@ describe("<CallGuestLinkButton />", () => {
 
     it("opens the share dialog with the correct share link in an encrypted room", () => {
         jest.spyOn(room, "getJoinRule").mockReturnValue(JoinRule.Public);
-        jest.spyOn(SDKContextClass.instance.roomViewStore, "isViewingCall").mockReturnValue(true);
+        jest.spyOn(sdkContext.roomViewStore, "isViewingCall").mockReturnValue(true);
 
         getComponent(room);
         const modalSpy = jest.spyOn(Modal, "createDialog");
@@ -201,7 +201,7 @@ describe("<CallGuestLinkButton />", () => {
     it("share dialog has correct link in an unencrypted room", () => {
         jest.spyOn(room, "getJoinRule").mockReturnValue(JoinRule.Public);
         jest.spyOn(room, "hasEncryptionStateEvent").mockReturnValue(false);
-        jest.spyOn(SDKContextClass.instance.roomViewStore, "isViewingCall").mockReturnValue(true);
+        jest.spyOn(sdkContext.roomViewStore, "isViewingCall").mockReturnValue(true);
 
         getComponent(room);
         const modalSpy = jest.spyOn(Modal, "createDialog");

--- a/apps/web/test/unit-tests/components/views/rooms/RoomHeader/VideoRoomChatButton-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/RoomHeader/VideoRoomChatButton-test.tsx
@@ -13,7 +13,7 @@ import { fireEvent, render, screen, waitFor } from "jest-matrix-react";
 
 import { VideoRoomChatButton } from "../../../../../../src/components/views/rooms/RoomHeader/VideoRoomChatButton";
 import { SDKContext } from "../../../../../../src/contexts/SDKContext";
-import { SDKContextClass } from "../../../../../../src/contexts/SDKContextClass";
+import { TestSDKContext } from "../../../../TestSDKContext.ts";
 import type RightPanelStore from "../../../../../../src/stores/right-panel/RightPanelStore";
 import { getMockClientWithEventEmitter, mockClientMethodsUser } from "../../../../../test-utils";
 import { RoomNotificationState } from "../../../../../../src/stores/notifications/RoomNotificationState";
@@ -23,7 +23,7 @@ import { RightPanelPhases } from "../../../../../../src/stores/right-panel/Right
 
 describe("<VideoRoomChatButton />", () => {
     const roomId = "!room:server.org";
-    let sdkContext!: SDKContextClass;
+    let sdkContext!: TestSDKContext;
     let rightPanelStore!: MockedObject<RightPanelStore>;
 
     /**
@@ -59,8 +59,8 @@ describe("<VideoRoomChatButton />", () => {
         rightPanelStore = {
             showOrHidePhase: jest.fn(),
         } as unknown as MockedObject<RightPanelStore>;
-        sdkContext = new SDKContextClass();
-        sdkContext.client = client;
+        sdkContext = new TestSDKContext();
+        sdkContext._client = client;
         jest.spyOn(sdkContext, "rightPanelStore", "get").mockReturnValue(rightPanelStore);
     });
 

--- a/apps/web/test/unit-tests/components/views/rooms/memberlist/common.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/memberlist/common.tsx
@@ -122,7 +122,7 @@ export async function renderMemberList(
     }
 
     const context = new TestSDKContext();
-    context.client = client;
+    context._client = client;
     context.memberListStore.isPresenceEnabled = jest.fn().mockReturnValue(enablePresence);
     const root = render(
         <MatrixClientContext.Provider value={client}>

--- a/apps/web/test/unit-tests/components/views/settings/tabs/user/AccountUserSettingsTab-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/tabs/user/AccountUserSettingsTab-test.tsx
@@ -16,7 +16,7 @@ import { ToastContext, ToastRack } from "@element-hq/web-shared-components";
 
 import AccountUserSettingsTab from "../../../../../../../src/components/views/settings/tabs/user/AccountUserSettingsTab";
 import { SDKContext } from "../../../../../../../src/contexts/SDKContext";
-import { SDKContextClass } from "../../../../../../../src/contexts/SDKContextClass";
+import { TestSDKContext } from "../../../../../TestSDKContext.ts";
 import SettingsStore from "../../../../../../../src/settings/SettingsStore";
 import {
     getMockClientWithEventEmitter,
@@ -51,7 +51,7 @@ describe("<AccountUserSettingsTab />", () => {
     const userId = "@alice:server.org";
     let mockClient: MockedObject<MatrixClient>;
 
-    let stores: SDKContextClass;
+    let stores: TestSDKContext;
 
     const getComponent = () => (
         <MatrixClientContext.Provider value={mockClient}>
@@ -87,8 +87,8 @@ describe("<AccountUserSettingsTab />", () => {
             id_server_unbind_result: "success",
         });
 
-        stores = new SDKContextClass();
-        stores.client = mockClient;
+        stores = new TestSDKContext();
+        stores._client = mockClient;
         // stub out this store completely to avoid mocking initialisation
         const mockOidcClientStore = {} as unknown as OidcClientStore;
         jest.spyOn(stores, "oidcClientStore", "get").mockReturnValue(mockOidcClientStore);

--- a/apps/web/test/unit-tests/components/views/settings/tabs/user/SecurityUserSettingsTab-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/tabs/user/SecurityUserSettingsTab-test.tsx
@@ -20,7 +20,7 @@ import {
     mockPlatformPeg,
 } from "../../../../../../test-utils";
 import { SDKContext } from "../../../../../../../src/contexts/SDKContext";
-import { SDKContextClass } from "../../../../../../../src/contexts/SDKContextClass";
+import { TestSDKContext } from "../../../../../TestSDKContext.ts";
 import defaultDispatcher from "../../../../../../../src/dispatcher/dispatcher";
 import { UIFeature } from "../../../../../../../src/settings/UIFeature";
 import SettingsStore from "../../../../../../../src/settings/SettingsStore";
@@ -42,8 +42,8 @@ describe("<SecurityUserSettingsTab />", () => {
         setIgnoredUsers,
     });
 
-    const sdkContext = new SDKContextClass();
-    sdkContext.client = mockClient;
+    const sdkContext = new TestSDKContext();
+    sdkContext._client = mockClient;
 
     const getComponent = () => (
         <MatrixClientContext.Provider value={mockClient}>

--- a/apps/web/test/unit-tests/components/views/settings/tabs/user/SessionManagerTab-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/tabs/user/SessionManagerTab-test.tsx
@@ -57,7 +57,7 @@ import { INACTIVE_DEVICE_AGE_MS } from "../../../../../../../src/components/view
 import SettingsStore from "../../../../../../../src/settings/SettingsStore";
 import { getClientInformationEventType } from "../../../../../../../src/utils/device/clientInformation";
 import { SDKContext } from "../../../../../../../src/contexts/SDKContext";
-import { SDKContextClass } from "../../../../../../../src/contexts/SDKContextClass";
+import { TestSDKContext } from "../../../../../TestSDKContext.ts";
 import { type OidcClientStore } from "../../../../../../../src/stores/oidc/OidcClientStore";
 import { makeDelegatedAuthConfig } from "../../../../../../test-utils/oidc";
 import MatrixClientContext from "../../../../../../../src/contexts/MatrixClientContext";
@@ -134,7 +134,7 @@ describe("<SessionManagerTab />", () => {
     } as unknown as CryptoApi);
 
     let mockClient!: MockedObject<MatrixClient>;
-    let sdkContext: SDKContextClass;
+    let sdkContext: TestSDKContext;
 
     const defaultProps = {};
     const getComponent = (props = {}): React.ReactElement => (
@@ -250,8 +250,8 @@ describe("<SessionManagerTab />", () => {
             }
         });
 
-        sdkContext = new SDKContextClass();
-        sdkContext.client = mockClient;
+        sdkContext = new TestSDKContext();
+        sdkContext._client = mockClient;
 
         // @ts-ignore allow delete of non-optional prop
         delete window.location;

--- a/apps/web/test/unit-tests/components/views/spaces/SpacePanel-test.tsx
+++ b/apps/web/test/unit-tests/components/views/spaces/SpacePanel-test.tsx
@@ -25,6 +25,7 @@ import SettingsStore from "../../../../../src/settings/SettingsStore";
 import UnwrappedSpacePanel from "../../../../../src/components/views/spaces/SpacePanel";
 import defaultDispatcher from "../../../../../src/dispatcher/dispatcher";
 import { Action } from "../../../../../src/dispatcher/actions";
+import { TestSDKContext } from "../../../TestSDKContext.ts";
 
 // DND test utilities based on
 // https://github.com/colinrobertbrooks/react-beautiful-dnd-test-utils/issues/18#issuecomment-1373388693
@@ -129,7 +130,10 @@ describe("<SpacePanel />", () => {
     beforeAll(() => {
         jest.spyOn(MatrixClientPeg, "get").mockReturnValue(mockClient);
         jest.spyOn(MatrixClientPeg, "safeGet").mockReturnValue(mockClient);
-        SDKContextClass.instance.client = mockClient;
+        const sdkContext = new TestSDKContext();
+        // @ts-ignore SpacePanel uses the SDKContext global
+        SDKContextClass.instance = sdkContext;
+        sdkContext._client = mockClient;
     });
 
     beforeEach(() => {

--- a/apps/web/test/unit-tests/components/views/spaces/SpacePanel-test.tsx
+++ b/apps/web/test/unit-tests/components/views/spaces/SpacePanel-test.tsx
@@ -17,7 +17,7 @@ import { MetaSpace, type SpaceKey } from "../../../../../src/stores/spaces";
 import { shouldShowComponent } from "../../../../../src/customisations/helpers/UIComponents";
 import { UIComponent } from "../../../../../src/settings/UIFeature";
 import { mkStubRoom, wrapInMatrixClientContext, wrapInSdkContext } from "../../../../test-utils";
-import { SDKContextClass } from "../../../../../src/contexts/SDKContextClass";
+import { TestSDKContext } from "../../../TestSDKContext.ts";
 import SpaceStore from "../../../../../src/stores/spaces/SpaceStore";
 import DMRoomMap from "../../../../../src/utils/DMRoomMap";
 import { type SpaceNotificationState } from "../../../../../src/stores/notifications/SpaceNotificationState";
@@ -25,7 +25,6 @@ import SettingsStore from "../../../../../src/settings/SettingsStore";
 import UnwrappedSpacePanel from "../../../../../src/components/views/spaces/SpacePanel";
 import defaultDispatcher from "../../../../../src/dispatcher/dispatcher";
 import { Action } from "../../../../../src/dispatcher/actions";
-import { TestSDKContext } from "../../../TestSDKContext.ts";
 
 // DND test utilities based on
 // https://github.com/colinrobertbrooks/react-beautiful-dnd-test-utils/issues/18#issuecomment-1373388693
@@ -125,14 +124,12 @@ describe("<SpacePanel />", () => {
         isVersionSupported: jest.fn().mockResolvedValue(true),
         doesServerSupportUnstableFeature: jest.fn().mockResolvedValue(false),
     } as unknown as MatrixClient;
-    const SpacePanel = wrapInSdkContext(wrapInMatrixClientContext(UnwrappedSpacePanel), SDKContextClass.instance);
+    const sdkContext = new TestSDKContext();
+    const SpacePanel = wrapInSdkContext(wrapInMatrixClientContext(UnwrappedSpacePanel), sdkContext);
 
     beforeAll(() => {
         jest.spyOn(MatrixClientPeg, "get").mockReturnValue(mockClient);
         jest.spyOn(MatrixClientPeg, "safeGet").mockReturnValue(mockClient);
-        const sdkContext = new TestSDKContext();
-        // @ts-ignore SpacePanel uses the SDKContext global
-        SDKContextClass.instance = sdkContext;
         sdkContext._client = mockClient;
     });
 

--- a/apps/web/test/unit-tests/contexts/SdkContext-test.ts
+++ b/apps/web/test/unit-tests/contexts/SdkContext-test.ts
@@ -54,6 +54,7 @@ describe("SDKContextClass", () => {
         it("onLoggedOut should clear the UserProfilesStore", () => {
             const store = sdkContext.userProfilesStore;
             sdkContext.onLoggedOut();
+            sdkContext._client = client;
             expect(sdkContext.userProfilesStore).not.toBe(store);
         });
 

--- a/apps/web/test/unit-tests/contexts/SdkContext-test.ts
+++ b/apps/web/test/unit-tests/contexts/SdkContext-test.ts
@@ -12,9 +12,10 @@ import { SDKContextClass } from "../../../src/contexts/SDKContextClass";
 import { OidcClientStore } from "../../../src/stores/oidc/OidcClientStore";
 import { UserProfilesStore } from "../../../src/stores/UserProfilesStore";
 import { createTestClient } from "../../test-utils";
+import { TestSDKContext } from "../TestSDKContext.ts";
 
 describe("SDKContextClass", () => {
-    let sdkContext = SDKContextClass.instance;
+    let sdkContext: TestSDKContext;
     let client: MatrixClient;
 
     beforeAll(() => {
@@ -22,7 +23,7 @@ describe("SDKContextClass", () => {
     });
 
     beforeEach(() => {
-        sdkContext = new SDKContextClass();
+        sdkContext = new TestSDKContext();
     });
 
     it("instance should always return the same instance", () => {
@@ -40,7 +41,7 @@ describe("SDKContextClass", () => {
 
     describe("when SDKContext has a client", () => {
         beforeEach(() => {
-            sdkContext.client = client;
+            sdkContext._client = client;
         });
 
         it("userProfilesStore should return a UserProfilesStore", () => {

--- a/apps/web/test/unit-tests/modules/ExtrasApi-test.tsx
+++ b/apps/web/test/unit-tests/modules/ExtrasApi-test.tsx
@@ -13,7 +13,7 @@ import { EventEmitter } from "events";
 import { stubClient } from "../../test-utils";
 import DMRoomMap from "../../../src/utils/DMRoomMap";
 import { SDKContext } from "../../../src/contexts/SDKContext";
-import { SDKContextClass } from "../../../src/contexts/SDKContextClass";
+import { TestSDKContext } from "../TestSDKContext.ts";
 import { ScopedRoomContextProvider } from "../../../src/contexts/ScopedRoomContext";
 import RoomContext, { type RoomContextType } from "../../../src/contexts/RoomContext";
 import MatrixClientContext from "../../../src/contexts/MatrixClientContext";
@@ -22,7 +22,7 @@ import { ModuleApi } from "../../../src/modules/Api";
 
 describe("ExtrasApi", () => {
     let client: MatrixClient;
-    let sdkContext: SDKContextClass;
+    let sdkContext: TestSDKContext;
     let room: Room;
     let roomContext: RoomContextType;
 
@@ -31,8 +31,8 @@ describe("ExtrasApi", () => {
         room = new Room("!test:room", client, "@alice:example.org", {
             pendingEventOrdering: PendingEventOrdering.Detached,
         });
-        sdkContext = new SDKContextClass();
-        sdkContext.client = client;
+        sdkContext = new TestSDKContext();
+        sdkContext._client = client;
         jest.spyOn(sdkContext.roomViewStore, "getRoomId").mockReturnValue(room.roomId);
 
         const mockRoomViewStore = new (class extends EventEmitter {

--- a/apps/web/test/unit-tests/stores/MemberListStore-test.ts
+++ b/apps/web/test/unit-tests/stores/MemberListStore-test.ts
@@ -29,7 +29,7 @@ describe("MemberListStore", () => {
         const context = new TestSDKContext();
         client = stubClient();
         client.baseUrl = "https://invalid.base.url.here";
-        context.client = client;
+        context._client = client;
         store = new MemberListStore(context);
         // alice is joined to the room.
         room = new Room(roomId, client, client.getUserId()!);

--- a/apps/web/test/unit-tests/stores/RoomViewStore-test.ts
+++ b/apps/web/test/unit-tests/stores/RoomViewStore-test.ts
@@ -193,7 +193,7 @@ describe("RoomViewStore", function () {
         dis = new MatrixDispatcher();
         slidingSyncManager = new MockSlidingSyncManager();
         stores = new TestSDKContext();
-        stores.client = mockClient;
+        stores._client = mockClient;
         stores._SlidingSyncManager = slidingSyncManager;
         stores._PosthogAnalytics = new MockPosthogAnalytics();
         // @ts-expect-error

--- a/apps/web/test/unit-tests/stores/TypingStore-test.ts
+++ b/apps/web/test/unit-tests/stores/TypingStore-test.ts
@@ -30,7 +30,7 @@ describe("TypingStore", () => {
             sendTyping: jest.fn(),
         } as unknown as MatrixClient;
         const context = new TestSDKContext();
-        context.client = mockClient;
+        context._client = mockClient;
         typingStore = new TypingStore(context);
         jest.spyOn(SettingsStore, "getValue").mockImplementation((name: string) => {
             return name === "sendTypingNotifications";

--- a/apps/web/test/unit-tests/stores/widgets/WidgetPermissionStore-test.ts
+++ b/apps/web/test/unit-tests/stores/widgets/WidgetPermissionStore-test.ts
@@ -54,7 +54,7 @@ describe("WidgetPermissionStore", () => {
         );
         mockClient = stubClient();
         const context = new TestSDKContext();
-        context.client = mockClient;
+        context._client = mockClient;
         widgetPermissionStore = new WidgetPermissionStore(context);
     });
 

--- a/apps/web/test/unit-tests/utils/exportUtils/HTMLExport-test.ts
+++ b/apps/web/test/unit-tests/utils/exportUtils/HTMLExport-test.ts
@@ -33,6 +33,7 @@ import DMRoomMap from "../../../../src/utils/DMRoomMap";
 import { mediaFromMxc } from "../../../../src/customisations/Media";
 import SettingsStore from "../../../../src/settings/SettingsStore";
 import { SDKContextClass } from "../../../../src/contexts/SDKContextClass";
+import { TestSDKContext } from "../../TestSDKContext.ts";
 
 jest.mock("jszip");
 jest.mock("../../../../src/settings/SettingsStore");
@@ -93,6 +94,7 @@ const EVENT_MENTION: IRoomEvent = {
 describe("HTMLExport", () => {
     let client: jest.Mocked<MatrixClient>;
     let room: Room;
+    let sdkContext: TestSDKContext;
 
     filterConsole(
         "Starting export",
@@ -111,7 +113,10 @@ describe("HTMLExport", () => {
         jest.setSystemTime(REPEATABLE_DATE);
 
         client = stubClient() as jest.Mocked<MatrixClient>;
-        SDKContextClass.instance.client = client;
+        sdkContext = new TestSDKContext();
+        // @ts-ignore HTMLExport uses SDKContext in the constructor
+        SDKContextClass.instance = sdkContext;
+        sdkContext._client = client;
         DMRoomMap.makeShared(client);
 
         room = new Room("!myroom:example.org", client, "@me:example.org");

--- a/apps/web/test/viewmodels/menus/UserMenuViewModel-test.ts
+++ b/apps/web/test/viewmodels/menus/UserMenuViewModel-test.ts
@@ -17,10 +17,13 @@ import { Action } from "../../../src/dispatcher/actions";
 import { UserTab } from "../../../src/components/views/dialogs/UserTab";
 import Modal from "../../../src/Modal";
 import FeedbackDialog from "../../../src/components/views/dialogs/FeedbackDialog";
+import { TestSDKContext } from "../../unit-tests/TestSDKContext.ts";
 
 describe("UserMenuViewModel", () => {
     let dispatcher: MatrixDispatcher;
     let client: MockedObject<MatrixClient>;
+    let sdkContext: TestSDKContext;
+
     beforeEach(() => {
         dispatcher = new MatrixDispatcher();
         client = getMockClientWithEventEmitter({
@@ -29,13 +32,15 @@ describe("UserMenuViewModel", () => {
             getAuthMetadata: jest.fn().mockRejectedValue(new MatrixError({ errcode: "M_UNRECOGNIZED" }, 404)),
             setExtendedProfileProperty: jest.fn().mockResolvedValue(undefined),
         });
-        SDKContextClass.instance.client = client;
+        sdkContext = new TestSDKContext();
+        // @ts-ignore UserMenuViewModel uses SDKContext in the constructor
+        SDKContextClass.instance = sdkContext;
+        sdkContext._client = client;
     });
     afterEach(() => {
         jest.resetAllMocks();
         SdkConfig.reset();
         SDKContextClass.instance.onLoggedOut();
-        SDKContextClass.instance.client = undefined;
     });
 
     it("should generate a menu options for a logged in client", () => {


### PR DESCRIPTION
Rather than via MatrixChat - this is predominantly for Lifecycle tests as they don't use a MatrixChat and it doesn't make much sense for this component to own this state.

Split out from https://github.com/element-hq/element-web/pull/34122
