### PR TITLE
Show preview for double quoted URLs

### DIFF
--- a/apps/web/src/viewmodels/composer/MessageComposerUrlPreviewViewModel.ts
+++ b/apps/web/src/viewmodels/composer/MessageComposerUrlPreviewViewModel.ts
@@ -76,7 +76,7 @@ export class MessageComposerUrlPreviewViewModel extends BaseViewModel<
 
         // add quoted links in form of `"XX://XXXXX"` for wysiwyg hyperlinks
         content
-            .match(/"[^:]*:\/\/[^"]*"/g)
+            .match(/"(http|https):\/\/[^"]*"/g)
             ?.map((w) => w.slice(1, -1))
             ?.filter((word) => URL.canParse(word))
             ?.forEach((w) => newLinks.add(w));

--- a/apps/web/src/viewmodels/composer/MessageComposerUrlPreviewViewModel.ts
+++ b/apps/web/src/viewmodels/composer/MessageComposerUrlPreviewViewModel.ts
@@ -73,6 +73,14 @@ export class MessageComposerUrlPreviewViewModel extends BaseViewModel<
                 .map((w) => w.trim())
                 .filter((word) => URL.canParse(word)),
         );
+
+        // add quoted links in form of `"XX://XXXXX"` for wysiwyg hyperlinks
+        content
+            .match(/"[^:]*:\/\/[^"]*"/g)
+            ?.map((w) => w.slice(1, -1))
+            ?.filter((word) => URL.canParse(word))
+            ?.forEach((w) => newLinks.add(w));
+
         if (this.links.symmetricDifference(newLinks).size === 0) {
             // Skip if the URL set hasn't changed
             return;


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)

Double quoted URLs are used by the rich text editor for hyperlinks. So now the underlying links in a hyperlinked text can be previewed.