### PR TITLE
Announce the created DM/invite result to screen readers

### DIFF
--- a/apps/web/res/css/views/dialogs/_InviteDialog.pcss
+++ b/apps/web/res/css/views/dialogs/_InviteDialog.pcss
@@ -11,6 +11,19 @@ Please see LICENSE files in the repository root for full details.
     flex-direction: column;
 }
 
+.mx_InviteDialog_completionAnnouncement {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    border: 0;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(100%);
+    white-space: nowrap;
+}
+
 .mx_InviteDialog_transferWrapper .mx_Dialog {
     padding-bottom: $spacing-16;
 }

--- a/apps/web/src/components/views/dialogs/InviteDialog.tsx
+++ b/apps/web/src/components/views/dialogs/InviteDialog.tsx
@@ -179,6 +179,9 @@ interface IInviteDialogState {
 
     /** Error from the last attempt to send invites. */
     errorText?: string;
+
+    /** Message announced to screen readers once the DM/invite completes successfully. */
+    completionAnnouncement: string | null;
 }
 
 export default class InviteDialog extends React.PureComponent<Props, IInviteDialogState> {
@@ -242,6 +245,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
             unknownIdentityUsers: null,
 
             busy: false,
+            completionAnnouncement: null,
         };
     }
 
@@ -401,7 +405,9 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
             const cli = MatrixClientPeg.safeGet();
             const targets = this.convertFilter();
             await startDmOnFirstMessage(cli, targets);
-            this.props.onFinished(true);
+            this.announceCompletionAndFinish(
+                _t("invite|dm_started_announcement", { names: targets.map((t) => t.name).join(", ") }),
+            );
         } catch (err) {
             logger.error(err);
             this.setState({
@@ -410,6 +416,11 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
             });
         }
     };
+
+    private announceCompletionAndFinish(announcement: string): void {
+        this.setState({ completionAnnouncement: announcement });
+        window.setTimeout(() => this.props.onFinished(true), 250);
+    }
 
     private setBusy(busy: boolean): void {
         this.setState({
@@ -443,7 +454,13 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
             const states = await inviter.invite(targetIds);
             if (!this.shouldAbortAfterInviteError(states, inviter, room)) {
                 // handles setting error message too
-                this.props.onFinished(true);
+                const invitedCount = Object.values(states).filter((state) => state === "invited").length;
+                this.announceCompletionAndFinish(
+                    _t("invite|invited_announcement", {
+                        count: invitedCount,
+                        roomName: room.name || _t("common|unnamed_room"),
+                    }),
+                );
             }
         } catch (err) {
             logger.error(err);
@@ -1368,7 +1385,12 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
                 title={title}
                 screenName={this.screenName}
             >
-                <div className="mx_InviteDialog_content">{this.renderMainTab()}</div>
+                <div className="mx_InviteDialog_content">
+                    <div role="status" aria-live="polite" className="mx_InviteDialog_completionAnnouncement">
+                        {this.state.completionAnnouncement}
+                    </div>
+                    {this.renderMainTab()}
+                </div>
             </BaseDialog>
         );
     }

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -1360,6 +1360,7 @@
             "start_chat_title_multiple_users": "Start a chat with these new contacts?",
             "start_chat_title_one_user": "Start a chat with this new contact?"
         },
+        "dm_started_announcement": "You started a conversation with %(names)s",
         "email_caption": "Invite by email",
         "email_limit_one": "Invites by email can only be sent one at a time",
         "email_use_default_is": "Use an identity server to invite by email. <default>Use the default (%(defaultIdentityServerName)s)</default> or manage in <settings>Settings</settings>.",
@@ -1387,6 +1388,10 @@
         "failed_generic": "Operation failed",
         "failed_title": "Failed to invite",
         "invalid_address": "Unrecognised address",
+        "invited_announcement": {
+            "one": "Invited %(count)s person to %(roomName)s",
+            "other": "Invited %(count)s people to %(roomName)s"
+        },
         "name_email_mxid_share_room": "Invite someone using their name, email address, username (like <userId/>) or <a>share this room</a>.",
         "name_email_mxid_share_space": "Invite someone using their name, email address, username (like <userId/>) or <a>share this space</a>.",
         "name_mxid_share_room": "Invite someone using their name, username (like <userId/>) or <a>share this room</a>.",


### PR DESCRIPTION
## Description

`InviteDialog`'s `startDm()` and `inviteUsers()` both close the dialog on success (`onFinished(true)`) with no feedback for assistive technology about what just happened — a sighted user sees the dialog close and the new/updated room appear, but a screen reader user gets silence. No shared "toast"/announcement utility fit this dialog-closing case, so this PR adds a dedicated visually-hidden `role="status" aria-live="polite"` region inside the dialog, populated right before closing:

- `startDm()`: announces who the new conversation was started with.
- `inviteUsers()`: announces how many people were invited and to which room.

Since setting the announcement and calling `onFinished(true)` in the same tick risks both updates being batched into a single React commit (meaning the live-region text change would never actually be painted before the dialog unmounts), the dialog now waits a short moment (250ms) after setting the announcement before actually closing, giving the browser one paint/mutation cycle to register the change for assistive technology.

New strings added directly to `apps/web/src/i18n/strings/en_EN.json` (the Localazy upload source for this repo, per its own docs) — `invite.dm_started_announcement`, `invite.invited_announcement`. Reviewer: please pick these up in Localazy.

Notes: Announce the result of a successful DM creation or room invite to screen readers before closing the dialog

## Testing strategy

1. With a screen reader enabled, open the "Direct Message" dialog, pick a user, and start a chat. Confirm the screen reader announces starting a conversation with that user's name shortly before the dialog closes.
2. With a screen reader enabled, from within a room, open "Invite to this room", pick one or more users, and invite them. Confirm the screen reader announces how many people were invited and to which room shortly before the dialog closes.
3. Confirm the dialog still closes promptly (sub-second delay) and the existing error paths (failed DM, failed invite) are unaffected.

## Before / after

No meaningful visual change — the live region is visually hidden, and the dialog close is delayed by 250ms. The difference is only observable via accessibility tools (e.g. the browser's Accessibility Tree inspector or a screen reader), not a screenshot.

## Checklist

- [x] I have read through the [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate TSDoc documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the CLA (account: unclejay80, https://cla-assistant.io/element-hq/element-web).