### PR TITLE
Add share_history_on_autojoin labs flag enabling MSC4509 key bundle claims

### DIFF
--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -1565,6 +1565,8 @@
         "notifications": "Enable the notifications panel in the room header",
         "render_reaction_images": "Render custom images in reactions",
         "render_reaction_images_description": "Sometimes referred to as \"custom emojis\".",
+        "share_history_on_autojoin": "Share encrypted history on automatic joins (MSC4509)",
+        "share_history_on_autojoin_description": "When the server joins you to a room automatically (such as an accepted knock on an encrypted room), coordinate between your devices which one downloads the shared message history. Requires a homeserver with MSC4509 support.",
         "sliding_sync": "Sliding Sync mode",
         "sliding_sync_description": "Under active development, cannot be disabled. Currently, not compatible with Element Call.",
         "sliding_sync_disabled_notice": "Sign in again to disable",

--- a/apps/web/src/settings/Settings.tsx
+++ b/apps/web/src/settings/Settings.tsx
@@ -227,6 +227,7 @@ export interface Settings {
     "feature_ask_to_join": IFeature;
     "feature_notifications": IFeature;
     "feature_msc4362_encrypted_state_events": IFeature;
+    "feature_share_history_on_autojoin": IFeature;
     "feature_user_status": IFeature;
     "feature_login_with_qr": IFeature;
     "feature_msc4095_url_preview_bundle": IFeature;
@@ -732,6 +733,17 @@ export const SETTINGS: Settings = {
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG_PRIORITISED,
         supportedLevelsAreOrdered: true,
         shouldWarn: true,
+        default: false,
+    },
+    "feature_share_history_on_autojoin": {
+        isFeature: true,
+        labsGroup: LabGroup.Encryption,
+        displayName: _td("labs|share_history_on_autojoin"),
+        description: _td("labs|share_history_on_autojoin_description"),
+        supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG_PRIORITISED,
+        supportedLevelsAreOrdered: true,
+        // The flag is handed to the js-sdk at client creation
+        controller: new ReloadOnChangeController(),
         default: false,
     },
     "feature_user_status": {

--- a/apps/web/src/utils/createMatrixClient.test.ts
+++ b/apps/web/src/utils/createMatrixClient.test.ts
@@ -5,10 +5,16 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { vi, describe, beforeEach, it, expect } from "vitest";
-import { type MatrixClient, RoomNameType } from "matrix-js-sdk/src/matrix";
+import { vi, describe, beforeEach, afterEach, it, expect } from "vitest";
+import { createClient, type MatrixClient, RoomNameType } from "matrix-js-sdk/src/matrix";
 
 import { createClientWithCreds } from "./createMatrixClient";
+import SettingsStore from "../settings/SettingsStore";
+
+vi.mock(import("matrix-js-sdk/src/matrix"), async (importOriginal) => {
+    const actual = await importOriginal();
+    return { ...actual, createClient: vi.fn(actual.createClient) };
+});
 
 describe("createMatrixClient", () => {
     let client: MatrixClient;
@@ -148,6 +154,32 @@ describe("createMatrixClient", () => {
                     expect(roomName).toBe("Inviting Alice and 3 others");
                 });
             });
+        });
+    });
+
+    describe("MSC4509 key bundle claims", () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it("are not enabled in the js-sdk by default", () => {
+            expect(vi.mocked(createClient)).toHaveBeenLastCalledWith(
+                expect.objectContaining({ unstableMSC4509KeyBundleClaim: false }),
+            );
+        });
+
+        it("are enabled in the js-sdk when the share_history_on_autojoin labs flag is set", () => {
+            vi.spyOn(SettingsStore, "getValue").mockImplementation(
+                (settingName) => settingName === "feature_share_history_on_autojoin",
+            );
+            createClientWithCreds({
+                homeserverUrl: "https://test.dummy",
+                userId: "@user:test.dummy",
+                accessToken: "access_token",
+            });
+            expect(vi.mocked(createClient)).toHaveBeenLastCalledWith(
+                expect.objectContaining({ unstableMSC4509KeyBundleClaim: true }),
+            );
         });
     });
 });

--- a/apps/web/src/utils/createMatrixClient.ts
+++ b/apps/web/src/utils/createMatrixClient.ts
@@ -155,6 +155,7 @@ export function createClientWithCreds(creds: IMatrixClientCreds, oauth?: OAuth2)
         cryptoCallbacks: { ...crossSigningCallbacks },
         enableEncryptedStateEvents: SettingsStore.getValue("feature_msc4362_encrypted_state_events"),
         unstableMSC1763Retention: SettingsStore.getValue("feature_retention"),
+        unstableMSC4509KeyBundleClaim: SettingsStore.getValue("feature_share_history_on_autojoin"),
         roomNameGenerator,
     };
 


### PR DESCRIPTION
Adds a labs feature flag, `share_history_on_autojoin` (off by default), which sets the js-sdk's new `unstableMSC4509KeyBundleClaim` client option at client creation: on a server-initiated join (e.g. an auto-accepted knock), MSC4268 key bundle downloads are deferred until the server designates this device via an `org.matrix.msc4509.key_bundle_claim` to-device message (or the room yields an undecryptable event), instead of every device downloading the bundle eagerly.

Requires matrix-org/matrix-js-sdk#5426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UL75t5KJNwHfn3noyYKBSK