### PR TITLE
Focus the last message instead of the composer when jumping to the live timeline

### DIFF
--- a/apps/web/src/components/structures/MessagePanel.tsx
+++ b/apps/web/src/components/structures/MessagePanel.tsx
@@ -474,6 +474,18 @@ export default class MessagePanel extends React.Component<IProps, IState> {
         }
     }
 
+    /* move keyboard focus to the last rendered message, if there is one */
+    public focusLastMessage(): void {
+        const events = this.props.events;
+        for (let i = events.length - 1; i >= 0; i--) {
+            const node = this.getNodeForEventId(events[i].getId()!);
+            if (node) {
+                node.focus();
+                return;
+            }
+        }
+    }
+
     private isUnmounting = (): boolean => {
         return this.unmounted;
     };

--- a/apps/web/src/components/structures/RoomView.tsx
+++ b/apps/web/src/components/structures/RoomView.tsx
@@ -1974,7 +1974,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         } else {
             // Otherwise we have to jump manually
             this.messagePanel?.jumpToLiveTimeline();
-            defaultDispatcher.fire(Action.FocusSendMessageComposer);
+            this.messagePanel?.focusLastMessage();
         }
     };
 

--- a/apps/web/src/components/structures/TimelinePanel.tsx
+++ b/apps/web/src/components/structures/TimelinePanel.tsx
@@ -1242,6 +1242,10 @@ class TimelinePanel extends React.Component<IProps, IState> {
         }
     };
 
+    public focusLastMessage = (): void => {
+        this.messagePanel.current?.focusLastMessage();
+    };
+
     public scrollToEventIfNeeded = (eventId: string): void => {
         this.messagePanel.current?.scrollToEventIfNeeded(eventId);
     };


### PR DESCRIPTION
## Description

`RoomView`'s `jumpToLiveTimeline()` — used for the "jump to bottom" affordance and reused when returning to the live timeline from a highlighted/permalinked event — scrolls the timeline to the bottom and then unconditionally fires `Action.FocusSendMessageComposer`. For a screen reader or keyboard user, this steals focus away from the newest message that they most likely just navigated to see, dropping them into the composer instead of letting them hear/read the latest message.

This PR focuses the last rendered message tile instead, reusing the existing `MessagePanel#getNodeForEventId` lookup (already used by `scrollToEventIfNeeded`) rather than introducing a new mechanism. Adds `MessagePanel#focusLastMessage` (iterates `this.props.events` from the end to find the last event with a rendered tile and focuses its DOM node — tiles in the default timeline rendering already carry `tabIndex={-1}`, so they're programmatically focusable) and a thin `TimelinePanel#focusLastMessage` wrapper, matching the existing `jumpToLiveTimeline`/`scrollToEventIfNeeded` delegation pattern between the two components.

Other call sites of `jumpToLiveTimeline` (e.g. `TimelineCard`) and other dispatches of `Action.FocusSendMessageComposer` elsewhere in `RoomView.tsx` are untouched — this only changes the one "jump to bottom" path in `RoomView`.

Notes: Focus the last rendered message instead of the composer after jumping to the live timeline

## Testing strategy

1. Open a room with several messages, scroll up so you're not at the bottom.
2. With a screen reader enabled, activate "jump to bottom" (or send a message from elsewhere so a "jump to latest" affordance appears).
3. Confirm focus lands on the last message tile (announced by the screen reader) rather than the message composer.
4. Confirm the composer can still be focused normally afterwards (e.g. by clicking it or tabbing to it).

## Before / after

No visual change — focus moves to an already-visible message tile instead of the composer; nothing changes in the rendered DOM/layout. The difference is only observable via accessibility tools (e.g. the browser's Accessibility Tree inspector, DOM focus indicator, or a screen reader), not a screenshot.

## Checklist

- [x] I have read through the [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate TSDoc documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the CLA (account: unclejay80, https://cla-assistant.io/element-hq/element-web).