### PR TITLE
Update to pnpm 11.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "devEngines": {
         "packageManager": {
             "name": "pnpm",
-            "version": "11.5.2",
+            "version": "11.11.0",
             "onFail": "download"
         }
     },

--- a/patches/matrix-js-sdk@41.9.0.patch
+++ b/patches/matrix-js-sdk@41.9.0.patch
@@ -1,0 +1,13 @@
+diff --git a/package.json b/package.json
+index 38e67612b92677a11658b48fe640acf1e4a8c6ef..f4caf4da2c3d9228a3d76a9a1f492f2227f856d7 100644
+--- a/package.json
++++ b/package.json
+@@ -13,7 +13,7 @@
+         }
+     },
+     "scripts": {
+-        "prepare": "pnpm build",
++        "//prepare": "pnpm build",
+         "start": "concurrently 'pnpm run build:compile --watch' 'pnpm run build:types --watch'",
+         "build": "pnpm build:compile && pnpm build:types",
+         "build:types": "tsc -p tsconfig-build.json --emitDeclarationOnly",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,7 @@ patchedDependencies:
   jsdom: 040623e87b1c8b676c2a705513c0276c0704dd1b23fc3a1bb77cde8128b64b5f
   knip: 9ee905cce2466e391db69dfcea905b0fe2502afd935d1dc6a6ac94ffe2855c28
   linkify-html: 1761c1eabe25d9fae83f74f27a20b3d24515840a4a8747bb04828df46bcfdea2
+  matrix-js-sdk@41.9.0: 4123ff7758933419e7a2578b3476f1e4523b5e7e40670d07e839f57131b9f175
   plist: 7a3c35087f0ab2a8efbac9e2899990f07d61e2b3e41d8d962ef0bdb0786e1af7
   postcss-mixins: 30fc882486b610a1c252340c87a99f1030c50e698a3c57c837eff7232e29d6d0
   react-blurhash: 58bc7f075478017ce27bcc252e8509876390db106246bd5b0a7446642cc4b505
@@ -641,7 +642,7 @@ importers:
         version: 1.0.3
       matrix-js-sdk:
         specifier: github:matrix-org/matrix-js-sdk#develop
-        version: https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/c76f6e44afc13194cf2d27d9faa19c2806fdacd3
+        version: https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/c76f6e44afc13194cf2d27d9faa19c2806fdacd3(patch_hash=4123ff7758933419e7a2578b3476f1e4523b5e7e40670d07e839f57131b9f175)
       matrix-widget-api:
         specifier: ^1.17.0
         version: 1.17.0
@@ -1295,7 +1296,7 @@ importers:
         version: '@typescript/typescript6@6.0.2'
       unplugin-dts:
         specifier: 'catalog:'
-        version: 1.0.1(@microsoft/api-extractor@7.58.9(@types/node@25.9.3))(@typescript/typescript6@6.0.2)(esbuild@0.27.4)(rolldown@1.1.4)(rollup@4.60.1)(vite@8.1.4(@types/node@25.9.3)(esbuild@0.27.4)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.27.4)(lightningcss@1.32.0)(postcss@8.5.16))
+        version: 1.0.1(@microsoft/api-extractor@7.58.9(@types/node@25.9.3))(@typescript/typescript6@6.0.2)(esbuild@0.27.4)(rolldown@1.1.4)(rollup@4.60.1)(supports-color@7.2.0)(vite@8.1.4(@types/node@25.9.3)(esbuild@0.27.4)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.27.4)(lightningcss@1.32.0)(postcss@8.5.16))
       vite:
         specifier: 'catalog:'
         version: 8.1.4(@types/node@25.9.3)(esbuild@0.27.4)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)(yaml@2.9.0)
@@ -1513,7 +1514,7 @@ importers:
         version: '@typescript/typescript6@6.0.2'
       unplugin-dts:
         specifier: 'catalog:'
