### PR TITLE
Update the space hierarchy buttons when you leave a room

### DIFF
--- a/apps/web/src/components/structures/SpaceHierarchy.tsx
+++ b/apps/web/src/components/structures/SpaceHierarchy.tsx
@@ -61,7 +61,7 @@ import { useDispatcher } from "../../hooks/useDispatcher";
 import { Action } from "../../dispatcher/actions";
 import { type IState, RovingTabIndexProvider, useRovingTabIndex } from "../../accessibility/RovingTabIndex";
 import MatrixClientContext from "../../contexts/MatrixClientContext";
-import { useTypedEventEmitterState } from "../../hooks/useEventEmitter";
+import { useTypedEventEmitter, useTypedEventEmitterState } from "../../hooks/useEventEmitter";
 import { awaitRoomDownSync } from "../../utils/RoomUpgrade";
 import { type ViewRoomPayload } from "../../dispatcher/payloads/ViewRoomPayload";
 import { type JoinRoomReadyPayload } from "../../dispatcher/payloads/JoinRoomReadyPayload";
@@ -105,10 +105,17 @@ const Tile: React.FC<ITileProps> = ({
     children,
 }) => {
     const cli = useContext(MatrixClientContext);
-    const joinedRoom = useTypedEventEmitterState(cli, ClientEvent.Room, () => {
+    const getJoinedRoom = useCallback((): Room | undefined => {
         const cliRoom = cli?.getRoom(room.room_id);
         return cliRoom?.getMyMembership() === KnownMembership.Join ? cliRoom : undefined;
-    });
+    }, [cli, room.room_id]);
+    // ClientEvent.Room fires when a room is added to the store, which covers joining. Leaving
+    // leaves the room in the store and only emits RoomEvent.MyMembership, so both are needed.
+    const [joinedRoom, setJoinedRoom] = useState<Room | undefined>(getJoinedRoom);
+    const refreshJoinedRoom = useCallback(() => setJoinedRoom(() => getJoinedRoom()), [getJoinedRoom]);
+    useEffect(refreshJoinedRoom, [refreshJoinedRoom]);
+    useTypedEventEmitter(cli, ClientEvent.Room, refreshJoinedRoom);
+    useTypedEventEmitter(cli, RoomEvent.MyMembership, refreshJoinedRoom);
     const joinedRoomName = useTypedEventEmitterState(joinedRoom, RoomEvent.Name, (room) => room?.name);
     const name =
         joinedRoomName ||

--- a/apps/web/test/unit-tests/components/structures/SpaceHierarchy-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/SpaceHierarchy-test.tsx
@@ -8,8 +8,15 @@ Please see LICENSE files in the repository root for full details.
 
 import React from "react";
 import { mocked } from "jest-mock";
-import { fireEvent, render, screen, waitFor, waitForElementToBeRemoved } from "jest-matrix-react";
-import { type HierarchyRoom, JoinRule, MatrixError, type MatrixClient, Room } from "matrix-js-sdk/src/matrix";
+import { act, fireEvent, render, screen, waitFor, waitForElementToBeRemoved } from "jest-matrix-react";
+import {
+    type HierarchyRoom,
+    JoinRule,
+    MatrixError,
+    type MatrixClient,
+    Room,
+    RoomEvent,
+} from "matrix-js-sdk/src/matrix";
 import { KnownMembership } from "matrix-js-sdk/src/types";
 import { RoomHierarchy } from "matrix-js-sdk/src/room-hierarchy";
 
@@ -380,6 +387,29 @@ describe("SpaceHierarchy", () => {
                 hierarchyKnockRoom1.room_id,
                 undefined,
             );
+        });
+
+        it("should offer to join again once the room is left", async () => {
+            mocked(client.getRooms).mockReturnValue([root, room1]);
+            mocked(room1.getMyMembership).mockReturnValue(KnownMembership.Join);
+
+            try {
+                render(getComponent());
+                await waitForElementToBeRemoved(screen.getAllByRole("progressbar"));
+
+                // Room 1 is joined, so it offers a preview. The knockable room offers one too.
+                expect(screen.getAllByRole("button", { name: "View" })).toHaveLength(2);
+
+                mocked(room1.getMyMembership).mockReturnValue(KnownMembership.Leave);
+                act(() => {
+                    client.emit(RoomEvent.MyMembership, room1, KnownMembership.Leave, KnownMembership.Join);
+                });
+
+                await waitFor(() => expect(screen.getAllByRole("button", { name: "View" })).toHaveLength(1));
+            } finally {
+                mocked(client.getRooms).mockReturnValue([root]);
+                mocked(room1.getMyMembership).mockReturnValue(KnownMembership.Leave);
+            }
         });
 
         it("should not render cycles", async () => {


### PR DESCRIPTION
Leaving a room while the space hierarchy was open left its tile showing "View" instead of reverting
to "Join". The tile derived its joined state from `ClientEvent.Room`, which fires when a room is
added to the client store. That covers joining, but leaving keeps the room in the store and emits
only `RoomEvent.MyMembership`, so the state was never recomputed.

The tile now recomputes on both events. `RoomEvent.MyMembership` is re-emitted on the client, which
is the same pattern `MemberListViewModel` and `RoomView` already use. The `ClientEvent.Room`
subscription is kept so the join path is unchanged.

Tests: a case in `SpaceHierarchy-test.tsx` that renders the hierarchy with a joined child room,
emits `RoomEvent.MyMembership` with `leave`, and asserts the button reverts.

Fixes #26770

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
