### PR TITLE
Discard a chosen space avatar when the settings are cancelled

### DIFF
--- a/apps/web/src/components/views/spaces/SpaceBasicSettings.tsx
+++ b/apps/web/src/components/views/spaces/SpaceBasicSettings.tsx
@@ -17,6 +17,11 @@ import { chromeFileInputFix } from "../../../utils/BrowserWorkarounds";
 interface IProps {
     avatarUrl?: string;
     avatarDisabled?: boolean;
+    /**
+     * Changing this value discards an avatar the user has picked but not saved, returning the
+     * preview to `avatarUrl`.
+     */
+    avatarResetKey?: number;
     name: string;
     nameDisabled?: boolean;
     topic?: string;
@@ -113,6 +118,7 @@ export const SpaceAvatar: React.FC<Pick<IProps, "avatarUrl" | "avatarDisabled" |
 const SpaceBasicSettings: React.FC<IProps> = ({
     avatarUrl,
     avatarDisabled = false,
+    avatarResetKey,
     setAvatar,
     name = "",
     nameDisabled = false,
@@ -123,7 +129,12 @@ const SpaceBasicSettings: React.FC<IProps> = ({
 }) => {
     return (
         <div className="mx_SpaceBasicSettings">
-            <SpaceAvatar avatarUrl={avatarUrl} avatarDisabled={avatarDisabled} setAvatar={setAvatar} />
+            <SpaceAvatar
+                key={avatarResetKey}
+                avatarUrl={avatarUrl}
+                avatarDisabled={avatarDisabled}
+                setAvatar={setAvatar}
+            />
 
             <Field
                 name="spaceName"

--- a/apps/web/src/components/views/spaces/SpaceSettingsGeneralTab.tsx
+++ b/apps/web/src/components/views/spaces/SpaceSettingsGeneralTab.tsx
@@ -33,6 +33,8 @@ const SpaceSettingsGeneralTab: React.FC<IProps> = ({ matrixClient: cli, space })
     const userId = cli.getUserId()!;
 
     const [newAvatar, setNewAvatar] = useState<File | null | undefined>(null); // undefined means to remove avatar
+    // SpaceAvatar caches the chosen image internally, so cancelling has to discard that state too.
+    const [avatarResetKey, setAvatarResetKey] = useState(0);
     const canSetAvatar = space.currentState.maySendStateEvent(EventType.RoomAvatar, userId);
     const avatarChanged = newAvatar !== null;
 
@@ -47,6 +49,7 @@ const SpaceSettingsGeneralTab: React.FC<IProps> = ({ matrixClient: cli, space })
 
     const onCancel = (): void => {
         setNewAvatar(null);
+        setAvatarResetKey((key) => key + 1);
         setName(space.name);
         setTopic(currentTopic);
     };
@@ -97,6 +100,7 @@ const SpaceSettingsGeneralTab: React.FC<IProps> = ({ matrixClient: cli, space })
                     <SpaceBasicSettings
                         avatarUrl={avatarUrlForRoom(space, 80, 80, "crop") ?? undefined}
                         avatarDisabled={busy || !canSetAvatar}
+                        avatarResetKey={avatarResetKey}
                         setAvatar={setNewAvatar}
                         name={name}
                         nameDisabled={busy || !canSetName}

--- a/apps/web/test/unit-tests/components/views/spaces/SpaceSettingsGeneralTab-test.tsx
+++ b/apps/web/test/unit-tests/components/views/spaces/SpaceSettingsGeneralTab-test.tsx
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 hayaksi1
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "jest-matrix-react";
+import { type MatrixClient, Room } from "matrix-js-sdk/src/matrix";
+
+import SpaceSettingsGeneralTab from "../../../../../src/components/views/spaces/SpaceSettingsGeneralTab";
+import { stubClient } from "../../../../test-utils";
+import DMRoomMap from "../../../../../src/utils/DMRoomMap";
+
+describe("<SpaceSettingsGeneralTab />", () => {
+    let client: MatrixClient;
+    let space: Room;
+
+    const AVATAR_SELECTOR = "img.mx_SpaceBasicSettings_avatar";
+
+    beforeEach(() => {
+        client = stubClient();
+        jest.spyOn(DMRoomMap, "shared").mockReturnValue(new DMRoomMap(client));
+        space = new Room("!space:example.com", client, client.getSafeUserId());
+        space.name = "Test space";
+        jest.spyOn(space.currentState, "maySendStateEvent").mockReturnValue(true);
+    });
+
+    const renderTab = (): ReturnType<typeof render> =>
+        render(<SpaceSettingsGeneralTab matrixClient={client} space={space} />);
+
+    const chooseAvatar = async (container: HTMLElement): Promise<void> => {
+        const fileInput = container.querySelector<HTMLInputElement>('input[type="file"]')!;
+        fireEvent.change(fileInput, {
+            target: { files: [new File(["avatar"], "avatar.png", { type: "image/png" })] },
+        });
+        await waitFor(() => expect(container.querySelector(AVATAR_SELECTOR)).toBeInTheDocument());
+    };
+
+    it("should discard a chosen avatar when the changes are cancelled", async () => {
+        const { container } = renderTab();
+
+        // Guard: the space has no avatar, so anything shown afterwards is the user's choice.
+        expect(container.querySelector(AVATAR_SELECTOR)).toBeNull();
+
+        await chooseAvatar(container);
+
+        fireEvent.click(screen.getByText("Cancel"));
+
+        expect(container.querySelector(AVATAR_SELECTOR)).toBeNull();
+    });
+
+    it("should keep a chosen avatar until the changes are cancelled", async () => {
+        const { container } = renderTab();
+
+        await chooseAvatar(container);
+
+        expect(container.querySelector(AVATAR_SELECTOR)).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
The space avatar control caches the picked image in its own state, seeded from its prop only when it
first mounts. Cancelling the general settings resets the tab's state but cannot reach that cache, and
the space's real avatar has not changed, so the picture the user chose stays on screen even though it
will not be uploaded.

Cancelling now also resets the avatar control, by changing the `key` it is rendered with, so its
cached preview is discarded and it goes back to showing the space's current icon. The space creation
menu renders the same control without the new prop and is unaffected.

An alternative would be to move this control onto the shared `AvatarSetting`, which syncs its preview
from its prop. That is a larger change, and the sync alone would not fix this: cancelling does not
change the avatar url, so the pending image would have to be lifted into the parent too. Happy to do
that instead if preferred.

Tests: a new suite for the general settings tab covering the preview being discarded on cancel, and a
control showing it is kept until then.

Fixes #31773

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
