### PR TITLE
Make resized room list sections scrollable within the outer list

### DIFF
--- a/apps/web/src/settings/Settings.tsx
+++ b/apps/web/src/settings/Settings.tsx
@@ -367,6 +367,7 @@ export interface Settings {
     "RoomList.CustomSectionData": IBaseSetting<CustomSectionsData>;
     "RoomList.OrderedCustomSections": IBaseSetting<ReorderableSection[]>;
     "RoomList.showSections": IBaseSetting<boolean>;
+    "RoomList.sectionVisibleLimits": IBaseSetting<Record<string, Record<string, number>>>;
 }
 
 export type SettingKey = keyof Settings;
@@ -1372,6 +1373,14 @@ export const SETTINGS: Settings = {
     "RoomList.OrderedCustomSections": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         default: [],
+    },
+    /**
+     * Managed by the room list section header view models: how many rooms each section shows,
+     * keyed by space ID then section tag. Sections without an entry show all their rooms.
+     */
+    "RoomList.sectionVisibleLimits": {
+        supportedLevels: [SettingLevel.DEVICE],
+        default: {},
     },
     [UIFeature.RoomHistorySettings]: {
         supportedLevels: LEVELS_UI_FEATURE,

--- a/apps/web/src/viewmodels/room-list/RoomListSectionHeaderViewModel.ts
+++ b/apps/web/src/viewmodels/room-list/RoomListSectionHeaderViewModel.ts
@@ -18,6 +18,7 @@ import { RoomNotificationStateStore } from "../../stores/notifications/RoomNotif
 import { NotificationStateEvents } from "../../stores/notifications/NotificationState";
 import { type RoomNotificationState } from "../../stores/notifications/RoomNotificationState";
 import SettingsStore from "../../settings/SettingsStore";
+import { SettingLevel } from "../../settings/SettingLevel";
 import RoomListStoreV3 from "../../stores/room-list-v3/RoomListStoreV3";
 import {
     CHATS_TAG,
@@ -55,6 +56,13 @@ export class RoomListSectionHeaderViewModel
     private readonly expandedBySpace = new Map<string, boolean>();
 
     /**
+     * Tracks how many rooms of this section to show, per space (the user can shrink a section
+     * by dragging the divider below it). Key is spaceId; absent means show all rooms.
+     * Hydrated from and persisted to the {@link RoomList.sectionVisibleLimits} device setting.
+     */
+    private readonly visibleLimitBySpace = new Map<string, number>();
+
+    /**
      * The calls of the rooms currently in this section that we are listening to, used to aggregate the call decoration.
      */
     private currentCalls = new Set<Call>();
@@ -69,6 +77,11 @@ export class RoomListSectionHeaderViewModel
             displaySectionMenu: !isDefaultSection,
             canBeReordered: !isDefaultSection || props.tag === CHATS_TAG,
         });
+        for (const [spaceId, limits] of Object.entries(SettingsStore.getValue("RoomList.sectionVisibleLimits") ?? {})) {
+            const limit = limits[props.tag];
+            if (typeof limit === "number") this.visibleLimitBySpace.set(spaceId, limit);
+        }
+
         const sectionWatherRef = SettingsStore.watchSetting("RoomList.CustomSectionData", null, () =>
             this.onCustomSectionDataChange(),
         );
@@ -102,6 +115,28 @@ export class RoomListSectionHeaderViewModel
 
         const kind = value ? "Expand" : "Collapse";
         PosthogTrackers.trackCollapseOrExpandSection(kind, "SectionHeader");
+    }
+
+    /**
+     * How many rooms of this section to show for the current space, or undefined to show all.
+     * Set when the user resizes the section by dragging the divider below it; persisted per
+     * device. Setting `undefined` clears the limit (shows all rooms).
+     */
+    public get visibleLimit(): number | undefined {
+        return this.visibleLimitBySpace.get(this.props.spaceId);
+    }
+
+    public set visibleLimit(value: number | undefined) {
+        if (value === undefined) this.visibleLimitBySpace.delete(this.props.spaceId);
+        else this.visibleLimitBySpace.set(this.props.spaceId, value);
+
+        const allLimits = { ...SettingsStore.getValue("RoomList.sectionVisibleLimits") };
+        const spaceLimits = { ...allLimits[this.props.spaceId] };
+        if (value === undefined) delete spaceLimits[this.props.tag];
+        else spaceLimits[this.props.tag] = value;
+        if (Object.keys(spaceLimits).length === 0) delete allLimits[this.props.spaceId];
+        else allLimits[this.props.spaceId] = spaceLimits;
+        void SettingsStore.setValue("RoomList.sectionVisibleLimits", null, SettingLevel.DEVICE, allLimits);
     }
 
     /**

--- a/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
+++ b/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
@@ -168,8 +168,14 @@ export class RoomListViewModel
 
         const filterIds = getVisibleFilterIds();
 
-        // By default, all sections are expanded
-        const { sections, isFlatList } = computeSections(roomsResult, (tag) => true);
+        // By default, all sections are expanded. Section header view models don't exist yet,
+        // so hydrate any persisted visible limits straight from the setting.
+        const initialLimits = SettingsStore.getValue("RoomList.sectionVisibleLimits")?.[roomsResult.spaceId] ?? {};
+        const { sections, isFlatList } = computeSections(
+            roomsResult,
+            (tag) => true,
+            (tag) => initialLimits[tag],
+        );
         const isRoomListEmpty = roomsResult.sections.every((section) => section.rooms.length === 0);
 
         super(props, {
@@ -184,7 +190,7 @@ export class RoomListViewModel
                 filterKeys: undefined,
             },
             isFlatList,
-            sections: toRoomListSection(sections),
+            sections: toRoomListSection(sections, roomsResult.sections),
             canCreateRoom,
         });
 
@@ -512,11 +518,18 @@ export class RoomListViewModel
         if (!section) return;
 
         const headerViewModel = this.roomSectionHeaderViewModels.get(section.tag);
-        // Expand and rebuild the section
+        // Expand the section, and clear any resize limit hiding the room, then rebuild
+        let needsRebuild = false;
         if (headerViewModel && !headerViewModel.isExpanded) {
             headerViewModel.isExpanded = true;
-            await this.updateRoomListData();
+            needsRebuild = true;
         }
+        const indexInSection = section.rooms.findIndex((room) => room.roomId === roomId);
+        if (headerViewModel?.visibleLimit !== undefined && indexInSection >= headerViewModel.visibleLimit) {
+            headerViewModel.visibleLimit = undefined;
+            needsRebuild = true;
+        }
+        if (needsRebuild) await this.updateRoomListData();
 
         // Scroll to the room
         const index = this.getRoomEntryIndex(roomId);
@@ -781,6 +794,7 @@ export class RoomListViewModel
         const { sections, isFlatList } = computeSections(
             this.roomsResult,
             (tag) => this.roomSectionHeaderViewModels.get(tag)?.isExpanded ?? true,
+            (tag) => this.roomSectionHeaderViewModels.get(tag)?.visibleLimit,
         );
         // If it's a flat list, we need to make sure the single section is expanded and has all rooms, otherwise the room list will be empty
         if (isFlatList) {
@@ -796,7 +810,7 @@ export class RoomListViewModel
         // Update filter keys - only update if they have actually changed to prevent unnecessary re-renders of the room list
         const previousFilterKeys = this.snapshot.current.roomListState.filterKeys;
         const newFilterKeys = this.roomsResult.filterKeys?.map((k) => String(k));
-        const viewSections = toRoomListSection(this.sections);
+        const viewSections = toRoomListSection(this.sections, this.roomsResult.sections);
 
         const resolvedScrollToSectionTag =
             scrollToSectionTag && viewSections.some((s) => s.id === scrollToSectionTag)
@@ -946,6 +960,23 @@ export class RoomListViewModel
         this.updateRoomListData();
     };
 
+    /**
+     * Limit how many rooms a section shows (the user resizing the section by dragging the
+     * divider below it, or via its minimise/maximise button). Counts of at least the section's
+     * total (or `undefined`) clear the limit; anything else is clamped to at least one room.
+     */
+    public setSectionVisibleLimit = (tag: string, visibleCount: number | undefined): void => {
+        const headerViewModel = this.roomSectionHeaderViewModels.get(tag);
+        if (!headerViewModel) return;
+
+        const totalCount = this.roomsResult.sections.find((section) => section.tag === tag)?.rooms.length ?? 0;
+        const limit = visibleCount === undefined || visibleCount >= totalCount ? undefined : Math.max(1, visibleCount);
+        if (headerViewModel.visibleLimit === limit) return;
+
+        headerViewModel.visibleLimit = limit;
+        this.updateRoomListData();
+    };
+
     public changeRoomSection = (roomId: string, tag: string): void => {
         const room = this.props.client.getRoom(roomId);
         if (!room) return;
@@ -959,40 +990,53 @@ export class RoomListViewModel
 }
 
 /**
- * Compute the sections to display in the room list based on the rooms result and section expansion state.
+ * Compute the sections to display in the room list based on the rooms result, section expansion state and section visible limits.
  * @param roomsResult - The current rooms result containing sections and rooms
  * @param isSectionExpanded - A function that takes a section tag and returns whether that section is currently expanded
- * @returns An object containing the computed sections (with rooms removed for collapsed sections) and a boolean indicating if this is a flat list (only one section with all rooms)
+ * @param visibleLimitFor - A function that takes a section tag and returns how many of its rooms to show (undefined = all)
+ * @returns An object containing the computed sections (with rooms removed for collapsed sections and truncated for resized sections) and a boolean indicating if this is a flat list (only one section with all rooms)
  */
 function computeSections(
     roomsResult: RoomsResult,
     isSectionExpanded: (tag: string) => boolean,
+    visibleLimitFor: (tag: string) => number | undefined,
 ): { sections: Section[]; isFlatList: boolean } {
     const customSections = getCustomSectionData();
 
-    const sections = roomsResult.sections
-        // Only include sections that have rooms, or custom sections that were created in the current space.
-        .filter(
-            (section) =>
-                section.rooms.length > 0 ||
-                (isCustomSectionTag(section.tag) && customSections[section.tag]?.spaceId === roomsResult.spaceId),
-        )
-        // Remove roomIds for sections that are currently collapsed according to their section header view model
-        .map((section) => ({
-            ...section,
-            rooms: isSectionExpanded(section.tag) ? section.rooms : [],
-        }));
-    const isFlatList = sections.length === 0 || (sections.length === 1 && sections[0].tag === CHATS_TAG);
+    // Only include sections that have rooms, or custom sections that were created in the current space.
+    const filteredSections = roomsResult.sections.filter(
+        (section) =>
+            section.rooms.length > 0 ||
+            (isCustomSectionTag(section.tag) && customSections[section.tag]?.spaceId === roomsResult.spaceId),
+    );
+    // A flat list has no section headers, hence no dividers to undo a resize with, so visible
+    // limits are only applied in section mode.
+    const isFlatList =
+        filteredSections.length === 0 || (filteredSections.length === 1 && filteredSections[0].tag === CHATS_TAG);
+
+    // Remove rooms for sections that are currently collapsed according to their section header
+    // view model, and truncate sections resized to show fewer rooms.
+    const sections = filteredSections.map((section) => {
+        if (!isSectionExpanded(section.tag)) return { ...section, rooms: [] };
+        const limit = isFlatList ? undefined : visibleLimitFor(section.tag);
+        const rooms =
+            limit !== undefined && limit < section.rooms.length ? section.rooms.slice(0, limit) : section.rooms;
+        return { ...section, rooms };
+    });
 
     return { sections, isFlatList };
 }
 
 /**
  * Convert from the internal Section type used in the view model to the RoomListSection type used in the snapshot.
+ * @param sections - The displayed sections (possibly collapsed/truncated)
+ * @param fullSections - The full sections from the rooms result, used to compute each section's total room count
  */
