### PR TITLE
Keep line breaks in messages serialised through the plain text path

### DIFF
--- a/apps/web/src/Markdown.ts
+++ b/apps/web/src/Markdown.ts
@@ -365,7 +365,14 @@ export default class Markdown {
      * which has no formatting.  Otherwise it emits HTML(!).
      */
     public toPlaintext(): string {
-        const renderer = new commonmark.HtmlRenderer({ safe: false });
+        const renderer = new commonmark.HtmlRenderer({
+            safe: false,
+
+            // As with toHTML, render soft breaks as hard HTML breaks: the output of this method
+            // ends up in formatted_body, where a bare newline collapses into a space
+            // (https://github.com/element-hq/element-web/issues/33032).
+            softbreak: "<br />",
+        });
 
         renderer.paragraph = function (node: commonmark.Node, entering: boolean) {
             // as with toHTML, only append lines to paragraphs if there are
@@ -377,14 +384,22 @@ export default class Markdown {
             }
         };
 
+        // Raw HTML never reaches this method unless its tag is disallowed (see isPlainText), so the
+        // literal is escaped here rather than passed through.
+        renderer.html_inline = function (node: commonmark.Node) {
+            if (node.literal) this.lit(escape(node.literal));
+        };
+
         renderer.html_block = function (node: commonmark.Node) {
-            if (node.literal) this.lit(node.literal);
+            if (node.literal) this.lit(escape(node.literal));
             if (isMultiLine(node) && node.next) this.lit("\n\n");
         };
 
-        // We inhibit the default escape function as we escape the entire output string to correctly handle backslashes
-        renderer.esc = (input: string) => input;
+        // Escape each literal as it is emitted rather than escaping the rendered string as a whole,
+        // so that markup the renderer generates itself — a line break, for instance — survives
+        // (https://github.com/element-hq/element-web/issues/28602).
+        renderer.esc = escape;
 
-        return escape(renderer.render(this.parsed));
+        return renderer.render(this.parsed);
     }
 }

--- a/apps/web/src/editor/serialize.test.ts
+++ b/apps/web/src/editor/serialize.test.ts
@@ -169,6 +169,14 @@ describe("editor/serialize", function () {
             const html = htmlSerializeFromMdIfNeeded("\\<b>test</b>", {});
             expect(html).toBe("&lt;b&gt;test&lt;/b&gt;");
         });
+        it("should render a hard line break in escaped markdown as a break, not as text", () => {
+            const html = htmlSerializeFromMdIfNeeded("\\*hello\\* world  \nsecond line", {});
+            expect(html).toBe("*hello* world<br />\nsecond line");
+        });
+        it("should keep a soft line break in escaped markdown", () => {
+            const html = htmlSerializeFromMdIfNeeded("\\*hello\\* world\nsecond line", {});
+            expect(html).toBe("*hello* world<br />second line");
+        });
     });
 
     describe("feature_latex_maths", () => {


### PR DESCRIPTION
`Markdown.toPlaintext()` renders with a commonmark HTML renderer and then escapes the whole rendered
string in one pass. That escape does not distinguish between text the user typed and markup the
renderer generated, so the `<br />` commonmark emits for a hard line break arrives in
`formatted_body` as `&lt;br /&gt;` and is displayed as readable text. Soft breaks have the opposite
problem on the same path: they stay bare newlines, which collapse into spaces when the body is
rendered, so a multi-line message loses its line breaks when it is edited.

Each literal is now escaped as it is emitted rather than escaping the rendered output as a whole,
and soft breaks are rendered as breaks the way `toHTML` already does. Raw HTML only reaches this
method when its tag is disallowed, so it is escaped explicitly and still comes out as visible text.

Tests: two cases in the plaintext serialisation suite covering a hard break and a soft break.

Fixes #28602
Fixes #33032

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
