### PR TITLE
Render a notification message for live location share start events (MSC4505)

### DIFF
--- a/apps/web/src/TextForEvent.tsx
+++ b/apps/web/src/TextForEvent.tsx
@@ -17,6 +17,7 @@ import {
     MsgType,
     M_POLL_START,
     M_POLL_END,
+    M_BEACON_INFO,
     ContentHelpers,
 } from "matrix-js-sdk/src/matrix";
 import { KnownMembership } from "matrix-js-sdk/src/types";
@@ -888,6 +889,14 @@ function textForPollEndEvent(event: MatrixEvent): (() => string) | null {
         });
 }
 
+function textForBeaconInfoEvent(event: MatrixEvent): (() => string) | null {
+    if (event.getContent().live !== true) return null;
+    return () =>
+        _t("timeline|m.beacon_info|live_location_started", {
+            senderName: getSenderName(event),
+        });
+}
+
 type Renderable = string | React.ReactNode | null;
 
 interface IHandlers {
@@ -923,6 +932,8 @@ const stateHandlers: IHandlers = {
     [EventType.RoomTombstone]: textForTombstoneEvent,
     [EventType.RoomJoinRules]: textForJoinRulesEvent,
     [EventType.RoomGuestAccess]: textForGuestAccessEvent,
+    [M_BEACON_INFO.name]: textForBeaconInfoEvent,
+    [M_BEACON_INFO.altName]: textForBeaconInfoEvent,
 
     // TODO: Enable support for m.widget event type (https://github.com/vector-im/element-web/issues/13111)
     "im.vector.modular.widgets": textForWidgetEvent,

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -3339,6 +3339,7 @@
             "error_processing_voice_message": "Error processing voice message"
         },
         "m.beacon_info": {
+            "live_location_started": "%(senderName)s started sharing their live location",
             "view_live_location": "View live location"
         },
         "m.call": {

--- a/apps/web/test/unit-tests/TextForEvent-test.tsx
+++ b/apps/web/test/unit-tests/TextForEvent-test.tsx
@@ -425,6 +425,43 @@ describe("TextForEvent", () => {
         });
     });
 
+    describe("textForBeaconInfoEvent()", () => {
+        const mockBeaconInfoEvent = (live: boolean | undefined, type = "org.matrix.msc3672.beacon_info"): MatrixEvent =>
+            new MatrixEvent({
+                type,
+                state_key: "@a:example.com",
+                sender: "@a:example.com",
+                content: {
+                    description: "test beacon",
+                    timeout: 300000,
+                    ...(live !== undefined ? { live } : {}),
+                },
+            });
+
+        it("returns correct message for a live beacon start", () => {
+            const event = mockBeaconInfoEvent(true);
+            expect(textForEvent(event, mockClient)).toEqual("@a:example.com started sharing their live location");
+            expect(hasText(event, mockClient)).toBe(true);
+        });
+
+        it("returns correct message for a live beacon start with the stable event type", () => {
+            const event = mockBeaconInfoEvent(true, "m.beacon_info");
+            expect(textForEvent(event, mockClient)).toEqual("@a:example.com started sharing their live location");
+        });
+
+        it("returns nothing for a beacon stop", () => {
+            const event = mockBeaconInfoEvent(false);
+            expect(textForEvent(event, mockClient)).toEqual("");
+            expect(hasText(event, mockClient)).toBe(false);
+        });
+
+        it("returns nothing when live is absent", () => {
+            const event = mockBeaconInfoEvent(undefined);
+            expect(textForEvent(event, mockClient)).toEqual("");
+            expect(hasText(event, mockClient)).toBe(false);
+        });
+    });
+
     describe("textForMessageEvent()", () => {
         let messageEvent: MatrixEvent;
 


### PR DESCRIPTION
Add a stateHandlers entry in TextForEvent for m.beacon_info / org.matrix.msc3672.beacon_info so that Notifier can produce a desktop notification ("<sender> started sharing their live location") when a beacon_info state event with live: true arrives via a matching push rule. Stop/expiry events (live false or absent) intentionally render nothing.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