-function toRoomListSection(sections: Section[]): RoomListSection[] {
+function toRoomListSection(sections: Section[], fullSections: Section[]): RoomListSection[] {
+    const totalRoomCounts = new Map(fullSections.map((section) => [section.tag, section.rooms.length]));
     return sections.map(({ tag, rooms }) => ({
         id: tag,
         roomIds: rooms.map((room) => room.roomId),
+        totalRoomCount: totalRoomCounts.get(tag) ?? rooms.length,
     }));
 }

--- a/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
+++ b/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
@@ -118,6 +118,12 @@ export class RoomListViewModel
     // Don't clear section vm because we want to keep the expand/collapse state even during space changes.
     private readonly roomSectionHeaderViewModels = new Map<string, RoomListSectionHeaderViewModel>();
     /**
+     * How far each resized section's visible window is scrolled down its full room list, in
+     * (possibly fractional) rooms, keyed by section tag. Transient UI state: not persisted,
+     * cleared on space changes and when a section's visible limit is cleared.
+     */
+    private readonly sectionScrollOffsets = new Map<string, number>();
+    /**
      * When dragging sections, we want to temporarily expand all sections to make it easier to move rooms between sections.
      * This map stores the original expansion state of each section before the drag starts, so we can restore it after the drag ends.
      */
@@ -169,12 +175,14 @@ export class RoomListViewModel
         const filterIds = getVisibleFilterIds();
 
         // By default, all sections are expanded. Section header view models don't exist yet,
-        // so hydrate any persisted visible limits straight from the setting.
+        // so hydrate any persisted visible limits straight from the setting. Scroll offsets
+        // are transient and start at the top of each section.
         const initialLimits = SettingsStore.getValue("RoomList.sectionVisibleLimits")?.[roomsResult.spaceId] ?? {};
-        const { sections, isFlatList, lastRoomVisibleFractions } = computeSections(
+        const { sections, isFlatList, sectionWindows } = computeSections(
             roomsResult,
             (tag) => true,
             (tag) => initialLimits[tag],
+            (tag) => undefined,
         );
         const isRoomListEmpty = roomsResult.sections.every((section) => section.rooms.length === 0);
 
@@ -190,7 +198,7 @@ export class RoomListViewModel
                 filterKeys: undefined,
             },
             isFlatList,
-            sections: toRoomListSection(sections, roomsResult.sections, lastRoomVisibleFractions),
+            sections: toRoomListSection(sections, roomsResult.sections, sectionWindows),
             canCreateRoom,
         });
 
@@ -509,7 +517,8 @@ export class RoomListViewModel
 
     /**
      * Scroll a room into view, expanding its section first if it is collapsed so the tile can
-     * actually be shown.
+     * actually be shown, and scrolling a resized section's visible window to the room if it is
+     * currently outside it.
      */
     private async scrollRoomIntoView(roomId: string): Promise<void> {
         // Look in the full (pre-collapse) sections so we can find rooms hidden in collapsed sections.
@@ -518,17 +527,27 @@ export class RoomListViewModel
         if (!section) return;
 
         const headerViewModel = this.roomSectionHeaderViewModels.get(section.tag);
-        // Expand the section, and clear any resize limit hiding the room, then rebuild
+        // Expand the section, and scroll its window to the room if a resize limit hides it, then rebuild
         let needsRebuild = false;
         if (headerViewModel && !headerViewModel.isExpanded) {
             headerViewModel.isExpanded = true;
             needsRebuild = true;
         }
-        // A room is only fully shown if the (possibly fractional) limit covers its whole row.
+        // A resized section shows a scrollable window of its rooms: slide the window just far
+        // enough that the room's whole row is inside it (the limit is at least one room, so
+        // the row always fits).
         const indexInSection = section.rooms.findIndex((room) => room.roomId === roomId);
-        if (headerViewModel?.visibleLimit !== undefined && indexInSection + 1 > headerViewModel.visibleLimit) {
-            headerViewModel.visibleLimit = undefined;
-            needsRebuild = true;
+        const limit = headerViewModel?.visibleLimit;
+        if (limit !== undefined) {
+            const maxOffset = Math.max(0, section.rooms.length - limit);
+            const current = Math.min(Math.max(this.sectionScrollOffsets.get(section.tag) ?? 0, 0), maxOffset);
+            let target = current;
+            if (indexInSection < current) target = indexInSection;
+            else if (indexInSection + 1 > current + limit) target = Math.min(indexInSection + 1 - limit, maxOffset);
+            if (target !== current) {
+                this.sectionScrollOffsets.set(section.tag, target);
+                needsRebuild = true;
+            }
         }
         if (needsRebuild) await this.updateRoomListData();
 
@@ -791,11 +810,17 @@ export class RoomListViewModel
             this.getSectionHeaderViewModel(section.tag).setRooms(section.rooms);
         }
 
+        // Section scroll offsets are transient per-space UI state: reset them when the space changes.
+        if (this.snapshot.current.roomListState.spaceId !== this.roomsResult.spaceId) {
+            this.sectionScrollOffsets.clear();
+        }
+
         // Build the complete state atomically to ensure consistency
-        const { sections, isFlatList, lastRoomVisibleFractions } = computeSections(
+        const { sections, isFlatList, sectionWindows } = computeSections(
             this.roomsResult,
             (tag) => this.roomSectionHeaderViewModels.get(tag)?.isExpanded ?? true,
             (tag) => this.roomSectionHeaderViewModels.get(tag)?.visibleLimit,
+            (tag) => this.sectionScrollOffsets.get(tag),
         );
         // If it's a flat list, we need to make sure the single section is expanded and has all rooms, otherwise the room list will be empty
         if (isFlatList) {
@@ -811,7 +836,7 @@ export class RoomListViewModel
         // Update filter keys - only update if they have actually changed to prevent unnecessary re-renders of the room list
         const previousFilterKeys = this.snapshot.current.roomListState.filterKeys;
         const newFilterKeys = this.roomsResult.filterKeys?.map((k) => String(k));
-        const viewSections = toRoomListSection(this.sections, this.roomsResult.sections, lastRoomVisibleFractions);
+        const viewSections = toRoomListSection(this.sections, this.roomsResult.sections, sectionWindows);
 
         const resolvedScrollToSectionTag =
             scrollToSectionTag && viewSections.some((s) => s.id === scrollToSectionTag)
@@ -978,9 +1003,29 @@ export class RoomListViewModel
             const snapped = Math.round(limit);
             limit = snapped >= totalCount ? undefined : snapped;
         }
+        if (limit === undefined) this.sectionScrollOffsets.delete(tag);
         if (headerViewModel.visibleLimit === limit) return;
 
         headerViewModel.visibleLimit = limit;
+        this.updateRoomListData();
+    };
+
+    /**
+     * Scroll a resized section's visible window by a number of rooms (negative scrolls up).
+     * The window slides over the section's full room list, clamped to its ends; the visible
+     * limit itself is unchanged. No-op for sections without a visible limit.
+     */
+    public scrollSectionBy = (tag: string, deltaRooms: number): void => {
+        const limit = this.roomSectionHeaderViewModels.get(tag)?.visibleLimit;
+        if (limit === undefined || !deltaRooms) return;
+
+        const totalCount = this.roomsResult.sections.find((section) => section.tag === tag)?.rooms.length ?? 0;
+        const maxOffset = Math.max(0, totalCount - limit);
+        const current = Math.min(Math.max(this.sectionScrollOffsets.get(tag) ?? 0, 0), maxOffset);
+        const offset = Math.min(Math.max(current + deltaRooms, 0), maxOffset);
+        if (offset === current) return;
+
+        this.sectionScrollOffsets.set(tag, offset);
         this.updateRoomListData();
     };
 
@@ -997,17 +1042,41 @@ export class RoomListViewModel
 }
 
 /**
- * Compute the sections to display in the room list based on the rooms result, section expansion state and section visible limits.
+ * The visible window of a section resized shorter than its content: its (possibly fractional)
+ * height in rooms, how far it is scrolled down the section's full room list, and the visible
+ * fractions of the partially clipped rows at its boundaries.
+ */
+interface SectionWindow {
+    /** Effective (clamped) visible limit in rooms; may be fractional. */
+    visibleLimit: number;
+    /** Effective (clamped) scroll offset in rooms; may be fractional. */
+    scrollOffset: number;
+    /** Visible fraction (0..1 exclusive) of the window's first row, when clipped at the top. */
+    firstRoomVisibleFraction?: number;
+    /** Visible fraction (0..1 exclusive) of the window's last row, when clipped at the bottom. */
+    lastRoomVisibleFraction?: number;
+}
+
+/**
+ * Window bounds within half a percent of a row (about a pixel's worth of fraction) are treated
+ * as sitting exactly on the row edge, so float noise never leaves a sliver of a clipped row.
+ */
+const WINDOW_EDGE_EPSILON = 0.005;
+
+/**
+ * Compute the sections to display in the room list based on the rooms result, section expansion state, section visible limits and scroll offsets.
  * @param roomsResult - The current rooms result containing sections and rooms
  * @param isSectionExpanded - A function that takes a section tag and returns whether that section is currently expanded
  * @param visibleLimitFor - A function that takes a section tag and returns how many of its rooms to show (undefined = all; may be fractional, the boundary row is then partially visible)
- * @returns The computed sections (with rooms removed for collapsed sections and truncated for resized sections), a boolean indicating if this is a flat list (only one section with all rooms), and per-tag visible fractions for boundary rows of fractionally resized sections
+ * @param scrollOffsetFor - A function that takes a section tag and returns how far its visible window is scrolled down its room list, in rooms (undefined = 0; clamped so the window stays within the list)
+ * @returns The computed sections (with rooms removed for collapsed sections and reduced to the visible window for resized sections), a boolean indicating if this is a flat list (only one section with all rooms), and per-tag window data for resized sections
  */
 function computeSections(
     roomsResult: RoomsResult,
     isSectionExpanded: (tag: string) => boolean,
     visibleLimitFor: (tag: string) => number | undefined,
-): { sections: Section[]; isFlatList: boolean; lastRoomVisibleFractions: Map<string, number> } {
+    scrollOffsetFor: (tag: string) => number | undefined,
+): { sections: Section[]; isFlatList: boolean; sectionWindows: Map<string, SectionWindow> } {
     const customSections = getCustomSectionData();
 
     // Only include sections that have rooms, or custom sections that were created in the current space.
@@ -1022,38 +1091,56 @@ function computeSections(
         filteredSections.length === 0 || (filteredSections.length === 1 && filteredSections[0].tag === CHATS_TAG);
 
     // Remove rooms for sections that are currently collapsed according to their section header
-    // view model, and truncate sections resized to show fewer rooms. A fractional limit keeps
-    // the boundary row and records the fraction of it to show.
-    const lastRoomVisibleFractions = new Map<string, number>();
+    // view model, and reduce resized sections to their visible window: `limit` rooms starting
+    // `offset` rooms down the section. Fractional bounds keep the boundary row and record the
+    // fraction of it to show.
+    const sectionWindows = new Map<string, SectionWindow>();
     const sections = filteredSections.map((section) => {
         if (!isSectionExpanded(section.tag)) return { ...section, rooms: [] };
         const limit = isFlatList ? undefined : visibleLimitFor(section.tag);
         if (limit === undefined || limit >= section.rooms.length) return section;
-        const wholeRooms = Math.floor(limit);
-        const fraction = limit - wholeRooms;
-        if (fraction > 0) lastRoomVisibleFractions.set(section.tag, fraction);
-        return { ...section, rooms: section.rooms.slice(0, fraction > 0 ? wholeRooms + 1 : wholeRooms) };
+
+        const maxOffset = section.rooms.length - limit;
+        const offset = Math.min(Math.max(scrollOffsetFor(section.tag) ?? 0, 0), maxOffset);
+        const start = Math.floor(offset + WINDOW_EDGE_EPSILON);
+        const end = offset + limit;
+        const endIndex = Math.ceil(end - WINDOW_EDGE_EPSILON);
+
+        const window: SectionWindow = { visibleLimit: limit, scrollOffset: offset };
+        const firstFraction = 1 - (offset - start);
+        if (firstFraction < 1 - WINDOW_EDGE_EPSILON) window.firstRoomVisibleFraction = firstFraction;
+        const lastFraction = end - (endIndex - 1);
+        if (lastFraction < 1 - WINDOW_EDGE_EPSILON) window.lastRoomVisibleFraction = lastFraction;
+        sectionWindows.set(section.tag, window);
+
+        return { ...section, rooms: section.rooms.slice(start, endIndex) };
     });
 
-    return { sections, isFlatList, lastRoomVisibleFractions };
+    return { sections, isFlatList, sectionWindows };
 }
 
 /**
  * Convert from the internal Section type used in the view model to the RoomListSection type used in the snapshot.
- * @param sections - The displayed sections (possibly collapsed/truncated)
+ * @param sections - The displayed sections (possibly collapsed/reduced to their visible window)
  * @param fullSections - The full sections from the rooms result, used to compute each section's total room count
- * @param lastRoomVisibleFractions - Per-tag visible fraction of the boundary row for fractionally resized sections
+ * @param sectionWindows - Per-tag visible window data for resized sections
  */
 function toRoomListSection(
     sections: Section[],
     fullSections: Section[],
-    lastRoomVisibleFractions: Map<string, number>,
+    sectionWindows: Map<string, SectionWindow>,
 ): RoomListSection[] {
     const totalRoomCounts = new Map(fullSections.map((section) => [section.tag, section.rooms.length]));
-    return sections.map(({ tag, rooms }) => ({
-        id: tag,
-        roomIds: rooms.map((room) => room.roomId),
-        totalRoomCount: totalRoomCounts.get(tag) ?? rooms.length,
-        lastRoomVisibleFraction: lastRoomVisibleFractions.get(tag),
-    }));
+    return sections.map(({ tag, rooms }) => {
+        const window = sectionWindows.get(tag);
+        return {
+            id: tag,
+            roomIds: rooms.map((room) => room.roomId),
+            totalRoomCount: totalRoomCounts.get(tag) ?? rooms.length,
+            visibleLimit: window?.visibleLimit,
+            scrollOffset: window?.scrollOffset,
+            firstRoomVisibleFraction: window?.firstRoomVisibleFraction,
+            lastRoomVisibleFraction: window?.lastRoomVisibleFraction,
+        };
+    });
 }

--- a/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
+++ b/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
@@ -171,7 +171,7 @@ export class RoomListViewModel
         // By default, all sections are expanded. Section header view models don't exist yet,
         // so hydrate any persisted visible limits straight from the setting.
         const initialLimits = SettingsStore.getValue("RoomList.sectionVisibleLimits")?.[roomsResult.spaceId] ?? {};
-        const { sections, isFlatList } = computeSections(
+        const { sections, isFlatList, lastRoomVisibleFractions } = computeSections(
             roomsResult,
             (tag) => true,
             (tag) => initialLimits[tag],
@@ -190,7 +190,7 @@ export class RoomListViewModel
                 filterKeys: undefined,
             },
             isFlatList,
-            sections: toRoomListSection(sections, roomsResult.sections),
+            sections: toRoomListSection(sections, roomsResult.sections, lastRoomVisibleFractions),
             canCreateRoom,
         });
 
