### PR TITLE
Do not ask for a room address when the room already has one

### DIFF
--- a/apps/web/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
@@ -249,8 +249,13 @@ export default class SecurityRoomSettingsTab extends React.Component<IProps, ISt
     };
 
     private async hasAliases(): Promise<boolean> {
+        // The published addresses can live on any server, so a room can be linkable without this
+        // server holding a local alias for it.
+        const room = this.props.room;
+        if (room.getCanonicalAlias() || room.getAltAliases().length > 0) return true;
+
         const cli = this.context;
-        const response = await cli.getLocalAliases(this.props.room.roomId);
+        const response = await cli.getLocalAliases(room.roomId);
         const localAliases = response.aliases;
         return Array.isArray(localAliases) && localAliases.length !== 0;
     }

--- a/apps/web/test/unit-tests/components/views/settings/tabs/room/SecurityRoomSettingsTab-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/tabs/room/SecurityRoomSettingsTab-test.tsx
@@ -581,4 +581,60 @@ describe("<SecurityRoomSettingsTab />", () => {
             });
         });
     });
+
+    describe("public room address warning", () => {
+        const warning = "To link to this room, please add an address.";
+
+        const setCanonicalAlias = (room: Room, content: object): void => {
+            room.currentState.setStateEvents([
+                new MatrixEvent({
+                    type: EventType.RoomCanonicalAlias,
+                    content,
+                    sender: userId,
+                    state_key: "",
+                    room_id: room.roomId,
+                }),
+            ]);
+        };
+
+        const renderPublicRoom = async (configure?: (room: Room) => void): Promise<void> => {
+            const room = new Room(roomId, client, userId);
+            setRoomStateEvents(room, JoinRule.Public);
+            configure?.(room);
+            getComponent(room);
+            await flushPromises();
+        };
+
+        it("warns when the room has no address anywhere", async () => {
+            client.getLocalAliases.mockResolvedValue({ aliases: [] });
+
+            await renderPublicRoom();
+
+            expect(screen.getByText(warning)).toBeInTheDocument();
+        });
+
+        it("does not warn when the room's main address is on another server", async () => {
+            client.getLocalAliases.mockResolvedValue({ aliases: [] });
+
+            await renderPublicRoom((room) => setCanonicalAlias(room, { alias: "#room:other.server.org" }));
+
+            expect(screen.queryByText(warning)).not.toBeInTheDocument();
+        });
+
+        it("does not warn when the room only has alternative addresses", async () => {
+            client.getLocalAliases.mockResolvedValue({ aliases: [] });
+
+            await renderPublicRoom((room) => setCanonicalAlias(room, { alt_aliases: ["#room:other.server.org"] }));
+
+            expect(screen.queryByText(warning)).not.toBeInTheDocument();
+        });
+
+        it("does not warn when the local server has an address for the room", async () => {
+            client.getLocalAliases.mockResolvedValue({ aliases: ["#room:server.org"] });
+
+            await renderPublicRoom();
+
+            expect(screen.queryByText(warning)).not.toBeInTheDocument();
+        });
+    });
 });


### PR DESCRIPTION
The warning under a public room's join rule asks the user to add an address whenever the local
homeserver holds no alias for the room. A room's published addresses can point at any server, so a
room whose main address is on another homeserver is told to add one it already has.

The check now treats a published main or alternative address as an address, and only falls back to
asking the local server for its aliases when the room has neither. A public room with no address
anywhere is still warned about.

Tests: the settings tab had no alias coverage; a new block covers a remote main address and
alt-aliases-only, with controls for no address at all and for a local address.

Fixes #19987

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
