### PR TITLE
Move keyboard focus to the target message after jumping from pinned messages

### DIFF
--- a/apps/web/src/components/views/rooms/PinnedEventTile.tsx
+++ b/apps/web/src/components/views/rooms/PinnedEventTile.tsx
@@ -35,6 +35,7 @@ import { createRedactEventDialog } from "../dialogs/ConfirmRedactDialog";
 import { type ShowThreadPayload } from "../../../dispatcher/payloads/ShowThreadPayload";
 import PinningUtils from "../../../utils/PinningUtils.ts";
 import PosthogTrackers from "../../../PosthogTrackers.ts";
+import { focusEventTileAfterScroll } from "../../../utils/FocusUtils";
 
 const AVATAR_SIZE = "32px";
 
@@ -160,6 +161,11 @@ function PinMenu({ event, room, permalinkCreator, contentId }: PinMenuProps): JS
             room_id: event.getRoomId(),
             metricsTrigger: undefined, // room doesn't change
         });
+
+        const eventId = event.getId();
+        if (eventId) {
+            focusEventTileAfterScroll(eventId);
+        }
     }, [event]);
 
     /**

--- a/apps/web/src/components/views/rooms/PinnedMessageBanner.tsx
+++ b/apps/web/src/components/views/rooms/PinnedMessageBanner.tsx
@@ -27,6 +27,7 @@ import PosthogTrackers from "../../../PosthogTrackers.ts";
 import { SDKContext } from "../../../contexts/SDKContext.ts";
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import { EventPreviewViewModel } from "../../../viewmodels/room/timeline/event-tile/EventPreviewViewModel";
+import { focusEventTileAfterScroll } from "../../../utils/FocusUtils";
 
 /**
  * The props for the {@link PinnedMessageBanner} component.
@@ -79,6 +80,11 @@ export function PinnedMessageBanner({ room, permalinkCreator }: PinnedMessageBan
             room_id: room.roomId,
             metricsTrigger: undefined, // room doesn't change
         });
+
+        const pinnedEventId = pinnedEvent.getId();
+        if (pinnedEventId) {
+            focusEventTileAfterScroll(pinnedEventId);
+        }
 
         // Cycle through the pinned messages
         // When we reach the first message, we go back to the last message

--- a/apps/web/src/utils/FocusUtils.ts
+++ b/apps/web/src/utils/FocusUtils.ts
@@ -1,0 +1,18 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+const FOCUS_EVENT_TILE_MAX_ATTEMPTS = 90;
+
+export function focusEventTileAfterScroll(eventId: string, attempt = 0): void {
+    const tile = document.querySelector<HTMLElement>(`[data-event-id="${CSS.escape(eventId)}"]`);
+    if (tile) {
+        tile.focus();
+        return;
+    }
+    if (attempt >= FOCUS_EVENT_TILE_MAX_ATTEMPTS) return;
+    requestAnimationFrame(() => focusEventTileAfterScroll(eventId, attempt + 1));
+}


### PR DESCRIPTION
## Description

Jumping to a message from the pinned messages panel or banner — via `PinnedEventTile`'s "View in timeline" menu action, or by clicking the pinned message banner — dispatches `Action.ViewRoom` with the target `event_id`, which scrolls the timeline and highlights the message. Keyboard focus, however, stays on the trigger element (the menu item or the banner button), so keyboard and screen reader users lose their place: the message scrolls into view but nothing tells them, and they'd have to re-navigate the DOM to reach it.

This PR adds `focusEventTileAfterScroll` in a new `apps/web/src/utils/FocusUtils.ts`, and calls it right after both `Action.ViewRoom` dispatches (in `PinnedEventTile`'s `onViewInTimeline` and `PinnedMessageBanner`'s `onBannerClick`), passing the target event's ID. Because timeline scrolling/rendering is asynchronous, the target message tile (`[data-event-id="..."]` in `EventTile`) is not necessarily in the DOM yet when the dispatch returns, so the helper retries via `requestAnimationFrame` for up to 90 attempts (roughly 1.5s at 60fps) until the tile appears, then calls `.focus()` on it; it gives up silently if the tile never appears (e.g. the event failed to load).

Notes: Focus the target message tile after jumping to it from the pinned messages panel/banner

## Testing strategy

1. Pin a couple of messages in a room, open the pinned messages panel.
2. With a screen reader enabled (or just visible focus outline), use the "View in timeline" menu action on a pinned message that isn't currently in view.
3. Confirm the timeline scrolls to and highlights the message, and that keyboard focus lands on the message tile (announced by the screen reader / visible focus ring on the tile), not left on the menu trigger.
4. Repeat by clicking the pinned message banner instead of using the panel.
5. Confirm keyboard navigation (e.g. arrow keys/Tab) from that point continues naturally from the focused message tile.

## Before / after

No visual change beyond the existing scroll/highlight behaviour — the only difference is where keyboard focus ends up afterwards, which is observable via accessibility tools (Accessibility Tree inspector, DOM focus indicator, or a screen reader) rather than a screenshot.

## Checklist

- [x] I have read through the [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate TSDoc documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the CLA (account: unclejay80, https://cla-assistant.io/element-hq/element-web).