### PR TITLE
Stop pointing at the pinned list once nothing is pinned

### DIFF
--- a/apps/web/src/TextForEvent.tsx
+++ b/apps/web/src/TextForEvent.tsx
@@ -626,6 +626,9 @@ function textForPinnedEvent(event: MatrixEvent, client: MatrixClient, allowJSX: 
         return () => _t("timeline|m.room.pinned_events|pinned", { senderName });
     }
 
+    // Nothing is pinned any more, so the copy must not send the reader off to an empty pinned list.
+    const noPinsRemain = pinned.length === 0;
+
     if (newlyUnpinned.length === 1 && newlyPinned.length === 0) {
         // A single message was unpinned, include a link to that message.
         if (allowJSX) {
@@ -634,7 +637,9 @@ function textForPinnedEvent(event: MatrixEvent, client: MatrixClient, allowJSX: 
             return () => (
                 <span>
                     {_t(
-                        "timeline|m.room.pinned_events|unpinned_link",
+                        noPinsRemain
+                            ? "timeline|m.room.pinned_events|unpinned_last_link"
+                            : "timeline|m.room.pinned_events|unpinned_link",
                         { senderName },
                         {
                             a: (sub) => (
@@ -659,7 +664,16 @@ function textForPinnedEvent(event: MatrixEvent, client: MatrixClient, allowJSX: 
             );
         }
 
-        return () => _t("timeline|m.room.pinned_events|unpinned", { senderName });
+        return () =>
+            _t(
+                noPinsRemain ? "timeline|m.room.pinned_events|unpinned_last" : "timeline|m.room.pinned_events|unpinned",
+                { senderName },
+            );
+    }
+
+    if (noPinsRemain) {
+        // Several messages were unpinned at once and none are left, so there is nothing to link to.
+        return () => _t("timeline|m.room.pinned_events|unpinned_all", { senderName });
     }
 
     if (allowJSX) {

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -3478,6 +3478,9 @@
             "pinned": "%(senderName)s pinned a message to this room. See all pinned messages.",
             "pinned_link": "%(senderName)s pinned <a>a message</a> to this room. See all <b>pinned messages</b>.",
             "unpinned": "%(senderName)s unpinned a message from this room. See all pinned messages.",
+            "unpinned_all": "%(senderName)s unpinned all messages from this room.",
+            "unpinned_last": "%(senderName)s unpinned a message from this room.",
+            "unpinned_last_link": "%(senderName)s unpinned <a>a message</a> from this room.",
             "unpinned_link": "%(senderName)s unpinned <a>a message</a> from this room. See all <b>pinned messages</b>."
         },
         "m.room.power_levels": {

--- a/apps/web/test/unit-tests/TextForEvent-test.tsx
+++ b/apps/web/test/unit-tests/TextForEvent-test.tsx
@@ -88,14 +88,26 @@ describe("TextForEvent", () => {
             expect(component.container).toHaveTextContent(expectedText);
         });
 
-        it("mentions message when a single message was unpinned, with a single message previously pinned", () => {
+        it("does not offer the pinned list when the last pinned message was unpinned", () => {
             const event = mockPinnedEvent([], ["message-1"]);
             const plainText = textForEvent(event, mockClient);
             const component = render(textForEvent(event, mockClient, true) as ReactElement);
 
-            const expectedText = "@foo:example.com unpinned a message from this room. See all pinned messages.";
+            const expectedText = "@foo:example.com unpinned a message from this room.";
             expect(plainText).toBe(expectedText);
             expect(component.container).toHaveTextContent(expectedText);
+            expect(component.container).not.toHaveTextContent("pinned messages");
+        });
+
+        it("does not offer the pinned list when every pinned message was unpinned at once", () => {
+            const event = mockPinnedEvent([], ["message-1", "message-2"]);
+            const plainText = textForEvent(event, mockClient);
+            const component = render(textForEvent(event, mockClient, true) as ReactElement);
+
+            const expectedText = "@foo:example.com unpinned all messages from this room.";
+            expect(plainText).toBe(expectedText);
+            expect(component.container).toHaveTextContent(expectedText);
+            expect(component.container).not.toHaveTextContent("pinned messages");
         });
 
         it("mentions message when a single message was unpinned, with multiple previously pinned messages", () => {


### PR DESCRIPTION
Unpinning the last pinned message still says "See all pinned messages" and links to the pinned list,
which is now empty. Unpinning several at once is worse: it reports that the pinned messages were
changed and dangles the same link.

The number of remaining pins is already known where the text is built, so when none are left the
copy no longer offers the list. A single unpin keeps its deep link to the message that was unpinned;
removing everything at once now says so directly.

Tests: cases for unpinning the last message and for unpinning all of them, both asserting the pinned
list is not mentioned. The existing case that asserted the old wording described the bug and has been
replaced; its sibling, where pins remain, is unchanged and still expects the link.

Fixes #27987

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
