### PR TITLE
Use the full chat width for the bubble layout

### DIFF
--- a/apps/web/playwright/e2e/settings/appearance-user-settings-tab/message-layout-panel.spec.ts
+++ b/apps/web/playwright/e2e/settings/appearance-user-settings-tab/message-layout-panel.spec.ts
@@ -7,10 +7,48 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { expect, test } from ".";
+import { SettingLevel } from "../../../../src/settings/SettingLevel";
+import { Layout } from "../../../../src/settings/enums/Layout";
 
 test.describe("Appearance user settings tab", () => {
     test.use({
         displayName: "Hanako",
+    });
+
+    /**
+     * The bubble layout must use the same width as the modern layout.
+     *
+     * This needs a viewport wide enough that `.mx_RoomView_body` itself exceeds 1200px, which is roughly 1650px once
+     * the room list is accounted for. At the default 1280px viewport the body is far narrower than that, so a
+     * regression here is invisible and this test would pass against it.
+     */
+    test.describe("Wide window", () => {
+        test.use({ viewport: { width: 1800, height: 900 } });
+
+        test("should use the same width for the bubble layout as for the modern layout", async ({
+            page,
+            app,
+            user,
+            util,
+        }) => {
+            await util.createAndDisplayRoom();
+            const timeline = page.locator(".mx_RoomView_timeline");
+            const composer = page.locator(".mx_MessageComposer");
+
+            await app.settings.setValue("layout", null, SettingLevel.DEVICE, Layout.Group);
+            await util.assertModernLayout();
+            const modernTimeline = await timeline.boundingBox();
+            const modernComposer = await composer.boundingBox();
+
+            // Guard the premise: the room body must be wide enough for a width cap to be observable at all.
+            const body = await page.locator(".mx_RoomView_body").boundingBox();
+            expect(body!.width).toBeGreaterThan(1200);
+
+            await app.settings.setValue("layout", null, SettingLevel.DEVICE, Layout.Bubble);
+            await util.assertBubbleLayout();
+            expect(await timeline.boundingBox()).toEqual(modernTimeline);
+            expect(await composer.boundingBox()).toEqual(modernComposer);
+        });
     });
 
     test.describe("Message Layout Panel", () => {

--- a/apps/web/res/css/views/rooms/_EventBubbleTile.pcss
+++ b/apps/web/res/css/views/rooms/_EventBubbleTile.pcss
@@ -6,16 +6,6 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-.mx_RoomView_body[data-layout="bubble"] {
-    .mx_RoomView_timeline,
-    .mx_RoomView_statusArea,
-    .mx_MessageComposer {
-        width: 100%;
-        max-width: 1200px;
-        margin: 0 auto;
-    }
-}
-
 .mx_EventTile[data-layout="bubble"],
 .mx_GenericEventListSummary[data-layout="bubble"] {
     --avatarSize: 32px;


### PR DESCRIPTION
### Problem

In the bubble layout the timeline, status area and composer are centred in a
1200px column. On a window wider than roughly 1650px this leaves a large part of
the chat pane unused on both sides — the conversation sits in a narrow band with
empty canvas either side of it, while the modern layout on the same window uses
the full width.

Measured at a 1800px viewport: the timeline is 1357px wide in the modern layout
and 1200px in the bubble layout. At 2200px it is 1757px vs 1200px, leaving ~280px
of empty canvas on each side.

### Fix

Remove the cap, so the bubble layout uses the full width of the chat pane like the
modern layout does. The three elements fall back to their base rules — the ones the
modern layout already uses — so the two layouts stay in step by construction rather
than through a second set of values. This also restores the timeline's container
half-gap, which the cap's `margin: 0 auto` shorthand had been overriding.

### Tests

Adds a Playwright regression test asserting the bubble layout's timeline and
composer boxes match the modern layout's.

The test sets its own 1800px viewport deliberately. The cap only binds once
`.mx_RoomView_body` exceeds 1200px, which never happens at the suite's default
1280px viewport — so this regression is currently invisible to the test suite and a
test written at the default viewport would pass against it. Verified by mutation:
with the cap restored the test fails (1200 vs 1357).

### Prior art — this is deliberate today, so I appreciate this needs a decision

I'm aware the cap is intentional: it was added in #7458 to close #18072, and
defended in #20504 and #21492. I'm raising this as a PR rather than another issue
because the current behaviour is hard to live with on a wide screen, and #21492 is
still open.

If removing the cap outright is too blunt, the obvious alternative is a setting to
opt out of the centred column — which is what #20504 asked for. Happy to rework it
that way, or to close this in favour of the design discussion on #21492 if that's
preferred.


## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
