### PR TITLE
Update a DM avatar when the other member's profile arrives

### DIFF
--- a/apps/web/src/Avatar.test.ts
+++ b/apps/web/src/Avatar.test.ts
@@ -69,8 +69,16 @@ describe("avatarUrlForRoom", () => {
 
     it("should return null if the room is not a DM", () => {
         vi.mocked(dmRoomMap).getUserIdForRoomId.mockReturnValue(undefined);
+        vi.mocked(room.getAvatarFallbackMember).mockReturnValue(roomMember);
+        vi.mocked(roomMember.getMxcAvatarUrl).mockReturnValue(avatarUrl2);
         expect(avatarUrlForRoom(room, 128, 128)).toBeNull();
         expect(dmRoomMap.getUserIdForRoomId).toHaveBeenCalledWith(roomId);
+    });
+
+    it("should not consult the DM map when there is nothing to fall back to", () => {
+        vi.mocked(room.getAvatarFallbackMember).mockReturnValue(undefined);
+        expect(avatarUrlForRoom(room, 128, 128)).toBeNull();
+        expect(dmRoomMap.getUserIdForRoomId).not.toHaveBeenCalled();
     });
 
     it("should return null if there is no other member in the room", () => {

--- a/apps/web/src/Avatar.ts
+++ b/apps/web/src/Avatar.ts
@@ -157,6 +157,36 @@ export function getInitialLetter(name: string): string | undefined {
     return getFirstGrapheme(name).toUpperCase();
 }
 
+/**
+ * Resolve which mxc URI a room's avatar should be rendered from, falling back to the other member's
+ * avatar for a DM which has no avatar of its own.
+ *
+ * @param room - The room to resolve an avatar for. May be null.
+ * @param avatarMxcOverride - Use this mxc URI as the room's own avatar instead of its `m.room.avatar`.
+ * @returns The mxc URI to render, or null if the room has no avatar to show.
+ */
+export function avatarMxcForRoom(room: Room | null, avatarMxcOverride?: string): string | null {
+    if (!room) return null; // null-guard
+    const mxc = avatarMxcOverride ?? room.getMxcAvatarUrl();
+    if (mxc) return mxc;
+
+    // space rooms cannot be DMs so skip the rest
+    if (room.isSpaceRoom()) return null;
+
+    // If there are only two members in the DM use the avatar of the other member. This is checked
+    // before the DM lookup below so that a room with nothing to fall back to — the common case —
+    // does not have to reach for the DMRoomMap singleton at all.
+    const fallbackMxc = room.getAvatarFallbackMember()?.getMxcAvatarUrl();
+    if (!fallbackMxc) return null;
+
+    // If the room is not a DM don't fallback to a member avatar
+    if (!DMRoomMap.shared().getUserIdForRoomId(room.roomId) && !isLocalRoom(room)) {
+        return null;
+    }
+
+    return fallbackMxc;
+}
+
 export function avatarUrlForRoom(
     room: Room | null,
     width?: number,
@@ -164,32 +194,12 @@ export function avatarUrlForRoom(
     resizeMethod?: ResizeMethod,
     avatarMxcOverride?: string,
 ): string | null {
-    if (!room) return null; // null-guard
-    const mxc = avatarMxcOverride ?? room.getMxcAvatarUrl();
-    if (mxc) {
-        const media = mediaFromMxc(mxc);
-        if (width !== undefined && height !== undefined) {
-            return media.getThumbnailOfSourceHttp(width, height, resizeMethod);
-        }
-        return media.srcHttp;
-    }
+    const mxc = avatarMxcForRoom(room, avatarMxcOverride);
+    if (!mxc) return null;
 
-    // space rooms cannot be DMs so skip the rest
-    if (room.isSpaceRoom()) return null;
-
-    // If the room is not a DM don't fallback to a member avatar
-    if (!DMRoomMap.shared().getUserIdForRoomId(room.roomId) && !isLocalRoom(room)) {
-        return null;
+    const media = mediaFromMxc(mxc);
+    if (width !== undefined && height !== undefined) {
+        return media.getThumbnailOfSourceHttp(width, height, resizeMethod);
     }
-
-    // If there are only two members in the DM use the avatar of the other member
-    const otherMember = room.getAvatarFallbackMember();
-    if (otherMember?.getMxcAvatarUrl()) {
-        const media = mediaFromMxc(otherMember.getMxcAvatarUrl());
-        if (width !== undefined && height !== undefined) {
-            return media.getThumbnailOfSourceHttp(width, height, resizeMethod);
-        }
-        return media.srcHttp;
-    }
-    return null;
+    return media.srcHttp;
 }

--- a/apps/web/src/components/views/avatars/RoomAvatar.tsx
+++ b/apps/web/src/components/views/avatars/RoomAvatar.tsx
@@ -7,8 +7,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import React, { useCallback, useMemo, type ComponentProps } from "react";
-import { type Room, RoomType, KnownMembership, EventType, RoomEvent } from "matrix-js-sdk/src/matrix";
-import { type RoomAvatarEventContent } from "matrix-js-sdk/src/types";
+import { type Room, RoomType, KnownMembership, RoomEvent } from "matrix-js-sdk/src/matrix";
 
 import BaseAvatar from "./BaseAvatar";
 import ImageView from "../elements/ImageView";
@@ -40,11 +39,12 @@ interface IProps extends Omit<ComponentProps<typeof BaseAvatar>, "name" | "idNam
 const RoomAvatar: React.FC<IProps> = ({ room, viewAvatarOnClick, onClick, oobData, size = "36px", ...otherProps }) => {
     const name = useTypedEventEmitterState(room, RoomEvent.Name, () => room?.name);
     const roomName = name ?? oobData?.name ?? "?";
-    const avatarEvent = useRoomState(room, (state) => state.getStateEvents(EventType.RoomAvatar, ""));
     // A DM without an avatar of its own falls back to the other member's avatar, and that member's
-    // profile usually arrives after the first render. Watch it so the memo below keeps up. The
-    // mapper yields the mxc string rather than the member, so an unchanged avatar costs no render.
-    const fallbackMemberAvatarMxc = useRoomState(room, () => room?.getAvatarFallbackMember?.()?.getMxcAvatarUrl());
+    // profile usually arrives after the first render, so resolve the whole thing from room state
+    // instead of watching the `m.room.avatar` event alone. The mapper yields an mxc string, so a
+    // state change which leaves the avatar alone costs no render. Sizing stays in the memo below,
+    // as the mapper is not re-run when `size` changes.
+    const avatarMxc = useRoomState(room, () => Avatar.avatarMxcForRoom(room ?? null));
     const roomIdName = useRoomIdName(room, oobData);
 
     const showAvatarsOnInvites =
@@ -77,18 +77,9 @@ const RoomAvatar: React.FC<IProps> = ({ room, viewAvatarOnClick, onClick, oobDat
 
         return filterBoolean([
             oobAvatar, // highest priority
-            Avatar.avatarUrlForRoom(
-                room ?? null,
-                sizeInt,
-                sizeInt,
-                "crop",
-                avatarEvent?.getContent<RoomAvatarEventContent>().url,
-            ),
+            Avatar.avatarUrlForRoom(room ?? null, sizeInt, sizeInt, "crop", avatarMxc ?? undefined),
         ]);
-        // fallbackMemberAvatarMxc is not read directly here; avatarUrlForRoom reads it for us, so
-        // it is the dependency that tells us the DM fallback avatar has changed.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [showAvatarsOnInvites, room, size, avatarEvent, fallbackMemberAvatarMxc, oobData]);
+    }, [showAvatarsOnInvites, room, size, avatarMxc, oobData]);
 
     return (
         <BaseAvatar

--- a/apps/web/src/components/views/avatars/RoomAvatar.tsx
+++ b/apps/web/src/components/views/avatars/RoomAvatar.tsx
@@ -41,6 +41,10 @@ const RoomAvatar: React.FC<IProps> = ({ room, viewAvatarOnClick, onClick, oobDat
     const name = useTypedEventEmitterState(room, RoomEvent.Name, () => room?.name);
     const roomName = name ?? oobData?.name ?? "?";
     const avatarEvent = useRoomState(room, (state) => state.getStateEvents(EventType.RoomAvatar, ""));
+    // A DM without an avatar of its own falls back to the other member's avatar, and that member's
+    // profile usually arrives after the first render. Watch it so the memo below keeps up. The
+    // mapper yields the mxc string rather than the member, so an unchanged avatar costs no render.
+    const fallbackMemberAvatarMxc = useRoomState(room, () => room?.getAvatarFallbackMember?.()?.getMxcAvatarUrl());
     const roomIdName = useRoomIdName(room, oobData);
 
     const showAvatarsOnInvites =
@@ -81,7 +85,10 @@ const RoomAvatar: React.FC<IProps> = ({ room, viewAvatarOnClick, onClick, oobDat
                 avatarEvent?.getContent<RoomAvatarEventContent>().url,
             ),
         ]);
-    }, [showAvatarsOnInvites, room, size, avatarEvent, oobData]);
+        // fallbackMemberAvatarMxc is not read directly here; avatarUrlForRoom reads it for us, so
+        // it is the dependency that tells us the DM fallback avatar has changed.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [showAvatarsOnInvites, room, size, avatarEvent, fallbackMemberAvatarMxc, oobData]);
 
     return (
         <BaseAvatar

--- a/apps/web/test/unit-tests/components/views/avatars/RoomAvatar-test.tsx
+++ b/apps/web/test/unit-tests/components/views/avatars/RoomAvatar-test.tsx
@@ -7,8 +7,8 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import React from "react";
-import { render } from "jest-matrix-react";
-import { EventType, type MatrixClient, MatrixEvent, Room, RoomMember } from "matrix-js-sdk/src/matrix";
+import { act, render } from "jest-matrix-react";
+import { EventType, type MatrixClient, MatrixEvent, Room, RoomMember, RoomStateEvent } from "matrix-js-sdk/src/matrix";
 import { mocked } from "jest-mock";
 
 import RoomAvatar from "../../../../../src/components/views/avatars/RoomAvatar";
@@ -65,6 +65,32 @@ describe("RoomAvatar", () => {
         room.name = "DM room";
         mocked(DMRoomMap.shared().getUserIdForRoomId).mockReturnValue(userId);
         expect(render(<RoomAvatar room={room} />).container).toMatchSnapshot();
+    });
+
+    it("should show the other member's avatar for a DM once their profile arrives", () => {
+        const userId = "@dm_user:example.com";
+        const room = new Room("!room:example.com", client, client.getSafeUserId());
+        room.name = "DM room";
+        mocked(DMRoomMap.shared().getUserIdForRoomId).mockReturnValue(userId);
+
+        let memberAvatarUrl: string | null = null;
+        jest.spyOn(room, "getAvatarFallbackMember").mockImplementation(
+            () => ({ getMxcAvatarUrl: () => memberAvatarUrl }) as unknown as RoomMember,
+        );
+
+        const { container } = render(<RoomAvatar room={room} />);
+
+        // Guard: the member has no avatar yet, so there is nothing to show.
+        expect(container.querySelector("img")).toBeNull();
+
+        memberAvatarUrl = "mxc://example.com/dm-avatar";
+        act(() => {
+            room.currentState.emit(RoomStateEvent.Update, room.currentState);
+        });
+
+        const avatarImage = container.querySelector("img");
+        expect(avatarImage).not.toBeNull();
+        expect(avatarImage!.getAttribute("src")).toContain("dm-avatar");
     });
 
     it("should render as expected for a LocalRoom", () => {


### PR DESCRIPTION
A DM without an avatar of its own shows the other member's avatar instead. The room avatar component
only recomputes its urls when the `m.room.avatar` state event changes, and nothing subscribes to the
member's profile, so when that profile arrives after the first render — the normal case for a
freshly loaded DM — the avatar never appears.

The fallback member's avatar is now watched through the room state hook the component already uses,
and feeds the same memo. The mapper returns the mxc string rather than the member so an unchanged
avatar does not cause a re-render, which matters for the room list.

Tests: a DM whose member has no avatar at first, then gains one, asserting the image appears with
the new source.

Fixes #31856

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