-        version: 1.0.1(@microsoft/api-extractor@7.58.9(@types/node@25.9.3))(@typescript/typescript6@6.0.2)(esbuild@0.27.4)(rolldown@1.1.4)(rollup@4.60.1)(vite@8.1.4(@types/node@25.9.3)(esbuild@0.27.4)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.27.4)(lightningcss@1.32.0)(postcss@8.5.16))
+        version: 1.0.1(@microsoft/api-extractor@7.58.9(@types/node@25.9.3))(@typescript/typescript6@6.0.2)(esbuild@0.27.4)(rolldown@1.1.4)(rollup@4.60.1)(supports-color@7.2.0)(vite@8.1.4(@types/node@25.9.3)(esbuild@0.27.4)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.27.4)(lightningcss@1.32.0)(postcss@8.5.16))
       vite:
         specifier: 'catalog:'
         version: 8.1.4(@types/node@25.9.3)(esbuild@0.27.4)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)(yaml@2.9.0)
@@ -8591,7 +8592,7 @@ packages:
     engines: {node: '>=12'}
 
   eslint-plugin-element-call@https://codeload.github.com/element-hq/element-call/tar.gz/1d088911e1e9698b0b8c9811e2544c16010bd6a4#path:/eslint:
-    resolution: {gitHosted: true, path: /eslint, integrity: sha512-M6bTOZ/RVEqL38838KgBJ76Sdo85mifKqyJ+mR3KXhegsf3D9WOW6psJgvn1kxhaLtwHwg0AIvbUu/N7MiDfDQ==, tarball: https://codeload.github.com/element-hq/element-call/tar.gz/1d088911e1e9698b0b8c9811e2544c16010bd6a4}
+    resolution: {gitHosted: true, integrity: sha512-M6bTOZ/RVEqL38838KgBJ76Sdo85mifKqyJ+mR3KXhegsf3D9WOW6psJgvn1kxhaLtwHwg0AIvbUu/N7MiDfDQ==, path: /eslint, tarball: https://codeload.github.com/element-hq/element-call/tar.gz/1d088911e1e9698b0b8c9811e2544c16010bd6a4}
     version: 0.0.0
 
   eslint-plugin-storybook@10.4.6:
@@ -22953,7 +22954,7 @@ snapshots:
 
   matrix-events-sdk@0.0.1: {}
 
-  matrix-js-sdk@https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/c76f6e44afc13194cf2d27d9faa19c2806fdacd3:
+  matrix-js-sdk@https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/c76f6e44afc13194cf2d27d9faa19c2806fdacd3(patch_hash=4123ff7758933419e7a2578b3476f1e4523b5e7e40670d07e839f57131b9f175):
     dependencies:
       '@babel/runtime': 8.0.0
       '@matrix-org/matrix-sdk-crypto-wasm': 18.3.1
@@ -26293,7 +26294,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-dts@1.0.1(@microsoft/api-extractor@7.58.9(@types/node@25.9.3))(@typescript/typescript6@6.0.2)(esbuild@0.27.4)(rolldown@1.1.4)(rollup@4.60.1)(vite@8.1.4(@types/node@25.9.3)(esbuild@0.27.4)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.27.4)(lightningcss@1.32.0)(postcss@8.5.16)):
+  unplugin-dts@1.0.1(@microsoft/api-extractor@7.58.9(@types/node@25.9.3))(@typescript/typescript6@6.0.2)(esbuild@0.27.4)(rolldown@1.1.4)(rollup@4.60.1)(supports-color@7.2.0)(vite@8.1.4(@types/node@25.9.3)(esbuild@0.27.4)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.27.4)(lightningcss@1.32.0)(postcss@8.5.16)):
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.60.1)
       '@volar/typescript': 2.4.28

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,52 +7,52 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       '@pnpm/exe':
-        specifier: 11.5.2
-        version: 11.5.2
+        specifier: 11.11.0
+        version: 11.11.0
       pnpm:
