### PR TITLE
Send a shared location as a reply when the composer is replying

### DIFF
--- a/apps/web/src/components/views/location/LocationButton.tsx
+++ b/apps/web/src/components/views/location/LocationButton.tsx
@@ -8,7 +8,7 @@ Please see LICENSE files in the repository root for full details.
 
 import React, { type ReactNode, type SyntheticEvent, useContext } from "react";
 import classNames from "classnames";
-import { type RoomMember, type IEventRelation } from "matrix-js-sdk/src/matrix";
+import { type RoomMember, type IEventRelation, type MatrixEvent } from "matrix-js-sdk/src/matrix";
 import { LocationPinIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
 
 import { _t } from "../../../languageHandler";
@@ -21,9 +21,10 @@ export interface IProps {
     sender: RoomMember;
     menuPosition?: MenuProps;
     relation?: IEventRelation;
+    replyToEvent?: MatrixEvent;
 }
 
-const LocationButton: React.FC<IProps> = ({ roomId, sender, menuPosition, relation }) => {
+const LocationButton: React.FC<IProps> = ({ roomId, sender, menuPosition, relation, replyToEvent }) => {
     const overflowMenuCloser = useContext(OverflowMenuContext);
     const [menuDisplayed, button, openMenu, closeMenu] = useContextMenu();
 
@@ -44,6 +45,7 @@ const LocationButton: React.FC<IProps> = ({ roomId, sender, menuPosition, relati
                 roomId={roomId}
                 openMenu={openMenu}
                 relation={relation}
+                replyToEvent={replyToEvent}
             />
         );
     }

--- a/apps/web/src/components/views/location/LocationShareMenu.tsx
+++ b/apps/web/src/components/views/location/LocationShareMenu.tsx
@@ -7,7 +7,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import React, { type SyntheticEvent, useContext, useState } from "react";
-import { type Room, type IEventRelation } from "matrix-js-sdk/src/matrix";
+import { type Room, type IEventRelation, type MatrixEvent } from "matrix-js-sdk/src/matrix";
 
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import ContextMenu, { type MenuProps } from "../../structures/ContextMenu";
@@ -20,6 +20,7 @@ import { OwnProfileStore } from "../../../stores/OwnProfileStore";
 import { EnableLiveShare } from "./EnableLiveShare";
 import { useFeatureEnabled } from "../../../hooks/useSettings";
 import { SettingLevel } from "../../../settings/SettingLevel";
+import { useScopedRoomContext } from "../../../contexts/ScopedRoomContext";
 
 type Props = Omit<ILocationPickerProps, "onChoose" | "shareType"> & {
     onFinished: (ev?: SyntheticEvent) => void;
@@ -27,6 +28,7 @@ type Props = Omit<ILocationPickerProps, "onChoose" | "shareType"> & {
     openMenu: () => void;
     roomId: Room["roomId"];
     relation?: IEventRelation;
+    replyToEvent?: MatrixEvent;
 };
 
 const getEnabledShareTypes = (relation?: IEventRelation): LocationShareType[] => {
@@ -43,8 +45,17 @@ const getEnabledShareTypes = (relation?: IEventRelation): LocationShareType[] =>
     return enabledShareTypes;
 };
 
-const LocationShareMenu: React.FC<Props> = ({ menuPosition, onFinished, sender, roomId, openMenu, relation }) => {
+const LocationShareMenu: React.FC<Props> = ({
+    menuPosition,
+    onFinished,
+    sender,
+    roomId,
+    openMenu,
+    relation,
+    replyToEvent,
+}) => {
     const matrixClient = useContext(MatrixClientContext);
+    const { timelineRenderingType } = useScopedRoomContext("timelineRenderingType");
     const enabledShareTypes = getEnabledShareTypes(relation);
     const isLiveShareEnabled = useFeatureEnabled("feature_location_share_live");
 
@@ -60,7 +71,15 @@ const LocationShareMenu: React.FC<Props> = ({ menuPosition, onFinished, sender, 
     const onLocationSubmit =
         shareType === LocationShareType.Live
             ? shareLiveLocation(matrixClient, roomId, displayName || userId, openMenu)
-            : shareLocation(matrixClient, roomId, shareType ?? LocationShareType.Own, relation, openMenu);
+            : shareLocation(
+                  matrixClient,
+                  roomId,
+                  shareType ?? LocationShareType.Own,
+                  relation,
+                  openMenu,
+                  replyToEvent,
+                  timelineRenderingType,
+              );
 
     const onLiveShareEnableSubmit = (): void => {
         SettingsStore.setValue("feature_location_share_live", null, SettingLevel.DEVICE, true);

--- a/apps/web/src/components/views/location/shareLocation.ts
+++ b/apps/web/src/components/views/location/shareLocation.ts
@@ -10,6 +10,7 @@ import {
     type MatrixClient,
     type IEventRelation,
     type MatrixError,
+    type MatrixEvent,
     THREAD_RELATION_TYPE,
     ContentHelpers,
     LocationAssetType,
@@ -23,6 +24,10 @@ import QuestionDialog, { type IQuestionDialogProps } from "../dialogs/QuestionDi
 import SdkConfig from "../../../SdkConfig";
 import { OwnBeaconStore } from "../../../stores/OwnBeaconStore";
 import { doMaybeLocalRoomAction } from "../../../utils/local-room";
+import { attachMentions } from "../../../utils/messages";
+import { addReplyToMessageContent } from "../../../utils/Reply";
+import defaultDispatcher from "../../../dispatcher/dispatcher";
+import { type TimelineRenderingType } from "../../../contexts/RoomContext";
 
 export enum LocationShareType {
     Own = "Own",
@@ -126,6 +131,8 @@ export const shareLocation =
         shareType: LocationShareType,
         relation: IEventRelation | undefined,
         openMenu: () => void,
+        replyToEvent?: MatrixEvent,
+        timelineRenderingType?: TimelineRenderingType,
     ): ShareLocationFn =>
     async ({ uri, timestamp }): Promise<void> => {
         if (!uri) return;
@@ -139,6 +146,20 @@ export const shareLocation =
                 undefined,
                 assetType,
             ) as RoomMessageEventContent;
+
+            // Only has an effect when there is something to reply to.
+            attachMentions(client.getSafeUserId(), content, null, replyToEvent);
+            if (replyToEvent) {
+                addReplyToMessageContent(content, replyToEvent);
+                // Clear the composer's reply state now the message is on its way; if the send fails,
+                // retry handles resending it.
+                defaultDispatcher.dispatch({
+                    action: "reply_to_event",
+                    event: null,
+                    context: timelineRenderingType,
+                });
+            }
+
             await doMaybeLocalRoomAction(
                 roomId,
                 (actualRoomId: string) => client.sendMessage(actualRoomId, threadId, content),

--- a/apps/web/src/components/views/rooms/MessageComposer.tsx
+++ b/apps/web/src/components/views/rooms/MessageComposer.tsx
@@ -716,6 +716,7 @@ export class MessageComposer extends React.Component<IProps, IState> {
                                     isStickerPickerOpen={this.state.isStickerPickerOpen}
                                     menuPosition={menuPosition}
                                     relation={this.props.relation}
+                                    replyToEvent={this.props.replyToEvent}
                                     onRecordStartEndClick={this.onRecordStartEndClick}
                                     setStickerPickerOpen={this.setStickerPickerOpen}
                                     showLocationButton={

--- a/apps/web/src/components/views/rooms/MessageComposerButtons.tsx
+++ b/apps/web/src/components/views/rooms/MessageComposerButtons.tsx
@@ -10,6 +10,7 @@ Please see LICENSE files in the repository root for full details.
 import classNames from "classnames";
 import {
     type IEventRelation,
+    type MatrixEvent,
     type Room,
     type MatrixClient,
     THREAD_RELATION_TYPE,
@@ -53,6 +54,7 @@ interface IProps {
     menuPosition?: MenuProps;
     onRecordStartEndClick: () => void;
     relation?: IEventRelation;
+    replyToEvent?: MatrixEvent;
     setStickerPickerOpen: (isStickerPickerOpen: boolean) => void;
     showLocationButton: boolean;
     showPollsButton: boolean;
@@ -265,6 +267,7 @@ function showLocationButton(props: IProps, room: Room, matrixClient: MatrixClien
             key="location"
             roomId={room.roomId}
             relation={props.relation}
+            replyToEvent={props.replyToEvent}
             sender={sender}
             menuPosition={props.menuPosition}
         />

--- a/apps/web/test/unit-tests/components/views/location/LocationShareMenu-test.tsx
+++ b/apps/web/test/unit-tests/components/views/location/LocationShareMenu-test.tsx
@@ -22,6 +22,7 @@ import { LocationShareType } from "../../../../../src/components/views/location/
 import {
     flushPromisesWithFakeTimers,
     getMockClientWithEventEmitter,
+    mkEvent,
     mockClientMethodsUser,
     setupAsyncStoreWithClient,
 } from "../../../../test-utils";
@@ -279,6 +280,28 @@ describe("<LocationShareMenu />", () => {
                     [M_ASSET.name]: {
                         type: LocationAssetType.Pin,
                     },
+                }),
+            );
+        });
+
+        it("sends the location as a reply when the composer is replying", () => {
+            const replyToEvent = mkEvent({
+                event: true,
+                type: "m.room.message",
+                room: defaultProps.roomId,
+                user: "@bob:server.org",
+                content: { msgtype: "m.text", body: "where are you?" },
+            });
+            const { getByText } = getComponent({ replyToEvent });
+
+            setShareType(getByText, LocationShareType.Pin);
+            setLocationClick();
+            fireEvent.click(getByText("Share location"));
+
+            const [, , messageBody] = mockClient.sendMessage.mock.calls[0];
+            expect(messageBody).toEqual(
+                expect.objectContaining({
+                    "m.relates_to": { "m.in_reply_to": { event_id: replyToEvent.getId() } },
                 }),
             );
         });

--- a/apps/web/test/unit-tests/components/views/location/shareLocation-test.ts
+++ b/apps/web/test/unit-tests/components/views/location/shareLocation-test.ts
@@ -20,6 +20,9 @@ import {
     shareLocation,
     type ShareLocationFn,
 } from "../../../../../src/components/views/location/shareLocation";
+import defaultDispatcher from "../../../../../src/dispatcher/dispatcher";
+import { TimelineRenderingType } from "../../../../../src/contexts/RoomContext";
+import { mkEvent } from "../../../../test-utils";
 
 jest.mock("../../../../../src/utils/local-room", () => ({
     doMaybeLocalRoomAction: jest.fn(),
@@ -36,6 +39,7 @@ describe("shareLocation", () => {
         const makeLocationContent = jest.spyOn(ContentHelpers, "makeLocationContent");
         client = {
             sendMessage: jest.fn(),
+            getSafeUserId: jest.fn().mockReturnValue("@alice:example.com"),
         } as unknown as MatrixClient;
 
         mocked(makeLocationContent).mockReturnValue(content);
@@ -51,5 +55,44 @@ describe("shareLocation", () => {
     it("should forward the call to doMaybeLocalRoomAction", () => {
         shareLocationFn({ uri: "https://example.com/" });
         expect(client.sendMessage).toHaveBeenCalledWith(roomId, null, content);
+    });
+
+    describe("when replying to an event", () => {
+        it("should send the location as a reply and clear the composer's reply state", () => {
+            const replyContent = { test: "location content" } as unknown as LegacyLocationEventContent &
+                MLocationEventContent;
+            mocked(ContentHelpers.makeLocationContent).mockReturnValue(replyContent);
+            const replyToEvent = mkEvent({
+                event: true,
+                type: "m.room.message",
+                room: roomId,
+                user: "@bob:example.com",
+                content: { msgtype: "m.text", body: "where are you?" },
+            });
+            const dispatchSpy = jest.spyOn(defaultDispatcher, "dispatch");
+
+            shareLocation(
+                client,
+                roomId,
+                shareType,
+                undefined,
+                () => {},
+                replyToEvent,
+                TimelineRenderingType.Room,
+            )({ uri: "https://example.com/" });
+
+            expect(client.sendMessage).toHaveBeenCalledWith(
+                roomId,
+                null,
+                expect.objectContaining({
+                    "m.relates_to": { "m.in_reply_to": { event_id: replyToEvent.getId() } },
+                }),
+            );
+            expect(dispatchSpy).toHaveBeenCalledWith({
+                action: "reply_to_event",
+                event: null,
+                context: TimelineRenderingType.Room,
+            });
+        });
     });
 });


### PR DESCRIPTION
Sharing a location while the composer is replying sends an ordinary message: the location share path
is given the composer's relation, which it uses only to work out a thread id, and never sees the
event being replied to. Nothing adds the reply relation to the content, and the composer is left
showing "Replying" afterwards.

The event being replied to is now threaded from the composer through to the location share, where it
attaches the reply relation and mentions and clears the composer's reply state once the message is on
its way — the same shape the voice message path already uses. Thread handling and live location
sharing are unchanged.

Tests: the location share now has a case covering the reply relation and the state being cleared, and
the share menu has one that drives the real pin-drop flow with a reply in progress. That second test
is there because the new props are optional, so a dropped pass-through would still compile.

Fixes #33323

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
