### PR TITLE
Support specifying alternative domains for matrix.to in the config

### DIFF
--- a/apps/web/src/utils/exportUtils/HtmlExport.tsx
+++ b/apps/web/src/utils/exportUtils/HtmlExport.tsx
@@ -20,7 +20,7 @@ import { mediaFromMxc } from "../../customisations/Media";
 import { Layout } from "../../settings/enums/Layout";
 import { shouldFormContinuation } from "../../components/structures/MessagePanel";
 import { formatFullDateNoDayNoTime, wantsDateSeparator } from "../../DateUtils";
-import { RoomPermalinkCreator } from "../permalinks/Permalinks";
+import { RoomPermalinkCreator, makeUserPermalink } from "../permalinks/Permalinks";
 import { _t } from "../../languageHandler";
 import * as Avatar from "../../Avatar";
 import EventTile from "../../components/views/rooms/EventTile";
@@ -109,11 +109,7 @@ export default class HTMLExporter extends Exporter {
                     {
                         roomName: () => <strong>{safeRoomName}</strong>,
                         exporterDetails: () => (
-                            <a
-                                href={`https://matrix.to/#/${encodeURIComponent(exporter)}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
+                            <a href={makeUserPermalink(exporter)} target="_blank" rel="noopener noreferrer">
                                 {exporterName ? (
                                     <>
                                         <strong>{escapeHtml(exporterName)}</strong>I {" (" + safeExporter + ")"}

--- a/apps/web/src/utils/permalinks/ElementPermalinkConstructor.ts
+++ b/apps/web/src/utils/permalinks/ElementPermalinkConstructor.ts
@@ -1,4 +1,5 @@
 /*
+Copyright 2026 Element Creations Ltd.
 Copyright 2024 New Vector Ltd.
 Copyright 2019-2021 The Matrix.org Foundation C.I.C.
 

--- a/apps/web/src/utils/permalinks/MatrixToPermalinkConstructor.ts
+++ b/apps/web/src/utils/permalinks/MatrixToPermalinkConstructor.ts
@@ -1,4 +1,5 @@
 /*
+Copyright 2026 Element Creations Ltd.
 Copyright 2024 New Vector Ltd.
 Copyright 2019 The Matrix.org Foundation C.I.C.
 
@@ -10,34 +11,42 @@ import PermalinkConstructor, { PermalinkParts } from "./PermalinkConstructor";
 
 export const host = "matrix.to";
 export const baseUrl = `https://${host}`;
-export const baseUrlPattern = `^(?:https?://)?${host.replace(".", "\\.")}/#/(.*)`;
+export function patternForHost(host: string): string {
+    return `^(?:https?://)?${host.replace(".", "\\.")}/#/(.*)`;
+}
+export const baseUrlPattern = patternForHost(host);
 
 /**
- * Generates matrix.to permalinks
+ * Generates matrix.to permalinks, or permalinks for a matrix.to-equivalent host
  */
 export default class MatrixToPermalinkConstructor extends PermalinkConstructor {
-    public constructor() {
+    private readonly host: string;
+    private readonly baseUrl: string;
+
+    public constructor(customHost: string = host) {
         super();
+        this.host = customHost;
+        this.baseUrl = `https://${customHost}`;
     }
 
     public forEvent(roomId: string, eventId: string, serverCandidates: string[]): string {
-        return `${baseUrl}/#/${roomId}/${eventId}${this.encodeServerCandidates(serverCandidates)}`;
+        return `${this.baseUrl}/#/${roomId}/${eventId}${this.encodeServerCandidates(serverCandidates)}`;
     }
 
     public forRoom(roomIdOrAlias: string, serverCandidates: string[]): string {
-        return `${baseUrl}/#/${roomIdOrAlias}${this.encodeServerCandidates(serverCandidates)}`;
+        return `${this.baseUrl}/#/${roomIdOrAlias}${this.encodeServerCandidates(serverCandidates)}`;
     }
 
     public forUser(userId: string): string {
-        return `${baseUrl}/#/${userId}`;
+        return `${this.baseUrl}/#/${userId}`;
     }
 
     public forEntity(entityId: string): string {
-        return `${baseUrl}/#/${entityId}`;
+        return `${this.baseUrl}/#/${entityId}`;
     }
 
     public isPermalinkHost(testHost: string): boolean {
-        return testHost === host;
+        return testHost === this.host;
     }
 
     public encodeServerCandidates(candidates: string[]): string {
@@ -52,7 +61,7 @@ export default class MatrixToPermalinkConstructor extends PermalinkConstructor {
             throw new Error("Does not appear to be a permalink");
         }
 
-        const matches = [...fullUrl.matchAll(new RegExp(baseUrlPattern, "gi"))][0];
+        const matches = [...fullUrl.matchAll(new RegExp(patternForHost(this.host), "gi"))][0];
 
         if (!matches || matches.length < 2) {
             throw new Error("Does not appear to be a permalink");

--- a/apps/web/src/utils/permalinks/Permalinks.ts
+++ b/apps/web/src/utils/permalinks/Permalinks.ts
@@ -1,4 +1,5 @@
 /*
+Copyright 2026 Element Creations Ltd.
 Copyright 2024 New Vector Ltd.
 Copyright 2019-2021 The Matrix.org Foundation C.I.C.
 
@@ -13,8 +14,8 @@ import { KnownMembership } from "matrix-js-sdk/src/types";
 import { logger } from "matrix-js-sdk/src/logger";
 
 import MatrixToPermalinkConstructor, {
-    baseUrl as matrixtoBaseUrl,
-    baseUrlPattern as matrixToBaseUrlPattern,
+    host as matrixtoHost,
+    patternForHost as matrixToPatternForHost,
 } from "./MatrixToPermalinkConstructor";
 import { type PermalinkParts } from "./PermalinkConstructor";
 import type PermalinkConstructor from "./PermalinkConstructor";
@@ -316,9 +317,11 @@ export function makeRoomPermalink(matrixClient: MatrixClient, roomId: string, is
 }
 
 export function isPermalinkHost(host: string): boolean {
-    // Always check if the permalink is a spec permalink (callers are likely to call
+    // Always check if the permalink is a matrix.to-equivalent host (callers are likely to call
     // parsePermalink after this function).
-    if (new MatrixToPermalinkConstructor().isPermalinkHost(host)) return true;
+    if (getMatrixToHostsForParsing().some((h) => new MatrixToPermalinkConstructor(h).isPermalinkHost(host))) {
+        return true;
+    }
     return getPermalinkConstructor().isPermalinkHost(host);
 }
 
@@ -340,15 +343,18 @@ export function tryTransformEntityToPermalink(matrixClient: MatrixClient, entity
         try {
             const permalinkParts = parsePermalink(entity);
             if (permalinkParts) {
+                const matrixToConstructor = new MatrixToPermalinkConstructor(getPrimaryMatrixToHost());
                 if (permalinkParts.roomIdOrAlias) {
-                    const eventIdPart = permalinkParts.eventId ? `/${permalinkParts.eventId}` : "";
-                    let pl = matrixtoBaseUrl + `/#/${permalinkParts.roomIdOrAlias}${eventIdPart}`;
-                    if (permalinkParts.viaServers?.length) {
-                        pl += new MatrixToPermalinkConstructor().encodeServerCandidates(permalinkParts.viaServers);
+                    if (permalinkParts.eventId) {
+                        return matrixToConstructor.forEvent(
+                            permalinkParts.roomIdOrAlias,
+                            permalinkParts.eventId,
+                            permalinkParts.viaServers ?? [],
+                        );
                     }
-                    return pl;
+                    return matrixToConstructor.forRoom(permalinkParts.roomIdOrAlias, permalinkParts.viaServers ?? []);
                 } else if (permalinkParts.userId) {
-                    return matrixtoBaseUrl + `/#/${permalinkParts.userId}`;
+                    return matrixToConstructor.forUser(permalinkParts.userId);
                 }
             }
         } catch {}
@@ -430,14 +436,48 @@ export function getPrimaryPermalinkEntity(permalink: string): string | null {
 }
 
 /**
- * Returns the correct PermalinkConstructor based on permalink_prefix
- * and isPill
+ * Reads the configured matrixto_prefix hostname(s), normalising the
+ * string | string[] | undefined config shape into an array.
+ */
+function getConfiguredMatrixToHosts(): string[] {
+    const configured = SdkConfig.get("matrixto_prefix");
+    if (!configured) return [];
+    return Array.isArray(configured) ? configured : [configured];
+}
+
+/**
+ * All hostnames that should be recognised as matrix.to-equivalent when parsing
+ * links: the real matrix.to, plus any configured matrixto_prefix hosts.
+ */
+function getMatrixToHostsForParsing(): string[] {
+    return [matrixtoHost, ...getConfiguredMatrixToHosts()];
+}
+
+/**
+ * The matrix.to-equivalent hostname to use when generating new permalinks.
+ * Defaults to matrix.to when matrixto_prefix isn't configured.
+ */
+function getPrimaryMatrixToHost(): string {
+    return getConfiguredMatrixToHosts()[0] ?? matrixtoHost;
+}
+
+/**
+ * Returns the correct PermalinkConstructor based on matrixto_prefix,
+ * permalink_prefix, and isPill
  * @param {boolean} isPill Should constructed links be pillifyable.
  * @returns {string|null} The transformed permalink or null if unable.
  */
 function getPermalinkConstructor(isPill = false): PermalinkConstructor {
+    const matrixToHost = getPrimaryMatrixToHost();
+    if (matrixToHost !== matrixtoHost) {
+        // A matrixto_prefix has been configured: it replaces matrix.to everywhere,
+        // including pills, since pills are exactly the links shared with parties
+        // who won't otherwise know about the custom host.
+        return new MatrixToPermalinkConstructor(matrixToHost);
+    }
+
     const elementPrefix = SdkConfig.get("permalink_prefix");
-    if (elementPrefix && elementPrefix !== matrixtoBaseUrl && !isPill) {
+    if (elementPrefix && elementPrefix !== `https://${matrixtoHost}` && !isPill) {
         return new ElementPermalinkConstructor(elementPrefix);
     }
 
@@ -446,11 +486,15 @@ function getPermalinkConstructor(isPill = false): PermalinkConstructor {
 
 export function parsePermalink(fullUrl: string): PermalinkParts | null {
     try {
-        const elementPrefix = SdkConfig.get("permalink_prefix");
         const decodedUrl = decodeURIComponent(fullUrl);
-        if (new RegExp(matrixToBaseUrlPattern, "i").test(decodedUrl)) {
-            return new MatrixToPermalinkConstructor().parsePermalink(decodedUrl);
-        } else if (fullUrl.startsWith("matrix:")) {
+        for (const matrixToHost of getMatrixToHostsForParsing()) {
+            if (new RegExp(matrixToPatternForHost(matrixToHost), "i").test(decodedUrl)) {
+                return new MatrixToPermalinkConstructor(matrixToHost).parsePermalink(decodedUrl);
+            }
+        }
+
+        const elementPrefix = SdkConfig.get("permalink_prefix");
+        if (fullUrl.startsWith("matrix:")) {
             return new MatrixSchemePermalinkConstructor().parsePermalink(fullUrl);
         } else if (elementPrefix && fullUrl.startsWith(elementPrefix)) {
             return new ElementPermalinkConstructor(elementPrefix).parsePermalink(fullUrl);

--- a/apps/web/test/unit-tests/utils/permalinks/MatrixToPermalinkConstructor-test.ts
+++ b/apps/web/test/unit-tests/utils/permalinks/MatrixToPermalinkConstructor-test.ts
@@ -1,4 +1,5 @@
 /*
+Copyright 2026 Element Creations Ltd.
 Copyright 2024 New Vector Ltd.
 Copyright 2023 The Matrix.org Foundation C.I.C.
 
@@ -47,6 +48,37 @@ describe("MatrixToPermalinkConstructor", () => {
             expect(
                 peramlinkConstructor.forEvent("!myroom:example.com", "$event4", ["one.example.com", "two.example.com"]),
             ).toEqual("https://matrix.to/#/!myroom:example.com/$event4?via=one.example.com&via=two.example.com");
+        });
+    });
+
+    describe("with a custom host", () => {
+        const customConstructor = new MatrixToPermalinkConstructor("matrixto.customer.internal");
+
+        it("constructs links against the custom host", () => {
+            expect(customConstructor.forUser("@user:example.com")).toEqual(
+                "https://matrixto.customer.internal/#/@user:example.com",
+            );
+            expect(customConstructor.forRoom("!myroom:example.com", ["one.example.com"])).toEqual(
+                "https://matrixto.customer.internal/#/!myroom:example.com?via=one.example.com",
+            );
+            expect(customConstructor.forEvent("!myroom:example.com", "$event4", [])).toEqual(
+                "https://matrixto.customer.internal/#/!myroom:example.com/$event4",
+            );
+        });
+
+        it("parses links against the custom host", () => {
+            expect(customConstructor.parsePermalink("https://matrixto.customer.internal/#/@user:example.com")).toEqual(
+                new PermalinkParts(null, null, "@user:example.com", null),
+            );
+        });
+
+        it("does not parse links against the default matrix.to host", () => {
+            expect(() => customConstructor.parsePermalink("https://matrix.to/#/@user:example.com")).toThrow();
+        });
+
+        it("recognises only its own host via isPermalinkHost", () => {
+            expect(customConstructor.isPermalinkHost("matrixto.customer.internal")).toBe(true);
+            expect(customConstructor.isPermalinkHost("matrix.to")).toBe(false);
         });
     });
 });

--- a/apps/web/test/unit-tests/utils/permalinks/Permalinks-test.ts
+++ b/apps/web/test/unit-tests/utils/permalinks/Permalinks-test.ts
@@ -1,4 +1,5 @@
 /*
+Copyright 2026 Element Creations Ltd.
 Copyright 2024 New Vector Ltd.
 Copyright 2019-2022 The Matrix.org Foundation C.I.C.
 Copyright 2018 New Vector Ltd
@@ -425,6 +426,44 @@ describe("Permalinks", function () {
         expect(result).toBe("https://element.fs.tld/#/user/@someone:example.org");
     });
 
+    function mockMatrixToPrefix(value: string | string[]): void {
+        const sdkConfigGet = SdkConfig.get;
+        jest.spyOn(SdkConfig, "get").mockImplementation((key: keyof IConfigOptions, altCaseName?: string) => {
+            if (key === "matrixto_prefix") {
+                return value;
+            } else return sdkConfigGet(key, altCaseName);
+        });
+    }
+
+    it("should use matrixto_prefix (string) for permalinks, including pills", function () {
+        mockMatrixToPrefix("matrixto.customer.internal");
+        expect(makeUserPermalink("@someone:example.org")).toBe(
+            "https://matrixto.customer.internal/#/@someone:example.org",
+        );
+        expect(makeUserPermalink("@someone:example.org", true)).toBe(
+            "https://matrixto.customer.internal/#/@someone:example.org",
+        );
+    });
+
+    it("should use the first entry of matrixto_prefix (array) for generating permalinks", function () {
+        mockMatrixToPrefix(["matrixto.customer.internal", "matrixto.legacy.internal"]);
+        expect(makeUserPermalink("@someone:example.org")).toBe(
+            "https://matrixto.customer.internal/#/@someone:example.org",
+        );
+    });
+
+    it("should prefer matrixto_prefix over permalink_prefix when both are configured", function () {
+        const sdkConfigGet = SdkConfig.get;
+        jest.spyOn(SdkConfig, "get").mockImplementation((key: keyof IConfigOptions, altCaseName?: string) => {
+            if (key === "matrixto_prefix") return "matrixto.customer.internal";
+            if (key === "permalink_prefix") return "https://element.fs.tld";
+            return sdkConfigGet(key, altCaseName);
+        });
+        expect(makeUserPermalink("@someone:example.org")).toBe(
+            "https://matrixto.customer.internal/#/@someone:example.org",
+        );
+    });
+
     describe("parsePermalink", () => {
         it("should correctly parse room permalinks with a via argument", () => {
             const result = parsePermalink("https://matrix.to/#/!room_id:server?via=some.org");
@@ -457,6 +496,27 @@ describe("Permalinks", function () {
             expect(parsePermalink("matrix.to/#/@user:example.com")).toEqual(
                 new PermalinkParts(null, null, "@user:example.com", null),
             );
+        });
+
+        describe("with matrixto_prefix configured", () => {
+            beforeEach(() => {
+                mockMatrixToPrefix(["matrixto.customer.internal", "matrixto.legacy.internal"]);
+            });
+
+            it("should parse links from every configured host", () => {
+                expect(parsePermalink("https://matrixto.customer.internal/#/@user:example.com")).toEqual(
+                    new PermalinkParts(null, null, "@user:example.com", null),
+                );
+                expect(parsePermalink("https://matrixto.legacy.internal/#/@user:example.com")).toEqual(
+                    new PermalinkParts(null, null, "@user:example.com", null),
+                );
+            });
+
+            it("should still parse links from the real matrix.to", () => {
+                expect(parsePermalink("https://matrix.to/#/@user:example.com")).toEqual(
+                    new PermalinkParts(null, null, "@user:example.com", null),
+                );
+            });
         });
     });
 });

--- a/docs/config.md
+++ b/docs/config.md
@@ -130,44 +130,52 @@ complete re-branding/private labeling, a more personalised experience can be ach
    templated string. Note that this option does not support templating, currently.
 3. `brand`: Optional name for the app. Defaults to `Element`. This is used throughout the application in various strings/locations.
 4. `permalink_prefix`: An optional URL pointing to an Element Web deployment. For example, `https://app.element.io`. This will
-   change all permalinks (via the "Share" menus) to point at the Element Web deployment rather than `matrix.to`.
-5. `desktop_builds`: Optional. Where the desktop builds for the application are, if available. This is explained in more detail
+   change all permalinks (via the "Share" menus) to point at the Element Web deployment rather than `matrix.to`. Note this
+   does not affect pills (in-message links to rooms/users), which always use a matrix.to-shaped URL — see `matrixto_prefix`
+   below if you need to change that too.
+5. `matrixto_prefix`: An optional hostname, or array of hostnames (e.g. `matrixto.example.org`, no scheme), that should be
+   treated as equivalent to `matrix.to`. Unlike `permalink_prefix`, this preserves matrix.to's own URL shape
+   (`https://<host>/#/<entity>`) and applies to **all** generated permalinks, including pills — the first hostname in the
+   list is used for generation. All listed hostnames, plus the real `matrix.to`, are recognised when parsing incoming
+   links. This is intended for deployments that cannot reach the real `matrix.to` (for example, an airgapped network) and
+   instead self-host a [matrix.to-compatible redirector](https://github.com/matrix-org/matrix.to) on a reachable domain.
+6. `desktop_builds`: Optional. Where the desktop builds for the application are, if available. This is explained in more detail
    down below.
-6. `mobile_builds`: Optional. Like `desktop_builds`, except for the mobile apps. Also described in more detail down below.
-7. `mobile_guide_toast`: When `true` (default), users accessing the Element Web instance from a mobile device will be prompted to
+7. `mobile_builds`: Optional. Like `desktop_builds`, except for the mobile apps. Also described in more detail down below.
+8. `mobile_guide_toast`: When `true` (default), users accessing the Element Web instance from a mobile device will be prompted to
    download the app instead.
-8. `mobile_guide_app_variant`: Optional. The mobile app that the user is prompted to download from the `/mobile_guide` page. When omitted
+9. `mobile_guide_app_variant`: Optional. The mobile app that the user is prompted to download from the `/mobile_guide` page. When omitted
    the mobile guide will be configured for the new Element X apps. Allowed values are as follows:
     1. `element`: Element X Android/iOS.
     2. `element-classic`: Element Classic Android/iOS.
     3. `element-pro`: Element Pro Android/iOS.
-9. `update_base_url`: For the desktop app only, the URL where to acquire update packages. If specified, must be a path to a directory
-   containing `macos` and `win32` directories, with the update packages within. Defaults to `https://packages.element.io/desktop/update/`
-   in production.
-10. `map_style_url`: Map tile server style URL for location sharing. e.g. `https://api.maptiler.com/maps/streets/style.json?key=YOUR_KEY_GOES_HERE`
+10. `update_base_url`: For the desktop app only, the URL where to acquire update packages. If specified, must be a path to a directory
+    containing `macos` and `win32` directories, with the update packages within. Defaults to `https://packages.element.io/desktop/update/`
+    in production.
+11. `map_style_url`: Map tile server style URL for location sharing. e.g. `https://api.maptiler.com/maps/streets/style.json?key=YOUR_KEY_GOES_HERE`
     This setting is ignored if your homeserver provides `/.well-known/matrix/client` in its well-known location, and the JSON file
     at that location has a key `m.tile_server` (or the unstable version `org.matrix.msc3488.tile_server`). In this case, the
     configuration found in the well-known location is used instead.
-11. `welcome_user_id`: **DEPRECATED** An optional user ID to start a DM with after creating an account. Defaults to nothing (no DM created).
-12. `custom_translations_url`: An optional URL to allow overriding of translatable strings. The JSON file must be in a format of
+12. `welcome_user_id`: **DEPRECATED** An optional user ID to start a DM with after creating an account. Defaults to nothing (no DM created).
+13. `custom_translations_url`: An optional URL to allow overriding of translatable strings. The JSON file must be in a format of
     `{"affected|translation|key": {"languageCode": "new string"}}`. See https://github.com/matrix-org/matrix-react-sdk/pull/7886 for details.
-13. `branding`: Options for configuring various assets used within the app. Described in more detail down below.
-14. `embedded_pages`: Further optional URLs for various assets used within the app. Described in more detail down below.
-15. `disable_3pid_login`: When `false` (default), **enables** the options to log in with email address or phone number. Set to
+14. `branding`: Options for configuring various assets used within the app. Described in more detail down below.
+15. `embedded_pages`: Further optional URLs for various assets used within the app. Described in more detail down below.
+16. `disable_3pid_login`: When `false` (default), **enables** the options to log in with email address or phone number. Set to
     `true` to hide these options.
-16. `disable_login_language_selector`: When `false` (default), **enables** the language selector on the login pages. Set to `true`
+17. `disable_login_language_selector`: When `false` (default), **enables** the language selector on the login pages. Set to `true`
     to hide this dropdown.
-17. `disable_guests`: When `false` (default), **enable** guest-related functionality (peeking/previewing rooms, etc) for unregistered
+18. `disable_guests`: When `false` (default), **enable** guest-related functionality (peeking/previewing rooms, etc) for unregistered
     users. Set to `true` to disable this functionality.
-18. `user_notice`: Optional notice to show to the user, e.g. for sunsetting a deployment and pushing users to move in their own time.
+19. `user_notice`: Optional notice to show to the user, e.g. for sunsetting a deployment and pushing users to move in their own time.
     Takes a configuration object as below:
     1. `title`: Required. Title to show at the top of the notice.
     2. `description`: Required. The description to use for the notice.
     3. `show_once`: Optional. If true then the notice will only be shown once per device.
-19. `help_url`: The URL to point users to for help with the app, defaults to `https://element.io/help`.
-20. `help_encryption_url`: The URL to point users to for help with encryption, defaults to `https://element.io/help#encryption`.
-21. `help_key_storage_url`: The URL to point users to for help with key storage, defaults to `https://element.io/help#encryption5`.
-22. `force_verification`: If true, users must verify new logins (eg. with another device / their recovery key)
+20. `help_url`: The URL to point users to for help with the app, defaults to `https://element.io/help`.
+21. `help_encryption_url`: The URL to point users to for help with encryption, defaults to `https://element.io/help#encryption`.
+22. `help_key_storage_url`: The URL to point users to for help with key storage, defaults to `https://element.io/help#encryption5`.
+23. `force_verification`: If true, users must verify new logins (eg. with another device / their recovery key)
 
 ### `desktop_builds` and `mobile_builds`
 

--- a/packages/shared-types/lib/config.json.d.ts
+++ b/packages/shared-types/lib/config.json.d.ts
@@ -65,6 +65,15 @@ export interface WebConfigJson {
 
     permalink_prefix?: string;
 
+    /**
+     * One or more hostnames (e.g. "matrix.to", or a self-hosted equivalent) that should be treated as
+     * matrix.to-equivalent domains. The first entry is used when generating new permalinks and pills;
+     * all entries, plus the real "matrix.to", are recognised when parsing incoming links. Useful for
+     * deployments that cannot reach the real matrix.to (e.g. airgapped networks) and self-host a
+     * matrix.to-style redirector instead.
+     */
+    matrixto_prefix?: string | string[];
+
     desktop_builds?: {
         available?: boolean;
         logo?: string; // url


### PR DESCRIPTION
This is intended for customers who are fully airgapped and need to host their own matrix.to. Additionally, there may be *multiple* of these hosted depending on the region so the configuration supports resolving multiple.

We would not expect most users to ever need to host their own matrix.to or configure this, but the feature is there for the minority that do.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
