### PR TITLE
Remove spammy i18 output during shared component tests

### DIFF
--- a/packages/shared-components/vitest.config.ts
+++ b/packages/shared-components/vitest.config.ts
@@ -40,6 +40,11 @@ export default defineConfig({
             reporter: [["lcov", { projectRoot: "../../" }]],
         },
         reporters: rootConfig.test?.reporters,
+        onConsoleLog(log: string): boolean | void {
+            // Suppress the i18n language-loading log; it fires on every
+            // setLanguage() call in setup and adds noise to test output.
+            if (log.startsWith("Loading language from")) return false;
+        },
         environment: "node",
         pool: "threads",
         globals: false,


### PR DESCRIPTION

Remove spammy i18 output during shared component tests