### PR TITLE
Move EventTile to shared components - #4a

### DIFF
--- a/apps/web/src/components/views/rooms/EventTile.tsx
+++ b/apps/web/src/components/views/rooms/EventTile.tsx
@@ -48,7 +48,6 @@ import { type ComposerInsertPayload } from "../../../dispatcher/payloads/Compose
 import { Action } from "../../../dispatcher/actions";
 import PlatformPeg from "../../../PlatformPeg";
 import { type IReadReceiptPosition } from "./ReadReceiptMarker";
-import { getEventDisplayInfo } from "../../../utils/EventRenderingUtils";
 import RoomContext, { TimelineRenderingType } from "../../../contexts/RoomContext";
 import { MediaEventHelper } from "../../../utils/MediaEventHelper";
 import { copyPlaintext } from "../../../utils/strings";
@@ -74,6 +73,7 @@ import { EventTileTimestampSlot } from "./EventTile/EventTileTimestampSlot";
 import {
     EventTileViewModel,
     type EventTileViewModelProps,
+    type EventTileViewModelDependencies,
 } from "../../../viewmodels/room/timeline/event-tile/EventTileViewModel";
 import {
     getEventTileReceiptState,
@@ -271,7 +271,6 @@ interface IState {
 }
 
 interface EventTileRenderInputs {
-    displayInfo: ReturnType<typeof getEventDisplayInfo>;
     hasPinnedMessageBadge: boolean;
     hasReactionsRow: boolean;
     threadState: EventTileThreadState;
@@ -324,7 +323,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
             thread,
         };
 
-        this.viewModel = new EventTileViewModel({ mxEvent: this.props.mxEvent }, this.createViewModelProps());
+        this.viewModel = new EventTileViewModel(this.createViewModelDependencies(), this.createViewModelProps());
 
         this.e2eViewModel = new EventTileE2eViewModel({
             cli: MatrixClientPeg.safeGet(),
@@ -831,14 +830,16 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
         };
     }
 
-    private createRenderInputs(
-        displayInfo = getEventDisplayInfo(
-            MatrixClientPeg.safeGet(),
-            this.props.mxEvent,
-            this.context.showHiddenEvents,
-            shouldHideEventTile({ callEventGrouper: this.props.callEventGrouper }),
-        ),
-    ): EventTileRenderInputs {
+    private createViewModelDependencies(): EventTileViewModelDependencies {
+        return {
+            mxEvent: this.props.mxEvent,
+            matrixClient: MatrixClientPeg.safeGet(),
+            showHiddenEvents: this.context.showHiddenEvents,
+            hideEvent: shouldHideEventTile({ callEventGrouper: this.props.callEventGrouper }),
+        };
+    }
+
+    private createRenderInputs(): EventTileRenderInputs {
         const isRedacted = isMessageEvent(this.props.mxEvent) && this.props.isRedacted;
         const hasPinnedMessageBadge = PinningUtils.isPinned(MatrixClientPeg.safeGet(), this.props.mxEvent);
         const hasReactionsRow = !isRedacted;
@@ -847,7 +848,6 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
         const isOwnEvent = this.props.mxEvent?.getSender() === MatrixClientPeg.safeGet().getUserId();
 
         return {
-            displayInfo,
             hasPinnedMessageBadge,
             hasReactionsRow,
             threadState,
@@ -856,7 +856,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
     }
 
     private createViewModelProps(inputs: EventTileRenderInputs = this.createRenderInputs()): EventTileViewModelProps {
-        const { displayInfo, hasPinnedMessageBadge, hasReactionsRow, threadState, isOwnEvent } = inputs;
+        const { hasPinnedMessageBadge, hasReactionsRow, threadState, isOwnEvent } = inputs;
         const isProbablyMedia = MediaEventHelper.isEligible(this.props.mxEvent);
         const isEditing = !!this.props.editState;
         const isSending =
@@ -876,12 +876,6 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                 layout: this.props.layout,
                 continuation: this.props.continuation,
                 isProbablyMedia,
-                hasRenderer: displayInfo.hasRenderer,
-                isBubbleMessage: displayInfo.isBubbleMessage,
-                isLeftAlignedBubbleMessage: displayInfo.isLeftAlignedBubbleMessage,
-                isAlignedBetweenBubbles: displayInfo.isAlignedBetweenBubbles,
-                isInfoMessage: displayInfo.isInfoMessage,
-                noBubbleEvent: displayInfo.noBubbleEvent,
                 isTwelveHour: this.props.isTwelveHour,
                 isHighlighted: shouldHighlightEventTile({
                     cli: MatrixClientPeg.safeGet(),
@@ -956,25 +950,18 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
     }
 
     public render(): ReactNode {
-        const displayInfo = getEventDisplayInfo(
-            MatrixClientPeg.safeGet(),
-            this.props.mxEvent,
-            this.context.showHiddenEvents,
-            shouldHideEventTile({ callEventGrouper: this.props.callEventGrouper }),
-        );
-        const { hasRenderer, isSeeingThroughMessageHiddenForModeration } = displayInfo;
         const { isQuoteExpanded } = this.state;
-        const renderInputs = this.createRenderInputs(displayInfo);
+        const renderInputs = this.createRenderInputs();
         const { hasPinnedMessageBadge, hasReactionsRow, threadState } = renderInputs;
 
-        this.viewModel.setEvent(this.props.mxEvent);
+        this.viewModel.setDependencies(this.createViewModelDependencies());
         this.viewModel.setProps(this.createViewModelProps(renderInputs));
         const eventTileRenderState = this.viewModel.getSnapshot();
         const eventTileSnapshot = eventTileRenderState.snapshot;
 
         // This shouldn't happen: the caller should check we support this type
         // before trying to instantiate us
-        if (!hasRenderer) {
+        if (!eventTileSnapshot.event.hasRenderer) {
             logger.warn(
                 `Event type not supported: type:${eventTileSnapshot.event.eventType} isState:${eventTileSnapshot.event.isState}`,
             );
@@ -989,6 +976,8 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
         const tileClasses = eventTileRenderState.root.className;
         const tileAriaLive = eventTileRenderState.root.ariaLive;
         const isRenderingNotification = eventTileSnapshot.event.isRenderingNotification;
+        const isSeeingThroughMessageHiddenForModeration =
+            eventTileSnapshot.event.isSeeingThroughMessageHiddenForModeration;
 
         const permalink = this.getPermalink();
 

--- a/apps/web/src/components/views/rooms/EventTile.tsx
+++ b/apps/web/src/components/views/rooms/EventTile.tsx
@@ -55,12 +55,7 @@ import { copyPlaintext } from "../../../utils/strings";
 import { DecryptionFailureTracker } from "../../../DecryptionFailureTracker";
 import { type ViewRoomPayload } from "../../../dispatcher/payloads/ViewRoomPayload";
 import PosthogTrackers from "../../../PosthogTrackers";
-import {
-    haveRendererForEvent,
-    isMessageEvent,
-    renderTile,
-    type EventTileTypeProps,
-} from "../../../events/EventTileFactory";
+import { isMessageEvent, renderTile, type EventTileTypeProps } from "../../../events/EventTileFactory";
 import { type ShowThreadPayload } from "../../../dispatcher/payloads/ShowThreadPayload";
 import { UnreadNotificationBadge } from "./NotificationBadge/UnreadNotificationBadge";
 import { getLateEventInfo } from "../../structures/grouper/LateEventGrouper";
@@ -89,7 +84,6 @@ import {
     getEventTileThreadState,
     type EventTileThreadState,
 } from "../../../viewmodels/room/timeline/event-tile/EventTileThreadState";
-import { getEventTileReplyChainState } from "../../../viewmodels/room/timeline/event-tile/EventTileReplyChainState";
 import {
     eventTileActionBarFocusChange,
     eventTileBlurWithin,
@@ -882,6 +876,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                 layout: this.props.layout,
                 continuation: this.props.continuation,
                 isProbablyMedia,
+                hasRenderer: displayInfo.hasRenderer,
                 isBubbleMessage: displayInfo.isBubbleMessage,
                 isLeftAlignedBubbleMessage: displayInfo.isLeftAlignedBubbleMessage,
                 isAlignedBetweenBubbles: displayInfo.isAlignedBetweenBubbles,
@@ -1066,16 +1061,8 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
             />
         );
 
-        const replyChainState = getEventTileReplyChainState({
-            mxEvent: this.props.mxEvent,
-            hasRenderer: haveRendererForEvent(
-                this.props.mxEvent,
-                MatrixClientPeg.safeGet(),
-                this.context.showHiddenEvents,
-            ),
-        });
         let replyChain: JSX.Element | undefined;
-        if (replyChainState.shouldShowReplyChain) {
+        if (eventTileSnapshot.root.data.hasReply) {
             replyChain = (
                 <ReplyChain
                     parentEv={this.props.mxEvent}
@@ -1098,7 +1085,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                     this.props.as || "li",
                     {
                         ...this.createInteractiveRootAttributes(rootRenderState),
-                        "data-has-reply": !!replyChain,
+                        "data-has-reply": eventTileSnapshot.root.data.hasReply,
                         "data-layout": eventTileSnapshot.root.data.layout,
                         "data-self": eventTileSnapshot.root.data.isOwnEvent,
                         "data-event-id": eventTileSnapshot.root.data.eventId,
@@ -1155,7 +1142,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                         "data-layout": eventTileSnapshot.root.data.layout,
                         "data-shape": eventTileSnapshot.root.data.shape,
                         "data-self": eventTileSnapshot.root.data.isOwnEvent,
-                        "data-has-reply": !!replyChain,
+                        "data-has-reply": eventTileSnapshot.root.data.hasReply,
                         "onClick": (ev: MouseEvent) => {
                             const target = ev.currentTarget as HTMLElement;
                             let index = -1;
@@ -1193,7 +1180,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                             {timestamp}
                             <UnreadNotificationBadge
                                 room={room || undefined}
-                                threadId={this.props.mxEvent.getId()}
+                                threadId={eventTileSnapshot.root.data.eventId}
                                 forceDot={true}
                             />
                         </div>
@@ -1260,7 +1247,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                         "data-layout": eventTileSnapshot.root.data.layout,
                         "data-self": eventTileSnapshot.root.data.isOwnEvent,
                         "data-event-id": eventTileSnapshot.root.data.eventId,
-                        "data-has-reply": !!replyChain,
+                        "data-has-reply": eventTileSnapshot.root.data.hasReply,
                     },
                     <>
                         {ircTimestamp}
@@ -1278,7 +1265,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                             {groupPadlock}
                             {replyChain}
                             {renderTile(
-                                this.context.timelineRenderingType,
+                                eventTileSnapshot.root.data.shape,
                                 this.createRenderTileProps({
                                     isSeeingThroughMessageHiddenForModeration,
                                 }),

--- a/apps/web/src/components/views/rooms/EventTile.tsx
+++ b/apps/web/src/components/views/rooms/EventTile.tsx
@@ -961,9 +961,6 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
     }
 
     public render(): ReactNode {
-        const eventType = this.props.mxEvent.getType();
-        const replacingEventId = this.props.mxEvent.replacingEventId();
-
         const displayInfo = getEventDisplayInfo(
             MatrixClientPeg.safeGet(),
             this.props.mxEvent,
@@ -972,11 +969,20 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
         );
         const { hasRenderer, isSeeingThroughMessageHiddenForModeration } = displayInfo;
         const { isQuoteExpanded } = this.state;
+        const renderInputs = this.createRenderInputs(displayInfo);
+        const { hasPinnedMessageBadge, hasReactionsRow, threadState } = renderInputs;
+
+        this.viewModel.setEvent(this.props.mxEvent);
+        this.viewModel.setProps(this.createViewModelProps(renderInputs));
+        const eventTileRenderState = this.viewModel.getSnapshot();
+        const eventTileSnapshot = eventTileRenderState.snapshot;
+
         // This shouldn't happen: the caller should check we support this type
         // before trying to instantiate us
         if (!hasRenderer) {
-            const { mxEvent } = this.props;
-            logger.warn(`Event type not supported: type:${eventType} isState:${mxEvent.isState()}`);
+            logger.warn(
+                `Event type not supported: type:${eventTileSnapshot.event.eventType} isState:${eventTileSnapshot.event.isState}`,
+            );
             return (
                 <div className="mx_EventTile mx_EventTile_info mx_MNoticeBody">
                     <div className="mx_EventTile_line">{_t("timeline|error_no_renderer")}</div>
@@ -984,18 +990,10 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
             );
         }
 
-        const renderInputs = this.createRenderInputs(displayInfo);
-        const { hasPinnedMessageBadge, hasReactionsRow, threadState, isOwnEvent } = renderInputs;
-
-        this.viewModel.setEvent(this.props.mxEvent);
-        this.viewModel.setProps(this.createViewModelProps(renderInputs));
-        const eventTileRenderState = this.viewModel.getSnapshot();
-        const eventTileSnapshot = eventTileRenderState.snapshot;
-
         const lineClasses = eventTileRenderState.line.className;
         const tileClasses = eventTileRenderState.root.className;
         const tileAriaLive = eventTileRenderState.root.ariaLive;
-        const isRenderingNotification = eventTileRenderState.root.isRenderingNotification;
+        const isRenderingNotification = eventTileSnapshot.event.isRenderingNotification;
 
         const permalink = this.getPermalink();
 
@@ -1101,9 +1099,9 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                     {
                         ...this.createInteractiveRootAttributes(rootRenderState),
                         "data-has-reply": !!replyChain,
-                        "data-layout": this.props.layout,
-                        "data-self": isOwnEvent,
-                        "data-event-id": this.props.mxEvent.getId(),
+                        "data-layout": eventTileSnapshot.root.data.layout,
+                        "data-self": eventTileSnapshot.root.data.isOwnEvent,
+                        "data-event-id": eventTileSnapshot.root.data.eventId,
                     },
                     [
                         <div className="mx_EventTile_senderDetails" key="mx_EventTile_senderDetails">
@@ -1121,7 +1119,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                             {renderTile(
                                 TimelineRenderingType.Thread,
                                 this.createRenderTileProps({
-                                    replacingEventId,
+                                    replacingEventId: eventTileSnapshot.event.replacingEventId,
                                     isSeeingThroughMessageHiddenForModeration,
                                     permalinkCreator: this.props.permalinkCreator!,
                                 }),
@@ -1154,9 +1152,9 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                     {
                         ...this.createInteractiveRootAttributes(rootRenderState),
                         "tabIndex": -1,
-                        "data-layout": this.props.layout,
-                        "data-shape": this.context.timelineRenderingType,
-                        "data-self": isOwnEvent,
+                        "data-layout": eventTileSnapshot.root.data.layout,
+                        "data-shape": eventTileSnapshot.root.data.shape,
+                        "data-self": eventTileSnapshot.root.data.isOwnEvent,
                         "data-has-reply": !!replyChain,
                         "onClick": (ev: MouseEvent) => {
                             const target = ev.currentTarget as HTMLElement;
@@ -1259,9 +1257,9 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                     {
                         ...this.createInteractiveRootAttributes(rootRenderState),
                         "tabIndex": -1,
-                        "data-layout": this.props.layout,
-                        "data-self": isOwnEvent,
-                        "data-event-id": this.props.mxEvent.getId(),
+                        "data-layout": eventTileSnapshot.root.data.layout,
+                        "data-self": eventTileSnapshot.root.data.isOwnEvent,
+                        "data-event-id": eventTileSnapshot.root.data.eventId,
                         "data-has-reply": !!replyChain,
                     },
                     <>

--- a/apps/web/src/components/views/rooms/EventTile.tsx
+++ b/apps/web/src/components/views/rooms/EventTile.tsx
@@ -72,6 +72,7 @@ import { EventTileThreadInfo, EventTileThreadPanelSummary } from "./EventTile/Ev
 import { EventTileTimestampSlot } from "./EventTile/EventTileTimestampSlot";
 import {
     EventTileViewModel,
+    type EventTileRenderState,
     type EventTileViewModelProps,
     type EventTileViewModelDependencies,
 } from "../../../viewmodels/room/timeline/event-tile/EventTileViewModel";
@@ -275,12 +276,6 @@ interface EventTileRenderInputs {
     hasReactionsRow: boolean;
     threadState: EventTileThreadState;
     isOwnEvent: boolean;
-}
-
-interface EventTileRootRenderState {
-    tileClasses: string;
-    tileAriaLive?: "off";
-    scrollToken?: string;
 }
 
 /** EventTile implementation rendered inside a RoomContext with `timelineRenderingType` set. */
@@ -786,19 +781,19 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
     }
 
     private createRootAttributes({
-        tileClasses,
-        tileAriaLive,
+        className,
+        ariaLive,
         scrollToken,
-    }: EventTileRootRenderState): Record<string, unknown> {
+    }: EventTileRenderState["root"]): Record<string, unknown> {
         return {
-            "className": tileClasses,
-            "aria-live": tileAriaLive,
+            "className": className,
+            "aria-live": ariaLive,
             "aria-atomic": true,
             "data-scroll-tokens": scrollToken,
         };
     }
 
-    private createInteractiveRootAttributes(rootRenderState: EventTileRootRenderState): Record<string, unknown> {
+    private createInteractiveRootAttributes(rootRenderState: EventTileRenderState["root"]): Record<string, unknown> {
         return {
             ...this.createRootAttributes(rootRenderState),
             ref: this.ref,
@@ -973,16 +968,12 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
         }
 
         const lineClasses = eventTileRenderState.line.className;
-        const tileClasses = eventTileRenderState.root.className;
-        const tileAriaLive = eventTileRenderState.root.ariaLive;
         const isRenderingNotification = eventTileSnapshot.event.isRenderingNotification;
         const isSeeingThroughMessageHiddenForModeration =
             eventTileSnapshot.event.isSeeingThroughMessageHiddenForModeration;
 
         const permalink = this.getPermalink();
-
-        const scrollToken = eventTileRenderState.root.scrollToken;
-        const rootRenderState = { tileClasses, tileAriaLive, scrollToken };
+        const rootRenderState = eventTileRenderState.root;
 
         const avatarMember = this.getAvatarMember();
         const avatar = <EventTileAvatarAdapter avatarMember={avatarMember} senderSnapshot={eventTileSnapshot.sender} />;

--- a/apps/web/src/components/views/rooms/EventTile.tsx
+++ b/apps/web/src/components/views/rooms/EventTile.tsx
@@ -18,8 +18,6 @@ import React, {
 } from "react";
 import {
     EventStatus,
-    EventType,
-    MsgType,
     type MatrixEvent,
     MatrixEventEvent,
     type Relations,
@@ -332,7 +330,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
             thread,
         };
 
-        this.viewModel = new EventTileViewModel(this.createViewModelProps());
+        this.viewModel = new EventTileViewModel({ mxEvent: this.props.mxEvent }, this.createViewModelProps());
 
         this.e2eViewModel = new EventTileE2eViewModel({
             cli: MatrixClientPeg.safeGet(),
@@ -866,10 +864,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
     private createViewModelProps(inputs: EventTileRenderInputs = this.createRenderInputs()): EventTileViewModelProps {
         const { displayInfo, hasPinnedMessageBadge, hasReactionsRow, threadState, isOwnEvent } = inputs;
         const isProbablyMedia = MediaEventHelper.isEligible(this.props.mxEvent);
-        const isEncryptionFailure = this.props.mxEvent.isDecryptionFailure();
         const isEditing = !!this.props.editState;
-        const eventType = this.props.mxEvent.getType();
-        const msgtype = this.props.mxEvent.getContent().msgtype;
         const isSending =
             this.props.eventSendStatus === EventStatus.SENDING ||
             this.props.eventSendStatus === EventStatus.QUEUED ||
@@ -877,18 +872,9 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
 
         return {
             event: {
-                eventType,
-                msgtype,
-                eventTs: this.props.mxEvent.getTs(),
-                eventId: this.props.mxEvent.getId() ?? undefined,
-                isLocalEcho: !!this.props.mxEvent.status,
                 isSending,
                 ariaLive: this.props.eventSendStatus === null ? undefined : "off",
-                isRoomCreate: eventType === EventType.RoomCreate,
-                isCallInvite: eventType === EventType.CallInvite,
-                isRtcNotification: eventType === EventType.RTCNotification,
                 isEditing,
-                isEncryptionFailure,
                 forExport: this.props.forExport,
             },
             display: {
@@ -923,7 +909,6 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                 inhibitInteraction: this.props.inhibitInteraction,
             },
             sender: {
-                senderId: this.props.mxEvent.getSender() ?? undefined,
                 member: roomMemberToMemberInfo(
                     this.props.useEventSenderSnapshot
                         ? this.getAvatarMember()
@@ -936,7 +921,6 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                           }),
                 ),
                 hideSender: this.props.hideSender,
-                isEmote: this.props.mxEvent.getContent().msgtype === MsgType.Emote,
             },
             timestamp: {
                 alwaysShowTimestamps: this.props.alwaysShowTimestamps,
@@ -1003,6 +987,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
         const renderInputs = this.createRenderInputs(displayInfo);
         const { hasPinnedMessageBadge, hasReactionsRow, threadState, isOwnEvent } = renderInputs;
 
+        this.viewModel.setEvent(this.props.mxEvent);
         this.viewModel.setProps(this.createViewModelProps(renderInputs));
         const eventTileRenderState = this.viewModel.getSnapshot();
         const eventTileSnapshot = eventTileRenderState.snapshot;

--- a/apps/web/src/components/views/rooms/EventTile.tsx
+++ b/apps/web/src/components/views/rooms/EventTile.tsx
@@ -949,8 +949,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
         const renderInputs = this.createRenderInputs();
         const { hasPinnedMessageBadge, hasReactionsRow, threadState } = renderInputs;
 
-        this.viewModel.setDependencies(this.createViewModelDependencies());
-        this.viewModel.setProps(this.createViewModelProps(renderInputs));
+        this.viewModel.setInputs(this.createViewModelDependencies(), this.createViewModelProps(renderInputs));
         const eventTileRenderState = this.viewModel.getSnapshot();
         const eventTileSnapshot = eventTileRenderState.snapshot;
 

--- a/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
+++ b/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
@@ -45,6 +45,7 @@ import {
 import { EventPreviewViewModel, type EventPreviewViewModelProps } from "./EventPreviewViewModel";
 import { getEventTileReplyChainState } from "./EventTileReplyChainState";
 import { getEventDisplayInfo } from "../../../../utils/EventRenderingUtils";
+import { haveRendererForEvent } from "../../../../events/EventTileFactory";
 import {
     ThreadListActionBarViewModel,
     type ThreadListActionBarViewModelProps,
@@ -598,7 +599,8 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
         );
         const replyChainState = getEventTileReplyChainState({
             mxEvent,
-            hasRenderer: displayInfo.hasRenderer,
+            // Replacement events have a fallback tile but must not show their own reply chain
+            hasRenderer: haveRendererForEvent(mxEvent, dependencies.matrixClient, dependencies.showHiddenEvents),
         });
 
         return {

--- a/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
+++ b/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
@@ -401,7 +401,11 @@ export interface EventTileRenderState {
     };
 }
 
-/** Derives the current EventTile snapshot from component-owned inputs. */
+/**
+ * Aggregate application-side render-state boundary for EventTile.
+ *
+ * SDK objects are converted to plain render data here before the existing render tree consumes it.
+ */
 export class EventTileViewModel extends BaseViewModel<EventTileRenderState, EventTileViewModelProps> {
     private dependencies: EventTileViewModelDependencies;
     private messageTimestampViewModel?: MessageTimestampViewModel;

--- a/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
+++ b/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
@@ -7,6 +7,7 @@ Please see LICENSE files in the repository root for full details.
 
 import classNames from "classnames";
 import { BaseViewModel } from "@element-hq/web-shared-components";
+import { EventType, MsgType, type MatrixEvent } from "matrix-js-sdk/src/matrix";
 
 import {
     type EventTileSenderProfileState,
@@ -51,6 +52,18 @@ import { ReactionsRowViewModel, type ReactionsRowViewModelProps } from "./reacti
 
 /** Event-level inputs for deriving the EventTile snapshot. */
 export interface EventTileEventInput {
+    /** Whether the event is in a pending send state. */
+    isSending: boolean;
+    /** Whether EventTile should announce updates in an aria-live region. */
+    ariaLive?: "off";
+    /** Whether the event is currently being edited. */
+    isEditing: boolean;
+    /** Whether the tile is rendering for export. */
+    forExport?: boolean;
+}
+
+/** Event-level inputs after SDK data has been converted to pure values. */
+export interface EventTileDerivedEventInput extends EventTileEventInput {
     /** The event type rendered by the tile. */
     eventType: string;
     /** The Matrix message type rendered by the tile. */
@@ -61,22 +74,14 @@ export interface EventTileEventInput {
     eventId?: string;
     /** Whether the event is a local echo. */
     isLocalEcho: boolean;
-    /** Whether the event is in a pending send state. */
-    isSending: boolean;
-    /** Whether EventTile should announce updates in an aria-live region. */
-    ariaLive?: "off";
     /** Whether the event is a room create event. */
     isRoomCreate: boolean;
     /** Whether the event is a call invite. */
     isCallInvite: boolean;
     /** Whether the event is an RTC notification. */
     isRtcNotification: boolean;
-    /** Whether the event is currently being edited. */
-    isEditing: boolean;
     /** Whether the event failed decryption. */
     isEncryptionFailure: boolean;
-    /** Whether the tile is rendering for export. */
-    forExport?: boolean;
 }
 
 /** Display inputs for deriving the EventTile snapshot. */
@@ -138,7 +143,7 @@ export interface EventTileSenderInput {
     /** Whether sender details should be hidden. */
     hideSender?: boolean;
     /** Whether the event body renders as an emote. */
-    isEmote: boolean;
+    isEmote?: boolean;
 }
 
 /** Timestamp inputs for deriving the EventTile snapshot. */
@@ -177,6 +182,22 @@ export interface EventTileViewModelProps {
     timestamp: EventTileTimestampInput;
     /** Footer inputs. */
     footer: EventTileFooterInput;
+}
+
+/** Pure EventTile inputs after event and sender data has been normalized. */
+export interface NormalizedEventTileViewModelProps {
+    event: EventTileDerivedEventInput;
+    display: EventTileDisplayInput;
+    interaction: EventTileInteractionInput;
+    sender: EventTileSenderInput;
+    timestamp: EventTileTimestampInput;
+    footer: EventTileFooterInput;
+}
+
+/** Application dependencies used by EventTileViewModel to derive render data. */
+export interface EventTileViewModelDependencies {
+    /** The Matrix event being rendered. */
+    mxEvent: MatrixEvent;
 }
 
 /** Event-level state derived for the EventTile snapshot. */
@@ -345,6 +366,7 @@ export interface EventTileRenderState {
 
 /** Derives the current EventTile snapshot from component-owned inputs. */
 export class EventTileViewModel extends BaseViewModel<EventTileRenderState, EventTileViewModelProps> {
+    private dependencies: EventTileViewModelDependencies;
     private messageTimestampViewModel?: MessageTimestampViewModel;
     private linkedMessageTimestampViewModel?: MessageTimestampViewModel;
     private threadMessagePreviewViewModel?: ThreadMessagePreviewViewModel;
@@ -355,16 +377,31 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
     private actionBarViewModel?: EventTileActionBarViewModel;
     private reactionsRowViewModel?: ReactionsRowViewModel;
 
-    public constructor(props: EventTileViewModelProps) {
-        const initialRenderState = EventTileViewModel.createRenderState(props);
+    public constructor(dependencies: EventTileViewModelDependencies, props: EventTileViewModelProps) {
+        const normalizedProps = EventTileViewModel.normalizeDependencies(dependencies, props);
+        const initialRenderState = EventTileViewModel.createRenderState(normalizedProps);
 
         super(props, initialRenderState);
+        this.dependencies = dependencies;
+    }
+
+    /** Updates the SDK event used to derive event-level rendering state. */
+    public setEvent(mxEvent: MatrixEvent): void {
+        this.dependencies = {
+            ...this.dependencies,
+            mxEvent,
+        };
+
+        const normalizedProps = EventTileViewModel.normalizeDependencies(this.dependencies, this.props);
+        this.props = normalizedProps;
+        this.snapshot.set(EventTileViewModel.createRenderState(normalizedProps));
     }
 
     /** Updates root EventTile inputs and refreshes the derived render state. */
     public setProps(props: EventTileViewModelProps): void {
-        this.props = props;
-        this.snapshot.set(EventTileViewModel.createRenderState(props));
+        const normalizedProps = EventTileViewModel.normalizeDependencies(this.dependencies, props);
+        this.props = normalizedProps;
+        this.snapshot.set(EventTileViewModel.createRenderState(normalizedProps));
     }
 
     public override dispose(): void {
@@ -471,7 +508,7 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
     }
 
     /** Derives render-ready EventTile state from component-owned inputs. */
-    public static createRenderState(props: EventTileViewModelProps): EventTileRenderState {
+    public static createRenderState(props: NormalizedEventTileViewModelProps): EventTileRenderState {
         const snapshot = EventTileViewModel.createSnapshot(props);
         const useIRCLayout = snapshot.timestamp.displayState.useIRCLayout;
         const showPadlock = !props.display.isBubbleMessage;
@@ -506,8 +543,40 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
         };
     }
 
+    /**
+     * Derives pure inputs from application dependencies while keeping the VM's public props SDK-free.
+     */
+    private static normalizeDependencies(
+        dependencies: EventTileViewModelDependencies,
+        props: EventTileViewModelProps,
+    ): NormalizedEventTileViewModelProps {
+        const { mxEvent } = dependencies;
+        const eventType = mxEvent.getType();
+
+        return {
+            ...props,
+            event: {
+                ...props.event,
+                eventType,
+                msgtype: mxEvent.getContent().msgtype,
+                eventTs: mxEvent.getTs(),
+                eventId: mxEvent.getId() ?? undefined,
+                isLocalEcho: !!mxEvent.status,
+                isRoomCreate: eventType === EventType.RoomCreate,
+                isCallInvite: eventType === EventType.CallInvite,
+                isRtcNotification: eventType === EventType.RTCNotification,
+                isEncryptionFailure: mxEvent.isDecryptionFailure(),
+            },
+            sender: {
+                ...props.sender,
+                senderId: mxEvent.getSender() ?? undefined,
+                isEmote: mxEvent.getContent().msgtype === MsgType.Emote,
+            },
+        };
+    }
+
     /** Creates an EventTile view model snapshot. */
-    public static createSnapshot(props: EventTileViewModelProps): EventTileViewModelSnapshot {
+    public static createSnapshot(props: NormalizedEventTileViewModelProps): EventTileViewModelSnapshot {
         const { event, display, interaction, sender, timestamp, footer } = props;
         const isContinuation = getIsContinuation(display.continuation, display.timelineRenderingType, display.layout);
         const isRenderingNotification = display.timelineRenderingType === TimelineRenderingType.Notification;
@@ -600,7 +669,7 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
                     timelineRenderingType: display.timelineRenderingType,
                 }),
                 forceHistoricalAvatar: event.eventType === "m.room.member",
-                isEmote: sender.isEmote,
+                isEmote: sender.isEmote ?? false,
             },
             actionBar: {
                 show: getShouldShowMessageActionBar({
@@ -651,7 +720,7 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
         isContinuation,
         isRenderingNotification,
     }: {
-        event: EventTileEventInput;
+        event: EventTileDerivedEventInput;
         display: EventTileDisplayInput;
         interaction: EventTileInteractionInput;
         sender: EventTileSenderInput;

--- a/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
+++ b/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
@@ -7,7 +7,7 @@ Please see LICENSE files in the repository root for full details.
 
 import classNames from "classnames";
 import { BaseViewModel } from "@element-hq/web-shared-components";
-import { EventType, MsgType, type MatrixEvent } from "matrix-js-sdk/src/matrix";
+import { EventType, MsgType, type MatrixClient, type MatrixEvent } from "matrix-js-sdk/src/matrix";
 
 import {
     type EventTileSenderProfileState,
@@ -44,6 +44,7 @@ import {
 } from "./E2eMessageSharedIconViewModel";
 import { EventPreviewViewModel, type EventPreviewViewModelProps } from "./EventPreviewViewModel";
 import { getEventTileReplyChainState } from "./EventTileReplyChainState";
+import { getEventDisplayInfo } from "../../../../utils/EventRenderingUtils";
 import {
     ThreadListActionBarViewModel,
     type ThreadListActionBarViewModelProps,
@@ -87,6 +88,10 @@ export interface EventTileDerivedEventInput extends EventTileEventInput {
     isRtcNotification: boolean;
     /** Whether the event failed decryption. */
     isEncryptionFailure: boolean;
+    /** Whether a renderer is available for the event. */
+    hasRenderer: boolean;
+    /** Whether the event should be rendered through the moderation fallback. */
+    isSeeingThroughMessageHiddenForModeration: boolean;
     /** Whether EventTile should render the reply chain. */
     hasReplyChain: boolean;
 }
@@ -101,18 +106,16 @@ export interface EventTileDisplayInput {
     continuation?: boolean;
     /** Whether the event body is likely to render media content. */
     isProbablyMedia: boolean;
-    /** Whether the current event renderer is available. */
-    hasRenderer: boolean;
     /** Whether the tile should use bubble container styling. */
-    isBubbleMessage: boolean;
+    isBubbleMessage?: boolean;
     /** Whether the bubble tile is left-aligned. */
-    isLeftAlignedBubbleMessage: boolean;
+    isLeftAlignedBubbleMessage?: boolean;
     /** Whether the event is aligned between bubble columns. */
-    isAlignedBetweenBubbles: boolean;
+    isAlignedBetweenBubbles?: boolean;
     /** Whether the event renders as an informational timeline item. */
-    isInfoMessage: boolean;
+    isInfoMessage?: boolean;
     /** Whether bubble styling should be suppressed for this event. */
-    noBubbleEvent: boolean;
+    noBubbleEvent?: boolean;
     /** Whether timestamps use twelve-hour formatting. */
     isTwelveHour?: boolean;
     /** Whether the event should be highlighted. */
@@ -125,6 +128,15 @@ export interface EventTileDisplayInput {
     isLastInSection?: boolean;
     /** Whether the tile is being rendered in contextual mode. */
     isContextual?: boolean;
+}
+
+/** Event display inputs after renderer and event display information has been normalized. */
+export interface EventTileDerivedDisplayInput extends EventTileDisplayInput {
+    isBubbleMessage: boolean;
+    isLeftAlignedBubbleMessage: boolean;
+    isAlignedBetweenBubbles: boolean;
+    isInfoMessage: boolean;
+    noBubbleEvent: boolean;
 }
 
 /** Interaction inputs for deriving the EventTile snapshot. */
@@ -196,7 +208,7 @@ export interface EventTileViewModelProps {
 /** Pure EventTile inputs after event and sender data has been normalized. */
 export interface NormalizedEventTileViewModelProps {
     event: EventTileDerivedEventInput;
-    display: EventTileDisplayInput;
+    display: EventTileDerivedDisplayInput;
     interaction: EventTileInteractionInput;
     sender: EventTileSenderInput;
     timestamp: EventTileTimestampInput;
@@ -207,6 +219,12 @@ export interface NormalizedEventTileViewModelProps {
 export interface EventTileViewModelDependencies {
     /** The Matrix event being rendered. */
     mxEvent: MatrixEvent;
+    /** Matrix client used to select the event renderer. */
+    matrixClient: MatrixClient;
+    /** Whether hidden events should use their fallback renderer. */
+    showHiddenEvents: boolean;
+    /** Whether the event is hidden by the current tile context. */
+    hideEvent?: boolean;
 }
 
 /** Event-level state derived for the EventTile snapshot. */
@@ -235,6 +253,10 @@ export interface EventTileEventSnapshot {
     isRenderingNotification: boolean;
     /** Whether the event failed decryption. */
     isEncryptionFailure: boolean;
+    /** Whether a renderer is available for the event. */
+    hasRenderer: boolean;
+    /** Whether the event should be rendered through the moderation fallback. */
+    isSeeingThroughMessageHiddenForModeration: boolean;
 }
 
 /** Plain data attributes rendered on the EventTile root element. */
@@ -400,12 +422,9 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
         this.dependencies = dependencies;
     }
 
-    /** Updates the SDK event used to derive event-level rendering state. */
-    public setEvent(mxEvent: MatrixEvent): void {
-        this.dependencies = {
-            ...this.dependencies,
-            mxEvent,
-        };
+    /** Updates application dependencies and refreshes the derived render state. */
+    public setDependencies(dependencies: EventTileViewModelDependencies): void {
+        this.dependencies = dependencies;
 
         const normalizedProps = EventTileViewModel.normalizeDependencies(this.dependencies, this.props);
         this.props = normalizedProps;
@@ -567,9 +586,15 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
     ): NormalizedEventTileViewModelProps {
         const { mxEvent } = dependencies;
         const eventType = mxEvent.getType();
+        const displayInfo = getEventDisplayInfo(
+            dependencies.matrixClient,
+            mxEvent,
+            dependencies.showHiddenEvents,
+            dependencies.hideEvent,
+        );
         const replyChainState = getEventTileReplyChainState({
             mxEvent,
-            hasRenderer: props.display.hasRenderer,
+            hasRenderer: displayInfo.hasRenderer,
         });
 
         return {
@@ -587,7 +612,13 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
                 isCallInvite: eventType === EventType.CallInvite,
                 isRtcNotification: eventType === EventType.RTCNotification,
                 isEncryptionFailure: mxEvent.isDecryptionFailure(),
+                hasRenderer: displayInfo.hasRenderer,
+                isSeeingThroughMessageHiddenForModeration: displayInfo.isSeeingThroughMessageHiddenForModeration,
                 hasReplyChain: replyChainState.shouldShowReplyChain,
+            },
+            display: {
+                ...props.display,
+                ...displayInfo,
             },
             sender: {
                 ...props.sender,
@@ -615,6 +646,8 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
             isContinuation,
             isRenderingNotification,
             isEncryptionFailure: event.isEncryptionFailure,
+            hasRenderer: event.hasRenderer,
+            isSeeingThroughMessageHiddenForModeration: event.isSeeingThroughMessageHiddenForModeration,
         };
         const senderProfileState = getEventTileSenderProfileState({
             isRenderingNotification,
@@ -746,7 +779,7 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
         isRenderingNotification,
     }: {
         event: EventTileDerivedEventInput;
-        display: EventTileDisplayInput;
+        display: EventTileDerivedDisplayInput;
         interaction: EventTileInteractionInput;
         sender: EventTileSenderInput;
         eventType: string;

--- a/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
+++ b/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
@@ -72,6 +72,10 @@ export interface EventTileDerivedEventInput extends EventTileEventInput {
     eventTs: number;
     /** The stable event identifier, when available. */
     eventId?: string;
+    /** The event identifier replaced by this event, when available. */
+    replacingEventId?: string;
+    /** Whether the event is a state event. */
+    isState: boolean;
     /** Whether the event is a local echo. */
     isLocalEcho: boolean;
     /** Whether the event is a room create event. */
@@ -208,6 +212,10 @@ export interface EventTileEventSnapshot {
     msgtype?: string;
     /** The stable event identifier, when available. */
     eventId?: string;
+    /** The event identifier replaced by this event, when available. */
+    replacingEventId?: string;
+    /** Whether the event is a state event. */
+    isState: boolean;
     /** The event origin timestamp. */
     eventTs: number;
     /** Whether the event is a local echo. */
@@ -561,6 +569,8 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
                 msgtype: mxEvent.getContent().msgtype,
                 eventTs: mxEvent.getTs(),
                 eventId: mxEvent.getId() ?? undefined,
+                replacingEventId: mxEvent.replacingEventId() ?? undefined,
+                isState: mxEvent.isState(),
                 isLocalEcho: !!mxEvent.status,
                 isRoomCreate: eventType === EventType.RoomCreate,
                 isCallInvite: eventType === EventType.CallInvite,
@@ -584,6 +594,8 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
             eventType: event.eventType,
             msgtype: event.msgtype,
             eventId: event.eventId,
+            replacingEventId: event.replacingEventId,
+            isState: event.isState,
             eventTs: event.eventTs,
             isLocalEcho: event.isLocalEcho,
             isSending: event.isSending,

--- a/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
+++ b/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
@@ -423,22 +423,14 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
         const normalizedProps = EventTileViewModel.normalizeDependencies(dependencies, props);
         const initialRenderState = EventTileViewModel.createRenderState(normalizedProps);
 
-        super(props, initialRenderState);
+        super(normalizedProps, initialRenderState);
         this.dependencies = dependencies;
     }
 
-    /** Updates application dependencies and refreshes the derived render state. */
-    public setDependencies(dependencies: EventTileViewModelDependencies): void {
+    /** Updates dependencies and root inputs together, emitting one consistent render state. */
+    public setInputs(dependencies: EventTileViewModelDependencies, props: EventTileViewModelProps): void {
         this.dependencies = dependencies;
-
-        const normalizedProps = EventTileViewModel.normalizeDependencies(this.dependencies, this.props);
-        this.props = normalizedProps;
-        this.snapshot.set(EventTileViewModel.createRenderState(normalizedProps));
-    }
-
-    /** Updates root EventTile inputs and refreshes the derived render state. */
-    public setProps(props: EventTileViewModelProps): void {
-        const normalizedProps = EventTileViewModel.normalizeDependencies(this.dependencies, props);
+        const normalizedProps = EventTileViewModel.normalizeDependencies(dependencies, props);
         this.props = normalizedProps;
         this.snapshot.set(EventTileViewModel.createRenderState(normalizedProps));
     }

--- a/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
+++ b/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
@@ -185,6 +185,12 @@ export interface EventTileEventSnapshot {
     eventType: string;
     /** The Matrix message type. */
     msgtype?: string;
+    /** The stable event identifier, when available. */
+    eventId?: string;
+    /** The event origin timestamp. */
+    eventTs: number;
+    /** Whether the event is a local echo. */
+    isLocalEcho: boolean;
     /** Whether the event is in a pending send state. */
     isSending: boolean;
     /** Whether the event is currently being edited. */
@@ -193,6 +199,20 @@ export interface EventTileEventSnapshot {
     isContinuation?: boolean;
     /** Whether the tile is rendering as a notification. */
     isRenderingNotification: boolean;
+    /** Whether the event failed decryption. */
+    isEncryptionFailure: boolean;
+}
+
+/** Plain data attributes rendered on the EventTile root element. */
+export interface EventTileRootData {
+    /** The event identifier exposed through `data-event-id`. */
+    eventId?: string;
+    /** The configured tile layout exposed through `data-layout`. */
+    layout?: Layout;
+    /** The timeline rendering mode exposed through `data-shape`. */
+    shape: TimelineRenderingType;
+    /** Whether the event belongs to the current user, exposed through `data-self`. */
+    isOwnEvent: boolean;
 }
 
 /** Root state derived for the EventTile snapshot. */
@@ -201,6 +221,8 @@ export interface EventTileRootSnapshot {
     ariaLive?: "off";
     /** The stable scroll token for the event. */
     scrollToken?: string;
+    /** Plain data attributes used by the EventTile root element. */
+    data: EventTileRootData;
     /** EventTile root CSS class flags. */
     classState: ReturnType<typeof getEventTileClassState>;
 }
@@ -288,6 +310,8 @@ export interface EventTileRenderState {
         scrollToken?: string;
         /** Whether the tile is rendering as a notification. */
         isRenderingNotification: boolean;
+        /** Plain data attributes used by the EventTile root element. */
+        data: EventTileRootData;
     };
     /** EventTile line render state. */
     line: {
@@ -459,6 +483,7 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
                 ariaLive: snapshot.root.ariaLive,
                 scrollToken: snapshot.root.scrollToken,
                 isRenderingNotification: snapshot.event.isRenderingNotification,
+                data: snapshot.root.data,
             },
             line: {
                 className: classNames("mx_EventTile_line", snapshot.line.classState),
@@ -489,10 +514,14 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
         const eventSnapshot: EventTileEventSnapshot = {
             eventType: event.eventType,
             msgtype: event.msgtype,
+            eventId: event.eventId,
+            eventTs: event.eventTs,
+            isLocalEcho: event.isLocalEcho,
             isSending: event.isSending,
             isEditing: event.isEditing,
             isContinuation,
             isRenderingNotification,
+            isEncryptionFailure: event.isEncryptionFailure,
         };
         const senderProfileState = getEventTileSenderProfileState({
             isRenderingNotification,
@@ -531,6 +560,12 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
                     eventId: event.eventId,
                     isLocalEcho: event.isLocalEcho,
                 }),
+                data: {
+                    eventId: event.eventId,
+                    layout: display.layout,
+                    shape: display.timelineRenderingType,
+                    isOwnEvent: footer.isOwnEvent,
+                },
                 classState: EventTileViewModel.getClassState({
                     event,
                     display,

--- a/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
+++ b/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
@@ -408,7 +408,6 @@ export interface EventTileRenderState {
  * SDK objects are converted to plain render data here before the existing render tree consumes it.
  */
 export class EventTileViewModel extends BaseViewModel<EventTileRenderState, EventTileViewModelProps> {
-    private dependencies: EventTileViewModelDependencies;
     private messageTimestampViewModel?: MessageTimestampViewModel;
     private linkedMessageTimestampViewModel?: MessageTimestampViewModel;
     private threadMessagePreviewViewModel?: ThreadMessagePreviewViewModel;
@@ -424,12 +423,10 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
         const initialRenderState = EventTileViewModel.createRenderState(normalizedProps);
 
         super(normalizedProps, initialRenderState);
-        this.dependencies = dependencies;
     }
 
     /** Updates dependencies and root inputs together, emitting one consistent render state. */
     public setInputs(dependencies: EventTileViewModelDependencies, props: EventTileViewModelProps): void {
-        this.dependencies = dependencies;
         const normalizedProps = EventTileViewModel.normalizeDependencies(dependencies, props);
         this.props = normalizedProps;
         this.snapshot.set(EventTileViewModel.createRenderState(normalizedProps));

--- a/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
+++ b/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
@@ -43,6 +43,7 @@ import {
     type E2eMessageSharedIconViewModelProps,
 } from "./E2eMessageSharedIconViewModel";
 import { EventPreviewViewModel, type EventPreviewViewModelProps } from "./EventPreviewViewModel";
+import { getEventTileReplyChainState } from "./EventTileReplyChainState";
 import {
     ThreadListActionBarViewModel,
     type ThreadListActionBarViewModelProps,
@@ -86,6 +87,8 @@ export interface EventTileDerivedEventInput extends EventTileEventInput {
     isRtcNotification: boolean;
     /** Whether the event failed decryption. */
     isEncryptionFailure: boolean;
+    /** Whether EventTile should render the reply chain. */
+    hasReplyChain: boolean;
 }
 
 /** Display inputs for deriving the EventTile snapshot. */
@@ -98,6 +101,8 @@ export interface EventTileDisplayInput {
     continuation?: boolean;
     /** Whether the event body is likely to render media content. */
     isProbablyMedia: boolean;
+    /** Whether the current event renderer is available. */
+    hasRenderer: boolean;
     /** Whether the tile should use bubble container styling. */
     isBubbleMessage: boolean;
     /** Whether the bubble tile is left-aligned. */
@@ -242,6 +247,8 @@ export interface EventTileRootData {
     shape: TimelineRenderingType;
     /** Whether the event belongs to the current user, exposed through `data-self`. */
     isOwnEvent: boolean;
+    /** Whether EventTile renders a reply chain, exposed through `data-has-reply`. */
+    hasReply: boolean;
 }
 
 /** Root state derived for the EventTile snapshot. */
@@ -560,6 +567,10 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
     ): NormalizedEventTileViewModelProps {
         const { mxEvent } = dependencies;
         const eventType = mxEvent.getType();
+        const replyChainState = getEventTileReplyChainState({
+            mxEvent,
+            hasRenderer: props.display.hasRenderer,
+        });
 
         return {
             ...props,
@@ -576,6 +587,7 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
                 isCallInvite: eventType === EventType.CallInvite,
                 isRtcNotification: eventType === EventType.RTCNotification,
                 isEncryptionFailure: mxEvent.isDecryptionFailure(),
+                hasReplyChain: replyChainState.shouldShowReplyChain,
             },
             sender: {
                 ...props.sender,
@@ -646,6 +658,7 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
                     layout: display.layout,
                     shape: display.timelineRenderingType,
                     isOwnEvent: footer.isOwnEvent,
+                    hasReply: event.hasReplyChain,
                 },
                 classState: EventTileViewModel.getClassState({
                     event,

--- a/apps/web/test/unit-tests/components/views/rooms/EventTile-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/EventTile-test.tsx
@@ -292,6 +292,15 @@ describe("EventTile", () => {
             expect(getTile(container)).toContainElement(getLine(container));
         });
 
+        it("preserves the existing root and line markup", () => {
+            const { container } = getComponent();
+            const tile = getTile(container);
+
+            expect(tile.tagName).toBe("LI");
+            expect(tile).toContainElement(getLine(container));
+            expect(getLine(container)).toHaveClass("mx_EventTile_line");
+        });
+
         it("does not expose a scroll token for local echo events", () => {
             const localEcho = makeOwnMessage();
             localEcho.setStatus(EventStatus.SENDING);

--- a/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
+++ b/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
@@ -602,6 +602,32 @@ describe("EventTileViewModel", () => {
         vm.dispose();
     });
 
+    it("does not show a reply chain for replacement events", () => {
+        const event = mkEvent({
+            event: true,
+            id: "$replacement-event",
+            room: "!room:example.org",
+            ts: 123,
+            type: "m.room.message",
+            user: "@alice:example.org",
+            content: {
+                msgtype: "m.text",
+                "m.relates_to": {
+                    rel_type: "m.replace",
+                    event_id: "$original-event",
+                    "m.in_reply_to": {
+                        event_id: "$parent-event",
+                    },
+                },
+            },
+        });
+        const vm = new EventTileViewModel(makeDependencies(event), makeProps());
+
+        expect(vm.getSnapshot().snapshot.root.data.hasReply).toBe(false);
+
+        vm.dispose();
+    });
+
     it("derives an unavailable renderer for unsupported events", () => {
         const event = mkEvent({
             event: true,

--- a/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
+++ b/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
@@ -43,6 +43,7 @@ describe("EventTileViewModel", () => {
                 eventTs: 123,
                 eventId: "$event",
                 isState: false,
+                hasReplyChain: false,
                 isLocalEcho: false,
                 isSending: false,
                 ariaLive: "off",
@@ -58,6 +59,7 @@ describe("EventTileViewModel", () => {
                 timelineRenderingType: TimelineRenderingType.Room,
                 layout: Layout.Group,
                 isProbablyMedia: false,
+                hasRenderer: true,
                 isBubbleMessage: false,
                 isLeftAlignedBubbleMessage: false,
                 isAlignedBetweenBubbles: false,
@@ -118,6 +120,7 @@ describe("EventTileViewModel", () => {
             layout: Layout.Group,
             shape: TimelineRenderingType.Room,
             isOwnEvent: false,
+            hasReply: false,
         });
         expect(snapshot.root.classState.mx_EventTile_sending).toBe(true);
     });

--- a/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
+++ b/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
@@ -513,10 +513,23 @@ describe("EventTileViewModel", () => {
 
         expect(vm.getSnapshot().snapshot.timestamp.show).toBe(false);
 
-        vm.setProps(makeProps({ interaction: { hover: true } }));
+        vm.setInputs(makeDependencies(), makeProps({ interaction: { hover: true } }));
 
         expect(vm.getSnapshot().snapshot.timestamp.show).toBe(true);
         expect(listener).toHaveBeenCalled();
+
+        unsubscribe();
+        vm.dispose();
+    });
+
+    it("emits once when dependencies and inputs are updated together", () => {
+        const vm = new EventTileViewModel(makeDependencies(), makeProps());
+        const listener = jest.fn();
+        const unsubscribe = vm.subscribe(listener);
+
+        vm.setInputs(makeDependencies(), makeProps({ interaction: { hover: true } }));
+
+        expect(listener).toHaveBeenCalledTimes(1);
 
         unsubscribe();
         vm.dispose();
@@ -559,7 +572,7 @@ describe("EventTileViewModel", () => {
             isEmote: false,
         });
 
-        vm.setDependencies(
+        vm.setInputs(
             makeDependencies(
                 mkEvent({
                     event: true,
@@ -571,6 +584,7 @@ describe("EventTileViewModel", () => {
                     content: { msgtype: "m.call.invite" },
                 }),
             ),
+            makeProps(),
         );
 
         expect(vm.getSnapshot().snapshot.event).toMatchObject({
@@ -655,7 +669,7 @@ describe("EventTileViewModel", () => {
 
         expect(vm.getSnapshot().snapshot.event.hasRenderer).toBe(false);
 
-        vm.setDependencies(makeDependencies(makeEvent()));
+        vm.setInputs(makeDependencies(makeEvent()), makeProps());
 
         expect(vm.getSnapshot().snapshot.event.hasRenderer).toBe(true);
 

--- a/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
+++ b/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
@@ -583,6 +583,59 @@ describe("EventTileViewModel", () => {
         vm.dispose();
     });
 
+    it("normalizes event identity, replacement, renderer, and decryption state", () => {
+        const event = makeEvent();
+        jest.spyOn(event, "replacingEventId").mockReturnValue("$replaced-event");
+        jest.spyOn(event, "isDecryptionFailure").mockReturnValue(true);
+
+        const vm = new EventTileViewModel(makeDependencies(event), makeProps());
+        const snapshot = vm.getSnapshot().snapshot;
+
+        expect(snapshot.event).toMatchObject({
+            eventType: "m.room.message",
+            eventId: "$event",
+            replacingEventId: "$replaced-event",
+            isEncryptionFailure: true,
+            hasRenderer: true,
+        });
+
+        vm.dispose();
+    });
+
+    it("derives an unavailable renderer for unsupported events", () => {
+        const event = mkEvent({
+            event: true,
+            room: "!room:example.org",
+            type: "org.example.unsupported",
+            user: "@alice:example.org",
+            content: {},
+        });
+        const vm = new EventTileViewModel(makeDependencies(event), makeProps());
+
+        expect(vm.getSnapshot().snapshot.event.hasRenderer).toBe(false);
+
+        vm.dispose();
+    });
+
+    it("recalculates renderer state when dependencies change", () => {
+        const event = mkEvent({
+            event: true,
+            room: "!room:example.org",
+            type: "org.example.unsupported",
+            user: "@alice:example.org",
+            content: {},
+        });
+        const vm = new EventTileViewModel(makeDependencies(event), makeProps());
+
+        expect(vm.getSnapshot().snapshot.event.hasRenderer).toBe(false);
+
+        vm.setDependencies(makeDependencies(makeEvent()));
+
+        expect(vm.getSnapshot().snapshot.event.hasRenderer).toBe(true);
+
+        vm.dispose();
+    });
+
     it("lazily owns timestamp child view models", () => {
         const vm = new EventTileViewModel(makeDependencies(), makeProps());
         const messageTimestampViewModel = vm.getMessageTimestampViewModel({ ts: 123 });

--- a/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
+++ b/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
@@ -42,6 +42,7 @@ describe("EventTileViewModel", () => {
                 msgtype: "m.text",
                 eventTs: 123,
                 eventId: "$event",
+                isState: false,
                 isLocalEcho: false,
                 isSending: false,
                 ariaLive: "off",
@@ -537,6 +538,7 @@ describe("EventTileViewModel", () => {
             eventType: "m.room.member",
             eventId: "$member-event",
             eventTs: 456,
+            isState: true,
         });
         expect(vm.getSnapshot().snapshot.sender).toMatchObject({
             senderId: "@bob:example.org",

--- a/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
+++ b/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
@@ -625,10 +625,10 @@ describe("EventTileViewModel", () => {
             type: "m.room.message",
             user: "@alice:example.org",
             content: {
-                msgtype: "m.text",
+                "msgtype": "m.text",
                 "m.relates_to": {
-                    rel_type: "m.replace",
-                    event_id: "$original-event",
+                    "rel_type": "m.replace",
+                    "event_id": "$original-event",
                     "m.in_reply_to": {
                         event_id: "$parent-event",
                     },

--- a/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
+++ b/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
@@ -7,14 +7,27 @@
 
 import { TimelineRenderingType } from "../../../src/contexts/RoomContext";
 import { Layout } from "../../../src/settings/enums/Layout";
+import { mkEvent } from "../../test-utils";
 import {
     EventTileViewModel,
+    type NormalizedEventTileViewModelProps,
     type EventTileViewModelProps,
 } from "../../../src/viewmodels/room/timeline/event-tile/EventTileViewModel";
 
 describe("EventTileViewModel", () => {
+    const makeEvent = () =>
+        mkEvent({
+            event: true,
+            id: "$event",
+            room: "!room:example.org",
+            ts: 123,
+            type: "m.room.message",
+            user: "@alice:example.org",
+            content: { msgtype: "m.text" },
+        });
+
     type EventTileViewModelPropsOverrides = {
-        event?: Partial<EventTileViewModelProps["event"]>;
+        event?: Partial<NormalizedEventTileViewModelProps["event"]>;
         display?: Partial<EventTileViewModelProps["display"]>;
         interaction?: Partial<EventTileViewModelProps["interaction"]>;
         sender?: Partial<EventTileViewModelProps["sender"]>;
@@ -22,7 +35,7 @@ describe("EventTileViewModel", () => {
         footer?: Partial<EventTileViewModelProps["footer"]>;
     };
 
-    function makeProps(overrides: EventTileViewModelPropsOverrides = {}): EventTileViewModelProps {
+    function makeProps(overrides: EventTileViewModelPropsOverrides = {}): NormalizedEventTileViewModelProps {
         return {
             event: {
                 eventType: "m.room.message",
@@ -480,7 +493,7 @@ describe("EventTileViewModel", () => {
     });
 
     it("updates an instance snapshot when inputs change", () => {
-        const vm = new EventTileViewModel(makeProps());
+        const vm = new EventTileViewModel({ mxEvent: makeEvent() }, makeProps());
         const listener = jest.fn();
         const unsubscribe = vm.subscribe(listener);
 
@@ -495,8 +508,66 @@ describe("EventTileViewModel", () => {
         vm.dispose();
     });
 
+    it("normalizes event and sender state from its SDK dependency", () => {
+        const event = mkEvent({
+            event: true,
+            id: "$member-event",
+            room: "!room:example.org",
+            ts: 456,
+            type: "m.room.member",
+            user: "@bob:example.org",
+            content: { membership: "join" },
+        });
+        const vm = new EventTileViewModel(
+            { mxEvent: event },
+            makeProps({
+                event: {
+                    eventType: "m.room.message",
+                    eventId: "$wrong-event",
+                    eventTs: 123,
+                },
+                sender: {
+                    senderId: "@wrong:example.org",
+                    isEmote: false,
+                },
+            }),
+        );
+
+        expect(vm.getSnapshot().snapshot.event).toMatchObject({
+            eventType: "m.room.member",
+            eventId: "$member-event",
+            eventTs: 456,
+        });
+        expect(vm.getSnapshot().snapshot.sender).toMatchObject({
+            senderId: "@bob:example.org",
+            forceHistoricalAvatar: true,
+            isEmote: false,
+        });
+
+        vm.setEvent(
+            mkEvent({
+                event: true,
+                id: "$updated-event",
+                room: "!room:example.org",
+                ts: 789,
+                type: "m.call.invite",
+                user: "@carol:example.org",
+                content: { msgtype: "m.call.invite" },
+            }),
+        );
+
+        expect(vm.getSnapshot().snapshot.event).toMatchObject({
+            eventType: "m.call.invite",
+            eventId: "$updated-event",
+            eventTs: 789,
+        });
+        expect(vm.getSnapshot().snapshot.sender.senderId).toBe("@carol:example.org");
+
+        vm.dispose();
+    });
+
     it("lazily owns timestamp child view models", () => {
-        const vm = new EventTileViewModel(makeProps());
+        const vm = new EventTileViewModel({ mxEvent: makeEvent() }, makeProps());
         const messageTimestampViewModel = vm.getMessageTimestampViewModel({ ts: 123 });
         const linkedMessageTimestampViewModel = vm.getLinkedMessageTimestampViewModel({ ts: 456 });
 
@@ -508,6 +579,7 @@ describe("EventTileViewModel", () => {
 
     it("does not initialize timestamp child view models for events without an origin timestamp", () => {
         const vm = new EventTileViewModel(
+            { mxEvent: makeEvent() },
             makeProps({
                 event: {
                     eventTs: 0,
@@ -524,7 +596,7 @@ describe("EventTileViewModel", () => {
     });
 
     it("owns and updates the thread-list action bar child view model", () => {
-        const vm = new EventTileViewModel(makeProps());
+        const vm = new EventTileViewModel({ mxEvent: makeEvent() }, makeProps());
         const onViewInRoomClick = jest.fn();
         const onCopyLinkClick = jest.fn();
 

--- a/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
+++ b/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
@@ -7,14 +7,17 @@
 
 import { TimelineRenderingType } from "../../../src/contexts/RoomContext";
 import { Layout } from "../../../src/settings/enums/Layout";
-import { mkEvent } from "../../test-utils";
+import { mkEvent, stubClient } from "../../test-utils";
 import {
     EventTileViewModel,
+    type EventTileViewModelDependencies,
     type NormalizedEventTileViewModelProps,
     type EventTileViewModelProps,
 } from "../../../src/viewmodels/room/timeline/event-tile/EventTileViewModel";
 
 describe("EventTileViewModel", () => {
+    const matrixClient = stubClient();
+
     const makeEvent = () =>
         mkEvent({
             event: true,
@@ -25,6 +28,12 @@ describe("EventTileViewModel", () => {
             user: "@alice:example.org",
             content: { msgtype: "m.text" },
         });
+
+    const makeDependencies = (mxEvent = makeEvent()): EventTileViewModelDependencies => ({
+        mxEvent,
+        matrixClient,
+        showHiddenEvents: false,
+    });
 
     type EventTileViewModelPropsOverrides = {
         event?: Partial<NormalizedEventTileViewModelProps["event"]>;
@@ -52,6 +61,8 @@ describe("EventTileViewModel", () => {
                 isRtcNotification: false,
                 isEditing: false,
                 isEncryptionFailure: false,
+                hasRenderer: true,
+                isSeeingThroughMessageHiddenForModeration: false,
                 forExport: false,
                 ...overrides.event,
             },
@@ -59,7 +70,6 @@ describe("EventTileViewModel", () => {
                 timelineRenderingType: TimelineRenderingType.Room,
                 layout: Layout.Group,
                 isProbablyMedia: false,
-                hasRenderer: true,
                 isBubbleMessage: false,
                 isLeftAlignedBubbleMessage: false,
                 isAlignedBetweenBubbles: false,
@@ -497,7 +507,7 @@ describe("EventTileViewModel", () => {
     });
 
     it("updates an instance snapshot when inputs change", () => {
-        const vm = new EventTileViewModel({ mxEvent: makeEvent() }, makeProps());
+        const vm = new EventTileViewModel(makeDependencies(), makeProps());
         const listener = jest.fn();
         const unsubscribe = vm.subscribe(listener);
 
@@ -523,7 +533,7 @@ describe("EventTileViewModel", () => {
             content: { membership: "join" },
         });
         const vm = new EventTileViewModel(
-            { mxEvent: event },
+            makeDependencies(event),
             makeProps({
                 event: {
                     eventType: "m.room.message",
@@ -549,16 +559,18 @@ describe("EventTileViewModel", () => {
             isEmote: false,
         });
 
-        vm.setEvent(
-            mkEvent({
-                event: true,
-                id: "$updated-event",
-                room: "!room:example.org",
-                ts: 789,
-                type: "m.call.invite",
-                user: "@carol:example.org",
-                content: { msgtype: "m.call.invite" },
-            }),
+        vm.setDependencies(
+            makeDependencies(
+                mkEvent({
+                    event: true,
+                    id: "$updated-event",
+                    room: "!room:example.org",
+                    ts: 789,
+                    type: "m.call.invite",
+                    user: "@carol:example.org",
+                    content: { msgtype: "m.call.invite" },
+                }),
+            ),
         );
 
         expect(vm.getSnapshot().snapshot.event).toMatchObject({
@@ -572,7 +584,7 @@ describe("EventTileViewModel", () => {
     });
 
     it("lazily owns timestamp child view models", () => {
-        const vm = new EventTileViewModel({ mxEvent: makeEvent() }, makeProps());
+        const vm = new EventTileViewModel(makeDependencies(), makeProps());
         const messageTimestampViewModel = vm.getMessageTimestampViewModel({ ts: 123 });
         const linkedMessageTimestampViewModel = vm.getLinkedMessageTimestampViewModel({ ts: 456 });
 
@@ -584,7 +596,7 @@ describe("EventTileViewModel", () => {
 
     it("does not initialize timestamp child view models for events without an origin timestamp", () => {
         const vm = new EventTileViewModel(
-            { mxEvent: makeEvent() },
+            makeDependencies(),
             makeProps({
                 event: {
                     eventTs: 0,
@@ -601,7 +613,7 @@ describe("EventTileViewModel", () => {
     });
 
     it("owns and updates the thread-list action bar child view model", () => {
-        const vm = new EventTileViewModel({ mxEvent: makeEvent() }, makeProps());
+        const vm = new EventTileViewModel(makeDependencies(), makeProps());
         const onViewInRoomClick = jest.fn();
         const onCopyLinkClick = jest.fn();
 

--- a/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
+++ b/apps/web/test/viewmodels/event-tiles/EventTileViewModel-test.ts
@@ -91,8 +91,20 @@ describe("EventTileViewModel", () => {
         );
 
         expect(snapshot.event.isSending).toBe(true);
+        expect(snapshot.event).toMatchObject({
+            eventId: "$event",
+            eventTs: 123,
+            isLocalEcho: true,
+            isEncryptionFailure: false,
+        });
         expect(snapshot.root.ariaLive).toBe("off");
         expect(snapshot.root.scrollToken).toBeUndefined();
+        expect(snapshot.root.data).toEqual({
+            eventId: "$event",
+            layout: Layout.Group,
+            shape: TimelineRenderingType.Room,
+            isOwnEvent: false,
+        });
         expect(snapshot.root.classState.mx_EventTile_sending).toBe(true);
     });
 


### PR DESCRIPTION
## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)

Partially implements: https://github.com/element-hq/element-web/issues/31651

## Summary - Step 4a
Refactor EventTile rendering state into `EventTileViewModel`, reducing direct event-derived logic in the React component while preserving existing rendering behavior. The VM now owns normalized event data, display metadata, reply-chain eligibility, root attributes, and render-state derivation.

Next: Step 4b will create the EventTileView in shared components as an extract from the now cleaned up UnwrappedEventTile.

## Changes
- Moved event and sender data derivation into EventTileViewModel.
- Moved root attributes and event identity data into VM render state.
- Simplified EventTile rendering to consume VM snapshots.
- Added VM normalization, rendering, lifecycle, and regression tests.
- Added component coverage for preserved root and line markup.

## Implementation plan
1. _Clean up the `EventTile` render boundary - https://github.com/element-hq/element-web/pull/33805_
_`EventTileViewModel` and `EventTileDervideState` without imports of matrix-js-sdk._
2. _Clean up `SenderIdentityAdapter` - https://github.com/element-hq/element-web/pull/33828_
_`SenderIdentityAdapter` plus the caller-side sender/avatar extraction_
3. Clean up simple body models to become render-only
a `MjolnirBodyViewModel` - https://github.com/element-hq/element-web/pull/34458
b `RedactedBodyViewModel` - https://github.com/element-hq/element-web/pull/34459
c `HiddenBodyViewModel`
d `DecryptionFailureBodyViewModel`
4. Create `EventTileView` in shared components
Add the functional shared root component with pure root props and slots for sender, avatar, body, timestamp, actions, footer, threads, and reactions. Keep existing application-side adapters and legacy components behind those slots.
5. Use `EventTileView` in the web application
Change `UnwrappedEventTile` to render `EventTileView`, keeping its current class/lifecycle implementation and SDK integration.
6. Migrate event-body selection to a pure render state
Make `EventTileFactory`, `MBodyFactory`, and `MessageEvent` create either render-ready body state or app-owned render slots.

## Further work after this PR series
- Migrate event previews
- Migrate thread state and summary rendering
- Migrate receipts and receipt avatars
- Migrate reactions
- Migrate E2E and encryption indicators
- Migrate the action bar
- Migrate media and special-event leaves
- Migrate remaining legacy leaf components

## Final goal of the PR series
The shared component, `EventTileView` (corresponding to the current `UnwrappedEventTile`) should be a functional layout component. Its markup should be driven entirely by snapshot values and slots. The exact markup can preserve the existing CSS and accessibility structure, but the key properties are:

- no `mxEvent` reads;
- no SDK-specific props;
- no factory selection inside the shared view;
- no Matrix-specific event logic;
- no class lifecycle;
- all behavior supplied through snapshots, slots, and callbacks.