### PR TITLE
Hide the redundant sender avatar in the pinned messages panel from assistive technology

### DIFF
--- a/apps/web/src/components/views/avatars/BaseAvatar.tsx
+++ b/apps/web/src/components/views/avatars/BaseAvatar.tsx
@@ -35,6 +35,7 @@ interface IProps {
     altText?: string;
     role?: AriaRole;
     ref?: Ref<HTMLElement>;
+    hidden?: boolean;
 }
 
 const calculateUrls = (url?: string | null, urls?: string[], lowBandwidth = false): string[] => {
@@ -101,6 +102,7 @@ const BaseAvatar = (props: IProps): JSX.Element => {
         type = "round",
         altText = _t("common|avatar"),
         ref,
+        hidden,
         ...otherProps
     } = props;
 
@@ -108,7 +110,11 @@ const BaseAvatar = (props: IProps): JSX.Element => {
 
     const extraProps: Partial<React.ComponentProps<typeof Avatar>> = {};
 
-    if (onClick) {
+    if (hidden) {
+        extraProps["role"] = "presentation";
+        extraProps["aria-hidden"] = true;
+        extraProps["aria-label"] = undefined;
+    } else if (onClick) {
         extraProps["aria-live"] = "off";
         extraProps["role"] = "button";
     } else if (!imageUrl) {

--- a/apps/web/src/components/views/rooms/PinnedEventTile.tsx
+++ b/apps/web/src/components/views/rooms/PinnedEventTile.tsx
@@ -77,6 +77,7 @@ export function PinnedEventTile({ event, room, permalinkCreator }: PinnedEventTi
                     member={event.sender}
                     size={AVATAR_SIZE}
                     fallbackUserId={sender}
+                    hidden
                 />
             </div>
             <div className="mx_PinnedEventTile_wrapper">

--- a/apps/web/test/unit-tests/components/views/rooms/PinnedEventTile-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/PinnedEventTile-test.tsx
@@ -90,6 +90,13 @@ describe("<PinnedEventTile />", () => {
         expect(container).toMatchSnapshot();
     });
 
+    it("should hide the sender avatar from assistive technology", () => {
+        const { container } = renderComponent(makePinEvent());
+        const avatar = container.querySelector('[data-testid="avatar-img"]');
+        expect(avatar).toHaveAttribute("aria-hidden", "true");
+        expect(avatar).not.toHaveAttribute("aria-label");
+    });
+
     it("should render pinned event with thread info", async () => {
         const event = makePinEvent({
             content: {

--- a/apps/web/test/unit-tests/components/views/rooms/__snapshots__/PinnedEventTile-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/rooms/__snapshots__/PinnedEventTile-test.tsx.snap
@@ -8,6 +8,7 @@ exports[`<PinnedEventTile /> should render pinned event 1`] = `
   >
     <div>
       <span
+        aria-hidden="true"
         class="_avatar_va14e_8 mx_BaseAvatar mx_PinnedEventTile_senderAvatar _avatar-imageless_va14e_55"
         data-color="2"
         data-testid="avatar-img"
@@ -87,6 +88,7 @@ exports[`<PinnedEventTile /> should render pinned event with thread info 1`] = `
   >
     <div>
       <span
+        aria-hidden="true"
         class="_avatar_va14e_8 mx_BaseAvatar mx_PinnedEventTile_senderAvatar _avatar-imageless_va14e_55"
         data-color="2"
         data-testid="avatar-img"


### PR DESCRIPTION
## Description

Each row in the "Pinned messages" panel already renders the sender's display name as visible, accessible text right next to their avatar. The avatar image itself currently still exposes its own accessible name (the sender's name, e.g. "Alice") to assistive technology, so a screen reader announces the same name twice for every pinned message row.

This PR adds an optional `hidden` prop to `BaseAvatar`. When set, it takes priority over the existing `onClick`/image-presence branches and marks the underlying element as `role="presentation"` with `aria-hidden="true"`, with no `aria-label` rendered. `PinnedEventTile` now passes `hidden` on the sender's `MemberAvatar`, so the decorative avatar image is skipped by assistive technology while the adjacent name text continues to convey the sender information once.

## Testing strategy

1. Open a room with at least one pinned message.
2. Open the "Pinned messages" panel from the right panel.
3. Inspect the accessibility tree (e.g. browser DevTools Accessibility panel) or use a screen reader and confirm each row's avatar is exposed with `role="presentation"`/`aria-hidden="true"` and no accessible name, while the sender's name text is still announced normally.
4. Confirm other consumers of `BaseAvatar`/`MemberAvatar` that don't pass `hidden` are unaffected.

Added a unit test asserting the pinned message row's avatar carries `aria-hidden="true"` and no `aria-label`, and updated the existing `PinnedEventTile` snapshot to reflect the new attribute.

## Before / after

No visual change — only `role="presentation"` and `aria-hidden="true"` are added to the existing avatar element; appearance and behaviour are unchanged. The difference is only observable via accessibility tools (e.g. the browser's Accessibility Tree inspector or a screen reader), not a screenshot.

## Checklist

- [x] I have read through the [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate TSDoc documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the CLA (account: unclejay80, https://cla-assistant.io/element-hq/element-web).