### PR TITLE
Move focus on phase change in the forgot password flow

### DIFF
--- a/apps/web/src/components/structures/auth/ForgotPassword.tsx
+++ b/apps/web/src/components/structures/auth/ForgotPassword.tsx
@@ -80,6 +80,7 @@ export default class ForgotPassword extends React.Component<Props, State> {
     private reset: PasswordReset;
     private fieldPassword: Field | null = null;
     private fieldPasswordConfirm: Field | null = null;
+    private phaseContainerRef = React.createRef<HTMLDivElement>();
 
     public constructor(props: Props) {
         super(props);
@@ -100,13 +101,17 @@ export default class ForgotPassword extends React.Component<Props, State> {
         this.reset = new PasswordReset(this.props.serverConfig.hsUrl, this.props.serverConfig.isUrl);
     }
 
-    public componentDidUpdate(prevProps: Readonly<Props>): void {
+    public componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<State>): void {
         if (
             prevProps.serverConfig.hsUrl !== this.props.serverConfig.hsUrl ||
             prevProps.serverConfig.isUrl !== this.props.serverConfig.isUrl
         ) {
             // Do a liveliness check on the new URLs
             this.checkServerLiveliness(this.props.serverConfig);
+        }
+
+        if (prevState.phase !== this.state.phase) {
+            this.phaseContainerRef.current?.focus();
         }
     }
 
@@ -471,7 +476,11 @@ export default class ForgotPassword extends React.Component<Props, State> {
         return (
             <AuthPage>
                 <AuthHeader />
-                <AuthBody className="mx_AuthBody_forgot-password">{resetPasswordJsx}</AuthBody>
+                <AuthBody className="mx_AuthBody_forgot-password">
+                    <div ref={this.phaseContainerRef} tabIndex={-1}>
+                        {resetPasswordJsx}
+                    </div>
+                </AuthBody>
             </AuthPage>
         );
     }


### PR DESCRIPTION
## Description

`ForgotPassword` steps a user through several phases (enter email, check email, enter new password, done) by swapping which sub-component it renders based on `this.state.phase`, but nothing moves focus when the phase changes. `componentDidUpdate` only reacts to `serverConfig` prop changes; there is no equivalent check for `this.state.phase`, and no `ref`/`.focus()` call anywhere in the file. A screen reader or keyboard user gets no indication that the step changed — focus stays wherever it was (typically on the just-submitted button) and the new phase's content has to be found manually.

This PR adds a `phaseContainerRef` (a `tabIndex={-1}` wrapper div around the rendered phase content) and extends `componentDidUpdate` to compare `prevState.phase` against `this.state.phase`, focusing the container whenever the phase changes. This moves both keyboard focus and the screen reader's point of regard to the start of the new phase's content without needing to add refs inside each of the four phase sub-components individually.

Notes: Move focus to the new step's content when the forgot-password flow's phase changes

## Testing strategy

1. Start the "Forgot password" flow, enter an email, submit.
2. Confirm focus moves to the "check your email" step content (not left on the submit button).
3. Complete verification and enter a new password; confirm focus moves again to the new password step, and again to the final "done" step after submitting.
4. Verify with a screen reader that each phase's content is announced on transition.

## Before / after

No visual change — the fix only adds a non-visual wrapper (`tabIndex={-1}`) and a `.focus()` call in `componentDidUpdate`. The difference is only observable via keyboard focus order or a screen reader, not a screenshot.

## Checklist

- [x] I have read through the [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate TSDoc documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the CLA (account: unclejay80, https://cla-assistant.io/element-hq/element-web).