### PR TITLE
Distinguish a failed video download from a failed decryption

### DIFF
--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -3496,6 +3496,7 @@
         "m.sticker": "%(senderDisplayName)s sent a sticker.",
         "m.video": {
             "error_decrypting": "Error decrypting video",
+            "error_downloading": "Error downloading video",
             "show_video": "Show video"
         },
         "m.widget": {

--- a/apps/web/src/viewmodels/message-body/VideoBodyViewModel.ts
+++ b/apps/web/src/viewmodels/message-body/VideoBodyViewModel.ts
@@ -23,6 +23,7 @@ import { mediaFromContent } from "../../customisations/Media";
 import { BLURHASH_FIELD } from "../../utils/image-media";
 import { type ImageSize, suggestedSize as suggestedVideoSize } from "../../settings/enums/ImageSize";
 import { type MediaEventHelper } from "../../utils/MediaEventHelper";
+import { DownloadError } from "../../utils/DecryptFile";
 
 export interface VideoBodyViewModelProps {
     /**
@@ -194,6 +195,20 @@ export class VideoBodyViewModel
         return null;
     }
 
+    /**
+     * The label shown in place of a video that could not be displayed.
+     *
+     * A failed fetch is reported as a download failure rather than a decryption failure, which is
+     * what the user actually hit when the media is unreachable.
+     *
+     * @param error - the error that stopped the media loading
+     * @returns the label to show in place of the video
+     */
+    private static computeErrorLabel(error: unknown): string {
+        if (error instanceof DownloadError) return _t("timeline|m.video|error_downloading");
+        return _t("timeline|m.video|error_decrypting");
+    }
+
     private static computeSnapshot(props: VideoBodyViewModelProps, state: InternalState): VideoBodyViewSnapshot {
         const content = props.mxEvent.getContent<MediaEventContent>();
         const autoplay = !props.inhibitInteraction && SettingsStore.getValue("autoplayVideo");
@@ -203,7 +218,7 @@ export class VideoBodyViewModel
         if (state.error !== null) {
             return {
                 state: VideoBodyViewState.ERROR,
-                errorLabel: _t("timeline|m.video|error_decrypting"),
+                errorLabel: VideoBodyViewModel.computeErrorLabel(state.error),
                 maxWidth,
                 maxHeight,
                 aspectRatio,

--- a/apps/web/test/viewmodels/message-body/VideoBodyViewModel-test.ts
+++ b/apps/web/test/viewmodels/message-body/VideoBodyViewModel-test.ts
@@ -17,6 +17,7 @@ import { mediaFromContent } from "../../../src/customisations/Media";
 import { BLURHASH_FIELD } from "../../../src/utils/image-media";
 import { type MediaEventHelper } from "../../../src/utils/MediaEventHelper";
 import { VideoBodyViewModel } from "../../../src/viewmodels/message-body/VideoBodyViewModel";
+import { DecryptError, DownloadError } from "../../../src/utils/DecryptFile";
 
 jest.mock("../../../src/customisations/Media", () => ({
     mediaFromContent: jest.fn(),
@@ -280,7 +281,49 @@ describe("VideoBodyViewModel", () => {
         await flushPromises();
 
         expect(vm.getSnapshot().state).toBe(VideoBodyViewState.ERROR);
-        expect(vm.getSnapshot().errorLabel).toBeTruthy();
+        expect(vm.getSnapshot().errorLabel).toBe("Error decrypting video");
+    });
+
+    it("reports a download failure as a download error rather than a decryption error", async () => {
+        const vm = createVm({
+            mxEvent: createEvent({
+                content: {
+                    file: { url: "mxc://server/encrypted-video" },
+                },
+            }),
+            mediaEventHelper: createMediaEventHelper({
+                encrypted: true,
+                thumbnailUrl: Promise.reject(new DownloadError(new Error("network is unreachable"))),
+            }),
+            mediaVisible: true,
+        });
+        vm.loadInitialMediaIfVisible();
+
+        await flushPromises();
+
+        expect(vm.getSnapshot().state).toBe(VideoBodyViewState.ERROR);
+        expect(vm.getSnapshot().errorLabel).toBe("Error downloading video");
+    });
+
+    it("still reports a decryption failure as a decryption error", async () => {
+        const vm = createVm({
+            mxEvent: createEvent({
+                content: {
+                    file: { url: "mxc://server/encrypted-video" },
+                },
+            }),
+            mediaEventHelper: createMediaEventHelper({
+                encrypted: true,
+                thumbnailUrl: Promise.reject(new DecryptError(new Error("bad key"))),
+            }),
+            mediaVisible: true,
+        });
+        vm.loadInitialMediaIfVisible();
+
+        await flushPromises();
+
+        expect(vm.getSnapshot().state).toBe(VideoBodyViewState.ERROR);
+        expect(vm.getSnapshot().errorLabel).toBe("Error decrypting video");
     });
 
     it("loads the encrypted source on play when only a placeholder url is present", async () => {


### PR DESCRIPTION
A video whose media could not be fetched is reported as "Error decrypting video", which sends people
looking for a key problem when the media was simply unreachable. The decryption helper already
throws distinct download and decryption errors, and both places that record the error keep it
intact — the label just never looks at which one it was.

The label now distinguishes the two, the same way the image body already does, and anything that is
not a download failure keeps the existing wording.

This is a relabelling only. The later discussion on the issue about a failed thumbnail not blocking
playback is a separate change to the media pipeline and is not attempted here.

Tests: cases covering a download failure, a decryption failure, and an unclassified error. The
existing error case asserted only that some label was present, so it is now pinned to the exact
string.

Fixes #28060

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
