### PR TITLE
Reserve the full media box before an image has loaded

### DIFF
--- a/packages/shared-components/src/room/timeline/event-tile/body/MImageBodyView/ImageBodyView.test.tsx
+++ b/packages/shared-components/src/room/timeline/event-tile/body/MImageBodyView/ImageBodyView.test.tsx
@@ -84,6 +84,32 @@ describe("ImageBodyView", () => {
         expect(screen.queryByRole("img")).not.toBeInTheDocument();
     });
 
+    it("reserves the media box before the image has an intrinsic size", () => {
+        const vm = new TestImageBodyViewModel({
+            state: ImageBodyViewState.READY,
+            alt: "Reserved image",
+            src: "https://example.invalid/full.png",
+            thumbnailSrc: "https://example.invalid/thumb.png",
+            linkUrl: "https://example.invalid/full.png",
+            linkTarget: "_blank",
+            maxWidth: 320,
+            maxHeight: 240,
+            aspectRatio: "320 / 240",
+        });
+
+        render(<ImageBodyView vm={vm} />);
+
+        const image = screen.getByRole("img") as HTMLImageElement;
+        // Guard: the image has not loaded, so it contributes no size of its own and the frame can
+        // only be as wide as the box the view reserves for it.
+        expect(image.naturalWidth).toBe(0);
+
+        const link = screen.getByRole("link");
+        const frame = link.firstElementChild!;
+        expect(link.getBoundingClientRect().width).toBeGreaterThanOrEqual(320);
+        expect(frame.getBoundingClientRect().width).toBeGreaterThanOrEqual(320);
+    });
+
     it("renders a link wrapper and forwards the click handler", () => {
         const onLinkClick = vi.fn();
         const vm = new TestImageBodyViewModel(

--- a/packages/shared-components/src/room/timeline/event-tile/body/MImageBodyView/ImageBodyView.tsx
+++ b/packages/shared-components/src/room/timeline/event-tile/body/MImageBodyView/ImageBodyView.tsx
@@ -267,17 +267,21 @@ export function ImageBodyView({
 
     // Reserve the media box on the container itself so the timeline doesn't jump
     // while the image element or loading state is still settling.
-    const resolvedWidth = maxWidth === undefined ? undefined : `min(100%, ${maxWidth}px)`;
+    //
+    // The width is a definite length rather than `min(100%, …)`: the frame is laid out inside a
+    // shrink-to-fit anchor, and a percentage width contributes nothing to a shrink-to-fit parent's
+    // size, so the box collapsed until the image supplied an intrinsic size of its own. `max-width`
+    // keeps it inside a narrow timeline.
     const containerStyle: CSSProperties = {
-        width: resolvedWidth,
-        maxWidth,
+        width: maxWidth,
+        maxWidth: "100%",
         maxHeight,
         aspectRatio,
     };
     const mediaStyle: CSSProperties | undefined = isSvg
         ? {
-              width: resolvedWidth,
-              maxWidth,
+              width: maxWidth,
+              maxWidth: "100%",
               maxHeight,
           }
         : undefined;

--- a/packages/shared-components/src/room/timeline/event-tile/body/MImageBodyView/__snapshots__/ImageBodyView.test.tsx.snap
+++ b/packages/shared-components/src/room/timeline/event-tile/body/MImageBodyView/__snapshots__/ImageBodyView.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`ImageBodyView > matches snapshot for animated-preview story 1`] = `
     >
       <div
         class="ImageBodyView-module_thumbnailContainer"
-        style="width: min(100%, 320px); max-width: 320px; max-height: 320px; aspect-ratio: 1 / 1;"
+        style="width: 320px; max-width: 100%; max-height: 320px; aspect-ratio: 1 / 1;"
       >
         <div
           class="ImageBodyView-module_mediaContent"
@@ -47,7 +47,7 @@ exports[`ImageBodyView > matches snapshot for default story 1`] = `
     >
       <div
         class="ImageBodyView-module_thumbnailContainer"
-        style="width: min(100%, 320px); max-width: 320px; max-height: 320px; aspect-ratio: 1 / 1;"
+        style="width: 320px; max-width: 100%; max-height: 320px; aspect-ratio: 1 / 1;"
       >
         <div
           class="ImageBodyView-module_mediaContent"
@@ -99,7 +99,7 @@ exports[`ImageBodyView > matches snapshot for hidden story 1`] = `
   >
     <div
       class="ImageBodyView-module_thumbnailContainer"
-      style="width: min(100%, 320px); max-width: 320px; max-height: 320px; aspect-ratio: 1 / 1;"
+      style="width: 320px; max-width: 100%; max-height: 320px; aspect-ratio: 1 / 1;"
     >
       <div
         class="ImageBodyView-module_mediaContent"
@@ -151,7 +151,7 @@ exports[`ImageBodyView > matches snapshot for loading-with-blurhash story 1`] = 
     >
       <div
         class="ImageBodyView-module_thumbnailContainer"
-        style="width: min(100%, 320px); max-width: 320px; max-height: 320px; aspect-ratio: 1 / 1;"
+        style="width: 320px; max-width: 100%; max-height: 320px; aspect-ratio: 1 / 1;"
       >
         <div
           class="ImageBodyView-module_placeholder ImageBodyView-module_placeholderBlurhash"
@@ -196,7 +196,7 @@ exports[`ImageBodyView > matches snapshot for loading-with-spinner story 1`] = `
     >
       <div
         class="ImageBodyView-module_thumbnailContainer"
-        style="width: min(100%, 320px); max-width: 320px; max-height: 320px; aspect-ratio: 1 / 1;"
+        style="width: 320px; max-width: 100%; max-height: 320px; aspect-ratio: 1 / 1;"
       >
         <div
           class="ImageBodyView-module_placeholder"


### PR DESCRIPTION
The box reserved for an image is sized with `width: min(100%, <maxWidth>px)`, and the frame sits
inside a shrink-to-fit anchor. A percentage width contributes nothing to a shrink-to-fit parent, so
the anchor is sized by the image element alone — which has no intrinsic size until the picture
arrives. The frame therefore collapses and the media renders tiny until it loads, then jumps to its
proper size.

The frame now takes a definite width with a separate `max-width: 100%` cap. That renders identically
once laid out, but it does contribute to the anchor's size, so the box is correct from the first
paint.

Measured in the browser-mode tests: with a 320px box and an image that has not loaded, the frame
previously measured 0px wide.

Tests: a case that asserts the reserved width is honoured while the image still has no intrinsic
size, guarded by a check that it really has not loaded. The existing DOM snapshots were regenerated
for the changed inline style.

Fixes #34148

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
