### PR TITLE
Make ended poll list items keyboard-operable

### DIFF
--- a/apps/web/src/components/views/polls/pollHistory/PollListItemEnded.tsx
+++ b/apps/web/src/components/views/polls/pollHistory/PollListItemEnded.tsx
@@ -92,8 +92,22 @@ export const PollListItemEnded: React.FC<Props> = ({ event, poll, onClick }) => 
     }
     const formattedDate = formatLocalDateShort(event.getTs());
 
+    const onKeyDown = (ev: React.KeyboardEvent<HTMLLIElement>): void => {
+        if (ev.key === "Enter" || ev.key === " ") {
+            ev.preventDefault();
+            onClick();
+        }
+    };
+
     return (
-        <li data-testid={`pollListItem-${event.getId()!}`} className="mx_PollListItemEnded" onClick={onClick}>
+        <li
+            data-testid={`pollListItem-${event.getId()!}`}
+            className="mx_PollListItemEnded"
+            onClick={onClick}
+            onKeyDown={onKeyDown}
+            role="button"
+            tabIndex={0}
+        >
             <Tooltip label={_t("right_panel|poll|view_poll")} placement="top" isTriggerInteractive={false}>
                 <div className="mx_PollListItemEnded_content">
                     <div className="mx_PollListItemEnded_title">


### PR DESCRIPTION
## Description

Each item in the poll history list for an ended poll is a `<li>` with an `onClick` handler used to open the poll detail view, but no `role`, `tabIndex`, or keyboard handler. This makes the item unreachable and unactivatable by keyboard, and it is not exposed as an interactive control to assistive technology. This PR adds `role="button"`, `tabIndex={0}`, and an `onKeyDown` handler so Enter/Space activate the item exactly like a click, matching how the rest of the poll list already exposes its interactive controls (e.g. the option radios).

Notes: Give poll history list items for ended polls a keyboard-operable interactive role

## Testing strategy

1. Open a room with an ended poll in the poll history panel.
2. Tab to the poll list item (no mouse).
3. Press Enter, then (in a separate run) press Space, and confirm each opens the poll detail view exactly like a click would.

## Before / after

No visual change — the fix only adds ARIA/keyboard semantics (`role`, `tabIndex`, `onKeyDown`), nothing rendered changes. The difference is only observable via keyboard navigation or the Accessibility Tree inspector, not a screenshot.

## Checklist

- [x] I have read through the [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate TSDoc documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the CLA (account: unclejay80, https://cla-assistant.io/element-hq/element-web).