### PR TITLE
Update Twemoji credits links

### DIFF
--- a/apps/web/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
@@ -168,10 +168,12 @@ export default class HelpUserSettingsTab extends React.Component<EmptyObject, IS
                                 {},
                                 {
                                     twemoji: (sub) => (
-                                        <ExternalLink href="https://twemoji.twitter.com/">{sub}</ExternalLink>
+                                        <ExternalLink href="https://github.com/twitter/twemoji">{sub}</ExternalLink>
                                     ),
                                     author: (sub) => (
-                                        <ExternalLink href="https://twemoji.twitter.com/">{sub}</ExternalLink>
+                                        <ExternalLink href="https://github.com/twitter/twemoji/graphs/contributors">
+                                            {sub}
+                                        </ExternalLink>
                                     ),
                                     terms: (sub) => (
                                         <ExternalLink

--- a/apps/web/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
@@ -168,10 +168,10 @@ export default class HelpUserSettingsTab extends React.Component<EmptyObject, IS
                                 {},
                                 {
                                     twemoji: (sub) => (
-                                        <ExternalLink href="https://github.com/twitter/twemoji">{sub}</ExternalLink>
+                                        <ExternalLink href="https://github.com/jdecked/twemoji">{sub}</ExternalLink>
                                     ),
                                     author: (sub) => (
-                                        <ExternalLink href="https://github.com/twitter/twemoji/graphs/contributors">
+                                        <ExternalLink href="https://github.com/jdecked/twemoji/graphs/contributors">
                                             {sub}
                                         </ExternalLink>
                                     ),


### PR DESCRIPTION
As https://twemoji.twitter.com/ is dead

Fixes https://github.com/element-hq/element-web/issues/34401