### PR TITLE
Include the room name in the room header info button's accessible name

### DIFF
--- a/apps/web/src/components/views/rooms/RoomHeader/RoomHeader.tsx
+++ b/apps/web/src/components/views/rooms/RoomHeader/RoomHeader.tsx
@@ -26,6 +26,7 @@ import { HistoryIcon, UserProfileSolidIcon } from "@vector-im/compound-design-to
 
 import { useRoomName } from "../../../../hooks/useRoomName.ts";
 import { RightPanelPhases } from "../../../../stores/right-panel/RightPanelStorePhases.ts";
+import { useCurrentPhase } from "../../../../hooks/right-panel/useCurrentPhase";
 import { useRoomMemberCount, useRoomMembers } from "../../../../hooks/useRoomMembers.ts";
 import { _t } from "../../../../languageHandler.tsx";
 import { getPlatformCallTypeProps, useRoomCall } from "../../../../hooks/room/useRoomCall.tsx";
@@ -453,6 +454,8 @@ export default function RoomHeader({
     const isRoomEncrypted = useIsEncrypted(sdkContext.client!, room);
     const e2eStatus = useEncryptionStatus(sdkContext.client!, room);
     const askToJoinEnabled = useFeatureEnabled("feature_ask_to_join");
+    const { currentPhase, isOpen: isRightPanelOpen } = useCurrentPhase(room.roomId);
+    const isRoomSummaryOpen = isRightPanelOpen && currentPhase === RightPanelPhases.RoomSummary;
     const onAvatarClick = (): void => {
         defaultDispatcher.dispatch({
             action: "open_room_settings",
@@ -477,7 +480,8 @@ export default function RoomHeader({
                 </WithPresenceIndicator>
                 {/* Disable on-click actions until the room is created */}
                 <button
-                    aria-label={_t("right_panel|room_summary_card|title")}
+                    aria-label={_t("room|header_info_button_label", { roomName })}
+                    aria-expanded={isRoomSummaryOpen}
                     tabIndex={0}
                     onClick={
                         room instanceof LocalRoom

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -2016,6 +2016,7 @@
         },
         "header_avatar_open_settings_label": "Open room settings",
         "header_face_pile_tooltip": "People",
+        "header_info_button_label": "%(roomName)s room info",
         "header_untrusted_label": "Untrusted",
         "inaccessible": "This room or space is not accessible at this time.",
         "inaccessible_name": "%(roomName)s is not accessible at this time.",


### PR DESCRIPTION
## Description

The room header's clickable info area wraps the visible room name heading and toggles the room summary panel, but its `aria-label` was just `_t("right_panel|room_summary_card|title")` ("Room info"). Because `aria-label` on a container overrides all of its text content for assistive technology, this meant a screen reader user tabbing to this control heard only "Room info, button" — the room name itself, which is visually right there, was never announced. The button also had no `aria-expanded`, so there was no way to tell whether the room summary panel was currently open.

This PR includes the room name in the button's accessible name via a new interpolated string, and adds `aria-expanded` driven by the existing `useCurrentPhase` hook (the same one backing `CurrentRightPanelPhaseContext`/`useToggled`, used elsewhere in this file for the icon-only info button's toggle state).

New string added directly to `apps/web/src/i18n/strings/en_EN.json` (the Localazy upload source for this repo, per its own docs) — `room.header_info_button_label`. Reviewer: please pick this string up in Localazy.

Notes: Include the room name in the room header info button's accessible name and add aria-expanded

## Testing strategy

1. Open a room with a screen reader enabled.
2. Tab to the room name/info area in the header.
3. Confirm it announces the room's name together with "room info", and that `aria-expanded` toggles between `false`/`true` as the room info panel is opened and closed.

## Before / after

No visual change — only `aria-label`/`aria-expanded` on the existing button change; nothing changes in the rendered DOM/layout. The difference is only observable via accessibility tools (e.g. the browser's Accessibility Tree inspector or a screen reader), not a screenshot.

## Checklist

- [x] I have read through the [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate TSDoc documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the CLA (account: unclejay80, https://cla-assistant.io/element-hq/element-web).