### PR TITLE
Remove support for MSC3391 & MSC3852

### DIFF
--- a/apps/web/src/components/views/settings/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/views/settings/devices/DeviceDetails.tsx
@@ -96,12 +96,7 @@ const DeviceDetails: React.FC<Props> = ({
         {
             id: "device",
             heading: _t("common|device"),
-            values: [
-                { label: _t("common|model"), value: device.deviceModel },
-                { label: _t("settings|sessions|os"), value: device.deviceOperatingSystem },
-                { label: _t("settings|sessions|browser"), value: device.client },
-                { label: _t("settings|sessions|ip"), value: device.last_seen_ip },
-            ],
+            values: [{ label: _t("settings|sessions|ip"), value: device.last_seen_ip }],
         },
     ]
         .map((section) =>

--- a/apps/web/src/components/views/settings/devices/DeviceTile.tsx
+++ b/apps/web/src/components/views/settings/devices/DeviceTile.tsx
@@ -14,6 +14,7 @@ import { type ExtendedDevice } from "./types";
 import { DeviceTypeIcon } from "./DeviceTypeIcon";
 import { preventDefaultWrapper } from "../../../../utils/NativeEventUtils";
 import { DeviceMetaData } from "./DeviceMetaData";
+import { DeviceType } from "../../../../utils/device/parseUserAgent.ts";
 export interface DeviceTileProps {
     device: ExtendedDevice;
     isSelected?: boolean;
@@ -38,7 +39,7 @@ const DeviceTile: React.FC<DeviceTileProps> = ({ device, children, isSelected, o
             data-testid={`device-tile-${device.device_id}`}
             onClick={onClick}
         >
-            <DeviceTypeIcon isVerified={device.isVerified} isSelected={isSelected} deviceType={device.deviceType} />
+            <DeviceTypeIcon isVerified={device.isVerified} isSelected={isSelected} deviceType={DeviceType.Unknown} />
             <div className="mx_DeviceTile_info">
                 <DeviceTileName device={device} />
                 <div className="mx_DeviceTile_metadata">

--- a/apps/web/src/components/views/settings/devices/types.ts
+++ b/apps/web/src/components/views/settings/devices/types.ts
@@ -8,8 +8,6 @@ Please see LICENSE files in the repository root for full details.
 
 import { type IMyDevice } from "matrix-js-sdk/src/matrix";
 
-import { type ExtendedDeviceInformation } from "../../../../utils/device/parseUserAgent";
-
 export type DeviceWithVerification = IMyDevice & {
     /**
      * `null` if the device is unknown or has not published encryption keys; otherwise a boolean
@@ -23,7 +21,7 @@ export type ExtendedDeviceAppInfo = {
     appVersion?: string;
     url?: string;
 };
-export type ExtendedDevice = DeviceWithVerification & ExtendedDeviceAppInfo & ExtendedDeviceInformation;
+export type ExtendedDevice = DeviceWithVerification & ExtendedDeviceAppInfo;
 export type DevicesDictionary = Record<ExtendedDevice["device_id"], ExtendedDevice>;
 
 export enum DeviceSecurityVariation {

--- a/apps/web/src/components/views/settings/devices/useOwnDevices.ts
+++ b/apps/web/src/components/views/settings/devices/useOwnDevices.ts
@@ -16,7 +16,6 @@ import {
     type MatrixEvent,
     PUSHER_DEVICE_ID,
     PUSHER_ENABLED,
-    UNSTABLE_MSC3852_LAST_SEEN_UA,
     type MatrixError,
     type LocalNotificationSettings,
 } from "matrix-js-sdk/src/matrix";
@@ -27,7 +26,6 @@ import { _t } from "../../../../languageHandler";
 import { getDeviceClientInformation, pruneClientInformation } from "../../../../utils/device/clientInformation";
 import { type DevicesDictionary, type ExtendedDevice, type ExtendedDeviceAppInfo } from "./types";
 import { useEventEmitter } from "../../../../hooks/useEventEmitter";
-import { parseUserAgent } from "../../../../utils/device/parseUserAgent";
 import { isDeviceVerified } from "../../../../utils/device/isDeviceVerified";
 import { SDKContext } from "../../../../contexts/SDKContext";
 
@@ -56,7 +54,6 @@ export async function fetchExtendedDeviceInformation(matrixClient: MatrixClient)
             ...device,
             isVerified: await isDeviceVerified(matrixClient, device.device_id),
             ...parseDeviceExtendedInformation(matrixClient, device),
-            ...parseUserAgent(device[UNSTABLE_MSC3852_LAST_SEEN_UA.name]),
         };
     }
     return devicesDict;

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -504,7 +504,6 @@
         "message_layout": "Message layout",
         "message_timestamp_invalid": "Invalid timestamp",
         "microphone": "Microphone",
-        "model": "Model",
         "moderation_and_safety": "Moderation and safety",
         "modern": "Modern",
         "mute": "Mute",
@@ -2852,7 +2851,6 @@
         "send_typing_notifications": "Send typing notifications",
         "sessions": {
             "best_security_note": "For best security, verify your sessions and remove any session that you don't recognize or use anymore.",
-            "browser": "Browser",
             "confirm_sign_out": {
                 "one": "Confirm removing this device",
                 "other": "Confirm removing these devices"
@@ -2903,7 +2901,6 @@
             "no_sessions": "No sessions found.",
             "no_unverified_sessions": "No unverified sessions found.",
             "no_verified_sessions": "No verified sessions found.",
-            "os": "Operating system",
             "other_sessions_heading": "Other sessions",
             "push_heading": "Push notifications",
             "push_subheading": "Receive push notifications on this session.",

--- a/apps/web/src/toasts/UnverifiedSessionToast.tsx
+++ b/apps/web/src/toasts/UnverifiedSessionToast.tsx
@@ -17,8 +17,8 @@ import ToastStore from "../stores/ToastStore";
 import GenericToast from "../components/views/toasts/GenericToast";
 import { Action } from "../dispatcher/actions";
 import { isDeviceVerified } from "../utils/device/isDeviceVerified";
-import { DeviceType } from "../utils/device/parseUserAgent";
 import { DeviceMetaData } from "../components/views/settings/devices/DeviceMetaData";
+import type { ExtendedDevice } from "../components/views/settings/devices/types.ts";
 
 function toastKey(deviceId: string): string {
     return "unverified_session_" + deviceId;
@@ -39,10 +39,9 @@ export const showToast = async (deviceId: string): Promise<void> => {
     };
 
     const device = await cli.getDevice(deviceId);
-    const extendedDevice = {
+    const extendedDevice: ExtendedDevice = {
         ...device,
         isVerified: await isDeviceVerified(cli, deviceId),
-        deviceType: DeviceType.Unknown,
     };
 
     ToastStore.sharedInstance().addOrReplaceToast({

--- a/apps/web/test/unit-tests/components/views/settings/devices/CurrentDeviceSection-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/devices/CurrentDeviceSection-test.tsx
@@ -10,20 +10,18 @@ import React from "react";
 import { act, fireEvent, render } from "jest-matrix-react";
 
 import CurrentDeviceSection from "../../../../../../src/components/views/settings/devices/CurrentDeviceSection";
-import { DeviceType } from "../../../../../../src/utils/device/parseUserAgent";
+import type { ExtendedDevice } from "../../../../../../src/components/views/settings/devices/types.ts";
 
 describe("<CurrentDeviceSection />", () => {
     const deviceId = "alices_device";
 
-    const alicesVerifiedDevice = {
+    const alicesVerifiedDevice: ExtendedDevice = {
         device_id: deviceId,
         isVerified: false,
-        deviceType: DeviceType.Unknown,
     };
-    const alicesUnverifiedDevice = {
+    const alicesUnverifiedDevice: ExtendedDevice = {
         device_id: deviceId,
         isVerified: false,
-        deviceType: DeviceType.Unknown,
     };
 
     const defaultProps = {

--- a/apps/web/test/unit-tests/components/views/settings/devices/DeviceDetailHeading-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/devices/DeviceDetailHeading-test.tsx
@@ -11,16 +11,15 @@ import { fireEvent, render, type RenderResult } from "jest-matrix-react";
 
 import { DeviceDetailHeading } from "../../../../../../src/components/views/settings/devices/DeviceDetailHeading";
 import { flushPromisesWithFakeTimers } from "../../../../../test-utils";
-import { DeviceType } from "../../../../../../src/utils/device/parseUserAgent";
+import type { ExtendedDevice } from "../../../../../../src/components/views/settings/devices/types.ts";
 
 jest.useFakeTimers();
 
 describe("<DeviceDetailHeading />", () => {
-    const device = {
+    const device: ExtendedDevice = {
         device_id: "123",
         display_name: "My device",
         isVerified: true,
-        deviceType: DeviceType.Unknown,
     };
     const defaultProps = {
         device,

--- a/apps/web/test/unit-tests/components/views/settings/devices/DeviceDetails-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/devices/DeviceDetails-test.tsx
@@ -12,13 +12,12 @@ import { PUSHER_ENABLED } from "matrix-js-sdk/src/matrix";
 
 import DeviceDetails from "../../../../../../src/components/views/settings/devices/DeviceDetails";
 import { mkPusher } from "../../../../../test-utils/test-utils";
-import { DeviceType } from "../../../../../../src/utils/device/parseUserAgent";
+import type { ExtendedDevice } from "../../../../../../src/components/views/settings/devices/types.ts";
 
 describe("<DeviceDetails />", () => {
-    const baseDevice = {
+    const baseDevice: ExtendedDevice = {
         device_id: "my-device",
         isVerified: false,
-        deviceType: DeviceType.Unknown,
     };
     const defaultProps: ComponentProps<typeof DeviceDetails> = {
         device: baseDevice,

--- a/apps/web/test/unit-tests/components/views/settings/devices/DeviceTile-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/devices/DeviceTile-test.tsx
@@ -11,14 +11,12 @@ import { render } from "jest-matrix-react";
 import { type IMyDevice } from "matrix-js-sdk/src/matrix";
 
 import DeviceTile from "../../../../../../src/components/views/settings/devices/DeviceTile";
-import { DeviceType } from "../../../../../../src/utils/device/parseUserAgent";
 
 describe("<DeviceTile />", () => {
     const defaultProps = {
         device: {
             device_id: "123",
             isVerified: false,
-            deviceType: DeviceType.Unknown,
         },
     };
     const getComponent = (props = {}) => <DeviceTile {...defaultProps} {...props} />;

--- a/apps/web/test/unit-tests/components/views/settings/devices/DeviceVerificationStatusCard-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/devices/DeviceVerificationStatusCard-test.tsx
@@ -14,14 +14,12 @@ import {
     type DeviceVerificationStatusCardProps,
 } from "../../../../../../src/components/views/settings/devices/DeviceVerificationStatusCard";
 import { type ExtendedDevice } from "../../../../../../src/components/views/settings/devices/types";
-import { DeviceType } from "../../../../../../src/utils/device/parseUserAgent";
 
 describe("<DeviceVerificationStatusCard />", () => {
     const deviceId = "test-device";
     const unverifiedDevice: ExtendedDevice = {
         device_id: deviceId,
         isVerified: false,
-        deviceType: DeviceType.Unknown,
     };
     const verifiedDevice: ExtendedDevice = {
         ...unverifiedDevice,

--- a/apps/web/test/unit-tests/components/views/settings/devices/FilteredDeviceList-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/devices/FilteredDeviceList-test.tsx
@@ -10,9 +10,11 @@ import React, { type ComponentProps } from "react";
 import { act, fireEvent, render } from "jest-matrix-react";
 
 import { FilteredDeviceList } from "../../../../../../src/components/views/settings/devices/FilteredDeviceList";
-import { DeviceSecurityVariation } from "../../../../../../src/components/views/settings/devices/types";
+import {
+    DeviceSecurityVariation,
+    type ExtendedDevice,
+} from "../../../../../../src/components/views/settings/devices/types";
 import { flushPromises, mockPlatformPeg } from "../../../../../test-utils";
-import { DeviceType } from "../../../../../../src/utils/device/parseUserAgent";
 
 mockPlatformPeg();
 
@@ -21,35 +23,30 @@ describe("<FilteredDeviceList />", () => {
     // 14.03.2022 16:15
     const now = 1647270879403;
     jest.spyOn(global.Date, "now").mockReturnValue(now);
-    const newDevice = {
+    const newDevice: ExtendedDevice = {
         device_id: "new",
         last_seen_ts: Date.now() - 500,
         last_seen_ip: "123.456.789",
         display_name: "My Device",
         isVerified: true,
-        deviceType: DeviceType.Unknown,
     };
-    const unverifiedNoMetadata = {
+    const unverifiedNoMetadata: ExtendedDevice = {
         device_id: "unverified-no-metadata",
         isVerified: false,
-        deviceType: DeviceType.Unknown,
     };
-    const verifiedNoMetadata = {
+    const verifiedNoMetadata: ExtendedDevice = {
         device_id: "verified-no-metadata",
         isVerified: true,
-        deviceType: DeviceType.Unknown,
     };
-    const hundredDaysOld = {
+    const hundredDaysOld: ExtendedDevice = {
         device_id: "100-days-old",
         isVerified: true,
         last_seen_ts: Date.now() - MS_DAY * 100,
-        deviceType: DeviceType.Unknown,
     };
-    const hundredDaysOldUnverified = {
+    const hundredDaysOldUnverified: ExtendedDevice = {
         device_id: "unverified-100-days-old",
         isVerified: false,
         last_seen_ts: Date.now() - MS_DAY * 100,
-        deviceType: DeviceType.Unknown,
     };
     const defaultProps: ComponentProps<typeof FilteredDeviceList> = {
         onFilterChange: jest.fn(),

--- a/apps/web/test/unit-tests/components/views/settings/devices/SelectableDeviceTile-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/devices/SelectableDeviceTile-test.tsx
@@ -10,15 +10,14 @@ import { act, fireEvent, render } from "jest-matrix-react";
 import React from "react";
 
 import SelectableDeviceTile from "../../../../../../src/components/views/settings/devices/SelectableDeviceTile";
-import { DeviceType } from "../../../../../../src/utils/device/parseUserAgent";
+import type { ExtendedDevice } from "../../../../../../src/components/views/settings/devices/types.ts";
 
 describe("<SelectableDeviceTile />", () => {
-    const device = {
+    const device: ExtendedDevice = {
         display_name: "My Device",
         device_id: "my-device",
         last_seen_ip: "123.456.789",
         isVerified: false,
-        deviceType: DeviceType.Unknown,
     };
     const defaultProps = {
         onSelect: jest.fn(),
@@ -55,7 +54,7 @@ describe("<SelectableDeviceTile />", () => {
         const { getByText } = render(getComponent({ onClick }));
 
         act(() => {
-            fireEvent.click(getByText(device.display_name));
+            fireEvent.click(getByText(device.display_name!));
         });
 
         expect(onClick).toHaveBeenCalled();

--- a/apps/web/test/unit-tests/components/views/settings/devices/__snapshots__/DeviceDetails-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/settings/devices/__snapshots__/DeviceDetails-test.tsx.snap
@@ -267,42 +267,6 @@ exports[`<DeviceDetails /> renders device with metadata 1`] = `
             <td
               class="mxDeviceDetails_metadataLabel"
             >
-              Model
-            </td>
-            <td
-              class="mxDeviceDetails_metadataValue"
-            >
-              Iphone X
-            </td>
-          </tr>
-          <tr>
-            <td
-              class="mxDeviceDetails_metadataLabel"
-            >
-              Operating system
-            </td>
-            <td
-              class="mxDeviceDetails_metadataValue"
-            >
-              Windows 95
-            </td>
-          </tr>
-          <tr>
-            <td
-              class="mxDeviceDetails_metadataLabel"
-            >
-              Browser
-            </td>
-            <td
-              class="mxDeviceDetails_metadataValue"
-            >
-              Firefox 100
-            </td>
-          </tr>
-          <tr>
-            <td
-              class="mxDeviceDetails_metadataLabel"
-            >
               IP address
             </td>
             <td

--- a/apps/web/test/unit-tests/components/views/settings/devices/filter-test.ts
+++ b/apps/web/test/unit-tests/components/views/settings/devices/filter-test.ts
@@ -7,38 +7,35 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { filterDevicesBySecurityRecommendation } from "../../../../../../src/components/views/settings/devices/filter";
-import { DeviceSecurityVariation } from "../../../../../../src/components/views/settings/devices/types";
-import { DeviceType } from "../../../../../../src/utils/device/parseUserAgent";
+import {
+    DeviceSecurityVariation,
+    type ExtendedDevice,
+} from "../../../../../../src/components/views/settings/devices/types";
 
 const MS_DAY = 86400000;
 describe("filterDevicesBySecurityRecommendation()", () => {
-    const unverifiedNoMetadata = {
+    const unverifiedNoMetadata: ExtendedDevice = {
         device_id: "unverified-no-metadata",
         isVerified: false,
-        deviceType: DeviceType.Unknown,
     };
-    const verifiedNoMetadata = {
+    const verifiedNoMetadata: ExtendedDevice = {
         device_id: "verified-no-metadata",
         isVerified: true,
-        deviceType: DeviceType.Unknown,
     };
-    const hundredDaysOld = {
+    const hundredDaysOld: ExtendedDevice = {
         device_id: "100-days-old",
         isVerified: true,
         last_seen_ts: Date.now() - MS_DAY * 100,
-        deviceType: DeviceType.Unknown,
     };
-    const hundredDaysOldUnverified = {
+    const hundredDaysOldUnverified: ExtendedDevice = {
         device_id: "unverified-100-days-old",
         isVerified: false,
         last_seen_ts: Date.now() - MS_DAY * 100,
-        deviceType: DeviceType.Unknown,
     };
-    const fiftyDaysOld = {
+    const fiftyDaysOld: ExtendedDevice = {
         device_id: "50-days-old",
         isVerified: true,
         last_seen_ts: Date.now() - MS_DAY * 50,
-        deviceType: DeviceType.Unknown,
     };
 
     const devices = [unverifiedNoMetadata, verifiedNoMetadata, hundredDaysOld, hundredDaysOldUnverified, fiftyDaysOld];


### PR DESCRIPTION
As they were both rejected & closed.

Synapse already removed support for MSC3852 which means it already did nothing: https://github.com/element-hq/synapse/pull/19430
