### PR TITLE
Let users join a restricted room they have left

### DIFF
--- a/apps/web/src/components/views/rooms/RoomPreviewCard.tsx
+++ b/apps/web/src/components/views/rooms/RoomPreviewCard.tsx
@@ -37,6 +37,8 @@ interface IProps {
     onRejectButtonClicked: () => void;
 }
 
+const JOINABLE_WITHOUT_INVITE: JoinRule[] = [JoinRule.Public, JoinRule.Restricted];
+
 // XXX This component is currently only used for spaces and video rooms, though
 // surely we should expand its use to all rooms for consistency? This already
 // handles the text room case, though we would need to add support for ignoring
@@ -54,8 +56,12 @@ const RoomPreviewCard: FC<IProps> = ({ room, onJoinButtonClicked, onRejectButton
     const [busy, setBusy] = useState(false);
 
     const joinRule = useRoomState(room, (state) => state.getJoinRule());
+    // Join rules under which a join can succeed without an invite. Restricted rooms admit members
+    // of the allowed spaces, so we must not refuse up front — a join that does turn out to be
+    // disallowed already surfaces through the Action.JoinRoomError handler above.
     const cannotJoin =
-        getEffectiveMembership(myMembership) === EffectiveMembership.Leave && joinRule !== JoinRule.Public;
+        getEffectiveMembership(myMembership) === EffectiveMembership.Leave &&
+        !JOINABLE_WITHOUT_INVITE.includes(joinRule);
     const name = useRoomName(room);
 
     const viewLabs = (): void =>

--- a/apps/web/test/unit-tests/components/views/rooms/RoomPreviewCard-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/RoomPreviewCard-test.tsx
@@ -9,7 +9,7 @@ Please see LICENSE files in the repository root for full details.
 import React from "react";
 import { mocked, type Mocked } from "jest-mock";
 import { render, screen, act } from "jest-matrix-react";
-import { PendingEventOrdering, Room, RoomStateEvent, RoomType } from "matrix-js-sdk/src/matrix";
+import { JoinRule, PendingEventOrdering, Room, RoomStateEvent, RoomType } from "matrix-js-sdk/src/matrix";
 import { KnownMembership } from "matrix-js-sdk/src/types";
 
 import type { MatrixClient, RoomMember } from "matrix-js-sdk/src/matrix";
@@ -86,5 +86,25 @@ describe("RoomPreviewCard", () => {
 
         await renderPreview();
         expect(screen.queryByRole("button", { name: /beta/i })).toBeNull();
+    });
+
+    it("lets you rejoin a restricted room you have left", async () => {
+        jest.spyOn(room, "getMyMembership").mockReturnValue(KnownMembership.Leave);
+        jest.spyOn(room.currentState, "getJoinRule").mockReturnValue(JoinRule.Restricted);
+
+        await renderPreview();
+
+        expect(screen.getByRole("button", { name: "Join" })).not.toHaveAttribute("aria-disabled");
+        expect(screen.queryByText(/you need an invite/)).toBeNull();
+    });
+
+    it("still refuses an invite-only room you have left", async () => {
+        jest.spyOn(room, "getMyMembership").mockReturnValue(KnownMembership.Leave);
+        jest.spyOn(room.currentState, "getJoinRule").mockReturnValue(JoinRule.Invite);
+
+        await renderPreview();
+
+        expect(screen.getByRole("button", { name: "Join" })).toHaveAttribute("aria-disabled", "true");
+        expect(screen.getByText(/you need an invite/)).toBeInTheDocument();
     });
 });

--- a/apps/web/test/unit-tests/components/views/rooms/RoomPreviewCard-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/RoomPreviewCard-test.tsx
@@ -88,7 +88,7 @@ describe("RoomPreviewCard", () => {
         expect(screen.queryByRole("button", { name: /beta/i })).toBeNull();
     });
 
-    it("lets you rejoin a restricted room you have left", async () => {
+    it("prompts the user to join in case of leaving a restricted room", async () => {
         jest.spyOn(room, "getMyMembership").mockReturnValue(KnownMembership.Leave);
         jest.spyOn(room.currentState, "getJoinRule").mockReturnValue(JoinRule.Restricted);
 
@@ -98,7 +98,7 @@ describe("RoomPreviewCard", () => {
         expect(screen.queryByText(/you need an invite/)).toBeNull();
     });
 
-    it("still refuses an invite-only room you have left", async () => {
+    it("does not prompt the user to join if the room is invite-only", async () => {
         jest.spyOn(room, "getMyMembership").mockReturnValue(KnownMembership.Leave);
         jest.spyOn(room.currentState, "getJoinRule").mockReturnValue(JoinRule.Invite);
 


### PR DESCRIPTION
Leaving a restricted room or space and then opening it again by ID showed a disabled Join button
and the notice "To view <room>, you need an invite", even for a user who is a member of an allowed
space and can join perfectly well.

`cannotJoin` treated every join rule other than `public` as un-joinable. Restricted rooms are now
allowed through as well. Nothing is assumed about whether the join will succeed — a join that
really is disallowed still comes back through the existing `Action.JoinRoomError` handler, which
already stops the spinner.

Tests: two cases in `RoomPreviewCard-test.tsx` — a left member of a restricted room gets an enabled
Join button and no notice, and a left member of an invite-only room still gets both.

Fixes #28109

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
