### PR TITLE
Fix join call button in header having two labels

### DIFF
--- a/apps/web/src/components/views/rooms/RoomHeader/RoomHeader.tsx
+++ b/apps/web/src/components/views/rooms/RoomHeader/RoomHeader.tsx
@@ -112,7 +112,7 @@ function RoomHeaderButtons({
 
     const joinCallButton = (
         <Tooltip
-            label={
+            description={
                 videoCallDisabledReason ??
                 (activeCallSessionType === CallType.Voice ? _t("voip|voice_call") : _t("voip|video_call"))
             }


### PR DESCRIPTION
Both the tooltip ("Video call") and the aria-label attribute ("Join video call") were trying to set different labels. I propose that the "Video call" tooltip should actually count as a description.