-        specifier: 11.5.2
-        version: 11.5.2
+        specifier: 11.11.0
+        version: 11.11.0
 
 packages:
 
-  '@pnpm/exe@11.5.2':
-    resolution: {integrity: sha512-4UFnP2rhNu1xjAQ+I1GdIUUEtCJuTYJlbpiWSFA4POAID3Lpt+2vrjImWO7eOJ7iCY3vpc4TFe2IW3sAolW4Kg==}
+  '@pnpm/exe@11.11.0':
+    resolution: {integrity: sha512-OpTrbkAU0Ur8gBwhAT6mbWwlA1bFU8zPcFNdp/img/RqFIc7Dn0j0crW9rz5hxTWo/UBQjy6Sb9jh+N5bRSd+g==}
     hasBin: true
 
-  '@pnpm/linux-arm64@11.5.2':
-    resolution: {integrity: sha512-MbJySnu2y9cCBqlODLjUlZ87JnRC3Inq40rvGHWJSrSQ0PnuHeSw2NDMnLI8Hf9hCY+ooussRc5iiR4IAkjUvg==}
+  '@pnpm/linux-arm64@11.11.0':
+    resolution: {integrity: sha512-62K/kQY3jaoQ96MNUi0NLcTSSDO2QrtziOA2IK5R/m+DxpSwXbxFSQHYx8oOg0r1+MFVqwuDkFjXe6DyW3y58g==}
     cpu: [arm64]
     os: [linux]
 
-  '@pnpm/linux-x64@11.5.2':
-    resolution: {integrity: sha512-g6g2BGpQA47wUACy6B1MdeSHPtnl6x4AeCg0IOWQ7xXorEtC+VRiSHhLpA5kByFGeSwyYh/nLc7mLul5DAaELw==}
+  '@pnpm/linux-x64@11.11.0':
+    resolution: {integrity: sha512-rwMbNJR+PstRu+ymWoApei1CWrAnsnW3tm+3H8qOxbp8duiaj6u7DxlMzhKbVpFwylxcJdeGwZ5tReBFOVpsdw==}
     cpu: [x64]
     os: [linux]
 
