### PR TITLE
Show joining feedback when rejoining a room after being kicked

### DIFF
--- a/apps/web/src/components/views/rooms/RoomPreviewBar.tsx
+++ b/apps/web/src/components/views/rooms/RoomPreviewBar.tsx
@@ -180,7 +180,9 @@ class RoomPreviewBar extends React.Component<IProps, IState> {
 
         if (myMember) {
             const previousMembership = myMember.events.member?.getPrevContent().membership;
-            if (myMember.isKicked()) {
+            // Let the joining case win while a rejoin is in flight, otherwise the bar keeps showing
+            // the kicked message and the user gets no feedback that their click did anything.
+            if (myMember.isKicked() && !this.props.joining) {
                 if (previousMembership === KnownMembership.Knock) {
                     return MessageCase.RequestDenied;
                 } else if (this.props.promptAskToJoin) {

--- a/apps/web/test/unit-tests/components/views/rooms/RoomPreviewBar-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/RoomPreviewBar-test.tsx
@@ -171,6 +171,15 @@ describe("<RoomPreviewBar />", () => {
         expect(getMessage(component)).toMatchSnapshot();
     });
 
+    it("renders joining message when rejoining after being kicked", () => {
+        const room = createRoom(roomId, otherUserId);
+        jest.spyOn(room, "getMember").mockReturnValue(makeMockRoomMember({ isKicked: true }));
+        const component = getComponent({ room, joining: true });
+
+        expect(isSpinnerRendered(component)).toBeTruthy();
+        expect(getMessage(component)?.textContent).toEqual("Joining…");
+    });
+
     it("renders denied request message", () => {
         const room = createRoom(roomId, otherUserId);
         jest.spyOn(room, "getMember").mockReturnValue(


### PR DESCRIPTION
Clicking "Rejoin" after being removed from a room gave no feedback at all — the bar kept showing
the kicked message until the join completed, so the click looked like it had done nothing.

`getMessageCase` evaluated the kicked branch before reaching the `joining` check, so the kicked
case always won and none of the spinner-bearing cases could render. The kicked branch now defers
while a join is in flight, letting the existing joining case show its title and spinner.

Tests: a case in `RoomPreviewBar-test.tsx` combining a kicked member with `joining`, asserting the
spinner and the joining title. The existing kicked, denied-request and banned snapshots are
unchanged.

Fixes #24598

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
