### PR TITLE
Announce successful kick/ban/unban with a toast

### DIFF
--- a/apps/web/src/components/viewmodels/right_panel/user_info/admin/UserInfoBanButtonViewModel.tsx
+++ b/apps/web/src/components/viewmodels/right_panel/user_info/admin/UserInfoBanButtonViewModel.tsx
@@ -15,6 +15,8 @@ import { bulkSpaceBehaviour } from "../../../../../utils/space";
 import ConfirmSpaceUserActionDialog from "../../../../views/dialogs/ConfirmSpaceUserActionDialog";
 import ConfirmUserActionDialog from "../../../../views/dialogs/ConfirmUserActionDialog";
 import ErrorDialog from "../../../../views/dialogs/ErrorDialog";
+import GenericToast from "../../../../views/toasts/GenericToast";
+import ToastStore from "../../../../../stores/ToastStore";
 import { type RoomAdminToolsProps } from "./UserInfoAdminToolsContainerViewModel";
 
 export interface BanButtonState {
@@ -129,9 +131,21 @@ export const useBanButtonViewModel = (props: RoomAdminToolsProps): BanButtonStat
         bulkSpaceBehaviour(room, rooms, (room) => fn(room.roomId))
             .then(
                 () => {
-                    // NO-OP; rely on the m.room.member event coming down else we could
-                    // get out of sync if we force setState here!
                     logger.info("Ban success");
+                    const toastKey = `ban-success-${member.userId}`;
+                    ToastStore.sharedInstance().addOrReplaceToast({
+                        key: toastKey,
+                        title: _t("common|success"),
+                        props: {
+                            description: isBanned
+                                ? _t("user_info|unban_success", { user: member.name })
+                                : _t("user_info|ban_success", { user: member.name }),
+                            primaryLabel: _t("action|ok"),
+                            onPrimaryClick: () => ToastStore.sharedInstance().dismissToast(toastKey),
+                        },
+                        component: GenericToast,
+                        priority: 40,
+                    });
                 },
                 function (err) {
                     logger.error("Ban error: " + err);

--- a/apps/web/src/components/viewmodels/right_panel/user_info/admin/UserInfoKickButtonViewModel.tsx
+++ b/apps/web/src/components/viewmodels/right_panel/user_info/admin/UserInfoKickButtonViewModel.tsx
@@ -15,6 +15,8 @@ import { bulkSpaceBehaviour } from "../../../../../utils/space";
 import ConfirmSpaceUserActionDialog from "../../../../views/dialogs/ConfirmSpaceUserActionDialog";
 import ConfirmUserActionDialog from "../../../../views/dialogs/ConfirmUserActionDialog";
 import ErrorDialog from "../../../../views/dialogs/ErrorDialog";
+import GenericToast from "../../../../views/toasts/GenericToast";
+import ToastStore from "../../../../../stores/ToastStore";
 import { type RoomAdminToolsProps } from "./UserInfoAdminToolsContainerViewModel";
 
 interface RoomKickButtonState {
@@ -107,9 +109,19 @@ export function useRoomKickButtonViewModel(props: RoomAdminToolsProps): RoomKick
         bulkSpaceBehaviour(room, rooms, (room) => cli.kick(room.roomId, member.userId, reason || undefined))
             .then(
                 () => {
-                    // NO-OP; rely on the m.room.member event coming down else we could
-                    // get out of sync if we force setState here!
                     logger.info("Kick success");
+                    const toastKey = `kick-success-${member.userId}`;
+                    ToastStore.sharedInstance().addOrReplaceToast({
+                        key: toastKey,
+                        title: _t("common|success"),
+                        props: {
+                            description: _t("user_info|kick_success", { user: member.name }),
+                            primaryLabel: _t("action|ok"),
+                            onPrimaryClick: () => ToastStore.sharedInstance().dismissToast(toastKey),
+                        },
+                        component: GenericToast,
+                        priority: 40,
+                    });
                 },
                 function (err) {
                     logger.error("Kick error: " + err);

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -3765,6 +3765,7 @@
         "ban_room_confirm_title": "Ban from %(roomName)s",
         "ban_space_everything": "Ban them from everything I'm able to",
         "ban_space_specific": "Ban them from specific things I'm able to",
+        "ban_success": "%(user)s was banned",
         "deactivate_confirm_action": "Deactivate user",
         "deactivate_confirm_description": "Deactivating this user will remove their devices and prevent them from logging back in. Additionally, they will leave all the rooms they are in. This action cannot be reversed. Are you sure you want to deactivate this user?",
         "deactivate_confirm_title": "Deactivate user?",
@@ -3792,6 +3793,7 @@
         "kick_button_space_everything": "Remove them from everything I'm able to",
         "kick_space_specific": "Remove them from specific things I'm able to",
         "kick_space_warning": "They'll still be able to access whatever you're not an admin of.",
+        "kick_success": "%(user)s was removed",
         "promote_warning": "You will not be able to undo this change as you are promoting the user to have the same power level as yourself.",
         "redact": {
             "confirm_button": {
@@ -3823,6 +3825,7 @@
         "unban_space_everything": "Unban them from everything I'm able to",
         "unban_space_specific": "Unban them from specific things I'm able to",
         "unban_space_warning": "They won't be able to access whatever you're not an admin of.",
+        "unban_success": "%(user)s was unbanned",
         "unignore_button": "Unignore",
         "verification_unavailable": "User verification unavailable",
         "verify_button": "Verify User",


### PR DESCRIPTION
## Description

The kick and ban/unban admin actions in the user info panel only surface feedback when the action fails — a successful kick, ban, or unban is a deliberate no-op on the success path (relying on the eventual `m.room.member` event to update the UI). For a sighted user watching the member list this is usually fine, but a screen reader user gets no confirmation at all that their action succeeded, and no indication anything happened until (or unless) the membership event arrives and updates the list. This PR adds a toast (reusing the existing `ToastStore`/`GenericToast` mechanism already used elsewhere in the app, e.g. `ServerLimitToast`) on the success path of both `useRoomKickButtonViewModel` and `useBanButtonViewModel`, confirming the action with the affected user's name.

New strings added directly to `apps/web/src/i18n/strings/en_EN.json` (the Localazy upload source for this repo, per its own docs) — `user_info.kick_success`, `user_info.ban_success`, `user_info.unban_success`. Reviewer: please pick these strings up in Localazy.

Notes: Show a confirmation toast after a successful kick, ban, or unban action in the user info panel

## Testing strategy

1. As a room admin, open a member's user info panel and click "Remove from room" (kick). Confirm the dialog.
2. Confirm a toast appears announcing the user was removed, with an "OK" button that dismisses it.
3. Repeat for ban and unban.
4. Confirm the existing error-path dialog (on a failed kick/ban) is unchanged.

## Before / after

No change to the error path. On success, a toast now appears where previously nothing was shown; screenshot not meaningful given screen-reader-first nature of the fix, but see: toast appears in the bottom-right toast stack with title "Success" and a description naming the affected user.

## Checklist

- [x] I have read through the [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate TSDoc documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the CLA (account: unclejay80, https://cla-assistant.io/element-hq/element-web).