### PR TITLE
Let mobile_guide_toast turn off the mobile guide redirect

### DIFF
--- a/apps/web/playwright/e2e/mobile-guide/mobile-guide.spec.ts
+++ b/apps/web/playwright/e2e/mobile-guide/mobile-guide.spec.ts
@@ -10,40 +10,25 @@ import { MobileAppVariant } from "../../../src/vector/mobile_guide/mobile-apps";
 
 const variants = [MobileAppVariant.Classic, MobileAppVariant.X, MobileAppVariant.Pro];
 
-const homeserver = {
-    default_server_config: {
-        "m.homeserver": {
-            base_url: "https://matrix.server.invalid",
-            server_name: "server.invalid",
-        },
-    },
-};
-
 const IPHONE_USER_AGENT = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15";
 
 test.describe("Mobile Guide redirect", () => {
     test.use({
         userAgent: IPHONE_USER_AGENT,
-        viewport: { width: 390, height: 844 }, // iPhone 16e
+        viewport: { width: 390, height: 844 },
     });
 
-    test.describe("by default", () => {
-        test.use({ config: homeserver });
-
-        test("should send a mobile browser to the mobile guide", async ({ page }) => {
-            await page.goto("/");
-            await expect(page).toHaveURL(/\/mobile_guide\/?$/);
-        });
+    test("should send a mobile browser to the mobile guide by default", async ({ page }) => {
+        await page.goto("/");
+        await expect(page).toHaveURL(/\/mobile_guide\/?$/);
     });
 
     test.describe("with mobile_guide_toast disabled", () => {
-        test.use({ config: { ...homeserver, mobile_guide_toast: false } });
+        test.use({ config: { mobile_guide_toast: false } });
 
         test("should leave a mobile browser in the web app", async ({ page }) => {
             await page.goto("/");
-            // Wait for the app itself to render, so the assertion below cannot pass simply because
-            // the redirect has not happened yet.
-            await expect(page.locator("#matrixchat")).toBeAttached();
+            await expect(page.locator(".mx_Welcome")).toBeVisible();
             expect(page.url()).not.toContain("mobile_guide");
         });
     });

--- a/apps/web/playwright/e2e/mobile-guide/mobile-guide.spec.ts
+++ b/apps/web/playwright/e2e/mobile-guide/mobile-guide.spec.ts
@@ -10,6 +10,45 @@ import { MobileAppVariant } from "../../../src/vector/mobile_guide/mobile-apps";
 
 const variants = [MobileAppVariant.Classic, MobileAppVariant.X, MobileAppVariant.Pro];
 
+const homeserver = {
+    default_server_config: {
+        "m.homeserver": {
+            base_url: "https://matrix.server.invalid",
+            server_name: "server.invalid",
+        },
+    },
+};
+
+const IPHONE_USER_AGENT = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15";
+
+test.describe("Mobile Guide redirect", () => {
+    test.use({
+        userAgent: IPHONE_USER_AGENT,
+        viewport: { width: 390, height: 844 }, // iPhone 16e
+    });
+
+    test.describe("by default", () => {
+        test.use({ config: homeserver });
+
+        test("should send a mobile browser to the mobile guide", async ({ page }) => {
+            await page.goto("/");
+            await expect(page).toHaveURL(/\/mobile_guide\/?$/);
+        });
+    });
+
+    test.describe("with mobile_guide_toast disabled", () => {
+        test.use({ config: { ...homeserver, mobile_guide_toast: false } });
+
+        test("should leave a mobile browser in the web app", async ({ page }) => {
+            await page.goto("/");
+            // Wait for the app itself to render, so the assertion below cannot pass simply because
+            // the redirect has not happened yet.
+            await expect(page.locator("#matrixchat")).toBeAttached();
+            expect(page.url()).not.toContain("mobile_guide");
+        });
+    });
+});
+
 test.describe("Mobile Guide Screenshots", { tag: "@screenshot" }, () => {
     for (const variant of variants) {
         test.describe(`for variant ${variant}`, () => {

--- a/apps/web/src/vector/index.ts
+++ b/apps/web/src/vector/index.ts
@@ -141,25 +141,18 @@ async function start(): Promise<void> {
 
         const parsedUrl = parseAppUrl(window.location);
 
-        // we're verifying a 3pid, or the user is following a deep link
-        // (https://github.com/element-hq/element-web/issues/7378)
-        const isDeepLink = !!parsedUrl.params.threepid || parsedUrl.location.length > 0;
-
         // set the platform for react sdk
         preparePlatform();
         // load config requires the platform to be ready
         const loadConfigPromise = loadConfig();
         await settled(loadConfigPromise); // wait for it to settle
 
-        // Only now that the config is loaded can we tell whether the deployment wants mobile
-        // browsers redirected to the native apps at all.
-        // (https://github.com/element-hq/element-web/issues/21616)
-        const { default: SdkConfig } = await import("../SdkConfig");
+        const { default: SdkConfig } = await import(/* webpackChunkName: "init" */ "../SdkConfig");
         if (
             shouldRedirectToMobileGuide({
                 userAgent: navigator.userAgent,
                 hasMSStream: !!window.MSStream,
-                isDeepLink,
+                parsedUrl,
                 hasSkippedRedirect: sessionStorage.getItem("skip_mobile_redirect") === "true",
                 mobileGuideToast: SdkConfig.get("mobile_guide_toast"),
             })

--- a/apps/web/src/vector/index.ts
+++ b/apps/web/src/vector/index.ts
@@ -15,6 +15,7 @@ import { shouldPolyfill as shouldPolyFillIntlSegmenter } from "@formatjs/intl-se
 
 // These are things that can run before the skin loads - be careful not to reference the react-sdk though.
 import { parseAppUrl } from "./url_utils";
+import { shouldRedirectToMobileGuide } from "./mobile_guide/shouldRedirectToMobileGuide";
 import "./modernizr.cjs";
 import { polyfillTouchEvent } from "../@types/polyfill";
 
@@ -140,28 +141,33 @@ async function start(): Promise<void> {
 
         const parsedUrl = parseAppUrl(window.location);
 
-        // don't try to redirect to the native apps if we're
-        // verifying a 3pid (but after we've loaded the config)
-        // or if the user is following a deep link
+        // we're verifying a 3pid, or the user is following a deep link
         // (https://github.com/element-hq/element-web/issues/7378)
-        const preventRedirect = !!parsedUrl.params.threepid || parsedUrl.location.length > 0;
-
-        if (!preventRedirect) {
-            const isIos = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
-            const isAndroid = /Android/.test(navigator.userAgent);
-            if (isIos || isAndroid) {
-                if (sessionStorage.getItem("skip_mobile_redirect") !== "true") {
-                    window.location.href = "mobile_guide/";
-                    return;
-                }
-            }
-        }
+        const isDeepLink = !!parsedUrl.params.threepid || parsedUrl.location.length > 0;
 
         // set the platform for react sdk
         preparePlatform();
         // load config requires the platform to be ready
         const loadConfigPromise = loadConfig();
         await settled(loadConfigPromise); // wait for it to settle
+
+        // Only now that the config is loaded can we tell whether the deployment wants mobile
+        // browsers redirected to the native apps at all.
+        // (https://github.com/element-hq/element-web/issues/21616)
+        const { default: SdkConfig } = await import("../SdkConfig");
+        if (
+            shouldRedirectToMobileGuide({
+                userAgent: navigator.userAgent,
+                hasMSStream: !!window.MSStream,
+                isDeepLink,
+                hasSkippedRedirect: sessionStorage.getItem("skip_mobile_redirect") === "true",
+                mobileGuideToast: SdkConfig.get("mobile_guide_toast"),
+            })
+        ) {
+            window.location.href = "mobile_guide/";
+            return;
+        }
+
         // keep initialising so that we can show any possible error with as many features (theme, i18n) as possible
 
         // now that the config is ready, try to persist logs

--- a/apps/web/src/vector/mobile_guide/shouldRedirectToMobileGuide.test.ts
+++ b/apps/web/src/vector/mobile_guide/shouldRedirectToMobileGuide.test.ts
@@ -8,15 +8,19 @@ Please see LICENSE files in the repository root for full details.
 import { describe, it, expect } from "vitest";
 
 import { shouldRedirectToMobileGuide, type MobileGuideRedirectOptions } from "./shouldRedirectToMobileGuide";
+import { parseAppUrl } from "../url_utils";
 
 const IPHONE = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15";
 const ANDROID = "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36";
 const DESKTOP = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120.0.0.0";
 
+const appUrl = (fragment = ""): ReturnType<typeof parseAppUrl> =>
+    parseAppUrl(new URL(`https://element.example.com/${fragment}`));
+
 const options = (overrides: Partial<MobileGuideRedirectOptions> = {}): MobileGuideRedirectOptions => ({
     userAgent: IPHONE,
     hasMSStream: false,
-    isDeepLink: false,
+    parsedUrl: appUrl(),
     hasSkippedRedirect: false,
     ...overrides,
 });
@@ -44,8 +48,16 @@ describe("shouldRedirectToMobileGuide", () => {
         expect(shouldRedirectToMobileGuide(options({ hasMSStream: true }))).toBe(false);
     });
 
-    it("does not redirect a deep link or a 3pid verification", () => {
-        expect(shouldRedirectToMobileGuide(options({ isDeepLink: true }))).toBe(false);
+    it("does not redirect a 3pid verification", () => {
+        const parsedUrl = appUrl("#?client_secret=abc&sid=1");
+        expect(parsedUrl.params.threepid).toEqual({ client_secret: "abc", sid: "1" });
+        expect(shouldRedirectToMobileGuide(options({ parsedUrl }))).toBe(false);
+    });
+
+    it("does not redirect a deep link", () => {
+        const parsedUrl = appUrl("#/room/!abc:example.com");
+        expect(parsedUrl.location).toBe("/room/!abc:example.com");
+        expect(shouldRedirectToMobileGuide(options({ parsedUrl }))).toBe(false);
     });
 
     it("does not redirect once the user has chosen to stay in the browser", () => {

--- a/apps/web/src/vector/mobile_guide/shouldRedirectToMobileGuide.test.ts
+++ b/apps/web/src/vector/mobile_guide/shouldRedirectToMobileGuide.test.ts
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 hayaksi1
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { describe, it, expect } from "vitest";
+
+import { shouldRedirectToMobileGuide, type MobileGuideRedirectOptions } from "./shouldRedirectToMobileGuide";
+
+const IPHONE = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15";
+const ANDROID = "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36";
+const DESKTOP = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120.0.0.0";
+
+const options = (overrides: Partial<MobileGuideRedirectOptions> = {}): MobileGuideRedirectOptions => ({
+    userAgent: IPHONE,
+    hasMSStream: false,
+    isDeepLink: false,
+    hasSkippedRedirect: false,
+    ...overrides,
+});
+
+describe("shouldRedirectToMobileGuide", () => {
+    it("redirects a mobile browser when the option is unset", () => {
+        expect(shouldRedirectToMobileGuide(options())).toBe(true);
+        expect(shouldRedirectToMobileGuide(options({ userAgent: ANDROID }))).toBe(true);
+    });
+
+    it("redirects a mobile browser when the option is explicitly true", () => {
+        expect(shouldRedirectToMobileGuide(options({ mobileGuideToast: true }))).toBe(true);
+    });
+
+    it("does not redirect when the option is false", () => {
+        expect(shouldRedirectToMobileGuide(options({ mobileGuideToast: false }))).toBe(false);
+        expect(shouldRedirectToMobileGuide(options({ userAgent: ANDROID, mobileGuideToast: false }))).toBe(false);
+    });
+
+    it("does not redirect a desktop browser", () => {
+        expect(shouldRedirectToMobileGuide(options({ userAgent: DESKTOP }))).toBe(false);
+    });
+
+    it("does not redirect Internet Explorer on Windows Phone", () => {
+        expect(shouldRedirectToMobileGuide(options({ hasMSStream: true }))).toBe(false);
+    });
+
+    it("does not redirect a deep link or a 3pid verification", () => {
+        expect(shouldRedirectToMobileGuide(options({ isDeepLink: true }))).toBe(false);
+    });
+
+    it("does not redirect once the user has chosen to stay in the browser", () => {
+        expect(shouldRedirectToMobileGuide(options({ hasSkippedRedirect: true }))).toBe(false);
+    });
+});

--- a/apps/web/src/vector/mobile_guide/shouldRedirectToMobileGuide.ts
+++ b/apps/web/src/vector/mobile_guide/shouldRedirectToMobileGuide.ts
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 hayaksi1
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+export interface MobileGuideRedirectOptions {
+    /**
+     * The browser's user agent string.
+     */
+    userAgent: string;
+    /**
+     * Whether `window.MSStream` is present. Internet Explorer on Windows Phone claimed to be an
+     * iPhone in its user agent while exposing this, so it is excluded from the iOS check.
+     */
+    hasMSStream: boolean;
+    /**
+     * Whether the URL says the user is in the middle of something the mobile guide would interrupt,
+     * such as verifying a 3pid or following a deep link.
+     */
+    isDeepLink: boolean;
+    /**
+     * Whether the user has already chosen to carry on in the browser during this session.
+     */
+    hasSkippedRedirect: boolean;
+    /**
+     * The `mobile_guide_toast` config option, if the deployment set one.
+     */
+    mobileGuideToast?: boolean;
+}
+
+/**
+ * Decide whether a mobile browser should be sent to the mobile guide page.
+ *
+ * @param options - the user agent, URL and configuration the decision is made from
+ * @returns true if the browser should be redirected to `mobile_guide/`
+ */
+export function shouldRedirectToMobileGuide({
+    userAgent,
+    hasMSStream,
+    isDeepLink,
+    hasSkippedRedirect,
+    mobileGuideToast,
+}: MobileGuideRedirectOptions): boolean {
+    // The deployment has turned the mobile guide off.
+    if (mobileGuideToast === false) return false;
+
+    // Don't interrupt a 3pid verification or a deep link.
+    // (https://github.com/element-hq/element-web/issues/7378)
+    if (isDeepLink) return false;
+
+    if (hasSkippedRedirect) return false;
+
+    const isIos = /iPad|iPhone|iPod/.test(userAgent) && !hasMSStream;
+    const isAndroid = /Android/.test(userAgent);
+    return isIos || isAndroid;
+}

--- a/apps/web/src/vector/mobile_guide/shouldRedirectToMobileGuide.ts
+++ b/apps/web/src/vector/mobile_guide/shouldRedirectToMobileGuide.ts
@@ -5,6 +5,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+import { type parseAppUrl } from "../url_utils";
+
 export interface MobileGuideRedirectOptions {
     /**
      * The browser's user agent string.
@@ -16,10 +18,11 @@ export interface MobileGuideRedirectOptions {
      */
     hasMSStream: boolean;
     /**
-     * Whether the URL says the user is in the middle of something the mobile guide would interrupt,
-     * such as verifying a 3pid or following a deep link.
+     * The app's URL, as returned by {@link parseAppUrl}. A 3pid verification or a deep link means
+     * the user is part way through something the mobile guide would interrupt.
+     * See https://github.com/element-hq/element-web/issues/7378.
      */
-    isDeepLink: boolean;
+    parsedUrl: ReturnType<typeof parseAppUrl>;
     /**
      * Whether the user has already chosen to carry on in the browser during this session.
      */
@@ -39,16 +42,13 @@ export interface MobileGuideRedirectOptions {
 export function shouldRedirectToMobileGuide({
     userAgent,
     hasMSStream,
-    isDeepLink,
+    parsedUrl,
     hasSkippedRedirect,
     mobileGuideToast,
 }: MobileGuideRedirectOptions): boolean {
-    // The deployment has turned the mobile guide off.
     if (mobileGuideToast === false) return false;
 
-    // Don't interrupt a 3pid verification or a deep link.
-    // (https://github.com/element-hq/element-web/issues/7378)
-    if (isDeepLink) return false;
+    if (parsedUrl.params.threepid || parsedUrl.location.length > 0) return false;
 
     if (hasSkippedRedirect) return false;
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -137,8 +137,8 @@ complete re-branding/private labeling, a more personalised experience can be ach
 5. `desktop_builds`: Optional. Where the desktop builds for the application are, if available. This is explained in more detail
    down below.
 6. `mobile_builds`: Optional. Like `desktop_builds`, except for the mobile apps. Also described in more detail down below.
-7. `mobile_guide_toast`: When `true` (default), users accessing the Element Web instance from a mobile device will be prompted to
-   download the app instead.
+7. `mobile_guide_toast`: When `true` (default), users accessing the Element Web instance from a mobile device are redirected to the
+   `/mobile_guide` page and prompted to download the app instead. Set it to `false` to leave mobile browsers on the web app.
 8. `mobile_guide_app_variant`: Optional. The mobile app that the user is prompted to download from the `/mobile_guide` page. When omitted
    the mobile guide will be configured for the new Element X apps. Allowed values are as follows:
     1. `element`: Element X Android/iOS.


### PR DESCRIPTION
Mobile browsers are redirected to `/mobile_guide` before the config has been loaded, so the
`mobile_guide_toast` option cannot influence it and there is no way for a deployment to switch the
redirect off. The comment above the redirect already claims the check happens after the config has
loaded, which is no longer the case.

The redirect now runs once the config has settled and honours `mobile_guide_toast`, which
`docs/config.md` already describes as controlling whether mobile users are prompted to download the
app. The decision itself moves into a small module of its own so it can be tested directly; the
existing user agent, deep link and "continue in browser" conditions are carried over unchanged.

Tests: unit coverage for the redirect decision, and two Playwright cases with a mobile user agent —
one confirming the redirect still happens by default, one confirming it does not when the option is
disabled.

Fixes #21616

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
