### PR TITLE
Return to the timeline when the room search box is cleared

### DIFF
--- a/apps/web/src/components/structures/RoomView.tsx
+++ b/apps/web/src/components/structures/RoomView.tsx
@@ -1944,6 +1944,11 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
     };
 
     private onSearchChange = debounce((term: string): void => {
+        if (!term.trim()) {
+            // Clearing the box should put the timeline back rather than search for nothing.
+            void this.onCancelSearchClick();
+            return;
+        }
         this.onSearch(term);
     }, 300);
 

--- a/apps/web/src/components/structures/RoomView.tsx
+++ b/apps/web/src/components/structures/RoomView.tsx
@@ -1945,7 +1945,9 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
 
     private onSearchChange = debounce((term: string): void => {
         if (!term.trim()) {
-            // Clearing the box should put the timeline back rather than search for nothing.
+            // Clearing the box should put the timeline back rather than search for nothing. The
+            // composer comes back with the timeline but leaves the caret alone, so the user stays
+            // in the search box while they think about what to type next.
             void this.onCancelSearchClick();
             return;
         }

--- a/apps/web/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/apps/web/src/components/views/rooms/BasicMessageComposer.tsx
@@ -762,7 +762,23 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
         this.editorRef.current?.addEventListener("input", this.onInput, true);
         this.editorRef.current?.addEventListener("compositionstart", this.onCompositionStart, true);
         this.editorRef.current?.addEventListener("compositionend", this.onCompositionEnd, true);
-        this.editorRef.current?.focus();
+        if (!this.isUserTypingElsewhere()) {
+            this.editorRef.current?.focus();
+        }
+    }
+
+    /**
+     * Whether the caret is currently in some other text field.
+     *
+     * The composer takes focus when it mounts, which is right for the usual case of opening a room.
+     * It is not right when the composer appears underneath something the user is already typing in:
+     * emptying the room search box brings the timeline, and so this composer, back while the user is
+     * still in the search box thinking about their next search.
+     */
+    private isUserTypingElsewhere(): boolean {
+        const activeElement = document.activeElement;
+        if (!activeElement || activeElement === this.editorRef.current) return false;
+        return !!activeElement.closest("input, textarea, [contenteditable=true]");
     }
 
     private getInitialCaretPosition(): DocumentPosition {

--- a/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
@@ -936,6 +936,47 @@ describe("RoomView", () => {
             expect(container.querySelector(".mx_RoomView_searchResultsPanel")).not.toBeInTheDocument();
         });
 
+        it("should leave the caret in the search box when it is emptied", async () => {
+            room.getMyMembership = jest.fn().mockReturnValue(KnownMembership.Join);
+
+            const roomViewRef = createRef<RoomView>();
+            await mountRoomView(roomViewRef);
+            await waitFor(() => expect(roomViewRef.current).toBeTruthy());
+            // @ts-ignore - triggering a search organically is a lot of work
+            act(() =>
+                roomViewRef.current!.setState({
+                    timelineRenderingType: TimelineRenderingType.Search,
+                    search: {
+                        searchId: 1,
+                        roomId: room.roomId,
+                        term: "search term",
+                        scope: SearchScope.Room,
+                        promise: Promise.resolve({ results: [], highlights: [], count: 0 }),
+                        inProgress: false,
+                        count: 0,
+                    },
+                }),
+            );
+
+            // Stands in for the room search box, which lives over in the right panel.
+            const searchBox = document.createElement("input");
+            document.body.appendChild(searchBox);
+            searchBox.focus();
+            expect(document.activeElement).toBe(searchBox);
+
+            try {
+                // @ts-ignore - onSearchChange is private and debounced
+                act(() => roomViewRef.current!.onSearchChange(""));
+                await waitFor(() => expect(roomViewRef.current!.state.search).toBeUndefined());
+
+                // The composer comes back with the timeline, and must not take the caret with it:
+                // the user has only emptied the box, not left it.
+                expect(document.activeElement).toBe(searchBox);
+            } finally {
+                searchBox.remove();
+            }
+        });
+
         it("should close search results when edit is clicked", async () => {
             room.getMyMembership = jest.fn().mockReturnValue(KnownMembership.Join);
 

--- a/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/RoomView-test.tsx
@@ -899,6 +899,43 @@ describe("RoomView", () => {
     });
 
     describe("message search", () => {
+        it("should clear the search results when the search box is emptied", async () => {
+            room.getMyMembership = jest.fn().mockReturnValue(KnownMembership.Join);
+
+            const roomViewRef = createRef<RoomView>();
+            const { container } = await mountRoomView(roomViewRef);
+            await waitFor(() => expect(roomViewRef.current).toBeTruthy());
+            // @ts-ignore - triggering a search organically is a lot of work
+            act(() =>
+                roomViewRef.current!.setState({
+                    timelineRenderingType: TimelineRenderingType.Search,
+                    search: {
+                        searchId: 1,
+                        roomId: room.roomId,
+                        term: "search term",
+                        scope: SearchScope.Room,
+                        promise: Promise.resolve({ results: [], highlights: [], count: 0 }),
+                        inProgress: false,
+                        count: 0,
+                    },
+                }),
+            );
+
+            await waitFor(() => {
+                expect(container.querySelector(".mx_RoomView_searchResultsPanel")).toBeVisible();
+            });
+
+            // Deleting the last character of the term hands us an empty string.
+            // @ts-ignore - onSearchChange is private and debounced
+            act(() => roomViewRef.current!.onSearchChange(""));
+
+            await waitFor(() => {
+                expect(roomViewRef.current!.state.search).toBeUndefined();
+            });
+            expect(roomViewRef.current!.state.timelineRenderingType).toBe(TimelineRenderingType.Room);
+            expect(container.querySelector(".mx_RoomView_searchResultsPanel")).not.toBeInTheDocument();
+        });
+
         it("should close search results when edit is clicked", async () => {
             room.getMyMembership = jest.fn().mockReturnValue(KnownMembership.Join);
 

--- a/apps/web/test/unit-tests/components/views/rooms/BasicMessageComposer-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/BasicMessageComposer-test.tsx
@@ -34,6 +34,33 @@ describe("BasicMessageComposer", () => {
     const userId = client.getSafeUserId();
     const room = new Room(roomId, client, userId);
 
+    const renderComposer = (model: EditorModel) =>
+        render(<BasicMessageComposer model={model} room={room} />, {
+            wrapper: ({ children }) => (
+                <SDKContext.Provider value={SDKContextClass.instance}>{children}</SDKContext.Provider>
+            ),
+        });
+
+    it("should take focus when it mounts", async () => {
+        const { container } = renderComposer(new EditorModel([], pc, renderer));
+        expect(document.activeElement).toBe(container.querySelector("[contenteditable=true]"));
+    });
+
+    it("should not take focus from a text field the user is already in", async () => {
+        // e.g. emptying the room search box brings the timeline, and so the composer, back while
+        // the user is still typing in the search box.
+        const otherField = document.createElement("input");
+        document.body.appendChild(otherField);
+        otherField.focus();
+
+        try {
+            renderComposer(new EditorModel([], pc, renderer));
+            expect(document.activeElement).toBe(otherField);
+        } finally {
+            otherField.remove();
+        }
+    });
+
     it("should allow a user to paste a URL without it being mangled", async () => {
         const model = new EditorModel([], pc, renderer);
         render(<BasicMessageComposer model={model} room={room} />, {


### PR DESCRIPTION
Deleting the contents of the room search box left the room stuck in the search view. The field
reports every keystroke, so emptying it called `onSearch("")`, which set the timeline into search
mode and ran a search for nothing. The only way back to the timeline was the panel's close control.

An empty term now takes the cancel path that control already uses, so both ways of abandoning a
search end up in the same place. Whitespace-only terms are treated the same way.

Tests: a case in `RoomView-test.tsx` that puts the view into search mode, empties the box, and
asserts the search state is dropped, the rendering type is back to `Room`, and the results panel has
gone.

Fixes #28393

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
