### PR TITLE
Room list: change `Edit section` label to `Save` in edit section dialog

### DIFF
--- a/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-custom-sections.spec.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-custom-sections.spec.ts
@@ -211,7 +211,7 @@ test.describe("Room list custom sections", () => {
 
             // Change the name and confirm
             await dialog.getByRole("textbox", { name: "Section name" }).fill("Personal");
-            await dialog.getByRole("button", { name: "Edit section" }).click();
+            await dialog.getByRole("button", { name: "Save" }).click();
 
             // Dialog should close
             await expect(dialog).not.toBeVisible();

--- a/apps/web/src/components/views/dialogs/CreateSectionDialog.tsx
+++ b/apps/web/src/components/views/dialogs/CreateSectionDialog.tsx
@@ -69,9 +69,7 @@ export function CreateSectionDialog({ onFinished, sectionToEdit }: CreateSection
                 </Form.Root>
             </Flex>
             <DialogButtons
-                primaryButton={
-                    isEdition ? _t("create_section_dialog|edit_section") : _t("create_section_dialog|create_section")
-                }
+                primaryButton={isEdition ? _t("common|save") : _t("create_section_dialog|create_section")}
                 primaryDisabled={isInvalid}
                 hasCancel={true}
                 onCancel={() => onFinished(false, "")}

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -677,7 +677,6 @@
     "create_section_dialog": {
         "create_section": "Create section",
         "description": "Sections are only for you",
-        "edit_section": "Edit section",
         "label": "Section name",
         "title": "Create a section",
         "title_edition": "Edit a section"

--- a/apps/web/test/unit-tests/components/views/dialogs/CreateSectionDialog-test.tsx
+++ b/apps/web/test/unit-tests/components/views/dialogs/CreateSectionDialog-test.tsx
@@ -68,26 +68,26 @@ describe("CreateSectionDialog", () => {
             expect(input).toHaveValue("Existing Section");
         });
 
-        it("shows the edit section button instead of create section", () => {
+        it("shows the save button instead of create section", () => {
             renderEditComponent();
-            expect(screen.getByRole("button", { name: "Edit section" })).toBeInTheDocument();
+            expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
             expect(screen.queryByRole("button", { name: "Create section" })).not.toBeInTheDocument();
         });
 
-        it("calls onFinished with the updated name when edit section is clicked", async () => {
+        it("calls onFinished with the updated name when save is clicked", async () => {
             renderEditComponent();
             const input = screen.getByRole("textbox");
             await userEvent.clear(input);
             await userEvent.type(input, "Updated Section");
-            await userEvent.click(screen.getByRole("button", { name: "Edit section" }));
+            await userEvent.click(screen.getByRole("button", { name: "Save" }));
             expect(onFinished).toHaveBeenCalledWith(true, "Updated Section");
         });
 
-        it("has the edit section button disabled when the input is empty", async () => {
+        it("has the save button disabled when the input is empty", async () => {
             renderEditComponent();
             const input = screen.getByRole("textbox");
             await userEvent.clear(input);
-            expect(screen.getByRole("button", { name: "Edit section" })).toBeDisabled();
+            expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
         });
     });
 });


### PR DESCRIPTION
Update this dialog to change the confirm button label to "Save":
<img width="604" height="551" alt="image" src="https://github.com/user-attachments/assets/5865b397-e77d-4547-b4ca-6918c604dceb" />
