### PR TITLE
Focus the expanded quote instead of the composer when clicking a reply preview

### DIFF
--- a/apps/web/src/components/views/elements/ReplyChain.tsx
+++ b/apps/web/src/components/views/elements/ReplyChain.tsx
@@ -12,11 +12,9 @@ import classNames from "classnames";
 import { type MatrixEvent, type Room, type MatrixClient } from "matrix-js-sdk/src/matrix";
 
 import { _t } from "../../../languageHandler";
-import dis from "../../../dispatcher/dispatcher";
 import { makeUserPermalink, type RoomPermalinkCreator } from "../../../utils/permalinks/Permalinks";
 import SettingsStore from "../../../settings/SettingsStore";
 import { getUserNameColorClass } from "../../../utils/FormattingUtils";
-import { Action } from "../../../dispatcher/actions";
 import Spinner from "./Spinner";
 import ReplyTile from "../rooms/ReplyTile";
 import { Pill } from "./Pill";
@@ -66,6 +64,7 @@ export default class ReplyChain extends React.Component<IProps, IState> {
     private unmounted = false;
     private room: Room;
     private blockquoteRef = React.createRef<HTMLQuoteElement>();
+    private quoteElements = new Map<string, HTMLQuoteElement>();
 
     public constructor(props: IProps) {
         super(props);
@@ -174,19 +173,17 @@ export default class ReplyChain extends React.Component<IProps, IState> {
 
     private onQuoteClick = async (): Promise<void> => {
         if (!this.state.loadedEv) return;
-        const events = [this.state.loadedEv, ...this.state.events];
+        const clickedEv = this.state.loadedEv;
+        const events = [clickedEv, ...this.state.events];
 
         let loadedEv: MatrixEvent | null = null;
         if (events.length > 0) {
             loadedEv = await this.getNextEvent(events[0]);
         }
 
-        this.setState({
-            loadedEv,
-            events,
+        this.setState({ loadedEv, events }, () => {
+            this.quoteElements.get(clickedEv.getId()!)?.focus();
         });
-
-        dis.fire(Action.FocusSendMessageComposer);
     };
 
     private getReplyChainColorClass(ev: MatrixEvent): string {
@@ -264,7 +261,19 @@ export default class ReplyChain extends React.Component<IProps, IState> {
                 "mx_ReplyChain--collapsed": isQuoteExpanded === false,
             });
             return (
-                <blockquote ref={this.blockquoteRef} className={classname} key={ev.getId()}>
+                <blockquote
+                    ref={(el) => {
+                        this.blockquoteRef.current = el;
+                        if (el) {
+                            this.quoteElements.set(ev.getId()!, el);
+                        } else {
+                            this.quoteElements.delete(ev.getId()!);
+                        }
+                    }}
+                    tabIndex={-1}
+                    className={classname}
+                    key={ev.getId()}
+                >
                     <ReplyTile
                         mxEvent={ev}
                         permalinkCreator={this.props.permalinkCreator}


### PR DESCRIPTION
## Description

Clicking a collapsed "In reply to ..." quote preview expands the reply chain to reveal the quoted message (`ReplyChain.onQuoteClick`), but the handler then unconditionally fired `Action.FocusSendMessageComposer`, moving keyboard focus to the message composer instead of the message that was just revealed. A keyboard or screen reader user who expands a quote to read it was immediately redirected away from it with no indication of what had just appeared.

This PR tracks each rendered quote's DOM node (a small `Map<eventId, HTMLQuoteElement>` populated via the existing `blockquote` ref callback, alongside the existing `blockquoteRef` used for the ellipsis-measurement logic) and, once the chain re-renders with the newly expanded quote, focuses that quote's element instead of firing `Action.FocusSendMessageComposer`. The quote's `<blockquote>` root gets `tabIndex={-1}` so it's programmatically focusable, matching the same convention `EventTile` already uses for its own timeline tiles.

Notes: Focus the newly expanded quote instead of the message composer after clicking a reply preview

## Testing strategy

1. Open a room containing a message that replies to another reply (a reply chain at least two deep), with a screen reader enabled.
2. Click the "In reply to ..." quote preview to expand it.
3. Confirm keyboard focus (and screen reader announcement) lands on the newly revealed quoted message, not the message composer.
4. If the chain has further nested quotes, repeat and confirm each click focuses the newly revealed quote.

## Before / after

No visual change — only where keyboard focus lands after the click changes; nothing changes in the rendered DOM/layout. The difference is only observable via accessibility tools (e.g. the browser's Accessibility Tree inspector, DOM focus indicator, or a screen reader), not a screenshot.

## Checklist

- [x] I have read through the [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate TSDoc documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the CLA (account: unclejay80, https://cla-assistant.io/element-hq/element-web).