### PR TITLE
Room list: fix when a room is added twice

### DIFF
--- a/apps/web/src/stores/room-list-v3/skip-list/RoomSkipList.ts
+++ b/apps/web/src/stores/room-list-v3/skip-list/RoomSkipList.ts
@@ -6,6 +6,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import type { Room } from "matrix-js-sdk/src/matrix";
+import { logger } from "matrix-js-sdk/src/logger";
 import type { Sorter, SortingAlgorithm } from "./sorters";
 import type { Filter, FilterKey } from "./filters";
 import { RoomNode } from "./RoomNode";
@@ -115,12 +116,13 @@ export class RoomSkipList implements Iterable<Room> {
 
     /**
      * Adds a new room to the skiplist.
-     * This method will throw an error if the room is already in the skiplist.
+     * This method does nothing if the room is already in the skiplist.
      * @param room the room to add
      */
     public addNewRoom(room: Room): void {
         if (this.roomNodeMap.has(room.roomId)) {
-            throw new Error(`Can't add room to skiplist: ${room.roomId} is already in the skiplist!`);
+            logger.error(`Can't add room to skiplist: ${room.roomId} is already in the skiplist!`);
+            return;
         }
         this.insertRoom(room);
     }

--- a/apps/web/test/unit-tests/stores/room-list-v3/skip-list/RoomSkipList-test.ts
+++ b/apps/web/test/unit-tests/stores/room-list-v3/skip-list/RoomSkipList-test.ts
@@ -100,10 +100,13 @@ describe("RoomSkipList", () => {
         }
     });
 
-    it("Throws error when same room is added via addNewRoom", () => {
+    it("Room is not duplicated when same room is added via addNewRoom", () => {
         const { skipList, rooms } = generateSkipList();
         const room = rooms[5];
-        expect(() => skipList.addNewRoom(room)).toThrow("Can't add room to skiplist");
+        const sizeBefore = skipList.size;
+        skipList.addNewRoom(room);
+
+        expect(skipList.size).toEqual(sizeBefore);
     });
 
     it("Filters are applied to existing nodes when useNewFilters is called", () => {


### PR DESCRIPTION
Related to https://github.com/element-hq/element-web/issues/34274
In the logs of https://github.com/element-hq/element-web/issues/34274, a lot of:
```
11:30:13.269 Uncaught (in promise) Error: Can't add room to skiplist: !hPnsLOZMwoUvGTFRHH:robin.town is already in the skiplist!
    addNewRoom RoomSkipList.ts:123
    addRoomAndEmit RoomListStoreV3.ts:464
    onAction RoomListStoreV3.ts:350
    onDispatch AsyncStoreWithClient.ts:58
    invokeCallback dispatcher.ts:115
    MatrixDispatcher dispatcher.ts:92
    setTimeout handler*dispatch dispatcher.ts:165
    listener MatrixActionCreators.ts:332
    emit events.js:153
    emit typed-event-emitter.ts:89
    forSource ReEmitter.ts:55
    emit events.js:153
    emit typed-event-emitter.ts:89
    updateMyMembership room.ts:1044
    recalculate room.ts:3363
    injectRoomEvents sync.ts:1876
    processSyncResponse sync.ts:1428
    processSyncResponse sync.ts:1260
    syncFromCache sync.ts:845
    savedSyncPromise sync.ts:727
    promise callback*sync sync.ts:724
    startClient client.ts:1523
    start MatrixClientPeg.ts:349
    startMatrixClient Lifecycle.ts:1065
    doSetLoggedIn Lifecycle.ts:856
    restoreSessionFromStorage Lifecycle.ts:661
    loadSession Lifecycle.ts:202
    loadSession MatrixChat.tsx:571
    promise callback*loadSession MatrixChat.tsx:570
    initSession MatrixChat.tsx:362
    MatrixChat MatrixChat.tsx:295
    componentDidMount MatrixChat.tsx:502
    React 10
    performWorkUntilDeadline scheduler.production.js:151
    scheduler 9295.js:27473
    Webpack 13
687.js:87713:13
```
The error is never catch and we don't know what to do with. Instead this PR logs the error and silently ignore the room if it's already added in the room list.
