### PR TITLE
add `background: "solid"` for EC

### DIFF
--- a/apps/web/src/models/Call.ts
+++ b/apps/web/src/models/Call.ts
@@ -763,6 +763,8 @@ export class ElementCall extends Call {
             lang: getCurrentLanguage().replace("_", "-"),
             fontScale: (FontWatcher.getRootFontSize() / FontWatcher.getBrowserDefaultFontSize()).toString(),
             theme: "$org.matrix.msc2873.client_theme",
+            // on EW we do not want the gradient EC background.
+            background: "solid",
         });
 
         if (typeof opts.skipLobby === "boolean") {


### PR DESCRIPTION
This EC url param is needed for a breaking change landing in the next release of EC ( v0.22.0 )
It has to be merged before the embedded package is updated to v0.22.0.

Context: https://github.com/element-hq/element-call/pull/4067

Test with: `https://pr4067--element-call.netlify.app/room` as the devtool EC url
## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
