### PR TITLE
Fix incorrect plural form in call tile

### DIFF
--- a/packages/shared-components/src/i18n/strings/en_EN.json
+++ b/packages/shared-components/src/i18n/strings/en_EN.json
@@ -243,7 +243,10 @@
                     "title": "Call in progress"
                 },
                 "room": {
-                    "join_count": "%(joinedCount)s joined",
+                    "join_count": {
+                        "one": "%(count)s joined",
+                        "other": "%(count)s joined"
+                    },
                     "title": "Group call in progress"
                 }
             },

--- a/packages/shared-components/src/room/timeline/event-tile/call/ongoing/room/RoomOngoingCallTileView.tsx
+++ b/packages/shared-components/src/room/timeline/event-tile/call/ongoing/room/RoomOngoingCallTileView.tsx
@@ -81,13 +81,12 @@ export function RoomOngoingCallTileView(props: Props): React.ReactNode {
  * the call was ignored (by clicking decline button on the toast).
  */
 function CallJoinedOrIgnoredContent({ snapshot }: { snapshot: RoomOngoingCallTileViewSnapshot }): React.ReactNode {
-    const { facePileViewModel, totalParticipants } = snapshot;
+    const { facePileViewModel, totalParticipants: count } = snapshot;
     const { translate: _t } = useI18n();
-    const joinedCount = totalParticipants;
     return (
         <Flex className={styles.subContainer} gap="6px" align="center">
             <FacePileView classNames={commonStyles.facepile} vm={facePileViewModel} />
-            {_t("timeline|call_tile|ongoing|room|join_count", { joinedCount })}
+            {_t("timeline|call_tile|ongoing|room|join_count", { count })}
         </Flex>
     );
 }


### PR DESCRIPTION
The current translation of `X joined` in a call tile doesn't allow to have different translations according to the numbers of participants. Updated following our [translation doc](https://github.com/element-hq/element-web/blob/develop/docs/translating.md#what-are-somethings) about pluralisation.