### PR TITLE
Restore focus and announce the new name after renaming a session

### DIFF
--- a/apps/web/src/components/views/settings/devices/DeviceDetailHeading.tsx
+++ b/apps/web/src/components/views/settings/devices/DeviceDetailHeading.tsx
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { _t } from "../../../../languageHandler";
 import AccessibleButton, { type ButtonEvent } from "../../elements/AccessibleButton";
@@ -111,13 +111,22 @@ const DeviceNameEditor: React.FC<Props & { stopEditing: () => void }> = ({ devic
 
 export const DeviceDetailHeading: React.FC<Props> = ({ device, saveDeviceName }) => {
     const [isEditing, setIsEditing] = useState(false);
+    const renameButtonRef = useRef<HTMLDivElement | null>(null);
+
+    const stopEditing = (): void => {
+        setIsEditing(false);
+        renameButtonRef.current?.focus();
+    };
 
     return isEditing ? (
-        <DeviceNameEditor device={device} saveDeviceName={saveDeviceName} stopEditing={() => setIsEditing(false)} />
+        <DeviceNameEditor device={device} saveDeviceName={saveDeviceName} stopEditing={stopEditing} />
     ) : (
         <div className="mx_DeviceDetailHeading" data-testid="device-detail-heading">
-            <Heading size="4">{device.display_name || device.device_id}</Heading>
+            <Heading size="4">
+                <span aria-live="polite">{device.display_name || device.device_id}</span>
+            </Heading>
             <AccessibleButton
+                ref={renameButtonRef}
                 kind="link_inline"
                 onClick={() => setIsEditing(true)}
                 className="mx_DeviceDetailHeading_renameCta"

--- a/apps/web/src/components/views/settings/devices/DeviceDetailHeading.tsx
+++ b/apps/web/src/components/views/settings/devices/DeviceDetailHeading.tsx
@@ -122,8 +122,8 @@ export const DeviceDetailHeading: React.FC<Props> = ({ device, saveDeviceName })
         <DeviceNameEditor device={device} saveDeviceName={saveDeviceName} stopEditing={stopEditing} />
     ) : (
         <div className="mx_DeviceDetailHeading" data-testid="device-detail-heading">
-            <Heading size="4">
-                <span aria-live="polite">{device.display_name || device.device_id}</span>
+            <Heading size="4" aria-live="polite">
+                {device.display_name || device.device_id}
             </Heading>
             <AccessibleButton
                 ref={renameButtonRef}

--- a/apps/web/test/unit-tests/components/views/settings/devices/__snapshots__/DeviceDetailHeading-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/settings/devices/__snapshots__/DeviceDetailHeading-test.tsx.snap
@@ -79,6 +79,7 @@ exports[`<DeviceDetailHeading /> renders device name 1`] = `
       data-testid="device-detail-heading"
     >
       <h4
+        aria-live="polite"
         class="mx_Heading_h4"
       >
         My device


### PR DESCRIPTION
## Description

Renaming a session (device) swaps out the rename form for a read-only heading + "Rename" button once editing finishes. The form (including whatever element currently has focus) unmounts and the read-only view remounts, but nothing moves focus anywhere — a keyboard or screen reader user is left with focus effectively lost (reset to the document body), and the updated device name is not announced. This PR gives the "Rename" button a ref and focuses it when editing stops (both on save and on cancel), and wraps the displayed device name in an `aria-live="polite"` region so a screen reader announces the new name after a successful rename.

Notes: Restore focus to the Rename button and announce the new device name after a rename

## Testing strategy

1. Open Settings > Sessions, expand a session, click "Rename".
2. Change the name and click "Save". Confirm focus lands back on the "Rename" button (not lost to the document body), and a screen reader announces the new device name.
3. Repeat clicking "Cancel" instead of "Save" — confirm focus still returns to the "Rename" button.

## Before / after

No visual change — the fix only adds a `ref`/`.focus()` call and an `aria-live` region, nothing rendered changes. The difference is only observable via keyboard focus order or a screen reader, not a screenshot.

## Checklist

- [x] I have read through the [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate TSDoc documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the CLA (account: unclejay80, https://cla-assistant.io/element-hq/element-web).