### PR TITLE
Allow widgets to receive MatrixRTC slot events

### DIFF
--- a/apps/web/src/stores/widgets/ElementWidgetDriver.ts
+++ b/apps/web/src/stores/widgets/ElementWidgetDriver.ts
@@ -140,6 +140,9 @@ export class ElementWidgetDriver extends WidgetDriver {
                 WidgetEventCapability.forStateEvent(EventDirection.Receive, "org.matrix.msc3401.call").raw,
             );
             this.allowedCapabilities.add(
+                WidgetEventCapability.forStateEvent(EventDirection.Receive, "org.matrix.msc4143.rtc.slot").raw,
+            );
+            this.allowedCapabilities.add(
                 WidgetEventCapability.forStateEvent(EventDirection.Receive, EventType.RoomEncryption).raw,
             );
             const clientUserId = MatrixClientPeg.safeGet().getSafeUserId();


### PR DESCRIPTION
Relates to https://github.com/element-hq/voip-internal/issues/633. This lets widgets receive the slot event from https://github.com/matrix-org/matrix-spec-proposals/pull/4143.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
