### PR TITLE
Give the collapsed space panel separator clearance from the macOS traffic lights

### DIFF
--- a/apps/desktop/src/macos-titlebar.test.ts
+++ b/apps/desktop/src/macos-titlebar.test.ts
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { expect, describe, it, beforeEach, afterEach, vi } from "vitest";
+import type { BrowserWindow } from "electron";
+
+import { setupMacosTitleBar } from "./macos-titlebar.js";
+
+function createFakeWindow(): {
+    window: BrowserWindow;
+    emitDidFinishLoad: () => void;
+    insertCSS: ReturnType<typeof vi.fn>;
+} {
+    const listeners: Record<string, () => void> = {};
+    const insertCSS = vi.fn().mockResolvedValue("css-key");
+    const window = {
+        isFullScreen: vi.fn().mockReturnValue(false),
+        on: vi.fn(),
+        webContents: {
+            insertCSS,
+            removeInsertedCSS: vi.fn(),
+            on: vi.fn((event: string, listener: () => void) => {
+                listeners[event] = listener;
+            }),
+        },
+    } as unknown as BrowserWindow;
+
+    return {
+        window,
+        insertCSS,
+        emitDidFinishLoad: () => listeners["did-finish-load"]?.(),
+    };
+}
+
+describe("setupMacosTitleBar", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe("on macOS", () => {
+        beforeEach(() => {
+            vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+        });
+
+        it("widens the collapsed space panel so the separator clears the traffic lights", async () => {
+            const { window, insertCSS, emitDidFinishLoad } = createFakeWindow();
+            setupMacosTitleBar(window);
+            emitDidFinishLoad();
+            // insertCSS is async; wait for the microtask queue to flush
+            await Promise.resolve();
+
+            expect(insertCSS).toHaveBeenCalledTimes(1);
+            const css = insertCSS.mock.calls[0][0] as string;
+            expect(css).toContain(".mx_SpacePanel.collapsed");
+            expect(css).toContain("width: 76px !important;");
+        });
+    });
+
+    it("does nothing on non-macOS platforms", () => {
+        vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+        const { window, insertCSS, emitDidFinishLoad } = createFakeWindow();
+        setupMacosTitleBar(window);
+        emitDidFinishLoad();
+        expect(insertCSS).not.toHaveBeenCalled();
+    });
+});

--- a/apps/desktop/src/macos-titlebar.test.ts
+++ b/apps/desktop/src/macos-titlebar.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Element Creations Ltd.
+Copyright 2026 Spencer Poisseroux
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.

--- a/apps/desktop/src/macos-titlebar.ts
+++ b/apps/desktop/src/macos-titlebar.ts
@@ -32,6 +32,15 @@ export function setupMacosTitleBar(window: BrowserWindow): void {
                 /* 19px original top value, 32px margin-top above, 12px original margin-top value */
                 top: calc(19px + 32px - 12px) !important;
             }
+            /* Widen the collapsed space panel so its right-hand separator clears the
+               traffic light buttons. The buttons are inset 9px (see trafficLightPosition
+               in electron-main) and the three-button cluster is ~52px wide, ending ~61px
+               from the window edge; against the default 68px rail the separator crowds the
+               green button. 76px restores ~15px of clearance, matching the compound 4x
+               spacing step. */
+            .mx_SpacePanel.collapsed {
+                width: 76px !important;
+            }
             /* Prevent the media lightbox sender info from clipping into the traffic light buttons */
             .mx_ImageView_info_wrapper {
                 margin-top: 32px;


### PR DESCRIPTION
### Why

On macOS the desktop app uses a frameless window and draws the traffic light buttons over the top of the space panel (via `trafficLightPosition` in `electron-main.ts`). The buttons are inset 9px and the three-button cluster is roughly 52px wide, so it ends about 61px from the window edge. The collapsed space panel is 68px wide, so its right-hand separator ends up sitting right against the green button.

It is only noticeable when the space panel is collapsed: the panel has just two states (expanded/collapsed) and the separator cannot be dragged, so there is no way for a user to space it out themselves.

Fixes https://github.com/element-hq/element-web/issues/32012

### What

Widen the collapsed space panel to 76px on macOS so the separator gets about 15px of clearance from the traffic lights, in line with the compound 4x spacing step. The rule is added to the CSS already injected for the macOS title bar in `apps/desktop/src/macos-titlebar.ts`, so it only affects the desktop app on macOS and is removed in full screen along with the rest of that styling.

### Before / After

| Before | After |
| --- | --- |
| <img width="400" alt="before" src="https://github.com/user-attachments/assets/b6a473d3-3aca-4cec-b053-aa47bc11aa40" /> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/08360319-371a-4c95-bcbb-033507a0b4e8" /> |

### Testing strategy

1. Run the desktop app on macOS with the space panel collapsed.
2. Confirm the vertical separator no longer crowds the green traffic light button.
3. Toggle full screen and back; spacing behaves as before, since the injected macOS styling is removed in full screen.

Also added a unit test in `apps/desktop/src/macos-titlebar.test.ts` asserting the widened rule is injected on macOS and that nothing is injected on other platforms.

Notes: Fix the collapsed space panel separator sitting too close to the macOS traffic light buttons.
