### PR TITLE
Add a region landmark to the pinned messages panel

### DIFF
--- a/apps/web/src/components/views/right_panel/BaseCard.tsx
+++ b/apps/web/src/components/views/right_panel/BaseCard.tsx
@@ -24,8 +24,9 @@ interface IProps {
     footer?: ReactNode;
     className?: string;
     id?: string;
-    role?: "tabpanel";
+    role?: "tabpanel" | "region";
     ariaLabelledBy?: string;
+    ariaLabel?: string;
     withoutScrollContainer?: boolean;
     closeLabel?: string;
     onClose?(this: void, ev: MouseEvent<HTMLButtonElement>): void;
@@ -44,6 +45,7 @@ const BaseCard: React.FC<IProps> = ({
     className,
     id,
     ariaLabelledBy,
+    ariaLabel,
     role,
     hideHeaderButtons,
     header,
@@ -113,6 +115,7 @@ const BaseCard: React.FC<IProps> = ({
             <div
                 id={id}
                 aria-labelledby={ariaLabelledBy}
+                aria-label={ariaLabel}
                 role={role}
                 className={classNames("mx_BaseCard", className)}
                 ref={ref}

--- a/apps/web/src/components/views/right_panel/PinnedMessagesCard.tsx
+++ b/apps/web/src/components/views/right_panel/PinnedMessagesCard.tsx
@@ -86,6 +86,8 @@ export function PinnedMessagesCard({ room, onClose, permalinkCreator }: PinnedMe
             header={_t("right_panel|pinned_messages|header", { count: pinnedEventIds.length })}
             className="mx_PinnedMessagesCard"
             onClose={onClose}
+            role="region"
+            ariaLabel={_t("right_panel|pinned_messages_button")}
         >
             <ScopedRoomContextProvider {...roomContext} timelineRenderingType={TimelineRenderingType.Pinned}>
                 {content}


### PR DESCRIPTION
## Description

The pinned messages side panel renders as a plain `<div>` with no ARIA landmark role or accessible name. Screen reader users navigating by landmarks have no way to jump directly to it or to recognise it as a distinct named region of the page.

This PR widens `BaseCard`'s `role` prop to also accept `"region"`, adds an optional `ariaLabel` prop that is rendered as `aria-label` on the card's wrapping element, and uses both on `PinnedMessagesCard` so the panel is exposed as `role="region"` with the accessible name "Pinned messages" (reusing the existing `right_panel|pinned_messages_button` string).

Notes: Add a region landmark with an accessible name to the pinned messages panel

## Testing strategy

1. Open a room with at least one pinned message.
2. Open the "Pinned messages" panel from the right panel.
3. Inspect the accessibility tree (e.g. browser DevTools Accessibility panel) or use a screen reader and confirm the panel's container now exposes `role="region"` with the accessible name "Pinned messages".
4. Confirm other consumers of `BaseCard` (which don't pass `role`/`ariaLabel`) are unaffected.

## Before / after

No visual change — only `role="region"` and `aria-label` are added to the existing panel container; appearance and behaviour are unchanged. The difference is only observable via accessibility tools (e.g. the browser's Accessibility Tree inspector or a screen reader), not a screenshot.

## Checklist

- [x] I have read through the [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate TSDoc documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the CLA (account: unclejay80, https://cla-assistant.io/element-hq/element-web).