-  '@pnpm/linuxstatic-arm64@11.5.2':
-    resolution: {integrity: sha512-xTxs9BLxYW39BPNGnmvYCUBnMPWm4mzmzujmdYbpRxDnBXrx55qPR5K/3LSohX7VrmsdDrYxuH6AmG1AaOlIfA==}
+  '@pnpm/linuxstatic-arm64@11.11.0':
+    resolution: {integrity: sha512-OcmrMw1hxNee7KTBpE0yToTZziH/SCmJWwjB7YN2NmsxZVPKM2vtOWFdZufW0YN5JffKMaHbPZ2ulgYBM5qAQw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/linuxstatic-x64@11.5.2':
-    resolution: {integrity: sha512-RGmmc/SoGLD90gmOHcU85UEKNoNRstLvizli4wzDASmETz/VeqJOqU5nD1YBgjzcP72sUMS352dh4bmzTfKyvQ==}
+  '@pnpm/linuxstatic-x64@11.11.0':
+    resolution: {integrity: sha512-pWeAYeS+PPah6mXcJbOr+nPwEpyQau4iPcsqNUhTK9G5/qpG5dU1m8oHeIH83PuUUvvdJddLE1PXUkGM+QCI6g==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/macos-arm64@11.5.2':
-    resolution: {integrity: sha512-gW3A2jRlC3SJRw8qX2SAzjMIu9o98daTSqCKzeeYcjF/uEbtbz3dn4HqYrYffBnenKbc4hsgZQmNOHAvUKIlSg==}
+  '@pnpm/macos-arm64@11.11.0':
+    resolution: {integrity: sha512-62P8Pe4yvMkdl2nxswCjM5X835i9Judk68CZvv8OnWsm7CVCEZ61SEBnNTpjJ4kXzdayFjRpPwE/jfJSvPaWww==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/win-arm64@11.5.2':
-    resolution: {integrity: sha512-+VJCDoH/pRzLXBikwjvxgAnGfQufT8EALBX8cfSmrwD40JABUZvgPtjBjde7OwEoK/XwtlH8w+ZceFV0K3/YHQ==}
+  '@pnpm/win-arm64@11.11.0':
+    resolution: {integrity: sha512-yYAx+A1oT+mSgrIzysuAvdYYMYEfAa+z3/UCGY3L5VC9oabs9qi71LbTan1cDui/AadrIvD177k9mV4V38KAJg==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/win-x64@11.5.2':
-    resolution: {integrity: sha512-zgglREh75RbFgV/E0tNRS03ElX+hJOV43KRSSeaboxtj3ei1rrguxOgOCXUs/GsizoHVsuD+qXGABE4Kc4GMCg==}
+  '@pnpm/win-x64@11.11.0':
+    resolution: {integrity: sha512-ehTuyM5Rrp4ye0SdtAJkUS+9ykfwdDY9SPqiK3+bxXPx3LD5aeDw2EBksTh/xRTgqFdYmoFR86cABFt9yBr0GA==}
     cpu: [x64]
     os: [win32]
 
@@ -116,45 +116,45 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  pnpm@11.5.2:
-    resolution: {integrity: sha512-ccYx44IGbvwlYl1c8CkHXeB7YbN/bic1D72Esb2lhkyMGWetwoB3a0XDCnFcA1mjvgj+9C1bsJ4rmQKZeWkpFg==}
+  pnpm@11.11.0:
+    resolution: {integrity: sha512-RGP2X9gO2A1pvB1L8WPulPYFxzgPwxi7Wy6+FfjNEtScUaTVnpUbQB52TTtsp1HL9RvFDtcAGmvLSTXmhMNIgg==}
     engines: {node: '>=22.13'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe@11.5.2':
+  '@pnpm/exe@11.11.0':
     dependencies:
       '@reflink/reflink': 0.1.19
       detect-libc: 2.1.2
     optionalDependencies:
-      '@pnpm/linux-arm64': 11.5.2
-      '@pnpm/linux-x64': 11.5.2
-      '@pnpm/linuxstatic-arm64': 11.5.2
-      '@pnpm/linuxstatic-x64': 11.5.2
-      '@pnpm/macos-arm64': 11.5.2
-      '@pnpm/win-arm64': 11.5.2
-      '@pnpm/win-x64': 11.5.2
+      '@pnpm/linux-arm64': 11.11.0
+      '@pnpm/linux-x64': 11.11.0
+      '@pnpm/linuxstatic-arm64': 11.11.0
+      '@pnpm/linuxstatic-x64': 11.11.0
+      '@pnpm/macos-arm64': 11.11.0
+      '@pnpm/win-arm64': 11.11.0
+      '@pnpm/win-x64': 11.11.0
 
-  '@pnpm/linux-arm64@11.5.2':
+  '@pnpm/linux-arm64@11.11.0':
     optional: true
 
-  '@pnpm/linux-x64@11.5.2':
+  '@pnpm/linux-x64@11.11.0':
     optional: true
 
-  '@pnpm/linuxstatic-arm64@11.5.2':
+  '@pnpm/linuxstatic-arm64@11.11.0':
     optional: true
 
-  '@pnpm/linuxstatic-x64@11.5.2':
+  '@pnpm/linuxstatic-x64@11.11.0':
     optional: true
 
-  '@pnpm/macos-arm64@11.5.2':
+  '@pnpm/macos-arm64@11.11.0':
     optional: true
 
-  '@pnpm/win-arm64@11.5.2':
+  '@pnpm/win-arm64@11.11.0':
     optional: true
 
-  '@pnpm/win-x64@11.5.2':
+  '@pnpm/win-x64@11.11.0':
     optional: true
 
   '@reflink/reflink-darwin-arm64@0.1.19':
@@ -194,7 +194,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  pnpm@11.5.2: {}
+  pnpm@11.11.0: {}
 
 ---
 lockfileVersion: '9.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ cleanupUnusedCatalogs: true
 ignorePatchFailures: false
 ignoreWorkspaceRootCheck: true
 minimumReleaseAgeStrict: true
+strictDepBuilds: false
 
 packages:
     - "apps/*"
@@ -57,9 +58,6 @@ packageExtensions:
             vite: "^8.0.0"
 
 allowBuilds:
-    # Needed to make the git dependency in layered.sh happy
-    "matrix-js-sdk@git+ssh://git@github.com/matrix-org/matrix-js-sdk.git": true
-    "matrix-js-sdk@github:matrix-org/matrix-js-sdk": true
     matrix-js-sdk: false
     # Installs the CLI, which we do not need
     "@sentry/cli": false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,6 +58,7 @@ packageExtensions:
 
 allowBuilds:
     # Needed to make the git dependency in layered.sh happy
+    "github:matrix-org/matrix-js-sdk#develop": true
     matrix-js-sdk: true
     # Installs the CLI, which we do not need
     "@sentry/cli": false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,7 +58,6 @@ packageExtensions:
             vite: "^8.0.0"
 
 allowBuilds:
-    matrix-js-sdk: false
     # Installs the CLI, which we do not need
     "@sentry/cli": false
     # Installs nx cloud client, which we do not need
@@ -107,6 +106,8 @@ patchedDependencies:
     plist: patches/plist.patch
     # Workaround for type fails
     "@arcmantle/vite-plugin-import-css-sheet": patches/@arcmantle__vite-plugin-import-css-sheet.patch
+    # Disable prepare script - we don't need it and it causes issues in the git dependency
+    matrix-js-sdk@41.9.0: patches/matrix-js-sdk@41.9.0.patch
 
 peerDependencyRules:
     allowedVersions:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,9 @@ cleanupUnusedCatalogs: true
 ignorePatchFailures: false
 ignoreWorkspaceRootCheck: true
 minimumReleaseAgeStrict: true
+# Workaround as part of https://github.com/element-hq/element-web/pull/34254
 strictDepBuilds: false
+allowUnusedPatches: true
 
 packages:
     - "apps/*"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,8 +58,9 @@ packageExtensions:
 
 allowBuilds:
     # Needed to make the git dependency in layered.sh happy
-    "github:matrix-org/matrix-js-sdk#develop": true
-    matrix-js-sdk: true
+    "matrix-js-sdk@git+ssh://git@github.com/matrix-org/matrix-js-sdk.git": true
+    "matrix-js-sdk@github:matrix-org/matrix-js-sdk": true
+    matrix-js-sdk: false
     # Installs the CLI, which we do not need
     "@sentry/cli": false
     # Installs nx cloud client, which we do not need
@@ -81,6 +82,7 @@ allowBuilds:
     # The following are to make wrangler-action happy - https://github.com/cloudflare/wrangler-action/issues/436
     sharp: true
     workerd: true
+    matrix-js-sdk@https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/c76f6e44afc13194cf2d27d9faa19c2806fdacd3: set this to true or false
 
 patchedDependencies:
     # Workaround for missing types export

--- a/scripts/layered.sh
+++ b/scripts/layered.sh
@@ -14,7 +14,7 @@ set -ex
 # for the primary repo (element-web in this case).
 
 # Install dependencies
-pnpm install --frozen-lockfile $@
+pnpm install --frozen-lockfile --ignore-scripts $@
 
 # Pass appropriate repo to fetchdep.sh
 export PR_ORG=element-hq


### PR DESCRIPTION
Picks up security fixed from 11.8
Picks up fix for sub-path git dependencies from 11.7
Picks up fix for allowBuilds & git dependencies from 11.11

Features temporary workaround for js-sdk prepare script until https://github.com/pnpm/pnpm/pull/12985 ships