### PR TITLE
Remove code to round panel size on resize

### DIFF
--- a/apps/web/src/viewmodels/structures/ResizerViewModel.test.ts
+++ b/apps/web/src/viewmodels/structures/ResizerViewModel.test.ts
@@ -147,19 +147,4 @@ describe("LeftPanelResizerViewModel", () => {
         vm.onLeftPanelResized(50);
         expect(mockHandle.resize).not.toHaveBeenCalled();
     });
-
-    it("should resize to nearest whole number", () => {
-        const vm = new ResizerViewModel(CallStore.instance);
-        const mockHandle = {
-            resize: vi.fn(),
-            getSize: vi.fn().mockReturnValue(0),
-        } as unknown as PanelImperativeHandle;
-        vm.setPanelHandle(mockHandle);
-
-        // Initial call is ignored
-        vm.onLeftPanelResized(70);
-        // This should be processed
-        vm.onLeftPanelResized(25.515);
-        expect(mockHandle.resize).toHaveBeenLastCalledWith("26%");
-    });
 });

--- a/apps/web/src/viewmodels/structures/ResizerViewModel.ts
+++ b/apps/web/src/viewmodels/structures/ResizerViewModel.ts
@@ -99,12 +99,6 @@ export class ResizerViewModel
 
         this.autoCollapse.onLeftPanelResized();
 
-        // We don't want the panels to have fractional widths as that can cause blurry UI elements.
-        if (!Number.isInteger(newSize)) {
-            this.panelHandle?.resize(`${Math.round(newSize)}%`);
-            return;
-        }
-
         const isCollapsed = newSize === 0;
         // Store the size if the panel isn't collapsed.
         if (!isCollapsed) {


### PR DESCRIPTION
Closes https://github.com/element-hq/element-web/issues/34462

This code was an incorrect fix for https://github.com/element-hq/element-web/issues/32978. Rounding the percentage can put the pixel value of the left panel beyond the max/min width constraints. When this happens, the resize is skipped and a subsequent `onLeftPanelResized` call does not happen. This amounts to the max and min widths of the left panel never being persisted in the settings.