### PR TITLE
Open space settings when editing a space topic

### DIFF
--- a/apps/web/src/components/views/elements/RoomTopic.tsx
+++ b/apps/web/src/components/views/elements/RoomTopic.tsx
@@ -22,6 +22,7 @@ import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import AccessibleButton, { type ButtonEvent } from "./AccessibleButton";
 import { topicToHtml } from "../../../HtmlUtils";
 import { tryTransformPermalinkToLocalHref } from "../../../utils/permalinks/Permalinks";
+import { showSpaceSettings } from "../../../utils/space";
 
 interface IProps {
     room: Room;
@@ -76,7 +77,13 @@ export default function RoomTopic({ room, className }: IProps): JSX.Element {
                                 kind="primary_outline"
                                 onClick={() => {
                                     modal.close();
-                                    dis.dispatch({ action: "open_room_settings" });
+                                    // SpaceRoomView renders this component for spaces too, and a space
+                                    // has its own settings dialog.
+                                    if (room.isSpaceRoom()) {
+                                        showSpaceSettings(room);
+                                    } else {
+                                        dis.dispatch({ action: "open_room_settings" });
+                                    }
                                 }}
                             >
                                 {_t("room|edit_topic")}

--- a/apps/web/test/unit-tests/components/views/elements/RoomTopic-test.tsx
+++ b/apps/web/test/unit-tests/components/views/elements/RoomTopic-test.tsx
@@ -17,6 +17,9 @@ import { MatrixClientPeg } from "../../../../../src/MatrixClientPeg";
 import RoomTopic from "../../../../../src/components/views/elements/RoomTopic";
 import dis from "../../../../../src/dispatcher/dispatcher";
 import { Action } from "../../../../../src/dispatcher/actions";
+import Modal from "../../../../../src/Modal";
+import { type ActionPayload } from "../../../../../src/dispatcher/payloads";
+import MatrixClientContext from "../../../../../src/contexts/MatrixClientContext";
 
 jest.mock("../../../../../src/dispatcher/dispatcher");
 
@@ -92,6 +95,62 @@ describe("<RoomTopic/>", () => {
         runClickTest(topic, topic);
         expect(window.location.href).toEqual(expectedHref);
         expect(dis.fire).toHaveBeenCalledWith(Action.ShowRoomTopic);
+    });
+
+    describe("the edit topic button in the topic dialog", () => {
+        /**
+         * Render the topic, open the topic dialog and render its contents, so the
+         * "Edit topic" button can be clicked.
+         * @param isSpaceRoom whether the room should report itself as a space
+         */
+        function renderTopicDialog(isSpaceRoom: boolean) {
+            const room = createRoom("a topic");
+            jest.spyOn(room, "isSpaceRoom").mockReturnValue(isSpaceRoom);
+            jest.spyOn(room.currentState, "maySendStateEvent").mockReturnValue(true);
+
+            const createDialog = jest
+                .spyOn(Modal, "createDialog")
+                .mockReturnValue({ close: jest.fn() } as unknown as ReturnType<typeof Modal.createDialog>);
+
+            render(<RoomTopic room={room} />, {
+                wrapper: ({ children }) => (
+                    <MatrixClientContext.Provider value={MatrixClientPeg.safeGet()}>
+                        <LinkedTextContext.Provider value={{}}>{children}</LinkedTextContext.Provider>
+                    </MatrixClientContext.Provider>
+                ),
+            });
+
+            // The dispatcher is mocked for this suite, so drive the registered handler directly
+            // instead of firing Action.ShowRoomTopic through it.
+            const handler = jest.mocked(dis.register).mock.calls.at(-1)![0] as (payload: ActionPayload) => void;
+            handler({ action: Action.ShowRoomTopic });
+
+            const { description } = createDialog.mock.calls.at(-1)![1] as { description: React.ReactNode };
+            render(
+                <LinkedTextContext.Provider value={{}}>
+                    <>{description}</>
+                </LinkedTextContext.Provider>,
+            );
+
+            return room;
+        }
+
+        it("opens space settings for a space", () => {
+            const room = renderTopicDialog(true);
+
+            fireEvent.click(screen.getByRole("button", { name: "Edit topic" }));
+
+            expect(dis.dispatch).toHaveBeenCalledWith({ action: Action.OpenSpaceSettings, space: room });
+            expect(dis.dispatch).not.toHaveBeenCalledWith({ action: "open_room_settings" });
+        });
+
+        it("opens room settings for a room", () => {
+            renderTopicDialog(false);
+
+            fireEvent.click(screen.getByRole("button", { name: "Edit topic" }));
+
+            expect(dis.dispatch).toHaveBeenCalledWith({ action: "open_room_settings" });
+        });
     });
 
     it("should open the tooltip when hovering a text", async () => {


### PR DESCRIPTION
`SpaceRoomView` renders `RoomTopic` for the space home view, but the "Edit topic" button in the
topic dialog dispatched `open_room_settings` with no check for the room type. Editing a space's
topic therefore opened the room settings dialog rather than space settings.

It now branches on `room.isSpaceRoom()` and uses the existing `showSpaceSettings()` helper, the
same one the space settings button and the space context menu already use.

`RoomSummaryCardTopicViewModel` has the same unconditional dispatch, but it is not reachable for
a space: `RoomView.render()` returns `SpaceRoomView` before the right panel is constructed. It
is left unchanged.

Tests: `RoomTopic-test.tsx` gains a case for each room type, asserting the dispatched action.

Fixes #31050

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
