### PR TITLE
Render knock membership events in notifications

### DIFF
--- a/apps/web/playwright/e2e/knock/knock-into-room.spec.ts
+++ b/apps/web/playwright/e2e/knock/knock-into-room.spec.ts
@@ -88,7 +88,15 @@ test.describe("Knock Into Room", () => {
             page.getByTestId("room-list").getByRole("option", { name: "Open room Cybersecurity" }),
         ).toBeVisible();
 
+        // The knock, invite and join events collapse into a membership summary; expand it
+        // to reveal the individual events, including the knock itself.
+        await expect(page.getByText("Alice requested to join, was granted access, and joined")).toBeVisible();
+        await page.locator(".mx_GenericEventListSummary_toggle[aria-expanded=false]").last().click();
+        await expect(page.getByText("Alice is requesting to join")).toBeVisible();
+        await expect(page.getByText("Bob granted access to Alice")).toBeVisible();
         await expect(page.getByText("Alice joined the room")).toBeVisible();
+        // Collapse it again so the summary assertions below see the collapsed form.
+        await page.locator(".mx_GenericEventListSummary_toggle[aria-expanded=true]").last().click();
 
         // bot kicks Alice
         await bot.kick(room.roomId, user.userId);
@@ -115,7 +123,12 @@ test.describe("Knock Into Room", () => {
         // It will be not needed when homeserver implements auto accept knock requests.
         await page.locator(".mx_RoomView").getByRole("button", { name: "Accept" }).click();
 
-        await expect(page.getByText("Alice was invited, joined, was removed, was invited, and joined")).toBeVisible();
+        await expect(
+            page.getByText(
+                "Alice requested to join, was granted access, joined, was removed, requested to join, " +
+                    "was granted access, and joined",
+            ),
+        ).toBeVisible();
     });
 
     test("should knock into the room then knock is approved and user joins the room then user is banned/unbanned and joins again", async ({
@@ -165,7 +178,15 @@ test.describe("Knock Into Room", () => {
             page.getByTestId("room-list").getByRole("option", { name: "Open room Cybersecurity" }),
         ).toBeVisible();
 
+        // The knock, invite and join events collapse into a membership summary; expand it
+        // to reveal the individual events, including the knock itself.
+        await expect(page.getByText("Alice requested to join, was granted access, and joined")).toBeVisible();
+        await page.locator(".mx_GenericEventListSummary_toggle[aria-expanded=false]").last().click();
+        await expect(page.getByText("Alice is requesting to join")).toBeVisible();
+        await expect(page.getByText("Bob granted access to Alice")).toBeVisible();
         await expect(page.getByText("Alice joined the room")).toBeVisible();
+        // Collapse it again so the summary assertions below see the collapsed form.
+        await page.locator(".mx_GenericEventListSummary_toggle[aria-expanded=true]").last().click();
 
         // bot bans Alice
         await bot.ban(room.roomId, user.userId);
@@ -200,7 +221,10 @@ test.describe("Knock Into Room", () => {
         await page.locator(".mx_RoomView").getByRole("button", { name: "Accept" }).click();
 
         await expect(
-            page.getByText("Alice was invited, joined, was banned, was unbanned, was invited, and joined"),
+            page.getByText(
+                "Alice requested to join, was granted access, joined, was banned, was unbanned, " +
+                    "requested to join, was granted access, and joined",
+            ),
         ).toBeVisible();
     });
 

--- a/apps/web/playwright/e2e/knock/manage-knocks.spec.ts
+++ b/apps/web/playwright/e2e/knock/manage-knocks.spec.ts
@@ -48,7 +48,12 @@ test.describe("Manage Knocks", () => {
 
         await expect(roomKnocksBar).not.toBeVisible();
 
-        await expect(page.getByText("Alice invited Bob")).toBeVisible();
+        // The knock and invite may collapse into a membership summary depending on what
+        // precedes them; expand it to reveal the individual events.
+        const collapsedSummary = page.locator(".mx_GenericEventListSummary_toggle[aria-expanded=false]");
+        if ((await collapsedSummary.count()) > 0) await collapsedSummary.last().click();
+        await expect(page.getByText("Bob is requesting to join")).toBeVisible();
+        await expect(page.getByText("Alice granted access to Bob")).toBeVisible();
     });
 
     test("should deny knock using bar", async ({ page, app, bot, room }) => {
@@ -71,6 +76,12 @@ test.describe("Manage Knocks", () => {
                     e.getContent()?.displayname === "Bob",
             );
         });
+
+        // The knock and its denial may collapse into a membership summary depending on what
+        // precedes them; expand it to reveal the individual events.
+        const collapsedSummary = page.locator(".mx_GenericEventListSummary_toggle[aria-expanded=false]");
+        if ((await collapsedSummary.count()) > 0) await collapsedSummary.last().click();
+        await expect(page.getByText("Alice rejected Bob's request to join")).toBeVisible();
     });
 
     test("should approve knock using people tab", async ({ page, app, bot, room }) => {
@@ -83,8 +94,14 @@ test.describe("Manage Knocks", () => {
         await expect(settingsGroup.getByText("Hello, can I join?")).toBeVisible();
         await settingsGroup.getByRole("button", { name: "Approve" }).click();
         await expect(settingsGroup.getByText(/^Bob/)).not.toBeVisible();
+        await app.settings.closeDialog();
 
-        await expect(page.getByText("Alice invited Bob")).toBeVisible();
+        // The knock and invite may collapse into a membership summary depending on what
+        // precedes them; expand it to reveal the individual events.
+        const collapsedSummary = page.locator(".mx_GenericEventListSummary_toggle[aria-expanded=false]");
+        if ((await collapsedSummary.count()) > 0) await collapsedSummary.last().click();
+        await expect(page.getByText("Bob is requesting to join: Hello, can I join?")).toBeVisible();
+        await expect(page.getByText("Alice granted access to Bob")).toBeVisible();
     });
 
     test("should deny knock using people tab", async ({ page, app, bot, room }) => {
@@ -108,5 +125,12 @@ test.describe("Manage Knocks", () => {
                     e.getContent()?.displayname === "Bob",
             );
         });
+        await app.settings.closeDialog();
+
+        // The knock and its denial may collapse into a membership summary depending on what
+        // precedes them; expand it to reveal the individual events.
+        const collapsedSummary = page.locator(".mx_GenericEventListSummary_toggle[aria-expanded=false]");
+        if ((await collapsedSummary.count()) > 0) await collapsedSummary.last().click();
+        await expect(page.getByText("Alice rejected Bob's request to join")).toBeVisible();
     });
 });

--- a/apps/web/src/TextForEvent.tsx
+++ b/apps/web/src/TextForEvent.tsx
@@ -151,10 +151,20 @@ function textForMemberEvent(
                 } else {
                     return () => _t("timeline|m.room.member|accepted_invite", { targetName });
                 }
+            } else if (
+                prevContent.membership === KnownMembership.Knock &&
+                SettingsStore.getValue("feature_ask_to_join")
+            ) {
+                return () => _t("timeline|m.room.member|knock_accepted", { senderName, targetName });
             } else {
                 return () => _t("timeline|m.room.member|invite", { senderName, targetName });
             }
         }
+        case KnownMembership.Knock:
+            if (!SettingsStore.getValue("feature_ask_to_join")) return null;
+            return reason
+                ? () => _t("timeline|m.room.member|knock_reason", { senderName, reason })
+                : () => _t("timeline|m.room.member|knock", { senderName });
         case KnownMembership.Ban:
             if (allowJSX) {
                 return reason
@@ -234,6 +244,11 @@ function textForMemberEvent(
                         reason
                             ? _t("timeline|m.room.member|reject_invite_reason", { targetName, reason })
                             : _t("timeline|m.room.member|reject_invite", { targetName });
+                } else if (
+                    prevContent.membership === KnownMembership.Knock &&
+                    SettingsStore.getValue("feature_ask_to_join")
+                ) {
+                    return () => _t("timeline|m.room.member|knock_retracted", { targetName });
                 } else {
                     return () =>
                         reason
@@ -260,6 +275,11 @@ function textForMemberEvent(
                               reason,
                           })
                         : _t("timeline|m.room.member|kick", { senderName, targetName });
+            } else if (
+                prevContent.membership === KnownMembership.Knock &&
+                SettingsStore.getValue("feature_ask_to_join")
+            ) {
+                return () => _t("timeline|m.room.member|knock_denied", { senderName, targetName });
             } else {
                 return null;
             }

--- a/apps/web/src/components/views/elements/EventListSummary.tsx
+++ b/apps/web/src/components/views/elements/EventListSummary.tsx
@@ -20,6 +20,7 @@ import GenericEventListSummary from "./GenericEventListSummary";
 import { RightPanelPhases } from "../../../stores/right-panel/RightPanelStorePhases";
 import { jsxJoin } from "../../../utils/ReactUtils";
 import { Layout } from "../../../settings/enums/Layout";
+import SettingsStore from "../../../settings/SettingsStore";
 import RightPanelStore from "../../../stores/right-panel/RightPanelStore";
 import AccessibleButton from "./AccessibleButton";
 import RoomContext from "../../../contexts/RoomContext";
@@ -59,6 +60,10 @@ enum TransitionType {
     InviteReject = "invite_reject",
     InviteWithdrawal = "invite_withdrawal",
     Invited = "invited",
+    Knocked = "knocked",
+    KnockAccepted = "knock_accepted",
+    KnockRetracted = "knock_retracted",
+    KnockDenied = "knock_denied",
     Banned = "banned",
     Unbanned = "unbanned",
     Kicked = "kicked",
@@ -414,6 +419,30 @@ export default class EventListSummary extends React.Component<Props, State> {
                         ? _t("timeline|summary|invited_multiple", { count })
                         : _t("timeline|summary|invited", { count });
                 break;
+            case TransitionType.Knocked:
+                res =
+                    userCount > 1
+                        ? _t("timeline|summary|knocked_multiple", { severalUsers: "", count })
+                        : _t("timeline|summary|knocked", { oneUser: "", count });
+                break;
+            case TransitionType.KnockAccepted:
+                res =
+                    userCount > 1
+                        ? _t("timeline|summary|knock_accepted_multiple", { count })
+                        : _t("timeline|summary|knock_accepted", { count });
+                break;
+            case TransitionType.KnockRetracted:
+                res =
+                    userCount > 1
+                        ? _t("timeline|summary|knock_retracted_multiple", { severalUsers: "", count })
+                        : _t("timeline|summary|knock_retracted", { oneUser: "", count });
+                break;
+            case TransitionType.KnockDenied:
+                res =
+                    userCount > 1
+                        ? _t("timeline|summary|knock_denied_multiple", { count })
+                        : _t("timeline|summary|knock_denied", { count });
+                break;
             case TransitionType.Banned:
                 res =
                     userCount > 1
@@ -527,7 +556,15 @@ export default class EventListSummary extends React.Component<Props, State> {
             case EventType.RoomMember:
                 switch (e.mxEvent.getContent().membership) {
                     case KnownMembership.Invite:
+                        if (
+                            e.mxEvent.getPrevContent().membership === KnownMembership.Knock &&
+                            SettingsStore.getValue("feature_ask_to_join")
+                        ) {
+                            return TransitionType.KnockAccepted;
+                        }
                         return TransitionType.Invited;
+                    case KnownMembership.Knock:
+                        return TransitionType.Knocked;
                     case KnownMembership.Ban:
                         return TransitionType.Banned;
                     case KnownMembership.Join:
@@ -546,6 +583,12 @@ export default class EventListSummary extends React.Component<Props, State> {
                             if (e.mxEvent.getPrevContent().membership === KnownMembership.Invite) {
                                 return TransitionType.InviteReject;
                             }
+                            if (
+                                e.mxEvent.getPrevContent().membership === KnownMembership.Knock &&
+                                SettingsStore.getValue("feature_ask_to_join")
+                            ) {
+                                return TransitionType.KnockRetracted;
+                            }
                             return TransitionType.Left;
                         }
                         switch (e.mxEvent.getPrevContent().membership) {
@@ -553,6 +596,11 @@ export default class EventListSummary extends React.Component<Props, State> {
                                 return TransitionType.InviteWithdrawal;
                             case KnownMembership.Ban:
                                 return TransitionType.Unbanned;
+                            case KnownMembership.Knock:
+                                if (SettingsStore.getValue("feature_ask_to_join")) {
+                                    return TransitionType.KnockDenied;
+                                }
+                                return TransitionType.Kicked;
                             // sender is not target and made the target leave, if not from invite/ban then this is a kick
                             default:
                                 return TransitionType.Kicked;

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -3457,6 +3457,11 @@
             "join": "%(targetName)s joined the room",
             "kick": "%(senderName)s removed %(targetName)s",
             "kick_reason": "%(senderName)s removed %(targetName)s: %(reason)s",
+            "knock": "%(senderName)s is requesting to join",
+            "knock_accepted": "%(senderName)s granted access to %(targetName)s",
+            "knock_denied": "%(senderName)s rejected %(targetName)s's request to join",
+            "knock_reason": "%(senderName)s is requesting to join: %(reason)s",
+            "knock_retracted": "%(targetName)s is no longer interested in joining",
             "left": "%(targetName)s left the room",
             "left_reason": "%(targetName)s left the room: %(reason)s",
             "no_change": "%(senderName)s made no change",
@@ -3640,6 +3645,38 @@
             "kicked_multiple": {
                 "one": "were removed",
                 "other": "were removed %(count)s times"
+            },
+            "knock_accepted": {
+                "one": "was granted access",
+                "other": "was granted access %(count)s times"
+            },
+            "knock_accepted_multiple": {
+                "one": "were granted access",
+                "other": "were granted access %(count)s times"
+            },
+            "knock_denied": {
+                "one": "had their request to join rejected",
+                "other": "had their request to join rejected %(count)s times"
+            },
+            "knock_denied_multiple": {
+                "one": "had their requests to join rejected",
+                "other": "had their requests to join rejected %(count)s times"
+            },
+            "knock_retracted": {
+                "one": "%(oneUser)scancelled their request to join",
+                "other": "%(oneUser)scancelled their request to join %(count)s times"
+            },
+            "knock_retracted_multiple": {
+                "one": "%(severalUsers)scancelled their requests to join",
+                "other": "%(severalUsers)scancelled their requests to join %(count)s times"
+            },
+            "knocked": {
+                "one": "%(oneUser)srequested to join",
+                "other": "%(oneUser)srequested to join %(count)s times"
+            },
+            "knocked_multiple": {
+                "one": "%(severalUsers)srequested to join",
+                "other": "%(severalUsers)srequested to join %(count)s times"
             },
             "left": {
                 "one": "%(oneUser)sleft",

--- a/apps/web/test/unit-tests/Notifier-test.ts
+++ b/apps/web/test/unit-tests/Notifier-test.ts
@@ -18,6 +18,7 @@ import {
     SyncState,
     type AccountDataEvents,
 } from "matrix-js-sdk/src/matrix";
+import { KnownMembership } from "matrix-js-sdk/src/types";
 import { waitFor } from "jest-matrix-react";
 import { CallMembership, type SessionMembershipData, type MatrixRTCSession } from "matrix-js-sdk/src/matrixrtc";
 import { randomUUID } from "node:crypto";
@@ -409,6 +410,60 @@ describe("Notifier", () => {
                 testRoom,
                 spoilerEvent,
             );
+        });
+
+        describe("knocks", () => {
+            let getValueSpy: jest.SpyInstance;
+
+            const mkKnockEvent = (reason?: string): MatrixEvent =>
+                mkEvent({
+                    event: true,
+                    type: EventType.RoomMember,
+                    user: "@alice:example.org",
+                    room: roomId,
+                    skey: "@alice:example.org",
+                    content: { membership: KnownMembership.Knock, reason },
+                });
+
+            beforeEach(() => {
+                getValueSpy = jest
+                    .spyOn(SettingsStore, "getValue")
+                    .mockImplementation((name): any => name === "feature_ask_to_join");
+            });
+
+            afterEach(() => {
+                getValueSpy.mockRestore();
+            });
+
+            it("should display a notification for a knock", () => {
+                const knockEvent = mkKnockEvent();
+                notifier.displayPopupNotification(knockEvent, testRoom);
+                expect(MockPlatform.displayNotification).toHaveBeenCalledWith(
+                    testRoom.name,
+                    "@alice:example.org is requesting to join",
+                    expect.any(String),
+                    testRoom,
+                    knockEvent,
+                );
+            });
+
+            it("should include the knock reason in the notification", () => {
+                const knockEvent = mkKnockEvent("Let me in please!");
+                notifier.displayPopupNotification(knockEvent, testRoom);
+                expect(MockPlatform.displayNotification).toHaveBeenCalledWith(
+                    testRoom.name,
+                    "@alice:example.org is requesting to join: Let me in please!",
+                    expect.any(String),
+                    testRoom,
+                    knockEvent,
+                );
+            });
+
+            it("should not display a notification for a knock when the ask to join labs flag is disabled", () => {
+                getValueSpy.mockReturnValue(false);
+                notifier.displayPopupNotification(mkKnockEvent(), testRoom);
+                expect(MockPlatform.displayNotification).not.toHaveBeenCalled();
+            });
         });
     });
 

--- a/apps/web/test/unit-tests/TextForEvent-test.tsx
+++ b/apps/web/test/unit-tests/TextForEvent-test.tsx
@@ -564,6 +564,103 @@ describe("TextForEvent", () => {
             ).toMatchInlineSnapshot(`"Andy changed their display name and profile picture"`);
         });
 
+        describe("knocks", () => {
+            const knockEvent = (reason?: string): MatrixEvent =>
+                new MatrixEvent({
+                    type: "m.room.member",
+                    sender: "@a:foo",
+                    content: {
+                        membership: KnownMembership.Knock,
+                        reason,
+                    },
+                    state_key: "@a:foo",
+                });
+
+            beforeEach(() => {
+                (SettingsStore.getValue as jest.Mock).mockImplementation((name) => name === "feature_ask_to_join");
+            });
+
+            afterEach(() => {
+                (SettingsStore.getValue as jest.Mock).mockReturnValue(true);
+            });
+
+            it("should handle knocks", () => {
+                expect(textForEvent(knockEvent(), mockClient)).toMatchInlineSnapshot(`"Member is requesting to join"`);
+            });
+
+            it("should handle knocks with a reason", () => {
+                expect(textForEvent(knockEvent("Let me in please!"), mockClient)).toMatchInlineSnapshot(
+                    `"Member is requesting to join: Let me in please!"`,
+                );
+            });
+
+            it("should handle an accepted knock", () => {
+                expect(
+                    textForEvent(
+                        new MatrixEvent({
+                            type: "m.room.member",
+                            sender: "@b:foo",
+                            content: { membership: KnownMembership.Invite },
+                            unsigned: { prev_content: { membership: KnownMembership.Knock } },
+                            state_key: "@a:foo",
+                        }),
+                        mockClient,
+                    ),
+                ).toMatchInlineSnapshot(`"Member granted access to Member"`);
+            });
+
+            it("should handle a retracted knock", () => {
+                expect(
+                    textForEvent(
+                        new MatrixEvent({
+                            type: "m.room.member",
+                            sender: "@a:foo",
+                            content: { membership: KnownMembership.Leave },
+                            unsigned: { prev_content: { membership: KnownMembership.Knock } },
+                            state_key: "@a:foo",
+                        }),
+                        mockClient,
+                    ),
+                ).toMatchInlineSnapshot(`"Member is no longer interested in joining"`);
+            });
+
+            it("should handle a denied knock", () => {
+                expect(
+                    textForEvent(
+                        new MatrixEvent({
+                            type: "m.room.member",
+                            sender: "@b:foo",
+                            content: { membership: KnownMembership.Leave },
+                            unsigned: { prev_content: { membership: KnownMembership.Knock } },
+                            state_key: "@a:foo",
+                        }),
+                        mockClient,
+                    ),
+                ).toMatchInlineSnapshot(`"Member rejected Member's request to join"`);
+            });
+
+            it("should fall back to the plain invite copy when the ask to join labs flag is disabled", () => {
+                (SettingsStore.getValue as jest.Mock).mockReturnValue(false);
+                expect(
+                    textForEvent(
+                        new MatrixEvent({
+                            type: "m.room.member",
+                            sender: "@b:foo",
+                            content: { membership: KnownMembership.Invite },
+                            unsigned: { prev_content: { membership: KnownMembership.Knock } },
+                            state_key: "@a:foo",
+                        }),
+                        mockClient,
+                    ),
+                ).toMatchInlineSnapshot(`"Member invited Member"`);
+            });
+
+            it("should hide knocks when the ask to join labs flag is disabled", () => {
+                (SettingsStore.getValue as jest.Mock).mockReturnValue(false);
+                expect(textForEvent(knockEvent(), mockClient)).toEqual("");
+            });
+        });
+
         it("should handle rejected invites", () => {
             expect(
                 textForEvent(

--- a/apps/web/test/unit-tests/components/views/elements/EventListSummary-test.tsx
+++ b/apps/web/test/unit-tests/components/views/elements/EventListSummary-test.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../../../test-utils";
 import EventListSummary from "../../../../../src/components/views/elements/EventListSummary";
 import { Layout } from "../../../../../src/settings/enums/Layout";
+import SettingsStore from "../../../../../src/settings/SettingsStore";
 import MatrixClientContext from "../../../../../src/contexts/MatrixClientContext";
 import * as languageSettings from "../../../../../src/i18n/settings";
 
@@ -476,6 +477,8 @@ describe("EventListSummary", function () {
         const events = generateEvents([
             // invited
             { userId: "@user_1:some.domain", membership: KnownMembership.Invite },
+            // knocked
+            { userId: "@user_1:some.domain", membership: KnownMembership.Knock },
             // banned
             { userId: "@user_1:some.domain", membership: KnownMembership.Ban },
             // joined
@@ -535,10 +538,114 @@ describe("EventListSummary", function () {
         const { container } = renderComponent(props);
         const summary = container.querySelector(".mx_GenericEventListSummary_summary");
         expect(summary).toHaveTextContent(
-            "user_1 was invited, was banned, joined, rejected their invitation, left, " +
+            "user_1 was invited, requested to join, was banned, joined, rejected their invitation, left, " +
                 "had their invitation withdrawn, was unbanned, was removed, left and was removed",
         );
         expect(summary).toMatchSnapshot();
+    });
+
+    describe("knocks (ask to join enabled)", () => {
+        let getValueSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            getValueSpy = jest
+                .spyOn(SettingsStore, "getValue")
+                .mockImplementation((name): any => name === "feature_ask_to_join");
+        });
+
+        afterEach(() => {
+            getValueSpy.mockRestore();
+        });
+
+        it("summarises a knock that is accepted and joined", function () {
+            const events = generateEvents([
+                { userId: "@user_1:some.domain", membership: KnownMembership.Knock },
+                {
+                    userId: "@user_1:some.domain",
+                    prevMembership: KnownMembership.Knock,
+                    membership: KnownMembership.Invite,
+                    senderId: "@some_other_user:some.domain",
+                },
+                {
+                    userId: "@user_1:some.domain",
+                    prevMembership: KnownMembership.Invite,
+                    membership: KnownMembership.Join,
+                },
+            ]);
+            const props = {
+                events: events,
+                children: generateTiles(events),
+                summaryLength: 1,
+                avatarsMaxLength: 5,
+                threshold: 3,
+            };
+
+            const { container } = renderComponent(props);
+            const summary = container.querySelector(".mx_GenericEventListSummary_summary");
+            expect(summary).toHaveTextContent("user_1 requested to join, was granted access and joined");
+            expect(summary).toMatchSnapshot();
+        });
+
+        it("summarises a knock that is retracted and one that is denied", function () {
+            const events = generateEvents([
+                { userId: "@user_1:some.domain", membership: KnownMembership.Knock },
+                {
+                    userId: "@user_1:some.domain",
+                    prevMembership: KnownMembership.Knock,
+                    membership: KnownMembership.Leave,
+                    senderId: "@user_1:some.domain",
+                },
+                { userId: "@user_1:some.domain", membership: KnownMembership.Knock },
+                {
+                    userId: "@user_1:some.domain",
+                    prevMembership: KnownMembership.Knock,
+                    membership: KnownMembership.Leave,
+                    senderId: "@some_other_user:some.domain",
+                },
+            ]);
+            const props = {
+                events: events,
+                children: generateTiles(events),
+                summaryLength: 1,
+                avatarsMaxLength: 5,
+                threshold: 3,
+            };
+
+            const { container } = renderComponent(props);
+            const summary = container.querySelector(".mx_GenericEventListSummary_summary");
+            expect(summary).toHaveTextContent(
+                "user_1 requested to join, cancelled their request to join, requested to join and had their request to join rejected",
+            );
+            expect(summary).toMatchSnapshot();
+        });
+
+        it("falls back to invited when the ask to join labs flag is disabled", function () {
+            getValueSpy.mockReturnValue(false);
+            const events = generateEvents([
+                {
+                    userId: "@user_1:some.domain",
+                    prevMembership: KnownMembership.Knock,
+                    membership: KnownMembership.Invite,
+                    senderId: "@some_other_user:some.domain",
+                },
+                {
+                    userId: "@user_1:some.domain",
+                    prevMembership: KnownMembership.Invite,
+                    membership: KnownMembership.Join,
+                },
+            ]);
+            const props = {
+                events: events,
+                children: generateTiles(events),
+                summaryLength: 1,
+                avatarsMaxLength: 5,
+                threshold: 2,
+            };
+
+            const { container } = renderComponent(props);
+            const summary = container.querySelector(".mx_GenericEventListSummary_summary");
+            expect(summary).toHaveTextContent("user_1 was invited and joined");
+        });
     });
 
     it("handles invitation plurals correctly when there are multiple users", function () {

--- a/apps/web/test/unit-tests/components/views/elements/__snapshots__/EventListSummary-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/elements/__snapshots__/EventListSummary-test.tsx.snap
@@ -16,7 +16,7 @@ exports[`EventListSummary correctly identifies transitions 1`] = `
       </span>
     </button>
      
-    was invited, was banned, joined, rejected their invitation, left, had their invitation withdrawn, was unbanned, was removed, left and was removed
+    was invited, requested to join, was banned, joined, rejected their invitation, left, had their invitation withdrawn, was unbanned, was removed, left and was removed
   </span>
 </span>
 `;
@@ -167,6 +167,30 @@ exports[`EventListSummary handles multiple users following the same sequence of 
     </span>
      
     were unbanned, joined and left 2 times and were banned
+  </span>
+</span>
+`;
+
+exports[`EventListSummary knocks (ask to join enabled) summarises a knock that is accepted and joined 1`] = `
+<span
+  class="mx_TextualEvent mx_GenericEventListSummary_summary"
+>
+  <span>
+    user_1
+     
+    requested to join, was granted access and joined
+  </span>
+</span>
+`;
+
+exports[`EventListSummary knocks (ask to join enabled) summarises a knock that is retracted and one that is denied 1`] = `
+<span
+  class="mx_TextualEvent mx_GenericEventListSummary_summary"
+>
+  <span>
+    user_1
+     
+    requested to join, cancelled their request to join, requested to join and had their request to join rejected
   </span>
 </span>
 `;


### PR DESCRIPTION
textForMemberEvent had no knock case, so a knock rendered as nothing: in particular the desktop notification generated by the new MSC4506 knock push rule (users who can accept a knock get pushed) had an empty body. Matches EX wording ("%s is requesting to join").
