### PR TITLE
Open linkified room aliases and permalinks in the app rather than the browser

### DIFF
--- a/apps/web/src/viewmodels/room/timeline/event-tile/body/TextualBodyViewModel.tsx
+++ b/apps/web/src/viewmodels/room/timeline/event-tile/body/TextualBodyViewModel.tsx
@@ -9,7 +9,6 @@ import React, { type MouseEvent } from "react";
 import { MatrixEventEvent, MsgType, type MatrixEvent } from "matrix-js-sdk/src/matrix";
 import {
     BaseViewModel,
-    LINKIFIED_DATA_ATTRIBUTE,
     TextualBodyViewBodyWrapperKind,
     TextualBodyViewKind,
     type TextualBodyViewModel as TextualBodyViewModelInterface,
@@ -277,10 +276,6 @@ export class TextualBodyViewModel
 
     public onRootClick = (event: MouseEvent<HTMLDivElement>): void => {
         let target: HTMLLinkElement | null = event.target as HTMLLinkElement;
-
-        if (target.dataset?.[LINKIFIED_DATA_ATTRIBUTE]) {
-            return;
-        }
 
         if (target.nodeName !== "A") {
             target = target.closest<HTMLLinkElement>("a");

--- a/apps/web/test/viewmodels/message-body/TextualBodyViewModel-test.ts
+++ b/apps/web/test/viewmodels/message-body/TextualBodyViewModel-test.ts
@@ -213,10 +213,29 @@ describe("TextualBodyViewModel", () => {
         ).toThrow("TextualBodyViewModel should only render pending moderation for hidden messages");
     });
 
-    it("ignores linkified root clicks", () => {
+    it("rewrites linkified permalink clicks to local hashes", () => {
         const vm = createVm();
         const preventDefault = jest.fn();
-        const transformSpy = jest.spyOn(permalinkUtils, "tryTransformPermalinkToLocalHref");
+        jest.spyOn(permalinkUtils, "tryTransformPermalinkToLocalHref").mockReturnValue("#/room/#room:example.org");
+
+        vm.onRootClick({
+            preventDefault,
+            target: {
+                dataset: {
+                    [LINKIFIED_DATA_ATTRIBUTE]: "true",
+                },
+                href: "https://matrix.to/#/#room:example.org",
+                nodeName: "A",
+            },
+        } as any);
+
+        expect(preventDefault).toHaveBeenCalled();
+        expect(window.location.hash).toBe("#/room/#room:example.org");
+    });
+
+    it("leaves linkified ordinary links alone", () => {
+        const vm = createVm();
+        const preventDefault = jest.fn();
 
         vm.onRootClick({
             preventDefault,
@@ -229,8 +248,8 @@ describe("TextualBodyViewModel", () => {
             },
         } as any);
 
-        expect(transformSpy).not.toHaveBeenCalled();
         expect(preventDefault).not.toHaveBeenCalled();
+        expect(window.location.hash).toBe("");
     });
 
     it("rewrites permalink clicks to local hashes", () => {


### PR DESCRIPTION
A room alias written in a plain-text message is linkified into a `matrix.to` anchor, and the
timeline's click handler returns early for any anchor the linkifier produced. The in-app navigation
that the same handler performs a few lines further down is therefore never reached, and clicking the
alias leaves the app for the browser.

That early return is removed. Linkified anchors now take the same path as anchors from a formatted
body: a permalink is rewritten to a local route, and anything that is not a permalink comes back
unchanged from the rewrite and is still handled by the browser as before.

The `data-linkified` marker itself is left in place — it is part of the shared components' link
output and is asserted on elsewhere; only the click handler's use of it changes.

Tests: the case asserting that linkified clicks are ignored described the bug and has been replaced
by one covering a linkified permalink and one confirming that an ordinary linkified URL is still
left alone.

Fixes #31351

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
