### PR TITLE
Stop the desktop notification toggle from disabling audible notifications

### DIFF
--- a/apps/web/src/Notifier.ts
+++ b/apps/web/src/Notifier.ts
@@ -370,7 +370,7 @@ export default class Notifier extends TypedEventEmitter<keyof EmittedEvents, Emi
         // make sure that we persist the current setting audio_enabled setting
         // before changing anything
         if (SettingsStore.isLevelSupported(SettingLevel.DEVICE)) {
-            SettingsStore.setValue("audioNotificationsEnabled", null, SettingLevel.DEVICE, this.isEnabled());
+            SettingsStore.setValue("audioNotificationsEnabled", null, SettingLevel.DEVICE, this.isAudioEnabled());
         }
 
         if (enable) {

--- a/apps/web/test/unit-tests/Notifier-test.ts
+++ b/apps/web/test/unit-tests/Notifier-test.ts
@@ -26,6 +26,7 @@ import { PushProcessor } from "matrix-js-sdk/src/pushprocessor";
 import type BasePlatform from "../../src/BasePlatform";
 import Notifier, { NOTIFICATION_SOUND_THROTTLE_MS } from "../../src/Notifier";
 import SettingsStore from "../../src/settings/SettingsStore";
+import { SettingLevel } from "../../src/settings/SettingLevel";
 import ToastStore from "../../src/stores/ToastStore";
 import {
     createLocalNotificationSettingsIfNeeded,
@@ -889,6 +890,20 @@ describe("Notifier", () => {
                 action: "notifier_enabled",
                 value: true,
             });
+        });
+
+        it("should not turn audible notifications off when the browser withholds permission", async () => {
+            // The browser will not let us show desktop notifications...
+            mocked(MockPlatform.maySendNotifications).mockReturnValue(false);
+            mocked(MockPlatform.requestNotificationPermission).mockResolvedValue("denied");
+            jest.spyOn(Modal, "createDialog").mockReturnValue({} as ReturnType<typeof Modal.createDialog>);
+            const setValueSpy = jest.spyOn(SettingsStore, "setValue");
+            const notifier = new Notifier(dis, context);
+
+            notifier.setEnabled(true);
+
+            // ...which must not silently disable the separate audible notifications setting.
+            expect(setValueSpy).not.toHaveBeenCalledWith("audioNotificationsEnabled", null, SettingLevel.DEVICE, false);
         });
 
         it("should call fire notifier_enabled value=false when disabling", async () => {


### PR DESCRIPTION
Before requesting notification permission, `setEnabled` persists the audio setting so it has a
concrete device-level value. It persisted `isEnabled()`, which is about desktop notifications and
is false whenever the browser will not let us send them. Turning the desktop notifications
toggle on while permission was denied therefore wrote `audioNotificationsEnabled = false`, then
bailed out on the denied result without restoring it — so the audible notifications switch
silently turned itself off.

It now persists `isAudioEnabled()`, the audio setting's own value. The line keeps doing what its
comment says: a no-op when a device-level value already exists, and materialising the `true`
default when it does not.

Tests: `Notifier-test.ts` gains a case asserting the audio setting is not written to false when
permission is withheld.

Fixes #24572

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
