### PR TITLE
Restore a visible focus indicator on the auth-screen language selector

### DIFF
--- a/apps/web/res/css/views/auth/_LanguageSelector.pcss
+++ b/apps/web/res/css/views/auth/_LanguageSelector.pcss
@@ -16,6 +16,10 @@ Please see LICENSE files in the repository root for full details.
     width: auto;
 }
 
+.mx_AuthBody_language .mx_Dropdown_input:focus-visible {
+    outline: 2px solid $accent-alt;
+}
+
 .mx_AuthBody_language .mx_Dropdown_arrow {
     color: $authpage-lang-color;
 }


### PR DESCRIPTION
## Description

`.mx_AuthBody_language .mx_Dropdown_input` (`apps/web/res/css/views/auth/_LanguageSelector.pcss`) sets `border: none` to fit the auth-page styling. The base `.mx_Dropdown_input:focus` rule in `_Dropdown.pcss` indicates focus only via a `border-color` change, so in the auth context — where the border is removed entirely — keyboard focus on the language dropdown becomes invisible. A sighted keyboard user tabbing to the language selector on the login/registration screen has no visual indication that it is focused.

This adds an explicit `:focus-visible` outline scoped to `.mx_AuthBody_language .mx_Dropdown_input`, using the same `$accent-alt` color the base Dropdown style already uses for its own focus indicator, so the visual language stays consistent. The existing `border: none` is left untouched.

Notes: Add a visible focus-visible outline to the auth-screen language dropdown

## Testing strategy

1. Open the login or registration screen.
2. Tab (keyboard only, no mouse) until focus reaches the language selector.
3. Confirm a visible outline appears around it.
4. Confirm mouse clicks do not show the outline (`:focus-visible`, not `:focus`), and that other Dropdown instances elsewhere in the app are unaffected.

## Before / after

Before: tabbing to the auth-screen language dropdown shows no visible change at all. After: a 2px outline appears around the dropdown when it receives keyboard focus. No change to mouse-driven interaction or to any other Dropdown usage outside the auth pages.

## Checklist

- [x] I have read through the [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate TSDoc documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the CLA (account: unclejay80, https://cla-assistant.io/element-hq/element-web).