### PR TITLE
Stop caching Vite pre-bundled deps in shared-components vitest CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,12 +129,13 @@ jobs:
               run: "pnpm install"
               if: matrix.path == 'packages/shared-components'
 
-            - name: Cache storybook & vitest
+            - name: Cache storybook
               uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
               with:
+                  # NB: node_modules/.vite/vitest is intentionally not cached; a lockfile-keyed stale bundle
+                  # triggers a mid-run re-optimise + page reload that flakes browser-mode tests.
                   path: |
                       ${{ matrix.path }}/node_modules/.cache
-                      ${{ matrix.path }}/node_modules/.vite/vitest
                   key: ${{ matrix.path }}-${{ hashFiles('pnpm-lock.yaml') }}
 
             - name: Setup playwright


### PR DESCRIPTION
This is an attempt to fix https://github.com/element-hq/element-web/issues/33189

### Theory

The `shared-components` vitest (browser-mode) job flakes intermittently, failing to import the shared `src/test/setupTests.ts` and reporting a random suite (`Cannot connect to the iframe` / `Failed to fetch dynamically imported module`).

CI caches `node_modules/.vite/vitest` (Vite's pre-bundled deps) keyed **only** on the `pnpm-lock.yaml` hash. But the pre-bundle depends on what our source **imports**, not just what's **installed** — and `actions/cache` keys are immutable. So a source change that reaches a new (often transitive, CJS) dependency without touching the lockfile leaves a **stale bundle** in the cache. Vite then discovers the missing dep at runtime, re-optimises, and reloads the page mid-run — which aborts the in-flight `setupTests.ts` import and fails whichever suite was loading.

(The specific trigger is `glob-to-regexp`, a CJS dep reached via `setupTests.ts → @fetch-mock/vitest → fetch-mock`.)

### Fix

Drop `node_modules/.vite/vitest` from the cache so the pre-bundle is rebuilt fresh each run. A fresh scan always matches the current source, so nothing is discovered mid-run and the reload can't happen. Cost is sub-second (~356 ms) against a ~97 s job; dependency install and Storybook's `.cache` are unaffected.