@@ -524,8 +524,9 @@ export class RoomListViewModel
             headerViewModel.isExpanded = true;
             needsRebuild = true;
         }
+        // A room is only fully shown if the (possibly fractional) limit covers its whole row.
         const indexInSection = section.rooms.findIndex((room) => room.roomId === roomId);
-        if (headerViewModel?.visibleLimit !== undefined && indexInSection >= headerViewModel.visibleLimit) {
+        if (headerViewModel?.visibleLimit !== undefined && indexInSection + 1 > headerViewModel.visibleLimit) {
             headerViewModel.visibleLimit = undefined;
             needsRebuild = true;
         }
@@ -791,7 +792,7 @@ export class RoomListViewModel
         }
 
         // Build the complete state atomically to ensure consistency
-        const { sections, isFlatList } = computeSections(
+        const { sections, isFlatList, lastRoomVisibleFractions } = computeSections(
             this.roomsResult,
             (tag) => this.roomSectionHeaderViewModels.get(tag)?.isExpanded ?? true,
             (tag) => this.roomSectionHeaderViewModels.get(tag)?.visibleLimit,
@@ -810,7 +811,7 @@ export class RoomListViewModel
         // Update filter keys - only update if they have actually changed to prevent unnecessary re-renders of the room list
         const previousFilterKeys = this.snapshot.current.roomListState.filterKeys;
         const newFilterKeys = this.roomsResult.filterKeys?.map((k) => String(k));
-        const viewSections = toRoomListSection(this.sections, this.roomsResult.sections);
+        const viewSections = toRoomListSection(this.sections, this.roomsResult.sections, lastRoomVisibleFractions);
 
         const resolvedScrollToSectionTag =
             scrollToSectionTag && viewSections.some((s) => s.id === scrollToSectionTag)
@@ -970,7 +971,13 @@ export class RoomListViewModel
         if (!headerViewModel) return;
 
         const totalCount = this.roomsResult.sections.find((section) => section.tag === tag)?.rooms.length ?? 0;
-        const limit = visibleCount === undefined || visibleCount >= totalCount ? undefined : Math.max(1, visibleCount);
+        let limit = visibleCount === undefined || visibleCount >= totalCount ? undefined : Math.max(1, visibleCount);
+        // Snap within a couple of hundredths of a room (about a pixel) to the whole row, so a
+        // drag released on a row boundary doesn't leave a sliver of the next room behind.
+        if (limit !== undefined && Math.abs(limit - Math.round(limit)) < 0.02) {
+            const snapped = Math.round(limit);
+            limit = snapped >= totalCount ? undefined : snapped;
+        }
         if (headerViewModel.visibleLimit === limit) return;
 
         headerViewModel.visibleLimit = limit;
@@ -993,14 +1000,14 @@ export class RoomListViewModel
  * Compute the sections to display in the room list based on the rooms result, section expansion state and section visible limits.
  * @param roomsResult - The current rooms result containing sections and rooms
  * @param isSectionExpanded - A function that takes a section tag and returns whether that section is currently expanded
- * @param visibleLimitFor - A function that takes a section tag and returns how many of its rooms to show (undefined = all)
- * @returns An object containing the computed sections (with rooms removed for collapsed sections and truncated for resized sections) and a boolean indicating if this is a flat list (only one section with all rooms)
+ * @param visibleLimitFor - A function that takes a section tag and returns how many of its rooms to show (undefined = all; may be fractional, the boundary row is then partially visible)
+ * @returns The computed sections (with rooms removed for collapsed sections and truncated for resized sections), a boolean indicating if this is a flat list (only one section with all rooms), and per-tag visible fractions for boundary rows of fractionally resized sections
  */
 function computeSections(
     roomsResult: RoomsResult,
     isSectionExpanded: (tag: string) => boolean,
     visibleLimitFor: (tag: string) => number | undefined,
-): { sections: Section[]; isFlatList: boolean } {
+): { sections: Section[]; isFlatList: boolean; lastRoomVisibleFractions: Map<string, number> } {
     const customSections = getCustomSectionData();
 
     // Only include sections that have rooms, or custom sections that were created in the current space.
@@ -1015,28 +1022,38 @@ function computeSections(
         filteredSections.length === 0 || (filteredSections.length === 1 && filteredSections[0].tag === CHATS_TAG);
 
     // Remove rooms for sections that are currently collapsed according to their section header
-    // view model, and truncate sections resized to show fewer rooms.
+    // view model, and truncate sections resized to show fewer rooms. A fractional limit keeps
+    // the boundary row and records the fraction of it to show.
+    const lastRoomVisibleFractions = new Map<string, number>();
     const sections = filteredSections.map((section) => {
         if (!isSectionExpanded(section.tag)) return { ...section, rooms: [] };
         const limit = isFlatList ? undefined : visibleLimitFor(section.tag);
-        const rooms =
-            limit !== undefined && limit < section.rooms.length ? section.rooms.slice(0, limit) : section.rooms;
-        return { ...section, rooms };
+        if (limit === undefined || limit >= section.rooms.length) return section;
+        const wholeRooms = Math.floor(limit);
+        const fraction = limit - wholeRooms;
+        if (fraction > 0) lastRoomVisibleFractions.set(section.tag, fraction);
+        return { ...section, rooms: section.rooms.slice(0, fraction > 0 ? wholeRooms + 1 : wholeRooms) };
     });
 
-    return { sections, isFlatList };
+    return { sections, isFlatList, lastRoomVisibleFractions };
 }
 
 /**
  * Convert from the internal Section type used in the view model to the RoomListSection type used in the snapshot.
  * @param sections - The displayed sections (possibly collapsed/truncated)
  * @param fullSections - The full sections from the rooms result, used to compute each section's total room count
+ * @param lastRoomVisibleFractions - Per-tag visible fraction of the boundary row for fractionally resized sections
  */
-function toRoomListSection(sections: Section[], fullSections: Section[]): RoomListSection[] {
+function toRoomListSection(
+    sections: Section[],
+    fullSections: Section[],
+    lastRoomVisibleFractions: Map<string, number>,
+): RoomListSection[] {
     const totalRoomCounts = new Map(fullSections.map((section) => [section.tag, section.rooms.length]));
     return sections.map(({ tag, rooms }) => ({
         id: tag,
         roomIds: rooms.map((room) => room.roomId),
         totalRoomCount: totalRoomCounts.get(tag) ?? rooms.length,
+        lastRoomVisibleFraction: lastRoomVisibleFractions.get(tag),
     }));
 }

--- a/apps/web/test/viewmodels/room-list/RoomListSectionHeaderViewModel-test.ts
+++ b/apps/web/test/viewmodels/room-list/RoomListSectionHeaderViewModel-test.ts
@@ -100,6 +100,55 @@ describe("RoomListSectionHeaderViewModel", () => {
         expect(vm.isExpanded).toBe(false);
     });
 
+    describe("visibleLimit", () => {
+        it("should track the visible limit per space and persist it", () => {
+            const setValue = jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
+            const vm = new RoomListSectionHeaderViewModel({
+                tag: "m.favourite",
+                title: "Favourites",
+                spaceId: "!space:server",
+                onToggleExpanded,
+            });
+
+            expect(vm.visibleLimit).toBeUndefined();
+
+            vm.visibleLimit = 5;
+            expect(vm.visibleLimit).toBe(5);
+            expect(setValue).toHaveBeenCalledWith("RoomList.sectionVisibleLimits", null, expect.anything(), {
+                "!space:server": { "m.favourite": 5 },
+            });
+
+            // A different space has its own limit
+            vm.setSpace("!space2:server");
+            expect(vm.visibleLimit).toBeUndefined();
+            vm.setSpace("!space:server");
+            expect(vm.visibleLimit).toBe(5);
+
+            // Clearing the limit removes the persisted entry
+            vm.visibleLimit = undefined;
+            expect(vm.visibleLimit).toBeUndefined();
+            expect(setValue).toHaveBeenLastCalledWith("RoomList.sectionVisibleLimits", null, expect.anything(), {});
+        });
+
+        it("should hydrate the visible limit from the setting", () => {
+            jest.spyOn(SettingsStore, "getValue").mockImplementation((setting) => {
+                if (setting === "RoomList.sectionVisibleLimits") return { "!space:server": { "m.favourite": 3 } };
+                if (setting === "RoomList.OrderedCustomSections") return [];
+                return null;
+            });
+            const vm = new RoomListSectionHeaderViewModel({
+                tag: "m.favourite",
+                title: "Favourites",
+                spaceId: "!space:server",
+                onToggleExpanded,
+            });
+
+            expect(vm.visibleLimit).toBe(3);
+            vm.setSpace("!space2:server");
+            expect(vm.visibleLimit).toBeUndefined();
+        });
+    });
+
     describe("displaySectionMenu", () => {
         it.each([
             [DefaultTagID.Favourite, false],

--- a/apps/web/test/viewmodels/room-list/RoomListViewModel-test.tsx
+++ b/apps/web/test/viewmodels/room-list/RoomListViewModel-test.tsx
@@ -174,6 +174,26 @@ describe("RoomListViewModel", () => {
             expect(viewModel.getSnapshot().sections[0].roomIds).toHaveLength(8);
         });
 
+        it("should keep the boundary row partially visible for a fractional limit", async () => {
+            viewModel.setSectionVisibleLimit(DefaultTagID.Favourite, 5.5);
+            await flushPromises();
+
+            const snapshot = viewModel.getSnapshot();
+            // The partially visible boundary row is included, with its visible fraction
+            expect(snapshot.sections[0].roomIds).toHaveLength(6);
+            expect(snapshot.sections[0].lastRoomVisibleFraction).toBeCloseTo(0.5);
+            expect(snapshot.sections[0].totalRoomCount).toBe(8);
+        });
+
+        it("should snap a near-whole limit to the row boundary", async () => {
+            viewModel.setSectionVisibleLimit(DefaultTagID.Favourite, 5.995);
+            await flushPromises();
+
+            const snapshot = viewModel.getSnapshot();
+            expect(snapshot.sections[0].roomIds).toHaveLength(6);
+            expect(snapshot.sections[0].lastRoomVisibleFraction).toBeUndefined();
+        });
+
         it("should clamp the visible limit", async () => {
             // Below one room clamps to one
             viewModel.setSectionVisibleLimit(DefaultTagID.Favourite, -3);

--- a/apps/web/test/viewmodels/room-list/RoomListViewModel-test.tsx
+++ b/apps/web/test/viewmodels/room-list/RoomListViewModel-test.tsx
@@ -133,6 +133,66 @@ describe("RoomListViewModel", () => {
         });
     });
 
+    describe("Section resizing", () => {
+        let favouriteRooms: Room[];
+
+        beforeEach(() => {
+            jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
+            favouriteRooms = Array.from({ length: 8 }, (_, i) =>
+                mkStubRoom(`!fav${i}:server`, `Favourite ${i}`, matrixClient),
+            );
+            jest.spyOn(RoomListStoreV3.instance, "getSortedRoomsInActiveSpace").mockReturnValue({
+                spaceId: "home",
+                sections: [
+                    { tag: DefaultTagID.Favourite, rooms: favouriteRooms },
+                    { tag: CHATS_TAG, rooms: [room1, room2, room3] },
+                ],
+            });
+            viewModel = new RoomListViewModel({
+                client: matrixClient,
+                spaceStore: SDKContextClass.instance.spaceStore,
+                roomViewStore: SDKContextClass.instance.roomViewStore,
+            });
+            // Section header view models are created lazily by the view
+            viewModel.getSectionHeaderViewModel(DefaultTagID.Favourite);
+        });
+
+        it("should truncate a section to the visible limit and expose the total count", async () => {
+            viewModel.setSectionVisibleLimit(DefaultTagID.Favourite, 5);
+            await flushPromises();
+
+            const snapshot = viewModel.getSnapshot();
+            expect(snapshot.sections[0].roomIds).toEqual(favouriteRooms.slice(0, 5).map((room) => room.roomId));
+            expect(snapshot.sections[0].totalRoomCount).toBe(8);
+            // Other sections are unaffected
+            expect(snapshot.sections[1].roomIds).toHaveLength(3);
+            expect(snapshot.sections[1].totalRoomCount).toBe(3);
+
+            // Clearing the limit shows all rooms again
+            viewModel.setSectionVisibleLimit(DefaultTagID.Favourite, undefined);
+            await flushPromises();
+            expect(viewModel.getSnapshot().sections[0].roomIds).toHaveLength(8);
+        });
+
+        it("should clamp the visible limit", async () => {
+            // Below one room clamps to one
+            viewModel.setSectionVisibleLimit(DefaultTagID.Favourite, -3);
+            await flushPromises();
+            expect(viewModel.getSnapshot().sections[0].roomIds).toHaveLength(1);
+
+            // At least the section's total clears the limit
+            viewModel.setSectionVisibleLimit(DefaultTagID.Favourite, 100);
+            await flushPromises();
+            expect(viewModel.getSnapshot().sections[0].roomIds).toHaveLength(8);
+        });
+
+        it("should ignore sections without a header view model", async () => {
+            viewModel.setSectionVisibleLimit("no-such-section", 5);
+            await flushPromises();
+            expect(viewModel.getSnapshot().sections[0].roomIds).toHaveLength(8);
+        });
+    });
+
     describe("Room list updates", () => {
         it("should update room list when ListsUpdate event fires", () => {
             viewModel = new RoomListViewModel({

--- a/apps/web/test/viewmodels/room-list/RoomListViewModel-test.tsx
+++ b/apps/web/test/viewmodels/room-list/RoomListViewModel-test.tsx
@@ -211,6 +211,109 @@ describe("RoomListViewModel", () => {
             await flushPromises();
             expect(viewModel.getSnapshot().sections[0].roomIds).toHaveLength(8);
         });
+
+        it("should expose the effective visible limit on the section", async () => {
+            viewModel.setSectionVisibleLimit(DefaultTagID.Favourite, 5);
+            await flushPromises();
+
+            const snapshot = viewModel.getSnapshot();
+            expect(snapshot.sections[0].visibleLimit).toBe(5);
+            expect(snapshot.sections[0].scrollOffset).toBe(0);
+            // A section showing all its rooms has no window
+            expect(snapshot.sections[1].visibleLimit).toBeUndefined();
+            expect(snapshot.sections[1].scrollOffset).toBeUndefined();
+        });
+    });
+
+    describe("Section scrolling", () => {
+        let favouriteRooms: Room[];
+
+        beforeEach(() => {
+            jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
+            favouriteRooms = Array.from({ length: 8 }, (_, i) =>
+                mkStubRoom(`!fav${i}:server`, `Favourite ${i}`, matrixClient),
+            );
+            jest.spyOn(RoomListStoreV3.instance, "getSortedRoomsInActiveSpace").mockReturnValue({
+                spaceId: "home",
+                sections: [
+                    { tag: DefaultTagID.Favourite, rooms: favouriteRooms },
+                    { tag: CHATS_TAG, rooms: [room1, room2, room3] },
+                ],
+            });
+            viewModel = new RoomListViewModel({
+                client: matrixClient,
+                spaceStore: SDKContextClass.instance.spaceStore,
+                roomViewStore: SDKContextClass.instance.roomViewStore,
+            });
+            // Section header view models are created lazily by the view
+            viewModel.getSectionHeaderViewModel(DefaultTagID.Favourite);
+        });
+
+        it("should slide the visible window down the section's rooms", async () => {
+            viewModel.setSectionVisibleLimit(DefaultTagID.Favourite, 5);
+            viewModel.scrollSectionBy(DefaultTagID.Favourite, 2);
+            await flushPromises();
+
+            const snapshot = viewModel.getSnapshot();
+            expect(snapshot.sections[0].roomIds).toEqual(favouriteRooms.slice(2, 7).map((room) => room.roomId));
+            expect(snapshot.sections[0].scrollOffset).toBe(2);
+            expect(snapshot.sections[0].visibleLimit).toBe(5);
+            expect(snapshot.sections[0].firstRoomVisibleFraction).toBeUndefined();
+            expect(snapshot.sections[0].lastRoomVisibleFraction).toBeUndefined();
+        });
+
+        it("should clip both boundary rows for a fractional scroll offset", async () => {
+            viewModel.setSectionVisibleLimit(DefaultTagID.Favourite, 5);
+            viewModel.scrollSectionBy(DefaultTagID.Favourite, 1.5);
+            await flushPromises();
+
+            const snapshot = viewModel.getSnapshot();
+            // The window covers rooms 1.5..6.5: rows 1..6 rendered, half of row 1 and row 6 visible
+            expect(snapshot.sections[0].roomIds).toEqual(favouriteRooms.slice(1, 7).map((room) => room.roomId));
+            expect(snapshot.sections[0].firstRoomVisibleFraction).toBeCloseTo(0.5);
+            expect(snapshot.sections[0].lastRoomVisibleFraction).toBeCloseTo(0.5);
+        });
+
+        it("should clamp scrolling to the ends of the section", async () => {
+            viewModel.setSectionVisibleLimit(DefaultTagID.Favourite, 5);
+            viewModel.scrollSectionBy(DefaultTagID.Favourite, 100);
+            await flushPromises();
+            // 8 rooms, 5 visible: the window bottoms out at offset 3
+            expect(viewModel.getSnapshot().sections[0].roomIds).toEqual(
+                favouriteRooms.slice(3, 8).map((room) => room.roomId),
+            );
+            expect(viewModel.getSnapshot().sections[0].scrollOffset).toBe(3);
+
+            viewModel.scrollSectionBy(DefaultTagID.Favourite, -100);
+            await flushPromises();
+            expect(viewModel.getSnapshot().sections[0].scrollOffset).toBe(0);
+            expect(viewModel.getSnapshot().sections[0].roomIds).toEqual(
+                favouriteRooms.slice(0, 5).map((room) => room.roomId),
+            );
+        });
+
+        it("should ignore scrolling a section with no visible limit", async () => {
+            viewModel.scrollSectionBy(DefaultTagID.Favourite, 2);
+            await flushPromises();
+
+            const snapshot = viewModel.getSnapshot();
+            expect(snapshot.sections[0].roomIds).toHaveLength(8);
+            expect(snapshot.sections[0].scrollOffset).toBeUndefined();
+        });
+
+        it("should reset the scroll offset when the limit is cleared", async () => {
+            viewModel.setSectionVisibleLimit(DefaultTagID.Favourite, 5);
+            viewModel.scrollSectionBy(DefaultTagID.Favourite, 2);
+            viewModel.setSectionVisibleLimit(DefaultTagID.Favourite, undefined);
+            viewModel.setSectionVisibleLimit(DefaultTagID.Favourite, 5);
+            await flushPromises();
+
+            // Re-limiting after a clear starts back at the top of the section
+            expect(viewModel.getSnapshot().sections[0].scrollOffset).toBe(0);
+            expect(viewModel.getSnapshot().sections[0].roomIds).toEqual(
+                favouriteRooms.slice(0, 5).map((room) => room.roomId),
+            );
+        });
     });
 
     describe("Room list updates", () => {
@@ -1814,6 +1917,45 @@ describe("RoomListViewModel", () => {
 
             // Entry space: [Fav header(0), fav1(1), fav2(2), Chats header(3), reg1(4)]
             await waitFor(() => expect(scrollSpy).toHaveBeenCalledWith(4));
+        });
+
+        it("should scroll a resized section's window to reveal the room instead of clearing the limit", async () => {
+            jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
+            const favRooms = Array.from({ length: 8 }, (_, i) =>
+                mkStubRoom(`!fav${i}:server`, `Fav ${i}`, matrixClient),
+            );
+            jest.spyOn(RoomListStoreV3.instance, "getSortedRoomsInActiveSpace").mockReturnValue({
+                spaceId: "home",
+                sections: [
+                    { tag: DefaultTagID.Favourite, rooms: favRooms },
+                    { tag: CHATS_TAG, rooms: [room1] },
+                ],
+            });
+            viewModel = new RoomListViewModel({
+                client: matrixClient,
+                roomViewStore: sdkContext.roomViewStore,
+                spaceStore: sdkContext.spaceStore,
+            });
+            viewModel.getSectionHeaderViewModel(DefaultTagID.Favourite);
+            viewModel.setSectionVisibleLimit(DefaultTagID.Favourite, 3);
+            await flushPromises();
+            const scrollSpy = jest.fn();
+            viewModel.setScrollToIndex(scrollSpy);
+
+            dispatcher.dispatch({
+                action: Action.ViewRoom,
+                room_id: "!fav5:server",
+                show_room_tile: true,
+                metricsTrigger: undefined,
+            });
+
+            // The window slides down to rooms 3..5, making fav5 its last row: entry space is
+            // [Fav header(0), fav3(1), fav4(2), fav5(3), ...]
+            await waitFor(() => expect(scrollSpy).toHaveBeenCalledWith(3));
+            const snapshot = viewModel.getSnapshot();
+            expect(snapshot.sections[0].roomIds).toEqual(favRooms.slice(3, 6).map((room) => room.roomId));
+            expect(snapshot.sections[0].visibleLimit).toBe(3);
+            expect(snapshot.sections[0].scrollOffset).toBe(3);
         });
 
         it("should not scroll when the room is not in the current list", async () => {

--- a/packages/shared-components/src/i18n/strings/en_EN.json
+++ b/packages/shared-components/src/i18n/strings/en_EN.json
@@ -182,6 +182,10 @@
             "toggle": "Toggle %(section)s section",
             "toggle_unread": "Toggle %(section)s section with unread rooms"
         },
+        "section_resizer": {
+            "show_all": "Show all",
+            "show_fewer": "Show fewer"
+        },
         "show_message_previews": "Show message previews",
         "sort": "Sort",
         "sort_type": {

--- a/packages/shared-components/src/room-list/RoomListView/RoomListView.stories.tsx
+++ b/packages/shared-components/src/room-list/RoomListView/RoomListView.stories.tsx
@@ -48,6 +48,7 @@ const RoomListViewWrapperImpl = ({
     onSectionDragStart,
     onSectionDragEnd,
     setSectionVisibleLimit,
+    scrollSectionBy,
     ...rest
 }: RoomListViewProps): JSX.Element => {
     const vm = useMockedViewModel(rest, {
@@ -66,6 +67,7 @@ const RoomListViewWrapperImpl = ({
         onSectionDragStart,
         onSectionDragEnd,
         setSectionVisibleLimit,
+        scrollSectionBy,
     });
     return <RoomListView vm={vm} renderAvatar={renderAvatarProp} />;
 };
@@ -126,6 +128,7 @@ const meta = {
         onSectionDragStart: fn(),
         onSectionDragEnd: fn(),
         setSectionVisibleLimit: fn(),
+        scrollSectionBy: fn(),
     },
     parameters: {
         design: {

--- a/packages/shared-components/src/room-list/RoomListView/RoomListView.stories.tsx
+++ b/packages/shared-components/src/room-list/RoomListView/RoomListView.stories.tsx
@@ -47,6 +47,7 @@ const RoomListViewWrapperImpl = ({
     changeSectionOrder,
     onSectionDragStart,
     onSectionDragEnd,
+    setSectionVisibleLimit,
     ...rest
 }: RoomListViewProps): JSX.Element => {
     const vm = useMockedViewModel(rest, {
@@ -64,6 +65,7 @@ const RoomListViewWrapperImpl = ({
         changeSectionOrder,
         onSectionDragStart,
         onSectionDragEnd,
+        setSectionVisibleLimit,
     });
     return <RoomListView vm={vm} renderAvatar={renderAvatarProp} />;
 };
@@ -123,6 +125,7 @@ const meta = {
         changeSectionOrder: fn(),
         onSectionDragStart: fn(),
         onSectionDragEnd: fn(),
+        setSectionVisibleLimit: fn(),
     },
     parameters: {
         design: {

--- a/packages/shared-components/src/room-list/RoomListView/RoomListView.tsx
+++ b/packages/shared-components/src/room-list/RoomListView/RoomListView.tsx
@@ -30,6 +30,12 @@ export type RoomListSection = {
      * unless the section has been resized to show fewer rooms.
      */
     totalRoomCount: number;
+    /**
+     * When the section's visible limit is fractional (mid-resize, or left between two rows),
+     * the fraction (0..1 exclusive) of the LAST room in `roomIds` that is visible — the view
+     * clips that row to this fraction of its height. Absent when the last row is fully shown.
+     */
+    lastRoomVisibleFraction?: number;
 };
 
 /**
@@ -112,8 +118,10 @@ export interface RoomListViewActions {
     onSectionDragEnd: () => void;
     /**
      * Called to limit how many rooms a section shows (resizing the section by dragging the
-     * divider below it, or via its minimise/maximise button). `visibleCount` is clamped by
-     * the view model; `undefined` (or a count of at least the section's total) shows all rooms.
+     * divider below it, or via its minimise/maximise button). `visibleCount` may be fractional
+     * (the boundary row is then partially clipped — see
+     * {@link RoomListSection.lastRoomVisibleFraction}) and is clamped by the view model;
+     * `undefined` (or a count of at least the section's total) shows all rooms.
      */
     setSectionVisibleLimit: (sectionId: string, visibleCount: number | undefined) => void;
 }

--- a/packages/shared-components/src/room-list/RoomListView/RoomListView.tsx
+++ b/packages/shared-components/src/room-list/RoomListView/RoomListView.tsx
@@ -24,6 +24,12 @@ export type RoomListSection = {
     id: string;
     /** Array of room IDs that belong to this section */
     roomIds: string[];
+    /**
+     * The total number of rooms in the section, ignoring any visible-limit truncation
+     * (see {@link RoomListViewActions.setSectionVisibleLimit}). Equal to `roomIds.length`
+     * unless the section has been resized to show fewer rooms.
+     */
+    totalRoomCount: number;
 };
 
 /**
@@ -104,6 +110,12 @@ export interface RoomListViewActions {
     onSectionDragStart: () => void;
     /** Called when a section drag ends (drop or cancel) — restores expansion states */
     onSectionDragEnd: () => void;
+    /**
+     * Called to limit how many rooms a section shows (resizing the section by dragging the
+     * divider below it, or via its minimise/maximise button). `visibleCount` is clamped by
+     * the view model; `undefined` (or a count of at least the section's total) shows all rooms.
+     */
+    setSectionVisibleLimit: (sectionId: string, visibleCount: number | undefined) => void;
 }
 
 /**

--- a/packages/shared-components/src/room-list/RoomListView/RoomListView.tsx
+++ b/packages/shared-components/src/room-list/RoomListView/RoomListView.tsx
@@ -31,9 +31,29 @@ export type RoomListSection = {
      */
     totalRoomCount: number;
     /**
-     * When the section's visible limit is fractional (mid-resize, or left between two rows),
-     * the fraction (0..1 exclusive) of the LAST room in `roomIds` that is visible — the view
-     * clips that row to this fraction of its height. Absent when the last row is fully shown.
+     * The section's effective (clamped) visible limit in rooms — the height of the scrollable
+     * window the section shows when resized shorter than its content; may be fractional.
+     * Absent when the section shows all its rooms.
+     */
+    visibleLimit?: number;
+    /**
+     * How many rooms of the section are scrolled off the top of its visible window (see
+     * {@link RoomListViewActions.scrollSectionBy}); may be fractional. Only present when
+     * `visibleLimit` is set.
+     */
+    scrollOffset?: number;
+    /**
+     * When the section's window is scrolled to a fractional offset, the fraction
+     * (0..1 exclusive) of the FIRST room in `roomIds` that is visible — the view clips that
+     * row to this fraction of its height, cutting off its top edge. Absent when the first
+     * row is fully shown.
+     */
+    firstRoomVisibleFraction?: number;
+    /**
+     * When the bottom of the section's window falls between two rows (mid-resize, or left
+     * between two rows), the fraction (0..1 exclusive) of the LAST room in `roomIds` that is
+     * visible — the view clips that row to this fraction of its height. Absent when the last
+     * row is fully shown.
      */
     lastRoomVisibleFraction?: number;
 };
@@ -124,6 +144,12 @@ export interface RoomListViewActions {
      * `undefined` (or a count of at least the section's total) shows all rooms.
      */
     setSectionVisibleLimit: (sectionId: string, visibleCount: number | undefined) => void;
+    /**
+     * Called to scroll a resized section's visible window by a number of rooms (may be
+     * fractional; negative scrolls up). The window slides over the section's full room list,
+     * clamped to its ends; no-op for sections without a visible limit.
+     */
+    scrollSectionBy: (sectionId: string, deltaRooms: number) => void;
 }
 
 /**

--- a/packages/shared-components/src/room-list/RoomListView/__snapshots__/RoomListView.test.tsx.snap
+++ b/packages/shared-components/src/room-list/RoomListView/__snapshots__/RoomListView.test.tsx.snap
@@ -8286,6 +8286,7 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                     aria-posinset="1"
                     aria-rowindex="1"
                     aria-setsize="23"
+                    class="RoomListSectionHeaderView-module_headerRow"
                     role="row"
                   >
                     <div
@@ -11542,8 +11543,40 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                     aria-posinset="2"
                     aria-rowindex="25"
                     aria-setsize="29"
+                    class="RoomListSectionHeaderView-module_headerRow"
                     role="row"
                   >
+                    <div
+                      aria-hidden="true"
+                      class="RoomListSectionResizer-module_resizer"
+                      data-testid="section-resizer"
+                    >
+                      <button
+                        aria-label="Show fewer"
+                        class="_icon-button_1215g_8 RoomListSectionResizer-module_button"
+                        data-kind="primary"
+                        role="button"
+                        style="--cpd-icon-button-size: 20px;"
+                        tabindex="-1"
+                      >
+                        <div
+                          class="_indicator-icon_147l5_17"
+                          style="--cpd-icon-button-size: 100%;"
+                        >
+                          <svg
+                            fill="currentColor"
+                            height="1em"
+                            viewBox="0 0 24 24"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M12 11.034a1 1 0 0 0 .29.702l.005.005c.18.18.43.29.705.29h8a1 1 0 0 0 0-2h-5.586L22 3.445a1 1 0 0 0-1.414-1.414L14 8.617V3.031a1 1 0 1 0-2 0zm0 1.963a1 1 0 0 0-.29-.702l-.005-.004A1 1 0 0 0 11 12H3a1 1 0 1 0 0 2h5.586L2 20.586A1 1 0 1 0 3.414 22L10 15.414V21a1 1 0 0 0 2 0z"
+                            />
+                          </svg>
+                        </div>
+                      </button>
+                    </div>
                     <div
                       aria-expanded="true"
                       role="gridcell"
@@ -13805,6 +13838,7 @@ exports[`<RoomListView /> > renders SmallSectionList story 1`] = `
                     aria-posinset="1"
                     aria-rowindex="1"
                     aria-setsize="2"
+                    class="RoomListSectionHeaderView-module_headerRow"
                     role="row"
                   >
                     <div
@@ -14152,8 +14186,14 @@ exports[`<RoomListView /> > renders SmallSectionList story 1`] = `
                     aria-posinset="2"
                     aria-rowindex="4"
                     aria-setsize="0"
+                    class="RoomListSectionHeaderView-module_headerRow"
                     role="row"
                   >
+                    <div
+                      aria-hidden="true"
+                      class="RoomListSectionResizer-module_resizer"
+                      data-testid="section-resizer"
+                    />
                     <div
                       aria-expanded="true"
                       role="gridcell"

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionHeaderView/RoomListSectionHeaderView.module.css
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionHeaderView/RoomListSectionHeaderView.module.css
@@ -5,6 +5,11 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
+/* Anchor for the absolutely-positioned resize divider along the row's top edge. */
+.headerRow {
+    position: relative;
+}
+
 .header {
     /* Remove button default style */
     background: unset;

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionHeaderView/RoomListSectionHeaderView.tsx
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionHeaderView/RoomListSectionHeaderView.tsx
@@ -5,7 +5,7 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-import React, { memo, type JSX, type FocusEvent, useEffect, useRef, useState } from "react";
+import React, { memo, type JSX, type FocusEvent, type ReactNode, useEffect, useRef, useState } from "react";
 import classNames from "classnames";
 import { useDraggable, useDragOperation, useDroppable } from "@dnd-kit/react";
 import { useMergeRefs } from "react-merge-refs";
@@ -75,6 +75,11 @@ export interface RoomListSectionHeaderViewProps {
     sectionCount: number;
     /** Number of rooms in this section */
     roomCountInSection: number;
+    /**
+     * Optional resize divider rendered along this header's top edge (it resizes the section
+     * ABOVE this one). A pointer-only affordance, hidden from the accessibility tree.
+     */
+    resizer?: ReactNode;
 }
 
 /**
@@ -104,6 +109,7 @@ export const RoomListSectionHeaderView = memo(function RoomListSectionHeaderView
     sectionIndex,
     sectionCount,
     roomCountInSection,
+    resizer,
 }: Readonly<RoomListSectionHeaderViewProps>): JSX.Element {
     const { translate: _t } = useI18n();
     const { id, title, isExpanded, isUnread, canBeReordered } = useViewModel(vm);
@@ -194,8 +200,10 @@ export const RoomListSectionHeaderView = memo(function RoomListSectionHeaderView
     return (
         <div
             aria-expanded={ariaExpanded}
+            className={styles.headerRow}
             {...getGroupHeaderAccessibleProps(indexInList, sectionIndex, roomCountInSection)}
         >
+            {resizer}
             <div role="gridcell" aria-expanded={ariaExpanded}>
                 <button
                     ref={buttonRef}

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionHeaderView/__snapshots__/RoomListSectionHeaderView.test.tsx.snap
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionHeaderView/__snapshots__/RoomListSectionHeaderView.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`<RoomListSectionHeaderView /> stories > renders Default story 1`] = `
       aria-posinset="2"
       aria-rowindex="4"
       aria-setsize="5"
+      class="RoomListSectionHeaderView-module_headerRow"
       role="row"
     >
       <div

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionResizer/RoomListSectionResizer.module.css
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionResizer/RoomListSectionResizer.module.css
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+/*
+The hit area straddles the gap between the last room of the section above and this header:
+rooms leave 8px of padding below themselves and the header has 4px above, so a 16px band
+centred on the boundary covers the visual gap without eating into the header pill.
+*/
+.resizer {
+    position: absolute;
+    top: calc(-1 * var(--cpd-space-2x));
+    left: 0;
+    right: 0;
+    height: var(--cpd-space-4x);
+    z-index: 2;
+    cursor: ns-resize;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Hairline shown while hovering or dragging, marking the divider being resized. */
+.resizer::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    inset-inline: var(--cpd-space-3x);
+    height: 1px;
+    background: transparent;
+}
+
+.resizer:hover::before,
+.resizer.dragging::before {
+    background: var(--cpd-color-border-interactive-hovered);
+}
+
+/*
+The minimise/maximise button, revealed on hover. visibility (not display) so the flex layout
+is stable, and because the hidden button must not catch pointer events meant for the divider.
+*/
+.button {
+    visibility: hidden;
+    background: var(--cpd-color-bg-canvas-default);
+    border: 1px solid var(--cpd-color-border-interactive-secondary);
+}
+
+.resizer:hover .button {
+    visibility: visible;
+}
+
+/* While dragging, the button would flicker under the pointer — keep it hidden. */
+.resizer.dragging .button {
+    visibility: hidden;
+}

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionResizer/RoomListSectionResizer.test.tsx
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionResizer/RoomListSectionResizer.test.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@test-utils";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import userEvent from "@testing-library/user-event";
+
+import { MINIMISED_SECTION_VISIBLE_COUNT, RoomListSectionResizer } from "./RoomListSectionResizer";
+
+const ITEM_HEIGHT = 52;
+
+function renderResizer(props: Partial<React.ComponentProps<typeof RoomListSectionResizer>> = {}): {
+    onResize: ReturnType<typeof vi.fn>;
+    handle: HTMLElement;
+    unmount: () => void;
+} {
+    const onResize = vi.fn();
+    const { unmount } = render(
+        <RoomListSectionResizer
+            sectionId="favourites"
+            visibleCount={10}
+            totalCount={10}
+            itemHeight={ITEM_HEIGHT}
+            onResize={onResize}
+            {...props}
+        />,
+    );
+    return { onResize, handle: screen.getByTestId("section-resizer"), unmount };
+}
+
+function pointerMove(clientY: number): void {
+    window.dispatchEvent(new PointerEvent("pointermove", { clientY, bubbles: true }));
+}
+
+function pointerUp(): void {
+    window.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+}
+
+describe("<RoomListSectionResizer />", () => {
+    afterEach(() => {
+        // A test may end mid-drag; make sure no body styles leak between tests.
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+    });
+
+    it("shrinks the section one room per item height when dragging up", () => {
+        const { onResize, handle } = renderResizer();
+
+        fireEvent.pointerDown(handle, { button: 0, clientY: 400 });
+        expect(document.body.style.cursor).toBe("ns-resize");
+
+        pointerMove(400 - 2 * ITEM_HEIGHT);
+        expect(onResize).toHaveBeenLastCalledWith("favourites", 8);
+
+        pointerMove(400 - 5 * ITEM_HEIGHT);
+        expect(onResize).toHaveBeenLastCalledWith("favourites", 5);
+
+        pointerUp();
+        expect(document.body.style.cursor).toBe("");
+
+        // Released: further moves change nothing.
+        onResize.mockClear();
+        pointerMove(100);
+        expect(onResize).not.toHaveBeenCalled();
+    });
+
+    it("clamps the drag to at least one room and reports show-all past the total", () => {
+        const { onResize, handle } = renderResizer({ visibleCount: 3, totalCount: 5 });
+
+        fireEvent.pointerDown(handle, { button: 0, clientY: 400 });
+
+        // Well past the top room (but still inside the viewport): clamped to a single room.
+        pointerMove(0);
+        expect(onResize).toHaveBeenLastCalledWith("favourites", 1);
+
+        // Past the section's total: everything is shown, reported as undefined (no limit).
+        pointerMove(400 + 2 * ITEM_HEIGHT);
+        expect(onResize).toHaveBeenLastCalledWith("favourites", undefined);
+        pointerUp();
+    });
+
+    it("keeps resizing at the last speed when the pointer leaves the viewport", async () => {
+        const { onResize, handle } = renderResizer();
+
+        fireEvent.pointerDown(handle, { button: 0, clientY: 400 });
+        // Establish an upward velocity with a couple of spaced-out samples.
+        for (let i = 1; i <= 3; i++) {
+            await new Promise((resolve) => setTimeout(resolve, 20));
+            pointerMove(400 - i * 40);
+        }
+        // Exit through the top of the viewport: the resize keeps going at the same
+        // speed and eventually hits the one-room clamp.
+        pointerMove(-10);
+        await waitFor(() => expect(onResize).toHaveBeenLastCalledWith("favourites", 1));
+        pointerUp();
+    });
+
+    it("cleans up an in-progress drag when unmounted", () => {
+        const { onResize, handle, unmount } = renderResizer();
+
+        fireEvent.pointerDown(handle, { button: 0, clientY: 400 });
+        expect(document.body.style.cursor).toBe("ns-resize");
+
+        unmount();
+        expect(document.body.style.cursor).toBe("");
+
+        onResize.mockClear();
+        pointerMove(100);
+        expect(onResize).not.toHaveBeenCalled();
+    });
+
+    // The resizer is deliberately aria-hidden (a pointer-only affordance), so the buttons are
+    // found by their aria-label attribute rather than by accessible name.
+    it("shows a maximise button when the section is shrunken", async () => {
+        const user = userEvent.setup();
+        const { onResize, handle } = renderResizer({ visibleCount: 5 });
+
+        const button = handle.querySelector<HTMLButtonElement>('[aria-label="Show all"]')!;
+        expect(button).not.toBeNull();
+        await user.click(button);
+        expect(onResize).toHaveBeenCalledWith("favourites", undefined);
+    });
+
+    it("shows a minimise button when the section is fully shown", async () => {
+        const user = userEvent.setup();
+        const { onResize, handle } = renderResizer();
+
+        const button = handle.querySelector<HTMLButtonElement>('[aria-label="Show fewer"]')!;
+        expect(button).not.toBeNull();
+        await user.click(button);
+        expect(onResize).toHaveBeenCalledWith("favourites", MINIMISED_SECTION_VISIBLE_COUNT);
+    });
+
+    it("shows no button when a full section is too small to minimise", () => {
+        const { handle } = renderResizer({ visibleCount: 4, totalCount: 4 });
+        expect(handle.querySelector("button")).toBeNull();
+    });
+});

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionResizer/RoomListSectionResizer.test.tsx
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionResizer/RoomListSectionResizer.test.tsx
@@ -48,7 +48,7 @@ describe("<RoomListSectionResizer />", () => {
         document.body.style.userSelect = "";
     });
 
-    it("shrinks the section one room per item height when dragging up", () => {
+    it("resizes the section smoothly as the pointer moves", () => {
         const { onResize, handle } = renderResizer();
 
         fireEvent.pointerDown(handle, { button: 0, clientY: 400 });
@@ -56,6 +56,10 @@ describe("<RoomListSectionResizer />", () => {
 
         pointerMove(400 - 2 * ITEM_HEIGHT);
         expect(onResize).toHaveBeenLastCalledWith("favourites", 8);
+
+        // The count is continuous, not snapped to whole rows.
+        pointerMove(400 - 2.5 * ITEM_HEIGHT);
+        expect(onResize).toHaveBeenLastCalledWith("favourites", 7.5);
 
         pointerMove(400 - 5 * ITEM_HEIGHT);
         expect(onResize).toHaveBeenLastCalledWith("favourites", 5);

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionResizer/RoomListSectionResizer.tsx
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionResizer/RoomListSectionResizer.tsx
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import React, { memo, useCallback, useEffect, useRef, useState, type JSX } from "react";
+import classNames from "classnames";
+import { IconButton } from "@vector-im/compound-web";
+import CollapseIcon from "@vector-im/compound-design-tokens/assets/web/icons/collapse";
+import ExpandIcon from "@vector-im/compound-design-tokens/assets/web/icons/expand";
+
+import styles from "./RoomListSectionResizer.module.css";
+import { useI18n } from "../../../core/i18n/i18nContext";
+
+/** The number of rooms a section is shrunk to by its minimise button. */
+export const MINIMISED_SECTION_VISIBLE_COUNT = 5;
+
+/**
+ * Props for {@link RoomListSectionResizer}.
+ */
+export interface RoomListSectionResizerProps {
+    /** The ID of the section ABOVE this divider — the one the divider resizes. */
+    sectionId: string;
+    /** How many rooms of that section are currently shown. */
+    visibleCount: number;
+    /** How many rooms that section has in total (ignoring truncation). */
+    totalCount: number;
+    /** Height in pixels of one room list item, used to quantise the drag into whole rooms. */
+    itemHeight: number;
+    /** Called with the new visible count while resizing; `undefined` shows all rooms. */
+    onResize: (sectionId: string, visibleCount: number | undefined) => void;
+}
+
+/** Mutable state for an in-progress divider drag. */
+interface DragState {
+    /** Pointer Y at drag start. */
+    startY: number;
+    /** Visible room count at drag start. */
+    startCount: number;
+    /** Last observed pointer Y, for velocity measurement. */
+    lastY: number;
+    /** Timestamp of the last velocity/animation sample (ms). */
+    lastT: number;
+    /** Smoothed pointer velocity in px/ms, kept while the pointer is inside the viewport. */
+    velocity: number;
+    /** The drag distance in px driving the resize — pointer-derived inside the viewport, velocity-driven outside. */
+    virtualDelta: number;
+    /** The visible count last sent to onResize, to avoid redundant updates. */
+    lastSent: number;
+    /** Whether the pointer is currently outside the viewport (velocity mode). */
+    outside: boolean;
+    /** Handle of the velocity-mode animation frame, if one is scheduled. */
+    raf: number | null;
+    /** The body cursor/user-select values to restore when the drag ends. */
+    restoreBodyStyle: [cursor: string, userSelect: string];
+}
+
+/**
+ * The draggable divider between two room list sections.
+ *
+ * Rendered along the top edge of a section header, it resizes the section ABOVE it: dragging
+ * the divider changes how many of that section's rooms are shown, one whole room at a time.
+ * When the pointer leaves the viewport mid-drag, the resize keeps going at the pointer's last
+ * speed until the pointer returns or is released. Hovering the divider also reveals a button
+ * that maximises a shrunken section, or shrinks a full one down to
+ * {@link MINIMISED_SECTION_VISIBLE_COUNT} rooms.
+ *
+ * This is a pointer-only affordance (hidden from the accessibility tree): keyboard and screen
+ * reader users can collapse/expand sections from their headers instead.
+ */
+export const RoomListSectionResizer = memo(function RoomListSectionResizer({
+    sectionId,
+    visibleCount,
+    totalCount,
+    itemHeight,
+    onResize,
+}: Readonly<RoomListSectionResizerProps>): JSX.Element {
+    const { translate: _t } = useI18n();
+    const [isDragging, setIsDragging] = useState(false);
+
+    // The drag handlers live on window (the divider's DOM node can be recycled by the
+    // virtualized list mid-drag), so they read the latest props through a ref.
+    const propsRef = useRef({ sectionId, visibleCount, totalCount, itemHeight, onResize });
+    propsRef.current = { sectionId, visibleCount, totalCount, itemHeight, onResize };
+
+    const dragRef = useRef<DragState | null>(null);
+
+    /** Convert the current virtualDelta into a visible count and push it to the view model. */
+    const applyDrag = useCallback((): void => {
+        const drag = dragRef.current;
+        if (!drag) return;
+        const { sectionId, totalCount, itemHeight, onResize } = propsRef.current;
+        const target = drag.startCount + Math.round(drag.virtualDelta / itemHeight);
+        const clamped = Math.min(Math.max(target, 1), totalCount);
+        if (clamped === drag.lastSent) return;
+        drag.lastSent = clamped;
+        onResize(sectionId, clamped >= totalCount ? undefined : clamped);
+    }, []);
+
+    /** Velocity mode: keep resizing at the last measured speed while the pointer is off-screen. */
+    const velocityTick = useCallback(
+        (now: number): void => {
+            const drag = dragRef.current;
+            if (!drag || !drag.outside) return;
+            drag.virtualDelta += drag.velocity * (now - drag.lastT);
+            drag.lastT = now;
+            applyDrag();
+            drag.raf = requestAnimationFrame(velocityTick);
+        },
+        [applyDrag],
+    );
+
+    const onWindowPointerMove = useCallback(
+        (e: PointerEvent): void => {
+            const drag = dragRef.current;
+            if (!drag) return;
+            const now = performance.now();
+            const inside = e.clientY >= 0 && e.clientY <= window.innerHeight;
+
+            if (inside) {
+                // Pointer authority: follow the pointer and keep the velocity sample fresh so
+                // that leaving the viewport continues at the speed the pointer was moving.
+                const dt = now - drag.lastT;
+                if (dt > 0) {
+                    const instantaneous = (e.clientY - drag.lastY) / dt;
+                    drag.velocity = drag.velocity * 0.7 + instantaneous * 0.3;
+                }
+                if (drag.raf !== null) {
+                    cancelAnimationFrame(drag.raf);
+                    drag.raf = null;
+                }
+                drag.outside = false;
+                drag.virtualDelta = e.clientY - drag.startY;
+                drag.lastY = e.clientY;
+                drag.lastT = now;
+                applyDrag();
+            } else if (!drag.outside) {
+                // Pointer left the viewport: switch to velocity mode from the current position.
+                drag.outside = true;
+                drag.lastY = e.clientY;
+                drag.lastT = now;
+                drag.raf = requestAnimationFrame(velocityTick);
+            }
+        },
+        [applyDrag, velocityTick],
+    );
+
+    const endDrag = useCallback((): void => {
+        const drag = dragRef.current;
+        if (!drag) return;
+        if (drag.raf !== null) cancelAnimationFrame(drag.raf);
+        const [cursor, userSelect] = drag.restoreBodyStyle;
+        document.body.style.cursor = cursor;
+        document.body.style.userSelect = userSelect;
+        dragRef.current = null;
+        window.removeEventListener("pointermove", onWindowPointerMove);
+        window.removeEventListener("pointerup", endDrag);
+        window.removeEventListener("pointercancel", endDrag);
+        setIsDragging(false);
+    }, [onWindowPointerMove]);
+
+    const onPointerDown = useCallback(
+        (e: React.PointerEvent): void => {
+            if (e.button !== 0 || dragRef.current) return;
+            // Keep the pointer-down from starting a section drag-and-drop, moving focus, or
+            // selecting text.
+            e.preventDefault();
+            e.stopPropagation();
+            dragRef.current = {
+                startY: e.clientY,
+                startCount: propsRef.current.visibleCount,
+                lastY: e.clientY,
+                lastT: performance.now(),
+                velocity: 0,
+                virtualDelta: 0,
+                lastSent: propsRef.current.visibleCount,
+                outside: false,
+                raf: null,
+                restoreBodyStyle: [document.body.style.cursor, document.body.style.userSelect],
+            };
+            // The element under the pointer changes as rooms appear/disappear, so pin the
+            // cursor on the body for the duration of the drag.
+            document.body.style.cursor = "ns-resize";
+            document.body.style.userSelect = "none";
+            window.addEventListener("pointermove", onWindowPointerMove);
+            window.addEventListener("pointerup", endDrag);
+            window.addEventListener("pointercancel", endDrag);
+            setIsDragging(true);
+        },
+        [onWindowPointerMove, endDrag],
+    );
+
+    // If the divider unmounts mid-drag (e.g. recycled out of the virtualized window), tear the
+    // drag down so no window listeners or body styles leak.
+    useEffect(() => endDrag, [endDrag]);
+
+    const isShrunken = visibleCount < totalCount;
+    // A full section that couldn't get any smaller from minimising has nothing to offer.
+    const showButton = isShrunken || totalCount > MINIMISED_SECTION_VISIBLE_COUNT;
+
+    return (
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+        <div
+            className={classNames(styles.resizer, { [styles.dragging]: isDragging })}
+            onPointerDown={onPointerDown}
+            aria-hidden={true}
+            data-testid="section-resizer"
+        >
+            {showButton && (
+                <IconButton
+                    className={styles.button}
+                    size="20px"
+                    tabIndex={-1}
+                    aria-label={
+                        isShrunken
+                            ? _t("room_list|section_resizer|show_all")
+                            : _t("room_list|section_resizer|show_fewer")
+                    }
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={() => onResize(sectionId, isShrunken ? undefined : MINIMISED_SECTION_VISIBLE_COUNT)}
+                >
+                    {isShrunken ? <ExpandIcon /> : <CollapseIcon />}
+                </IconButton>
+            )}
+        </div>
+    );
+});

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionResizer/RoomListSectionResizer.tsx
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionResizer/RoomListSectionResizer.tsx
@@ -23,11 +23,11 @@ export const MINIMISED_SECTION_VISIBLE_COUNT = 5;
 export interface RoomListSectionResizerProps {
     /** The ID of the section ABOVE this divider — the one the divider resizes. */
     sectionId: string;
-    /** How many rooms of that section are currently shown. */
+    /** How many rooms of that section are currently shown; fractional when the boundary row is clipped. */
     visibleCount: number;
     /** How many rooms that section has in total (ignoring truncation). */
     totalCount: number;
-    /** Height in pixels of one room list item, used to quantise the drag into whole rooms. */
+    /** Height in pixels of one room list item, used to convert the drag distance into rooms. */
     itemHeight: number;
     /** Called with the new visible count while resizing; `undefined` shows all rooms. */
     onResize: (sectionId: string, visibleCount: number | undefined) => void;
@@ -61,7 +61,8 @@ interface DragState {
  * The draggable divider between two room list sections.
  *
  * Rendered along the top edge of a section header, it resizes the section ABOVE it: dragging
- * the divider changes how many of that section's rooms are shown, one whole room at a time.
+ * the divider changes how many of that section's rooms are shown, tracking the pointer
+ * smoothly (the row at the boundary is partially clipped between whole rows).
  * When the pointer leaves the viewport mid-drag, the resize keeps going at the pointer's last
  * speed until the pointer returns or is released. Hovering the divider also reveals a button
  * that maximises a shrunken section, or shrinks a full one down to
@@ -92,9 +93,12 @@ export const RoomListSectionResizer = memo(function RoomListSectionResizer({
         const drag = dragRef.current;
         if (!drag) return;
         const { sectionId, totalCount, itemHeight, onResize } = propsRef.current;
-        const target = drag.startCount + Math.round(drag.virtualDelta / itemHeight);
+        // Continuous (fractional) count, so the boundary follows the pointer smoothly rather
+        // than snapping to whole rows; the view model clips the boundary row to the fraction.
+        const target = drag.startCount + drag.virtualDelta / itemHeight;
         const clamped = Math.min(Math.max(target, 1), totalCount);
-        if (clamped === drag.lastSent) return;
+        // Skip sub-pixel changes to avoid churning the room list for nothing.
+        if (Math.abs(clamped - drag.lastSent) * itemHeight < 1) return;
         drag.lastSent = clamped;
         onResize(sectionId, clamped >= totalCount ? undefined : clamped);
     }, []);

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionResizer/index.ts
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListSectionResizer/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+export * from "./RoomListSectionResizer";

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.module.css
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.module.css
@@ -19,3 +19,18 @@
 .clippedRoom {
     overflow: hidden;
 }
+
+/**
+ * The partially visible first row of a scrolled section window: the wrapper's inline height is
+ * the visible fraction of the row, bottom-aligned so the row's top edge is what gets clipped.
+ */
+.clippedRoomTop {
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+}
+
+.clippedRoomTop > * {
+    flex-shrink: 0;
+}

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.module.css
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.module.css
@@ -11,3 +11,11 @@
 .roomList {
     width: 100%;
 }
+
+/**
+ * The partially visible boundary row of a fractionally resized section: the wrapper's inline
+ * height is set to the visible fraction of the row and the rest is clipped.
+ */
+.clippedRoom {
+    overflow: hidden;
+}

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.stories.tsx
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.stories.tsx
@@ -44,6 +44,7 @@ const RoomListWrapperImpl = ({
     onSectionDragStart,
     onSectionDragEnd,
     setSectionVisibleLimit,
+    scrollSectionBy,
     ...rest
 }: RoomListStoryProps): JSX.Element => {
     const vm = useMockedViewModel(rest, {
@@ -62,6 +63,7 @@ const RoomListWrapperImpl = ({
         onSectionDragStart,
         onSectionDragEnd,
         setSectionVisibleLimit,
+        scrollSectionBy,
     });
 
     return (
@@ -109,6 +111,7 @@ const meta = {
         onSectionDragStart: fn(),
         onSectionDragEnd: fn(),
         setSectionVisibleLimit: fn(),
+        scrollSectionBy: fn(),
     },
     parameters: {
         design: {

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.stories.tsx
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.stories.tsx
@@ -43,6 +43,7 @@ const RoomListWrapperImpl = ({
     changeSectionOrder,
     onSectionDragStart,
     onSectionDragEnd,
+    setSectionVisibleLimit,
     ...rest
 }: RoomListStoryProps): JSX.Element => {
     const vm = useMockedViewModel(rest, {
@@ -60,6 +61,7 @@ const RoomListWrapperImpl = ({
         changeSectionOrder,
         onSectionDragStart,
         onSectionDragEnd,
+        setSectionVisibleLimit,
     });
 
     return (
@@ -106,6 +108,7 @@ const meta = {
         changeSectionOrder: fn(),
         onSectionDragStart: fn(),
         onSectionDragEnd: fn(),
+        setSectionVisibleLimit: fn(),
     },
     parameters: {
         design: {

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.tsx
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.tsx
@@ -208,10 +208,36 @@ export function VirtualizedRoomListView({ vm, renderAvatar, onKeyDown }: Virtual
         });
     }, [syncObservedItems]);
 
+    // Latest snapshot data for the native wheel handler, which is attached once per scroller
+    // element and so reads through refs.
+    const sectionsRef = useRef(sections);
+    sectionsRef.current = sections;
+    const vmRef = useRef(vm);
+    vmRef.current = vm;
+
+    // A section resized shorter than its content is a scrollable window over its rooms: wheel
+    // events over its rows scroll the window instead of the outer list, chaining back to the
+    // outer list once the window hits the end the wheel is heading for. Attached as a native
+    // non-passive listener because React's synthetic onWheel cannot preventDefault.
+    const onSectionWheel = useCallback((e: WheelEvent) => {
+        const row = (e.target as HTMLElement | null)?.closest?.<HTMLElement>("[data-scroll-section]");
+        if (!row) return;
+        const section = sectionsRef.current.find((s) => s.id === row.dataset.scrollSection);
+        if (!section || section.visibleLimit === undefined) return;
+        const deltaPixels = e.deltaY * (e.deltaMode === WheelEvent.DOM_DELTA_LINE ? 16 : 1);
+        const offset = section.scrollOffset ?? 0;
+        const maxOffset = section.totalRoomCount - section.visibleLimit;
+        const canConsume = deltaPixels > 0 ? offset < maxOffset - 0.001 : deltaPixels < 0 && offset > 0.001;
+        if (!canConsume) return;
+        e.preventDefault();
+        vmRef.current.scrollSectionBy(section.id, deltaPixels / ROOM_LIST_ITEM_HEIGHT);
+    }, []);
+
     // Callback ref for Virtuoso's scroller element: (re)create an IntersectionObserver rooted
     // at it. The initial sync is covered by the rangeChanged Virtuoso fires on mount.
     const setScroller = useCallback(
         (element: HTMLElement | Window | null) => {
+            foldScrollerRef.current?.removeEventListener("wheel", onSectionWheel);
             foldObserverRef.current?.disconnect();
             foldObserverRef.current = null;
             itemVisibilityRef.current.clear();
@@ -223,11 +249,12 @@ export function VirtualizedRoomListView({ vm, renderAvatar, onKeyDown }: Virtual
             const scroller = element instanceof HTMLElement ? element : null;
             foldScrollerRef.current = scroller;
             if (scroller) {
+                scroller.addEventListener("wheel", onSectionWheel, { passive: false });
                 foldObserverRef.current = new IntersectionObserver(onItemIntersection, { root: scroller });
                 scheduleSyncObservedItems();
             }
         },
-        [onItemIntersection, scheduleSyncObservedItems],
+        [onItemIntersection, scheduleSyncObservedItems, onSectionWheel],
     );
     const roomIds = useMemo(() => sections.flatMap((section) => section.roomIds), [sections]);
     const roomCount = roomIds.length;
@@ -381,21 +408,31 @@ export function VirtualizedRoomListView({ vm, renderAvatar, onKeyDown }: Virtual
             const isInLastSection = groupIndex === sections.length - 1;
             const item = getItemComponent(index, roomId, context, onFocus, isInLastSection, roomIndexInSection);
 
-            // A fractionally resized section shows only part of its boundary row: clip that row
-            // to the visible fraction of its height so the divider tracks the pointer smoothly.
-            const fraction = section.lastRoomVisibleFraction;
-            if (fraction !== undefined && roomIndexInSection === section.roomIds.length - 1) {
-                return (
-                    <div
-                        key={roomId}
-                        className={styles.clippedRoom}
-                        style={{ height: Math.round(fraction * ROOM_LIST_ITEM_HEIGHT) }}
-                    >
-                        {item}
-                    </div>
-                );
+            // A resized section is a scrollable window over its rooms: tag its rows so wheel
+            // events can be routed to the section (see onSectionWheel), and clip a partially
+            // visible boundary row to the visible fraction of its height — the last row from
+            // the bottom, the first row from the top (bottom-aligned so its top edge is what
+            // gets cut off).
+            if (section.visibleLimit === undefined) return item;
+            let className: string | undefined;
+            let height: number | undefined;
+            if (section.lastRoomVisibleFraction !== undefined && roomIndexInSection === section.roomIds.length - 1) {
+                className = styles.clippedRoom;
+                height = Math.round(section.lastRoomVisibleFraction * ROOM_LIST_ITEM_HEIGHT);
+            } else if (section.firstRoomVisibleFraction !== undefined && roomIndexInSection === 0) {
+                className = styles.clippedRoomTop;
+                height = Math.round(section.firstRoomVisibleFraction * ROOM_LIST_ITEM_HEIGHT);
             }
-            return item;
+            return (
+                <div
+                    key={roomId}
+                    className={className}
+                    style={height !== undefined ? { height } : undefined}
+                    data-scroll-section={section.id}
+                >
+                    {item}
+                </div>
+            );
         },
         [getItemComponent],
     );
@@ -442,11 +479,9 @@ export function VirtualizedRoomListView({ vm, renderAvatar, onKeyDown }: Virtual
             // exists from the second header on, and only while that section shows any rooms
             // (a collapsed or empty section has no room rows to resize).
             const sectionAbove = groupIndex > 0 ? sections[groupIndex - 1] : undefined;
-            // A clipped boundary row counts for its visible fraction, so a drag starts from
-            // exactly where the divider currently sits.
-            const visibleCountAbove = sectionAbove
-                ? sectionAbove.roomIds.length - 1 + (sectionAbove.lastRoomVisibleFraction ?? 1)
-                : 0;
+            // The effective (possibly fractional) limit, so a drag starts from exactly where
+            // the divider currently sits; an unlimited section shows all its rooms.
+            const visibleCountAbove = sectionAbove ? (sectionAbove.visibleLimit ?? sectionAbove.roomIds.length) : 0;
             const resizer =
                 sectionAbove && sectionAbove.roomIds.length > 0 ? (
                     <RoomListSectionResizer

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.tsx
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.tsx
@@ -24,6 +24,7 @@ import type { RoomListViewSnapshot, RoomListViewModel } from "../RoomListView";
 import { RoomListSectionHeaderView, RoomListStickySectionHeaderView } from "./RoomListSectionHeaderView";
 import { RoomListSectionHeaderDragOverlayView } from "./RoomListSectionHeaderDragOverlayView";
 import { RoomListItemWrapper } from "./RoomListItemWrapper";
+import { RoomListSectionResizer } from "./RoomListSectionResizer";
 import { RoomListItemDragOverlayView } from "./RoomListItemDragOverlayView";
 import { isSectionDragData, type RoomListDragData } from "./dragAndDrop";
 import { useRoomListAccessibilityPlugin } from "./RoomListAccessibilityPlugin";
@@ -71,7 +72,7 @@ export interface VirtualizedRoomListViewProps {
 }
 
 /** Height of a single room list item in pixels (44px item + 8px padding bottom) */
-const ROOM_LIST_ITEM_HEIGHT = 52;
+export const ROOM_LIST_ITEM_HEIGHT = 52;
 
 /**
  * Number of pixels the keyboard sensor moves the dragged element per arrow keypress.
@@ -420,6 +421,21 @@ export function VirtualizedRoomListView({ vm, renderAvatar, onKeyDown }: Virtual
             // This matches the old RoomList implementation's roving tabindex pattern
             const isFocused = context.focused && context.tabIndexKey === headerId;
 
+            // The divider along this header's top edge resizes the section ABOVE it, so it only
+            // exists from the second header on, and only while that section shows any rooms
+            // (a collapsed or empty section has no room rows to resize).
+            const sectionAbove = groupIndex > 0 ? sections[groupIndex - 1] : undefined;
+            const resizer =
+                sectionAbove && sectionAbove.roomIds.length > 0 ? (
+                    <RoomListSectionResizer
+                        sectionId={sectionAbove.id}
+                        visibleCount={sectionAbove.roomIds.length}
+                        totalCount={sectionAbove.totalRoomCount}
+                        itemHeight={ROOM_LIST_ITEM_HEIGHT}
+                        onResize={vm.setSectionVisibleLimit}
+                    />
+                ) : undefined;
+
             return (
                 <RoomListSectionHeaderView
                     // Stable key per section avoids a @dnd-kit registration race when a new section is inserted.
@@ -431,6 +447,7 @@ export function VirtualizedRoomListView({ vm, renderAvatar, onKeyDown }: Virtual
                     sectionIndex={groupIndex}
                     sectionCount={sectionCount}
                     roomCountInSection={roomCountInSection}
+                    resizer={resizer}
                 />
             );
         },

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.tsx
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.tsx
@@ -376,9 +376,26 @@ export function VirtualizedRoomListView({ vm, renderAvatar, onKeyDown }: Virtual
             groupIndex: number,
         ): JSX.Element => {
             const { sections } = context.context;
-            const roomIndexInSection = sections[groupIndex].roomIds.findIndex((id) => id === roomId);
+            const section = sections[groupIndex];
+            const roomIndexInSection = section.roomIds.findIndex((id) => id === roomId);
             const isInLastSection = groupIndex === sections.length - 1;
-            return getItemComponent(index, roomId, context, onFocus, isInLastSection, roomIndexInSection);
+            const item = getItemComponent(index, roomId, context, onFocus, isInLastSection, roomIndexInSection);
+
+            // A fractionally resized section shows only part of its boundary row: clip that row
+            // to the visible fraction of its height so the divider tracks the pointer smoothly.
+            const fraction = section.lastRoomVisibleFraction;
+            if (fraction !== undefined && roomIndexInSection === section.roomIds.length - 1) {
+                return (
+                    <div
+                        key={roomId}
+                        className={styles.clippedRoom}
+                        style={{ height: Math.round(fraction * ROOM_LIST_ITEM_HEIGHT) }}
+                    >
+                        {item}
+                    </div>
+                );
+            }
+            return item;
         },
         [getItemComponent],
     );
@@ -425,11 +442,16 @@ export function VirtualizedRoomListView({ vm, renderAvatar, onKeyDown }: Virtual
             // exists from the second header on, and only while that section shows any rooms
             // (a collapsed or empty section has no room rows to resize).
             const sectionAbove = groupIndex > 0 ? sections[groupIndex - 1] : undefined;
+            // A clipped boundary row counts for its visible fraction, so a drag starts from
+            // exactly where the divider currently sits.
+            const visibleCountAbove = sectionAbove
+                ? sectionAbove.roomIds.length - 1 + (sectionAbove.lastRoomVisibleFraction ?? 1)
+                : 0;
             const resizer =
                 sectionAbove && sectionAbove.roomIds.length > 0 ? (
                     <RoomListSectionResizer
                         sectionId={sectionAbove.id}
-                        visibleCount={sectionAbove.roomIds.length}
+                        visibleCount={visibleCountAbove}
                         totalCount={sectionAbove.totalRoomCount}
                         itemHeight={ROOM_LIST_ITEM_HEIGHT}
                         onResize={vm.setSectionVisibleLimit}

--- a/packages/shared-components/src/room-list/story-mocks.tsx
+++ b/packages/shared-components/src/room-list/story-mocks.tsx
@@ -15,6 +15,7 @@ import {
     RoomNotifState,
 } from "./VirtualizedRoomListView/RoomListItemWrapper/RoomListItemView";
 import { type RoomListSectionHeaderViewModel } from "./VirtualizedRoomListView/RoomListSectionHeaderView";
+import { type RoomListSection } from "./RoomListView";
 import { MockViewModel } from "../core/viewmodel";
 
 /**
@@ -168,31 +169,40 @@ export const createGetSectionHeaderViewModel = (
 };
 
 /**
+ * Create a mock section showing all of its rooms
+ */
+const mockSection = (id: string, roomIds: string[]): RoomListSection => ({
+    id,
+    roomIds,
+    totalRoomCount: roomIds.length,
+});
+
+/**
  * Mock room IDs for different list sizes
  */
 export const mock10RoomsIds = Array.from({ length: 10 }, (_, i) => `!room${i}:server`);
 export const mock10RoomsSections = [
-    { id: "favourites", roomIds: mock10RoomsIds.slice(0, 3) },
-    { id: "chats", roomIds: mock10RoomsIds.slice(3, 4) },
-    { id: "low-priority", roomIds: mock10RoomsIds.slice(4) },
+    mockSection("favourites", mock10RoomsIds.slice(0, 3)),
+    mockSection("chats", mock10RoomsIds.slice(3, 4)),
+    mockSection("low-priority", mock10RoomsIds.slice(4)),
 ];
 
 export const mockRoomIds = Array.from({ length: 20 }, (_, i) => `!room${i}:server`);
 export const mockSections = [
-    { id: "favourites", roomIds: mockRoomIds.slice(0, 5) },
-    { id: "chats", roomIds: mockRoomIds.slice(5, 15) },
-    { id: "low-priority", roomIds: mockRoomIds.slice(15) },
+    mockSection("favourites", mockRoomIds.slice(0, 5)),
+    mockSection("chats", mockRoomIds.slice(5, 15)),
+    mockSection("low-priority", mockRoomIds.slice(15)),
 ];
 
 export const mockSmallListRoomIds = mockRoomIds.slice(0, 5);
 export const mockSmallListSections = [
-    { id: "favourites", roomIds: mockSmallListRoomIds.slice(0, 2) },
-    { id: "chats", roomIds: mockSmallListRoomIds.slice(2, 0) },
+    mockSection("favourites", mockSmallListRoomIds.slice(0, 2)),
+    mockSection("chats", mockSmallListRoomIds.slice(2, 0)),
 ];
 
 export const mockLargeListRoomIds = Array.from({ length: 100 }, (_, i) => `!room${i}:server`);
 export const mockLargeListSections = [
-    { id: "favourites", roomIds: mockLargeListRoomIds.slice(0, 23) },
-    { id: "chats", roomIds: mockLargeListRoomIds.slice(23, 52) },
-    { id: "low-priority", roomIds: mockLargeListRoomIds.slice(52) },
+    mockSection("favourites", mockLargeListRoomIds.slice(0, 23)),
+    mockSection("chats", mockLargeListRoomIds.slice(23, 52)),
+    mockSection("low-priority", mockLargeListRoomIds.slice(52)),
 ];


### PR DESCRIPTION
A room list section resized shorter than its content (via the draggable divider from #resizable-sections) now shows a scrollable window over its full room list instead of truncating it:

- Wheel/trackpad scrolling over a shrunken section's rooms slides its window; at either end the scroll chains back to the outer room list, which scrolls as before.
- The view model tracks a transient per-section scroll offset and slices the window in `computeSections`, exposing the effective limit, offset and boundary-row visible fractions on each section snapshot. Both boundary rows clip fractionally (a top-edge clip mirroring the existing bottom clip), so scrolling is pixel-smooth.
- Scrolling a hidden room into view (e.g. via notifications) now slides the section's window to the room rather than clearing the section's resize limit.
- Offsets reset on space changes and when the limit is cleared; nothing new is persisted.

The wheel handling is a native non-passive listener on the virtuoso scroller (React's synthetic `onWheel` cannot `preventDefault`), routed to sections via a `data-scroll-section` attribute on their rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)