### PR TITLE
Keep emoji at code size inside code blocks so line numbers stay aligned

### DIFF
--- a/apps/web/playwright/e2e/timeline/timeline.spec.ts
+++ b/apps/web/playwright/e2e/timeline/timeline.spec.ts
@@ -909,6 +909,30 @@ test.describe("Timeline", () => {
             });
         });
 
+        test("should not enlarge emoji inside a code block", async ({ page, app, room }) => {
+            await page.goto(`/#/room/${room.roomId}`);
+
+            const composer = app.getComposerField();
+            await composer.fill("```\nconst waving = '👋';\n```");
+            await composer.press("Enter");
+            await composer.fill("👋 hello");
+            await composer.press("Enter");
+
+            const codeBlock = page.locator(".mx_EventTile_pre_container").first();
+            await expect(codeBlock).toBeVisible();
+
+            const fontSize = (locator: Locator): Promise<string> =>
+                locator.evaluate((node) => window.getComputedStyle(node).fontSize);
+
+            // Inside a code block the emoji must not be any larger than the code around it,
+            // otherwise the line it sits on grows and the line numbers stop lining up
+            expect(await fontSize(codeBlock.locator(".mx_Emoji"))).toEqual(await fontSize(codeBlock.locator("code")));
+
+            // ...but emoji in an ordinary message are still enlarged
+            const message = page.locator(".mx_EventTile_last .mx_EventTile_body");
+            expect(await fontSize(message.locator(".mx_Emoji"))).not.toEqual(await fontSize(message));
+        });
+
         test(
             "should be able to hide an image",
             { tag: "@screenshot" },

--- a/apps/web/res/css/views/rooms/_EventTile.pcss
+++ b/apps/web/res/css/views/rooms/_EventTile.pcss
@@ -851,6 +851,12 @@ $left-gutter: 64px;
         /* For correct positioning of _copyButton (See TextualBody) */
         position: relative;
 
+        /* Emoji are enlarged in prose, but a code block's line numbers are one fixed-height block
+           per line and cannot follow a line that an enlarged emoji has made taller. */
+        .mx_Emoji {
+            font-size: inherit;
+        }
+
         &:focus-within,
         &:hover {
             .mx_EventTile_button {


### PR DESCRIPTION
Emoji are rendered larger than the surrounding text, including inside code blocks. A code block's
line numbers are one fixed-height block per line, so a line made taller by an emoji pushes every
following line out of step with its number.

Emoji inside a code block now inherit the code's font size, so the line keeps its height. Emoji
everywhere else are unchanged — scoping the override to the code block avoids the visual churn a
global line-height change would cause, which is the approach ara4n suggested first in the issue.

Tests: a Playwright case asserting an emoji in a code block matches the font size of the code
around it, while an emoji in an ordinary message is still enlarged.

Fixes #31310

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
