### PR TITLE
Keep the separate paragraphs of a loose list item

### DIFF
--- a/apps/web/src/Markdown.test.ts
+++ b/apps/web/src/Markdown.test.ts
@@ -173,4 +173,21 @@ describe("Markdown parser test", () => {
             expect(md.toHTML()).toEqual(expectedResult);
         });
     });
+
+    describe("lists", () => {
+        it("keeps the paragraphs of a loose list item separate", () => {
+            const md = new Markdown(["1. a", "2. b", "", "    c"].join("\n"));
+            expect(md.toHTML()).toEqual("<ol>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ol>\n");
+        });
+
+        it("does not wrap the items of a tight list in paragraphs", () => {
+            const md = new Markdown(["- a", "- b"].join("\n"));
+            expect(md.toHTML()).toEqual("<ul>\n<li>a</li>\n<li>b</li>\n</ul>\n");
+        });
+
+        it("still renders a single paragraph message inline", () => {
+            const md = new Markdown("hello");
+            expect(md.toHTML()).toEqual("hello");
+        });
+    });
 });

--- a/apps/web/src/Markdown.test.ts
+++ b/apps/web/src/Markdown.test.ts
@@ -190,4 +190,26 @@ describe("Markdown parser test", () => {
             expect(md.toHTML()).toEqual("hello");
         });
     });
+
+    describe("block quotes", () => {
+        it("wraps a single paragraph quote in a paragraph", () => {
+            const md = new Markdown("> hello");
+            expect(md.toHTML()).toEqual("<blockquote>\n<p>hello</p>\n</blockquote>\n");
+        });
+
+        it("keeps the paragraphs of a multi paragraph quote separate", () => {
+            const md = new Markdown(["> a", ">", "> b"].join("\n"));
+            expect(md.toHTML()).toEqual("<blockquote>\n<p>a</p>\n<p>b</p>\n</blockquote>\n");
+        });
+
+        it("still wraps a quote the message carries on after", () => {
+            const md = new Markdown(["> a", "", "b"].join("\n"));
+            expect(md.toHTML()).toEqual("<blockquote>\n<p>a</p>\n</blockquote>\n<p>b</p>\n");
+        });
+
+        it("keeps the paragraphs of a loose list item inside a quote separate", () => {
+            const md = new Markdown(["> 1. a", ">", ">     b"].join("\n"));
+            expect(md.toHTML()).toEqual("<blockquote>\n<ol>\n<li>\n<p>a</p>\n<p>b</p>\n</li>\n</ol>\n</blockquote>\n");
+        });
+    });
 });

--- a/apps/web/src/Markdown.ts
+++ b/apps/web/src/Markdown.ts
@@ -302,10 +302,13 @@ export default class Markdown {
             // 'inline', rather than unnecessarily wrapped in its own
             // p tag. If, however, we have multiple nodes, each gets
             // its own p tag to keep them as separate paragraphs.
-            // However, if it's a blockquote, adds a p tag anyway
-            // in order to avoid deviation to commonmark and unexpected
-            // results when parsing the formatted HTML.
-            if (node.parent?.type === "block_quote" || isMultiLine(node)) {
+            // Paragraphs nested inside another block — a blockquote or a
+            // list item — always go through commonmark, both to avoid
+            // deviating from it when the formatted HTML is parsed back, and
+            // because dropping them collapses the separate paragraphs of a
+            // loose list item into one. commonmark omits the p tags for
+            // tight lists itself, so those are unaffected.
+            if (node.parent?.type !== "document" || isMultiLine(node)) {
                 realParagraph.call(this, node, entering);
             }
         };


### PR DESCRIPTION
Writing a list item with more than one paragraph collapsed them into one — `1. a` / `2. b` /
blank / indented `c` sent `<li>bc</li>` instead of keeping `b` and `c` apart.

The `paragraph` renderer override dropped the `<p>` for any paragraph unless the message had more
than one top-level block, and `isMultiLine` measures the whole document. A message that is only a
list has a single top-level child, so every paragraph inside its items was dropped.

Paragraphs nested inside another block — a list item or a blockquote — now always go through
commonmark. Tight lists are unaffected because commonmark omits the `<p>` for them itself, and
single-paragraph messages are still sent inline.

Tests: three cases in `Markdown.test.ts` — a loose list keeps its paragraphs, a tight list gains
no paragraphs, and a one-line message stays inline.

Fixes #25933

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
