### PR TITLE
Correct an image's aspect ratio once the image itself has loaded

### DIFF
--- a/apps/web/src/viewmodels/message-body/ImageBodyViewModel.ts
+++ b/apps/web/src/viewmodels/message-body/ImageBodyViewModel.ts
@@ -168,10 +168,17 @@ export class ImageBodyViewModel
             props.maxImageHeight,
         );
 
+        // Once the image itself has loaded its own dimensions are authoritative, so the box we
+        // reserve for it matches the picture rather than whatever the sender claimed. Only the
+        // aspect ratio is taken from them: the src of an unencrypted image is a thumbnail, so
+        // sizing from the loaded dimensions would shrink every image in the timeline.
+        const ratioWidth = state.loadedImageDimensions?.naturalWidth || naturalWidth;
+        const ratioHeight = state.loadedImageDimensions?.naturalHeight || naturalHeight;
+
         return {
             maxWidth,
             maxHeight,
-            aspectRatio: `${naturalWidth}/${naturalHeight}`,
+            aspectRatio: `${ratioWidth}/${ratioHeight}`,
             isSvg: info?.mimetype === "image/svg+xml",
         };
     }

--- a/apps/web/test/viewmodels/message-body/ImageBodyViewModel-test.ts
+++ b/apps/web/test/viewmodels/message-body/ImageBodyViewModel-test.ts
@@ -274,6 +274,46 @@ describe("ImageBodyViewModel", () => {
         });
     });
 
+    it("corrects the aspect ratio when event info disagrees with the loaded image", () => {
+        const imageRefWithDimensions = {
+            current: {
+                naturalWidth: 480,
+                naturalHeight: 640,
+            },
+        } as RefObject<HTMLImageElement>;
+        const vm = createVm({
+            imageRef: imageRefWithDimensions,
+            mediaVisible: true,
+            // The sender claimed landscape, but the picture is portrait.
+            mxEvent: createEvent({ content: { info: { w: 640, h: 480 } } }),
+        });
+
+        // Guard: before the image loads we have nothing but the event info to go on.
+        expect(vm.getSnapshot().aspectRatio).toBe("640/480");
+
+        vm.onImageLoad();
+
+        expect(vm.getSnapshot().aspectRatio).toBe("480/640");
+    });
+
+    it("keeps the event info aspect ratio when the loaded image reports no dimensions", () => {
+        const imageRefWithoutDimensions = {
+            current: {
+                naturalWidth: 0,
+                naturalHeight: 0,
+            },
+        } as RefObject<HTMLImageElement>;
+        const vm = createVm({
+            imageRef: imageRefWithoutDimensions,
+            mediaVisible: true,
+            mxEvent: createEvent({ content: { info: { w: 640, h: 480 } } }),
+        });
+
+        vm.onImageLoad();
+
+        expect(vm.getSnapshot().aspectRatio).toBe("640/480");
+    });
+
     it("switches from blurhash placeholder after the delay", () => {
         jest.useFakeTimers();
         const vm = createVm({


### PR DESCRIPTION
The dimensions an event claims for an image always win over the dimensions the browser measured once
the picture actually loaded — the measured values are only used when the event has no size at all.
An image whose metadata is wrong therefore keeps a wrongly shaped box for as long as it is on
screen, even though the correct dimensions are known.

The aspect ratio is now taken from the loaded image when the browser has reported one. The size the
timeline reserves still comes from the event, because for unencrypted images the element is showing
a thumbnail and measuring that would shrink every image. Dimensions of zero, which some engines
report for SVGs and for images that failed to decode, fall back to the event info.

Tests: a case where the event claims landscape for a portrait image and the ratio corrects itself
once loaded, plus one confirming zero dimensions are ignored.

Fixes #18616

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
