### PR TITLE
Let the voice message duration grow to fit a wider font

### DIFF
--- a/apps/web/playwright/e2e/timeline/timeline.spec.ts
+++ b/apps/web/playwright/e2e/timeline/timeline.spec.ts
@@ -1040,6 +1040,58 @@ test.describe("Timeline", () => {
             await expect(roomViewBody.locator(".mx_MVoiceMessageBody")).toMatchScreenshot("voice-message.png");
         });
 
+        test("shows the whole voice message duration with a wide font", async ({ page, app, room, context }) => {
+            await app.viewRoomById(room.roomId);
+
+            const composerOptions = await app.openMessageComposerOptions();
+            await composerOptions.getByRole("menuitem", { name: "Voice Message" }).click();
+
+            // Record an empty message
+            await page.waitForTimeout(3000);
+
+            const roomViewBody = page.locator(".mx_RoomView_body");
+            await roomViewBody
+                .locator(".mx_MessageComposer")
+                .getByRole("button", { name: "Send voice message" })
+                .click();
+
+            const clock = roomViewBody.locator(".mx_MVoiceMessageBody .mx_Clock");
+            await expect(clock).toBeVisible();
+
+            // How many lines the digits occupy, how wide the widest of them is, and how much room
+            // the clock gives them. `scrollWidth` is no use here: the clock does not scroll, so it
+            // never reports more than its own padding box however far the text spills out of it.
+            const measure = (): Promise<{ lines: number; text: number; box: number; letterSpacing: string }> =>
+                clock.evaluate((el) => {
+                    const range = document.createRange();
+                    range.selectNodeContents(el);
+                    const rects = Array.from(range.getClientRects());
+                    const style = getComputedStyle(el);
+                    return {
+                        lines: rects.length,
+                        text: Math.max(...rects.map((r) => r.width)),
+                        box: el.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight),
+                        letterSpacing: style.letterSpacing,
+                    };
+                });
+
+            // Guard: the duration is on one line to begin with.
+            expect(await measure()).toMatchObject({ lines: 1 });
+
+            // Stand in for a custom font whose digits are wider than the clock's fixed width.
+            await page.addStyleTag({
+                content: ".mx_VoiceMessagePrimaryContainer .mx_Clock { letter-spacing: 4px; }",
+            });
+            const after = await measure();
+
+            // Guard: the simulated font really did apply.
+            expect(after.letterSpacing).toBe("4px");
+
+            // The clock grew with the digits, so the duration still reads as one line that fits.
+            expect(after.lines).toBe(1);
+            expect(after.box).toBeGreaterThanOrEqual(after.text);
+        });
+
         test("can reply with a voice message", async ({ page, app, room, context }) => {
             await viewRoomSendMessageAndSetupReply(page, app, room.roomId);
 

--- a/apps/web/playwright/e2e/timeline/timeline.spec.ts
+++ b/apps/web/playwright/e2e/timeline/timeline.spec.ts
@@ -30,6 +30,8 @@ const OLD_NAME = "Alan";
 const NEW_NAME = "Alan (away)";
 
 const VIDEO_FILE = readSampleFileSync("5secvid.webm", null);
+const VOICE_MESSAGE_FILE = readSampleFileSync("1sec.ogg", null);
+const VOICE_MESSAGE_WAVEFORM = [0, 128, 512, 1024, 512, 128, 0];
 
 const getEventTilesWithBodies = (page: Page): Locator => {
     return page.locator(".mx_EventTile").filter({ has: page.locator(".mx_EventTile_body") });
@@ -789,6 +791,55 @@ test.describe("Timeline", () => {
             ).toBeVisible();
         });
 
+        test(
+            "should show the whole voice message duration with a wide font",
+            { tag: ["@no-firefox", "@no-webkit"] },
+            async ({ page, app, room }) => {
+                const upload = await app.client.uploadContent(VOICE_MESSAGE_FILE, {
+                    name: "voice-message.ogg",
+                    type: "audio/ogg",
+                });
+                await app.client.sendEvent(room.roomId, null, "m.room.message" as EventType, {
+                    "msgtype": "m.audio" as MsgType,
+                    "body": "voice-message.ogg",
+                    "url": upload.content_uri,
+                    "info": { mimetype: "audio/ogg", size: VOICE_MESSAGE_FILE.byteLength, duration: 1000 },
+                    "org.matrix.msc1767.audio": { duration: 1000, waveform: VOICE_MESSAGE_WAVEFORM },
+                    "org.matrix.msc3245.voice": {},
+                });
+
+                await app.viewRoomById(room.roomId);
+
+                const clock = page.locator(".mx_RoomView_body .mx_MVoiceMessageBody .mx_Clock");
+                await expect(clock).toHaveText(/\d+:\d\d/);
+
+                const measure = (): Promise<{ lines: number; text: number; box: number; letterSpacing: string }> =>
+                    clock.evaluate((el) => {
+                        const range = document.createRange();
+                        range.selectNodeContents(el);
+                        const rects = Array.from(range.getClientRects());
+                        const style = getComputedStyle(el);
+                        return {
+                            lines: rects.length,
+                            text: Math.max(...rects.map((r) => r.width)),
+                            box: el.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight),
+                            letterSpacing: style.letterSpacing,
+                        };
+                    });
+
+                expect(await measure()).toMatchObject({ lines: 1 });
+
+                await page.addStyleTag({
+                    content: ".mx_VoiceMessagePrimaryContainer .mx_Clock { letter-spacing: 4px; }",
+                });
+                const after = await measure();
+
+                expect(after.letterSpacing).toBe("4px");
+                expect(after.lines).toBe(1);
+                expect(after.box).toBeGreaterThanOrEqual(after.text);
+            },
+        );
+
         test.describe("on search results panel", () => {
             test(
                 "should highlight search result words regardless of formatting",
@@ -1038,58 +1089,6 @@ test.describe("Timeline", () => {
                 .click();
 
             await expect(roomViewBody.locator(".mx_MVoiceMessageBody")).toMatchScreenshot("voice-message.png");
-        });
-
-        test("shows the whole voice message duration with a wide font", async ({ page, app, room, context }) => {
-            await app.viewRoomById(room.roomId);
-
-            const composerOptions = await app.openMessageComposerOptions();
-            await composerOptions.getByRole("menuitem", { name: "Voice Message" }).click();
-
-            // Record an empty message
-            await page.waitForTimeout(3000);
-
-            const roomViewBody = page.locator(".mx_RoomView_body");
-            await roomViewBody
-                .locator(".mx_MessageComposer")
-                .getByRole("button", { name: "Send voice message" })
-                .click();
-
-            const clock = roomViewBody.locator(".mx_MVoiceMessageBody .mx_Clock");
-            await expect(clock).toBeVisible();
-
-            // How many lines the digits occupy, how wide the widest of them is, and how much room
-            // the clock gives them. `scrollWidth` is no use here: the clock does not scroll, so it
-            // never reports more than its own padding box however far the text spills out of it.
-            const measure = (): Promise<{ lines: number; text: number; box: number; letterSpacing: string }> =>
-                clock.evaluate((el) => {
-                    const range = document.createRange();
-                    range.selectNodeContents(el);
-                    const rects = Array.from(range.getClientRects());
-                    const style = getComputedStyle(el);
-                    return {
-                        lines: rects.length,
-                        text: Math.max(...rects.map((r) => r.width)),
-                        box: el.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight),
-                        letterSpacing: style.letterSpacing,
-                    };
-                });
-
-            // Guard: the duration is on one line to begin with.
-            expect(await measure()).toMatchObject({ lines: 1 });
-
-            // Stand in for a custom font whose digits are wider than the clock's fixed width.
-            await page.addStyleTag({
-                content: ".mx_VoiceMessagePrimaryContainer .mx_Clock { letter-spacing: 4px; }",
-            });
-            const after = await measure();
-
-            // Guard: the simulated font really did apply.
-            expect(after.letterSpacing).toBe("4px");
-
-            // The clock grew with the digits, so the duration still reads as one line that fits.
-            expect(after.lines).toBe(1);
-            expect(after.box).toBeGreaterThanOrEqual(after.text);
         });
 
         test("can reply with a voice message", async ({ page, app, room, context }) => {

--- a/apps/web/res/css/views/audio_messages/_PlaybackContainer.pcss
+++ b/apps/web/res/css/views/audio_messages/_PlaybackContainer.pcss
@@ -43,8 +43,11 @@ Please see LICENSE files in the repository root for full details.
     }
 
     .mx_Clock {
-        width: $font-42px; /* we're not using a monospace font, so fake it */
-        min-width: $font-42px; /* force sensible layouts in awkward flexboxes (file panel, for example) */
+        /* We're not using a monospace font, so fake a stable width - but let the box grow when the
+           digits are wider than that, as they can be with a custom font. The floor also forces
+           sensible layouts in awkward flexboxes (file panel, for example). */
+        width: max-content;
+        min-width: $font-42px;
         padding-right: 6px; /* with the fixed width this ends up as a visual 8px most of the time, as intended. */
         padding-left: 8px; /* isolate from recording circle / play control */
     }


### PR DESCRIPTION
The voice message duration is given a width derived from the root font size, with a comment saying
it fakes a monospace advance. A custom font with wider digits does not fit that width, and since
the player is painted with `contain: content` the duration ends up wrapping or clipped.

The fixed value now acts as a minimum rather than a fixed size, so the box keeps its usual width
with the default font and grows only when the digits need more room. The floor that keeps the
layout steady in cramped flexboxes, such as the file panel, is retained.

Tests: a Playwright case that widens the clock's digits and asserts the duration still renders on
one line inside its box. The existing voice message screenshot is unchanged.

Fixes #18590

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
