### PR TITLE
Always summarise member events in timeline summaries when redacted

### DIFF
--- a/apps/web/src/components/views/elements/EventListSummary.tsx
+++ b/apps/web/src/components/views/elements/EventListSummary.tsx
@@ -509,11 +509,17 @@ export default class EventListSummary extends React.Component<Props, State> {
      * if a transition is not recognised.
      */
     private static getTransition(e: IUserEvents): TransitionType | null {
-        if (e.mxEvent.isRedacted()) {
+        const type = e.mxEvent.getType();
+
+        // Redaction preserves `membership` on a membership event, and the expanded events still
+        // read as the join or leave they are, so keep summarising them that way. Without this a
+        // user whose join is redacted right after they are banned — what a moderation bot does —
+        // is summarised as having removed a message.
+        if (e.mxEvent.isRedacted() && type !== EventType.RoomMember) {
             return TransitionType.MessageRemoved;
         }
 
-        switch (e.mxEvent.getType()) {
+        switch (type) {
             case EventType.RoomThirdPartyInvite:
                 // Handle 3pid invites the same as invites so they get bundled together
                 if (!isValid3pidInvite(e.mxEvent)) {

--- a/apps/web/test/unit-tests/components/views/elements/EventListSummary-test.tsx
+++ b/apps/web/test/unit-tests/components/views/elements/EventListSummary-test.tsx
@@ -716,4 +716,65 @@ describe("EventListSummary", function () {
         expect(summary).toHaveTextContent("n...@d... was invited 2 times, d...@w... was invited");
         expect(summary).toMatchSnapshot();
     });
+
+    describe("redacted events", () => {
+        const redact = (event: MatrixEvent, redactedBy = "@moderator:some.domain"): MatrixEvent => {
+            event.event.unsigned = {
+                ...event.event.unsigned,
+                redacted_because: {
+                    sender: redactedBy,
+                    type: "m.room.redaction",
+                    content: {},
+                    event_id: "$redaction",
+                    origin_server_ts: 0,
+                    unsigned: {},
+                },
+            };
+            return event;
+        };
+
+        const summaryFor = (events: MatrixEvent[]): string => {
+            const { container } = renderComponent({
+                events,
+                children: generateTiles(events),
+                summaryLength: 1,
+                avatarsMaxLength: 5,
+                threshold: 1,
+            });
+            return container.querySelector(".mx_GenericEventListSummary_summary")!.textContent!;
+        };
+
+        it("summarises a redacted membership event by its membership change", () => {
+            const [join, ban] = generateEvents([
+                {
+                    userId: "@user_1:some.domain",
+                    prevMembership: KnownMembership.Leave,
+                    membership: KnownMembership.Join,
+                },
+                {
+                    senderId: "@moderator:some.domain",
+                    userId: "@user_1:some.domain",
+                    prevMembership: KnownMembership.Join,
+                    membership: KnownMembership.Ban,
+                },
+            ]);
+            const summary = summaryFor([redact(join), ban]);
+            expect(summary).toContain("joined and was banned");
+            expect(summary).not.toContain("removed a message");
+        });
+
+        it("still summarises a redacted message as removed", () => {
+            const message = redact(
+                mkEvent({
+                    event: true,
+                    type: "m.room.message",
+                    room: roomId,
+                    user: "@user_1:some.domain",
+                    content: {},
+                }),
+            );
+            // The redactor, not the original sender, is credited with removing the message
+            expect(summaryFor([message])).toBe("@moderator:some.domain removed a message");
+        });
+    });
 });


### PR DESCRIPTION
When a moderation bot bans a user and redacts their events, the redacted join is one of them. The
collapsed timeline summary then reads "removed a message and was banned" instead of describing the
join, even though the same events read correctly when expanded.

`getTransition` checked for redaction before it looked at the event type, so any redacted event
became "removed a message". Redaction preserves `membership` on a membership event, which is why
the expanded view is unaffected.

A redacted `m.room.member` event is now classified by its membership like any other. Redacted
messages are unchanged, and so are redacted events of every other type — narrowing the bypass to
membership avoids relabelling things like a redacted topic change, which has no case of its own
and would fall through to "sent a hidden message".

Fixes #23588

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
