### PR TITLE
Fix credentials fixture when used with MAS

### DIFF
--- a/apps/web/playwright/e2e/crypto/dehydration-mas.spec.ts
+++ b/apps/web/playwright/e2e/crypto/dehydration-mas.spec.ts
@@ -14,7 +14,7 @@ import {
     logOutOfElement,
     verifyAfterLogin,
 } from "./utils.ts";
-import { registerAccountMas } from "../oidc";
+import { logInAccountMas } from "../oidc";
 import { Bot } from "../../pages/bot.ts";
 
 test.use({
@@ -27,19 +27,12 @@ test.use({
 });
 
 test.describe("Device dehydration, on a MAS-enabled homeserver", () => {
-    test("Can read messages sent while logged out", async ({ mailpitClient, homeserver, page, app }, testInfo) => {
+    test("Can read messages sent while logged out", async ({ homeserver, page, app, user }) => {
         test.slow();
-        const aliceUserId = `alice_${testInfo.testId}`;
-        const alicePassword = "Pa$sW0rD!";
 
-        const recoveryKey =
-            await test.step("Alice registers and sets up recovery => a dehydrated device is created", async () => {
-                await page.goto("/#/login");
-                await page.getByRole("button", { name: "Continue" }).click();
-
-                await registerAccountMas(page, mailpitClient, aliceUserId, `${aliceUserId}@email.com`, alicePassword);
-                return await enableKeyBackup(app);
-            });
+        const recoveryKey = await test.step("Alice sets up recovery => a dehydrated device is created", async () => {
+            return await enableKeyBackup(app);
+        });
 
         const [bob, testRoomId] = await test.step("Bob registers and joins a room with Alice", async () => {
             const bob = new Bot(page, homeserver, { displayName: "Bob" });
@@ -65,8 +58,7 @@ test.describe("Device dehydration, on a MAS-enabled homeserver", () => {
             await page.getByRole("link", { name: "Sign in" }).click();
             await page.getByRole("button", { name: "Continue" }).click();
 
-            await expect(page.getByText("Continue to Element?")).toBeVisible();
-            await page.getByRole("button", { name: "Continue" }).click();
+            await logInAccountMas(page, user.username, user.password);
 
             await verifyAfterLogin(page, recoveryKey);
             await app.viewRoomById(testRoomId);

--- a/apps/web/playwright/e2e/crypto/dehydration-mas.spec.ts
+++ b/apps/web/playwright/e2e/crypto/dehydration-mas.spec.ts
@@ -14,7 +14,7 @@ import {
     logOutOfElement,
     verifyAfterLogin,
 } from "./utils.ts";
-import { logInAccountMas } from "../oidc";
+import { registerAccountMas } from "../oidc";
 import { Bot } from "../../pages/bot.ts";
 
 test.use({
@@ -27,12 +27,19 @@ test.use({
 });
 
 test.describe("Device dehydration, on a MAS-enabled homeserver", () => {
-    test("Can read messages sent while logged out", async ({ homeserver, page, app, user }) => {
+    test("Can read messages sent while logged out", async ({ mailpitClient, homeserver, page, app }, testInfo) => {
         test.slow();
+        const aliceUserId = `alice_${testInfo.testId}`;
+        const alicePassword = "Pa$sW0rD!";
 
-        const recoveryKey = await test.step("Alice sets up recovery => a dehydrated device is created", async () => {
-            return await enableKeyBackup(app);
-        });
+        const recoveryKey =
+            await test.step("Alice registers and sets up recovery => a dehydrated device is created", async () => {
+                await page.goto("/#/login");
+                await page.getByRole("button", { name: "Continue" }).click();
+
+                await registerAccountMas(page, mailpitClient, aliceUserId, `${aliceUserId}@email.com`, alicePassword);
+                return await enableKeyBackup(app);
+            });
 
         const [bob, testRoomId] = await test.step("Bob registers and joins a room with Alice", async () => {
             const bob = new Bot(page, homeserver, { displayName: "Bob" });
@@ -58,7 +65,8 @@ test.describe("Device dehydration, on a MAS-enabled homeserver", () => {
             await page.getByRole("link", { name: "Sign in" }).click();
             await page.getByRole("button", { name: "Continue" }).click();
 
-            await logInAccountMas(page, user.username, user.password);
+            await expect(page.getByText("Continue to Element?")).toBeVisible();
+            await page.getByRole("button", { name: "Continue" }).click();
 
             await verifyAfterLogin(page, recoveryKey);
             await app.viewRoomById(testRoomId);

--- a/packages/playwright-common/src/fixtures/user.ts
+++ b/packages/playwright-common/src/fixtures/user.ts
@@ -17,8 +17,6 @@ import { type Credentials } from "../utils/api.js";
 
 /**
  * Adds an initScript to the given page which will populate localStorage appropriately so that Element will use the given credentials.
- *
- * Warning: this is an incomplete implementation, particularly in MAS environments: for example, a logout operation will not work correctly.
  */
 export async function populateLocalStorageWithCredentials(page: Page, credentials: Credentials) {
     await page.addInitScript(
@@ -31,13 +29,9 @@ export async function populateLocalStorageWithCredentials(page: Page, credential
             window.localStorage.setItem("mx_has_pickle_key", "false");
             window.localStorage.setItem("mx_has_access_token", "true");
 
-            // XXX: If the homeserver is using MAS, then Element uses additional localstorage settings to store more
-            // data. The fact that we don't populate them means that, for example, when you hit "Remove this device" in
-            // the app, it attempts to hit the legacy `/logout` endpoint, which returns a 40x error, which is silently
-            // ignored.
-            //
-            // If you fix this, (1) yay! (2) please remember to update the warning on the doc-comments of this method
-            // and its callers.
+            if (credentials.oauthClientId) {
+                window.localStorage.setItem("mx_oidc_client_id", credentials.oauthClientId);
+            }
 
             window.localStorage.setItem(
                 "mx_local_settings",
@@ -73,9 +67,6 @@ export interface TestFixtures {
      * but adds an initScript which will populate localStorage with the user's details from
      * {@link #credentials} and {@link #homeserver}.
      *
-     * Warning: this is an incomplete implementation, particularly in MAS environments: for example, a logout operation
-     * will not work correctly.
-     *
      * Similar to {@link #user}, but doesn't load the app.
      */
     pageWithCredentials: Page;
@@ -84,9 +75,6 @@ export interface TestFixtures {
      * A (rather poorly-named) test fixture which registers a user per {@link #credentials}, stores
      * the credentials into localStorage per {@link #pageWithCredentials}, and then loads the front page of the
      * app.
-     *
-     * Warning: the user credentials are an incomplete implementation, particularly in MAS environments: for example, a logout operation
-     * will not work correctly.
      */
     user: Credentials;
 }

--- a/packages/playwright-common/src/testcontainers/mas.ts
+++ b/packages/playwright-common/src/testcontainers/mas.ts
@@ -139,6 +139,12 @@ const DEFAULT_CONFIG = {
             per_second: 1,
         },
     },
+    clients: [
+        {
+            client_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            client_auth_method: "none",
+        },
+    ],
 } satisfies MasConfig;
 
 /**
@@ -209,6 +215,7 @@ export class MatrixAuthenticationServiceContainer extends GenericContainer {
             `http://localhost:${port}`,
             this.args,
             this.config.matrix.secret,
+            this.config.clients![0].client_id,
         );
     }
 }
@@ -224,6 +231,7 @@ export class StartedMatrixAuthenticationServiceContainer extends AbstractStarted
         public readonly baseUrl: string,
         private readonly args: string[],
         public readonly sharedSecret: string,
+        public readonly staticClientId: string,
     ) {
         super(container);
     }

--- a/packages/playwright-common/src/testcontainers/synapse.ts
+++ b/packages/playwright-common/src/testcontainers/synapse.ts
@@ -629,7 +629,7 @@ export class StartedSynapseWithMasContainer extends StartedSynapseContainer {
      */
     public async registerUser(username: string, password: string, displayName?: string): Promise<Credentials> {
         const registered = await this.mas.registerUser(username, password, displayName);
-        return { ...registered, homeserverBaseUrl: this.baseUrl };
+        return { ...registered, homeserverBaseUrl: this.baseUrl, oauthClientId: this.mas.staticClientId };
     }
 
     /**

--- a/packages/playwright-common/src/utils/api.ts
+++ b/packages/playwright-common/src/utils/api.ts
@@ -74,6 +74,9 @@ export interface Credentials {
     /** The domain part of the user's matrix ID. */
     homeServer: string;
 
+    /** The OAuth2 Client ID used by this client for native OAuth2 sessions **/
+    oauthClientId?: string;
+
     password: string | null; // null for password-less users
     displayName?: string;
     username: string; // the localpart of the userId

--- a/packages/playwright-common/src/utils/context.ts
+++ b/packages/playwright-common/src/utils/context.ts
@@ -15,8 +15,6 @@ import { populateLocalStorageWithCredentials } from "../fixtures/user.js";
 
 /** Create a new instance of the application, in a separate browser context, using the given credentials.
  *
- * Warning: `populateLocalStorageWithCredentials` is an incomplete implementation, particularly in MAS environments: for example, a logout operation will not work correctly.
- *
  * @param browser - the browser to use
  * @param credentials - the credentials to use for the new instance
  * @param additionalConfig - additional config for the `config.json` for the new instance


### PR DESCRIPTION
Without this it'd be using a Native OAuth2 session token but Element Web wouldn't know it was OAuth2-native and thus things like logout were broken
