### PR TITLE
Stop large audio playback when the media element ends

### DIFF
--- a/apps/web/src/audio/Playback.ts
+++ b/apps/web/src/audio/Playback.ts
@@ -134,6 +134,7 @@ export class Playback extends EventEmitter implements IDestroyable, PlaybackInte
         this.clock.destroy();
         this.waveformObservable.close();
         if (this.element) {
+            this.element.removeEventListener("ended", this.onPlaybackEnd);
             URL.revokeObjectURL(this.element.src);
             this.element.remove();
         }
@@ -235,12 +236,16 @@ export class Playback extends EventEmitter implements IDestroyable, PlaybackInte
 
         if (this.element) {
             this.source = this.context.createMediaElementSource(this.element);
+            // A MediaElementAudioSourceNode is not a scheduled source node and never emits "ended",
+            // so the media element has to be listened to instead. Without this, playback of a large
+            // file never returns to Stopped and the clock keeps running past the end of the clip.
+            this.element.addEventListener("ended", this.onPlaybackEnd);
         } else {
             this.source = this.context.createBufferSource();
             this.source.buffer = this.audioBuf ?? null;
+            this.source.addEventListener("ended", this.onPlaybackEnd);
         }
 
-        this.source.addEventListener("ended", this.onPlaybackEnd);
         this.source.connect(this.context.destination);
     }
 

--- a/apps/web/test/unit-tests/audio/Playback-test.ts
+++ b/apps/web/test/unit-tests/audio/Playback-test.ts
@@ -29,11 +29,18 @@ describe("Playback", () => {
         connect: jest.fn(),
         start: jest.fn(),
     };
+    const mockMediaElementSourceNode = {
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        connect: jest.fn(),
+        disconnect: jest.fn(),
+    };
     const mockAudioContext = {
         decodeAudioData: jest.fn(),
         suspend: jest.fn(),
         resume: jest.fn(),
         createBufferSource: jest.fn().mockReturnValue(mockAudioBufferSourceNode),
+        createMediaElementSource: jest.fn().mockReturnValue(mockMediaElementSourceNode),
         currentTime: 1337,
     };
 
@@ -179,6 +186,84 @@ describe("Playback", () => {
 
             // only called once in first prepare
             expect(mockAudioContext.decodeAudioData).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("audio larger than 5mb", () => {
+        // Anything over 5mb is played through an <audio /> element rather than a decoded buffer
+        const largeBuffer = (): ArrayBuffer => new ArrayBuffer(5 * 1024 * 1024 + 1);
+
+        let element: ReturnType<typeof mockAudioElement>;
+
+        /**
+         * A stand-in for the <audio /> element Playback creates. Assigning `src` resolves the load
+         * the same way the browser does, and listeners registered on it can be fired by hand.
+         */
+        const mockAudioElement = () => {
+            const listeners = new Map<string, Set<() => void | Promise<void>>>();
+            const el = {
+                duration: 42,
+                currentTime: 0,
+                onloadeddata: undefined as undefined | (() => void),
+                onerror: undefined as undefined | (() => void),
+                play: jest.fn().mockResolvedValue(undefined),
+                pause: jest.fn(),
+                remove: jest.fn(),
+                addEventListener: jest.fn((type: string, cb: () => void) => {
+                    if (!listeners.has(type)) listeners.set(type, new Set());
+                    listeners.get(type)!.add(cb);
+                }),
+                removeEventListener: jest.fn((type: string, cb: () => void) => {
+                    listeners.get(type)?.delete(cb);
+                }),
+                listenerCount: (type: string): number => listeners.get(type)?.size ?? 0,
+                fire: async (type: string): Promise<void> => {
+                    for (const cb of listeners.get(type) ?? []) await cb();
+                },
+            };
+            Object.defineProperty(el, "src", {
+                set() {
+                    el.onloadeddata?.();
+                },
+            });
+            return el;
+        };
+
+        beforeEach(() => {
+            element = mockAudioElement();
+            jest.spyOn(document, "createElement").mockReturnValue(element as unknown as HTMLElement);
+            global.URL.createObjectURL = jest.fn().mockReturnValue("blob:audio");
+            global.URL.revokeObjectURL = jest.fn();
+            mockAudioContext.createMediaElementSource.mockClear().mockReturnValue(mockMediaElementSourceNode);
+            mockMediaElementSourceNode.connect.mockClear();
+        });
+
+        afterEach(() => {
+            mocked(document.createElement).mockRestore();
+        });
+
+        it("stops when the media element ends", async () => {
+            const playback = new Playback(largeBuffer());
+            await playback.prepare();
+            await playback.play();
+            expect(playback.currentState).toEqual(PlaybackState.Playing);
+
+            await element.fire("ended");
+
+            expect(mockAudioContext.suspend).toHaveBeenCalled();
+            expect(playback.currentState).toEqual(PlaybackState.Stopped);
+            expect(playback.timeSeconds).toEqual(0);
+        });
+
+        it("stops listening to the media element once destroyed", async () => {
+            const playback = new Playback(largeBuffer());
+            await playback.prepare();
+            await playback.play();
+            expect(element.listenerCount("ended")).toEqual(1);
+
+            playback.destroy();
+
+            expect(element.listenerCount("ended")).toEqual(0);
         });
     });
 });


### PR DESCRIPTION
An audio file over 5MiB is played through an `<audio>` element rather than a decoded buffer. When
it reached the end, playback never returned to the stopped state — the clock kept running and, as
it is modular, wrapped around so the play bar walked through the track again while nothing was
audible.

The `ended` handler was attached to the source node in both cases, but a
`MediaElementAudioSourceNode` is not a scheduled source node and never emits `ended`, so for large
files it was never called. It is now attached to the media element itself, and removed again when
the playback is destroyed. The buffer path is unchanged.

Tests: a new describe covering the element path — firing `ended` stops playback and resets the
clock, and destroying the playback detaches the listener.

Fixes #21359

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
