### PR TITLE
Fix composer preview getting stuck on a single module API preview

### DIFF
--- a/apps/web/src/components/views/rooms/MessageComposerUrlPreview.test.tsx
+++ b/apps/web/src/components/views/rooms/MessageComposerUrlPreview.test.tsx
@@ -96,4 +96,29 @@ describe("MessageComposerUrlPreview", () => {
             { timeout: DEBOUNCE_REQUEST_TIMEOUT_MS },
         );
     });
+    test("to reset module component override when filter function does not match ", async () => {
+        const modApi = {
+            customComponents: new CustomComponentsApi(),
+        } as ModuleApi;
+        modApi.customComponents.registerComposerPreview(
+            (text) => text === "show-fake-preview",
+            () => <strong>Fake preview</strong>,
+        );
+        const { container, getByText, rerender } = wrapComponent(
+            <MessageComposerUrlPreviewWrapper content="show-fake-preview" moduleApi={modApi} />,
+        );
+        await waitFor(
+            () => {
+                expect(getByText("Fake preview")).toBeDefined();
+            },
+            { timeout: DEBOUNCE_REQUEST_TIMEOUT_MS },
+        );
+        rerender(<MessageComposerUrlPreviewWrapper content="other-text" moduleApi={modApi} />);
+        await waitFor(
+            () => {
+                expect(container).toMatchInlineSnapshot(`<div />`);
+            },
+            { timeout: DEBOUNCE_REQUEST_TIMEOUT_MS },
+        );
+    });
 });

--- a/apps/web/src/components/views/rooms/MessageComposerUrlPreview.tsx
+++ b/apps/web/src/components/views/rooms/MessageComposerUrlPreview.tsx
@@ -52,9 +52,7 @@ export function MessageComposerUrlPreviewWrapper({
                 () => <MessageComposerUrlPreviewView vm={vm} />,
             );
 
-            if (customComponent) {
-                setCustomComponent(customComponent);
-            }
+            setCustomComponent(customComponent);
             // We still update the VM even if the custom component is used since
             // the component may choose to render the original component.
             void vm.updateWithText(content);


### PR DESCRIPTION
This fixes a bug where composer previews would get stuck with a module override because we did not reset the state when the text changes.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
