### PR TITLE
Show "border" type of separator when clicking on separator

### DIFF
--- a/packages/shared-components/src/resize/separator/SeparatorView.module.css
+++ b/packages/shared-components/src/resize/separator/SeparatorView.module.css
@@ -51,7 +51,11 @@
 }
 
 /* When type=border and the user hovers/focuses the separator, we make the separator thicker */
-.separator[data-separator-type="border"]:is([data-separator="hover"], [data-separator="active"]),
+.separator[data-separator-type="border"]:is(
+    [data-separator="hover"],
+    [data-separator="active"],
+    [data-separator="focus"]
+),
 .separator[data-separator-type="border"]:focus-visible {
     .activeSeparatorContainer {
         .activeSeparator {


### PR DESCRIPTION
Closes https://github.com/element-hq/element-web/issues/34432

When the separator is clicked, it gets focused but remains looking the same. This PR fixes that issue so that the thicker separator is shown on focus.
