### PR TITLE
Fix font color on danger buttons to always be white

### DIFF
--- a/apps/web/res/css/_common.pcss
+++ b/apps/web/res/css/_common.pcss
@@ -695,7 +695,7 @@ legend {
 .mx_Dialog_buttons input[type="submit"].danger {
     background-color: var(--cpd-color-bg-critical-primary);
     border: solid 1px var(--cpd-color-bg-critical-primary);
-    color: var(--cpd-color-text-on-solid-primary);
+    color: #ffffff;
 }
 
 .mx_Dialog button.warning:not(.mx_Dialog_nonDialogButton, [class|="maplibregl"]),

--- a/apps/web/res/css/views/elements/_AccessibleButton.pcss
+++ b/apps/web/res/css/views/elements/_AccessibleButton.pcss
@@ -65,7 +65,7 @@ Please see LICENSE files in the repository root for full details.
         }
 
         &.mx_AccessibleButton_kind_danger_sm {
-            color: var(--cpd-color-text-on-solid-primary);
+            color: #ffffff;
             background-color: var(--cpd-color-bg-critical-primary);
             border: 1px solid var(--cpd-color-bg-critical-primary);
         }
@@ -112,12 +112,12 @@ Please see LICENSE files in the repository root for full details.
     }
 
     &.mx_AccessibleButton_kind_danger {
-        color: var(--cpd-color-text-on-solid-primary);
+        color: #ffffff;
         background-color: var(--cpd-color-bg-critical-primary);
         border: 1px solid var(--cpd-color-bg-critical-primary);
 
         &.mx_AccessibleButton_disabled {
-            color: var(--cpd-color-text-on-solid-primary);
+            color: #ffffff;
             background-color: var(--cpd-color-bg-critical-primary);
         }
     }


### PR DESCRIPTION
Fixes black text rendering on red danger buttons when dark theme is enabled.

Buttons with `bg-critical-primary` background (like "Leave room" or "Deactivate account") currently use the `var(--cpd-color-text-on-solid-primary)` font color token. While this works in light mode, the dark mode evaluates it to a dark font, making the text completely unreadable and aesthetically displeasing against the bright red background. 

This PR forces `#ffffff` font color specifically for `mx_AccessibleButton_kind_danger`, `mx_AccessibleButton_kind_danger_sm`, and `.danger` submit buttons, ensuring the text remains legible irrespective of the active theme.

**Before:** (Dark text on red background)
**After:** (White text on red background)

**Step-by-step testing strategy:**
1. Switch to Dark theme in Element settings.
2. Navigate to "Security & Privacy" in settings.
3. Locate the "Deactivate Account" button at the bottom and observe the font color. It should be fully white and readable.

Notes: Fix black text on red danger buttons in dark mode