### PR TITLE
Improve UI for file uploading + multi-upload.

### DIFF
--- a/apps/web/res/css/_components.pcss
+++ b/apps/web/res/css/_components.pcss
@@ -246,6 +246,7 @@
 @import "./views/rooms/_AuxPanel.pcss";
 @import "./views/rooms/_BasicMessageComposer.pcss";
 @import "./views/rooms/_CallGuestLinkButton.pcss";
+@import "./views/rooms/_ComposerAttachments.pcss";
 @import "./views/rooms/_E2EIcon.pcss";
 @import "./views/rooms/_E2EIconView.pcss";
 @import "./views/rooms/_EditMessageComposer.pcss";

--- a/apps/web/res/css/views/rooms/_ComposerAttachments.pcss
+++ b/apps/web/res/css/views/rooms/_ComposerAttachments.pcss
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+.mx_ComposerAttachments {
+    display: flex;
+    flex-direction: row;
+    gap: var(--cpd-space-3x);
+    align-items: flex-start;
+
+    list-style: none;
+    margin: 0;
+    /* Leaves room for a dragged card to lift; the scroll container cannot show overflow
+       on one axis only, so anything outside this padding is clipped. */
+    padding: 14px 0;
+
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
+.mx_ComposerAttachments_item {
+    position: relative;
+    flex: 0 0 auto;
+
+    box-sizing: border-box;
+    width: 180px;
+    padding: var(--cpd-space-3x);
+
+    background-color: var(--cpd-color-theme-bg);
+    border: 1px solid var(--cpd-color-border-interactive-secondary);
+    border-radius: var(--cpd-space-3x);
+
+    cursor: grab;
+    /* Dragging is driven by pointer events, so the browser must not pan or select instead. */
+    touch-action: none;
+    user-select: none;
+    /* Keep in step with DROP_ANIMATION_MS. */
+    transition:
+        transform 180ms ease,
+        box-shadow 180ms ease;
+}
+
+/* Raised while being dragged, and until it has finished easing into place. */
+.mx_ComposerAttachments_item--floating {
+    z-index: 1;
+    box-shadow: 0 2px 6px 0 $menu-box-shadow-color;
+}
+
+.mx_ComposerAttachments_item--dragging {
+    cursor: grabbing;
+}
+
+.mx_ComposerAttachments_preview {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    height: 120px;
+    margin-bottom: var(--cpd-space-2x);
+    overflow: hidden;
+
+    background-color: var(--cpd-color-theme-bg);
+    border-radius: var(--cpd-space-2x);
+}
+
+.mx_ComposerAttachments_image {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+
+    /* The card owns the drag, so the browser must not start an image drag instead. */
+    pointer-events: none;
+}
+
+.mx_ComposerAttachments_fileIcon {
+    width: 44px;
+    height: 44px;
+    color: var(--cpd-color-icon-secondary);
+}
+
+.mx_ComposerAttachments_meta {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cpd-space-1x);
+    min-width: 0;
+}
+
+.mx_ComposerAttachments_name,
+.mx_ComposerAttachments_description {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.mx_ComposerAttachments_name {
+    color: var(--cpd-color-text-primary);
+    font: var(--cpd-font-body-sm-medium);
+}
+
+.mx_ComposerAttachments_description {
+    color: var(--cpd-color-text-secondary);
+    font: var(--cpd-font-body-xs-regular);
+}
+
+.mx_ComposerAttachments_actions {
+    position: absolute;
+    top: var(--cpd-space-2x);
+    right: var(--cpd-space-2x);
+
+    display: flex;
+    gap: var(--cpd-space-1x);
+    padding: 3px;
+
+    background-color: var(--cpd-color-theme-bg);
+    border-radius: 7px;
+    box-shadow: 0 1px 3px 0 $menu-box-shadow-color;
+}
+
+.mx_ComposerAttachments_action {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    padding: 3px;
+    border-radius: 4px;
+
+    svg {
+        width: 18px;
+        height: 18px;
+    }
+
+    &:hover {
+        background-color: var(--cpd-color-bg-subtle-primary);
+    }
+}
+
+.mx_ComposerAttachments_action--remove svg {
+    color: var(--cpd-color-icon-critical-primary);
+}

--- a/apps/web/src/ContentMessages.ts
+++ b/apps/web/src/ContentMessages.ts
@@ -404,6 +404,7 @@ export async function uploadFile(
 export default class ContentMessages {
     private inprogress: RoomUpload[] = [];
     private mediaConfig: IMediaConfig | null = null;
+    private mediaConfigFetch?: Promise<void>;
 
     public sendStickerContentToRoom(
         url: string,
@@ -435,7 +436,9 @@ export default class ContentMessages {
      * @param replyToEvent - The event being replied to, if any.
      * @param matrixClient - The Matrix client to use for sending the files.
      * @param context - The context in which the files are being sent.
-     * @returns A promise that resolves when the files have been sent.
+     * @param opts - Set `skipConfirmation` when the caller has already shown the user what
+     *   is about to be sent, such as the composer staging area.
+     * @returns True once the files have been sent, false if the user backed out.
      */
     public async sendContentListToRoom(
         files: File[],
@@ -444,10 +447,11 @@ export default class ContentMessages {
         replyToEvent: MatrixEvent | undefined,
         matrixClient: MatrixClient,
         context = TimelineRenderingType.Room,
-    ): Promise<void> {
+        opts: { skipConfirmation?: boolean } = {},
+    ): Promise<boolean> {
         if (matrixClient.isGuest()) {
             dis.dispatch({ action: "require_registration" });
-            return;
+            return false;
         }
 
         if (!this.mediaConfig) {
@@ -456,7 +460,7 @@ export default class ContentMessages {
             await Promise.race([this.ensureMediaConfigFetched(matrixClient), modal.finished]);
             if (!this.mediaConfig) {
                 // User cancelled by clicking away on the spinner
-                return;
+                return false;
             } else {
                 modal.close();
             }
@@ -480,13 +484,14 @@ export default class ContentMessages {
                 contentMessages: this,
             });
             const [shouldContinue] = await finished;
-            if (!shouldContinue) return;
+            if (!shouldContinue) return false;
         }
 
-        let uploadAll = false;
+        let uploadAll = opts.skipConfirmation === true;
         // Promise to complete before sending next file into room, used for synchronisation of file-sending
         // to match the order the files were specified in
         let promBefore: Promise<any> = Promise.resolve();
+        let sentAny = false;
         for (let i = 0; i < okFiles.length; ++i) {
             const file = okFiles[i];
             const loopPromiseBefore = promBefore;
@@ -504,6 +509,7 @@ export default class ContentMessages {
                 }
             }
 
+            sentAny = true;
             promBefore = doMaybeLocalRoomAction(
                 roomId,
                 (actualRoomId) =>
@@ -533,6 +539,25 @@ export default class ContentMessages {
             action: Action.FocusSendMessageComposer,
             context,
         });
+
+        // Wait for the last file to be sent, so callers sending a message afterwards end up
+        // below these events rather than above them.
+        await promBefore;
+        return sentAny;
+    }
+
+    /**
+     * Fetch the media config ahead of time so sending does not block on it behind a modal
+     * spinner. Best effort: sending fetches it itself if this did not work out.
+     */
+    public prefetchMediaConfig(matrixClient: MatrixClient): void {
+        try {
+            this.ensureMediaConfigFetched(matrixClient).catch((e) => {
+                logger.warn("[Media Config] Prefetch failed", e);
+            });
+        } catch (e) {
+            logger.warn("[Media Config] Prefetch failed", e);
+        }
     }
 
     public getCurrentUploads(relation?: IEventRelation): RoomUpload[] {
@@ -691,9 +716,11 @@ export default class ContentMessages {
 
     private ensureMediaConfigFetched(matrixClient: MatrixClient): Promise<void> {
         if (this.mediaConfig !== null) return Promise.resolve();
+        // Callers before the first response lands should join it, not start another request.
+        if (this.mediaConfigFetch) return this.mediaConfigFetch;
 
         logger.log("[Media Config] Fetching");
-        return matrixClient
+        this.mediaConfigFetch = matrixClient
             .getMediaConfig()
             .then((config) => {
                 logger.log("[Media Config] Fetched config:", config);
@@ -706,7 +733,11 @@ export default class ContentMessages {
             })
             .then((config) => {
                 this.mediaConfig = config;
+            })
+            .finally(() => {
+                this.mediaConfigFetch = undefined;
             });
+        return this.mediaConfigFetch;
     }
 
     public static sharedInstance(): ContentMessages {

--- a/apps/web/src/components/views/rooms/ComposerAttachments.tsx
+++ b/apps/web/src/components/views/rooms/ComposerAttachments.tsx
@@ -1,0 +1,381 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import React, {
+    type CSSProperties,
+    type JSX,
+    type KeyboardEvent,
+    type PointerEvent as ReactPointerEvent,
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+} from "react";
+import { DeleteIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
+import { useViewModel } from "@element-hq/web-shared-components";
+
+import { _t } from "../../../languageHandler";
+import { type ComposerAttachment } from "../../../models/ComposerAttachment";
+import { useRoomUploadViewModel } from "../../../viewmodels/room/RoomUploadViewModel";
+import AccessibleButton from "../elements/AccessibleButton";
+
+/**
+ * A reorder in progress. Cards are only translated while dragging, never re-ordered in the
+ * DOM, so the browser animates the shuffle. The order is committed on release.
+ */
+interface DragState {
+    pointerId: number;
+    id: string;
+    fromIndex: number;
+    targetIndex: number;
+    originX: number;
+    originY: number;
+    dx: number;
+    dy: number;
+    /** Distance between the left edges of adjacent cards. */
+    step: number;
+    count: number;
+}
+
+/**
+ * The moment after release. The reorder is already committed, so the released card is left
+ * offset by however far short of its new slot the pointer stopped, then eases in.
+ */
+interface DropState {
+    id: string;
+    dx: number;
+    dy: number;
+    /** False for the first frame, while the card is pinned where it was released. */
+    animating: boolean;
+}
+
+// Keep in step with the transition duration in _ComposerAttachments.pcss.
+const DROP_ANIMATION_MS = 180;
+
+// Suppresses the transform transition while still letting the shadow fade.
+const POSITION_UNANIMATED = `box-shadow ${DROP_ANIMATION_MS}ms ease`;
+
+const VERTICAL_LIFT = 10;
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.max(min, Math.min(value, max));
+}
+
+function DocumentIcon(): JSX.Element {
+    return (
+        <svg
+            className="mx_ComposerAttachments_fileIcon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+        >
+            <path
+                fill="currentColor"
+                d="M6 2c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8.83c0-.53-.21-1.04-.59-1.41l-4.83-4.83c-.37-.38-.88-.59-1.41-.59zm7 6V3.5L18.5 9H14c-.55 0-1-.45-1-1"
+            />
+        </svg>
+    );
+}
+
+/** How far a card must shift to make room for the one being dragged over it. */
+function slotShift(index: number, drag: DragState): number {
+    const { fromIndex, targetIndex, step } = drag;
+    if (index === fromIndex) return 0;
+    if (fromIndex < targetIndex && index > fromIndex && index <= targetIndex) return -step;
+    if (targetIndex < fromIndex && index >= targetIndex && index < fromIndex) return step;
+    return 0;
+}
+
+function cardStyle(
+    attachmentId: string,
+    index: number,
+    drag: DragState | null,
+    drop: DropState | null,
+): CSSProperties | undefined {
+    if (drop) {
+        // Cards other than the released one are already in their final slot.
+        if (drop.id !== attachmentId) return { transition: POSITION_UNANIMATED };
+        return drop.animating
+            ? { transform: "translate(0px, 0px)" }
+            : { transform: `translate(${drop.dx}px, ${drop.dy}px)`, transition: POSITION_UNANIMATED };
+    }
+
+    if (!drag) return undefined;
+    if (drag.id === attachmentId) {
+        return { transform: `translate(${drag.dx}px, ${drag.dy}px)`, transition: POSITION_UNANIMATED };
+    }
+    return { transform: `translateX(${slotShift(index, drag)}px)` };
+}
+
+interface AttachmentCardProps {
+    attachment: ComposerAttachment;
+    index: number;
+    total: number;
+    drag: DragState | null;
+    drop: DropState | null;
+    onRemove: (id: string) => void;
+    onPointerDown: (ev: ReactPointerEvent<HTMLLIElement>, index: number) => void;
+    onPointerMove: (ev: ReactPointerEvent<HTMLLIElement>) => void;
+    onPointerUp: (ev: ReactPointerEvent<HTMLLIElement>) => void;
+    onPointerCancel: (ev: ReactPointerEvent<HTMLLIElement>) => void;
+    onKeyDown: (ev: KeyboardEvent<HTMLLIElement>, index: number) => void;
+    registerRef: (id: string, node: HTMLLIElement | null) => void;
+}
+
+function AttachmentCard({
+    attachment,
+    index,
+    total,
+    drag,
+    drop,
+    onRemove,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+    onKeyDown,
+    registerRef,
+}: AttachmentCardProps): JSX.Element {
+    let preview: JSX.Element;
+    switch (attachment.kind) {
+        case "image":
+            preview = (
+                <img className="mx_ComposerAttachments_image" src={attachment.previewUrl} alt="" draggable={false} />
+            );
+            break;
+        case "video":
+            // The video element paints its own first frame as a poster.
+            preview = (
+                <video className="mx_ComposerAttachments_image" src={attachment.previewUrl} muted preload="metadata" />
+            );
+            break;
+        default:
+            preview = <DocumentIcon />;
+            break;
+    }
+
+    const isDragging = drag?.id === attachment.id;
+    // Stays above its neighbours until it has finished easing into place.
+    const isFloating = isDragging || drop?.id === attachment.id;
+
+    const classes = [
+        "mx_ComposerAttachments_item",
+        isFloating && "mx_ComposerAttachments_item--floating",
+        isDragging && "mx_ComposerAttachments_item--dragging",
+    ].filter(Boolean);
+
+    return (
+        <li
+            ref={(node) => registerRef(attachment.id, node)}
+            className={classes.join(" ")}
+            style={cardStyle(attachment.id, index, drag, drop)}
+            tabIndex={0}
+            aria-label={_t("composer|attachments_item_a11y", {
+                fileName: attachment.name,
+                position: index + 1,
+                count: total,
+            })}
+            onPointerDown={(ev) => onPointerDown(ev, index)}
+            onPointerMove={onPointerMove}
+            onPointerUp={onPointerUp}
+            onPointerCancel={onPointerCancel}
+            onKeyDown={(ev) => onKeyDown(ev, index)}
+        >
+            <div className="mx_ComposerAttachments_preview">{preview}</div>
+            <div className="mx_ComposerAttachments_meta">
+                <span className="mx_ComposerAttachments_name" title={attachment.name}>
+                    {attachment.name}
+                </span>
+                <span className="mx_ComposerAttachments_description" title={attachment.description}>
+                    {attachment.description}
+                </span>
+            </div>
+            <div className="mx_ComposerAttachments_actions">
+                <AccessibleButton
+                    className="mx_ComposerAttachments_action mx_ComposerAttachments_action--remove"
+                    title={_t("composer|attachments_remove")}
+                    onClick={() => onRemove(attachment.id)}
+                >
+                    <DeleteIcon />
+                </AccessibleButton>
+            </div>
+        </li>
+    );
+}
+
+/**
+ * The row of files staged in the composer, shown above the input until they are sent.
+ * Cards can be dragged within the row to change the order they are sent in.
+ */
+export function ComposerAttachments(): JSX.Element | null {
+    const vm = useRoomUploadViewModel();
+    const { attachments } = useViewModel(vm);
+    const [drag, setDrag] = useState<DragState | null>(null);
+    const [drop, setDrop] = useState<DropState | null>(null);
+    // Mirrored so the pointer handlers can read the drag without a functional update.
+    const dragRef = useRef<DragState | null>(null);
+
+    const frame = useRef<number>(undefined);
+    const timer = useRef<number>(undefined);
+    const nodes = useRef(new Map<string, HTMLLIElement>());
+
+    const setDragState = useCallback((next: DragState | null) => {
+        dragRef.current = next;
+        setDrag(next);
+    }, []);
+
+    const cancelDropAnimation = useCallback(() => {
+        if (frame.current !== undefined) cancelAnimationFrame(frame.current);
+        if (timer.current !== undefined) clearTimeout(timer.current);
+        frame.current = undefined;
+        timer.current = undefined;
+    }, []);
+
+    useEffect(() => cancelDropAnimation, [cancelDropAnimation]);
+
+    const registerRef = useCallback((id: string, node: HTMLLIElement | null) => {
+        if (node) {
+            nodes.current.set(id, node);
+        } else {
+            nodes.current.delete(id);
+        }
+    }, []);
+
+    const onPointerDown = useCallback(
+        (ev: ReactPointerEvent<HTMLLIElement>, index: number) => {
+            if (ev.button !== 0) return;
+            if ((ev.target as Element).closest?.(".mx_ComposerAttachments_action")) return;
+            if (attachments.length < 2) return;
+
+            // offsetLeft ignores transforms, so a card still easing into place cannot skew this.
+            const offsets = attachments
+                .map((attachment) => nodes.current.get(attachment.id)?.offsetLeft)
+                .filter((offset): offset is number => offset !== undefined);
+            if (offsets.length < 2) return;
+            const step = offsets[1] - offsets[0];
+            if (step <= 0) return;
+
+            cancelDropAnimation();
+            setDrop(null);
+
+            // Stops the browser starting a native drag or selecting the label text.
+            ev.preventDefault();
+            ev.currentTarget.setPointerCapture?.(ev.pointerId);
+            setDragState({
+                pointerId: ev.pointerId,
+                id: attachments[index].id,
+                fromIndex: index,
+                targetIndex: index,
+                originX: ev.clientX,
+                originY: ev.clientY,
+                dx: 0,
+                dy: 0,
+                step,
+                count: attachments.length,
+            });
+        },
+        [attachments, cancelDropAnimation, setDragState],
+    );
+
+    const onPointerMove = useCallback(
+        (ev: ReactPointerEvent<HTMLLIElement>) => {
+            const current = dragRef.current;
+            if (!current || current.pointerId !== ev.pointerId) return;
+
+            // Clamped so the card cannot leave the row, which would clip against its scroll container.
+            const minDx = -current.fromIndex * current.step;
+            const maxDx = (current.count - 1 - current.fromIndex) * current.step;
+            const dx = clamp(ev.clientX - current.originX, minDx, maxDx);
+            const dy = clamp(ev.clientY - current.originY, -VERTICAL_LIFT, VERTICAL_LIFT);
+
+            const targetIndex = current.fromIndex + Math.round(dx / current.step);
+            if (dx === current.dx && dy === current.dy && targetIndex === current.targetIndex) return;
+            setDragState({ ...current, dx, dy, targetIndex });
+        },
+        [setDragState],
+    );
+
+    const onPointerUp = useCallback(
+        (ev: ReactPointerEvent<HTMLLIElement>) => {
+            const current = dragRef.current;
+            if (!current || current.pointerId !== ev.pointerId) return;
+            setDragState(null);
+
+            const movedSlots = current.targetIndex - current.fromIndex;
+            if (movedSlots !== 0) {
+                vm.moveAttachment(current.id, current.targetIndex);
+            }
+
+            // The reorder moved the card's slot under it, leaving the gap between where the
+            // pointer stopped and where it now belongs. Pin it there for a frame so the
+            // stylesheet transition can ease it in rather than it jumping.
+            setDrop({
+                id: current.id,
+                dx: current.dx - movedSlots * current.step,
+                dy: current.dy,
+                animating: false,
+            });
+            frame.current = requestAnimationFrame(() => {
+                frame.current = requestAnimationFrame(() => {
+                    setDrop((previous) => previous && { ...previous, animating: true });
+                    timer.current = window.setTimeout(() => setDrop(null), DROP_ANIMATION_MS);
+                });
+            });
+        },
+        [setDragState, vm],
+    );
+
+    const onPointerCancel = useCallback(
+        (ev: ReactPointerEvent<HTMLLIElement>) => {
+            const current = dragRef.current;
+            if (!current || current.pointerId !== ev.pointerId) return;
+            // The browser took the gesture over, so the user never chose this order.
+            setDragState(null);
+            setDrop(null);
+        },
+        [setDragState],
+    );
+
+    const onKeyDown = useCallback(
+        (ev: KeyboardEvent<HTMLLIElement>, index: number) => {
+            // Only when the card itself has focus, not the delete button inside it.
+            if (ev.target !== ev.currentTarget) return;
+            const delta = ev.key === "ArrowLeft" ? -1 : ev.key === "ArrowRight" ? 1 : 0;
+            if (delta === 0) return;
+            ev.preventDefault();
+            const attachment = attachments[index];
+            vm.moveAttachment(attachment.id, index + delta);
+            // Keep focus on the card the user is moving.
+            window.requestAnimationFrame(() => nodes.current.get(attachment.id)?.focus());
+        },
+        [attachments, vm],
+    );
+
+    if (!attachments.length) return null;
+
+    return (
+        <ul className="mx_ComposerAttachments" aria-label={_t("composer|attachments_label")}>
+            {attachments.map((attachment, index) => (
+                <AttachmentCard
+                    key={attachment.id}
+                    attachment={attachment}
+                    index={index}
+                    total={attachments.length}
+                    drag={drag}
+                    drop={drop}
+                    onRemove={vm.removeAttachment}
+                    onPointerDown={onPointerDown}
+                    onPointerMove={onPointerMove}
+                    onPointerUp={onPointerUp}
+                    onPointerCancel={onPointerCancel}
+                    onKeyDown={onKeyDown}
+                    registerRef={registerRef}
+                />
+            ))}
+        </ul>
+    );
+}

--- a/apps/web/src/components/views/rooms/MessageComposer.tsx
+++ b/apps/web/src/components/views/rooms/MessageComposer.tsx
@@ -19,7 +19,7 @@ import {
 import { Tooltip } from "@vector-im/compound-web";
 import { logger } from "matrix-js-sdk/src/logger";
 import { LockOffIcon, SendSolidIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
-import { useCreateAutoDisposedViewModel } from "@element-hq/web-shared-components";
+import { useCreateAutoDisposedViewModel, useViewModel } from "@element-hq/web-shared-components";
 
 import { _t } from "../../../languageHandler";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
@@ -64,6 +64,8 @@ import { MessageComposerUrlPreviewViewModel } from "../../../viewmodels/composer
 import { useScopedRoomContext } from "../../../contexts/ScopedRoomContext";
 import PlatformPeg from "../../../PlatformPeg";
 import { useSettingValue } from "../../../hooks/useSettings";
+import { ComposerAttachments } from "./ComposerAttachments";
+import { type RoomUploadViewModel, useRoomUploadViewModel } from "../../../viewmodels/room/RoomUploadViewModel";
 
 // The prefix used when persisting editor drafts to localstorage.
 export const WYSIWYG_EDITOR_STATE_STORAGE_PREFIX = "mx_wysiwyg_state_";
@@ -97,6 +99,8 @@ interface IProps extends MatrixClientProps {
     e2eStatus?: E2EStatus;
     compact?: boolean;
     urlPreviewVm: MessageComposerUrlPreviewViewModel;
+    uploadVm: RoomUploadViewModel;
+    hasAttachments: boolean;
 }
 
 interface IState {
@@ -408,7 +412,10 @@ export class MessageComposer extends React.Component<IProps, IState> {
         this.props.urlPreviewVm.updateWithText({ content: "", debounced: false });
         if (this.state.haveRecording && this.voiceRecordingButton.current) {
             // There shouldn't be any text message to send when a voice recording is active, so
-            // just send out the voice recording.
+            // just send out the voice recording. Files can still be dropped while recording.
+            if (this.props.hasAttachments) {
+                await this.props.uploadVm.sendStagedAttachments();
+            }
             await this.voiceRecordingButton.current?.send();
             return;
         }
@@ -423,6 +430,10 @@ export class MessageComposer extends React.Component<IProps, IState> {
                 action: Action.ClearAndFocusSendMessageComposer,
                 timelineRenderingType: this.context.timelineRenderingType,
             });
+            // Attachments go first so the text lands beneath them, and the text carries the reply.
+            if (this.props.hasAttachments) {
+                await this.props.uploadVm.sendStagedAttachments({ includeReply: !composerContent });
+            }
             await sendMessage(composerContent, this.state.isRichTextEnabled, {
                 mxClient: this.props.mxClient,
                 roomContext: this.context,
@@ -685,7 +696,8 @@ export class MessageComposer extends React.Component<IProps, IState> {
             />,
         );
 
-        const showSendButton = canSendMessages && (!this.state.isComposerEmpty || this.state.haveRecording);
+        const showSendButton =
+            canSendMessages && (!this.state.isComposerEmpty || this.state.haveRecording || this.props.hasAttachments);
 
         const classes = classNames({
             "mx_MessageComposer": true,
@@ -703,6 +715,7 @@ export class MessageComposer extends React.Component<IProps, IState> {
                         replyToEvent={this.props.replyToEvent}
                         permalinkCreator={this.props.permalinkCreator}
                     />
+                    {canSendMessages && <ComposerAttachments />}
                     <div className="mx_MessageComposer_row">
                         {leftIcon}
                         {composer}
@@ -747,9 +760,13 @@ export class MessageComposer extends React.Component<IProps, IState> {
 
 const MessageComposerWithMatrixClient = withMatrixClientHOC(MessageComposer);
 
-export default function MessageComposerWrapper(props: Omit<IProps, "mxClient" | "urlPreviewVm">): JSX.Element {
+export default function MessageComposerWrapper(
+    props: Omit<IProps, "mxClient" | "urlPreviewVm" | "uploadVm" | "hasAttachments">,
+): JSX.Element {
     const { showUrlPreview } = useScopedRoomContext("showUrlPreview");
     const client = useMatrixClientContext();
+    const uploadVm = useRoomUploadViewModel();
+    const { attachments } = useViewModel(uploadVm);
     const urlPreviewBundle = useSettingValue("feature_msc4095_url_preview_bundle");
     const urlPreviewVm = useCreateAutoDisposedViewModel(
         () =>
@@ -765,5 +782,12 @@ export default function MessageComposerWrapper(props: Omit<IProps, "mxClient" | 
         void urlPreviewVm.updateUrlPreviewVisible(showUrlPreview);
     }, [urlPreviewVm, showUrlPreview]);
 
-    return <MessageComposerWithMatrixClient {...props} urlPreviewVm={urlPreviewVm} />;
+    return (
+        <MessageComposerWithMatrixClient
+            {...props}
+            urlPreviewVm={urlPreviewVm}
+            uploadVm={uploadVm}
+            hasAttachments={attachments.length > 0}
+        />
+    );
 }

--- a/apps/web/src/components/views/rooms/SendMessageComposer.tsx
+++ b/apps/web/src/components/views/rooms/SendMessageComposer.tsx
@@ -342,8 +342,13 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
      */
     public async sendMessage({ urlPreviewSnapshot }: ISendMessageActionProps): Promise<void> {
         const model = this.model;
+        const hasAttachments = this.props.uploadVm.hasAttachments;
 
         if (model.isEmpty) {
+            // Attachments on their own are still worth sending, and carry the reply.
+            if (hasAttachments) {
+                await this.props.uploadVm.sendStagedAttachments();
+            }
             return;
         }
 
@@ -422,6 +427,11 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
             this.sendQuickReaction();
         }
 
+        // The text below them carries the reply, so the files are sent plain. Callers guard
+        // on hasAttachments: awaiting even a no-op would defer the text send by a microtask.
+        const sendAttachments = (): Promise<boolean> =>
+            this.props.uploadVm.sendStagedAttachments({ includeReply: false });
+
         const clearComposerAndPushHistory = (): void => {
             this.sendHistoryManager.save(model, replyToEvent);
             // clear composer
@@ -449,11 +459,17 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
             }
 
             // don't bother sending an empty message
-            if (!content.body.trim()) return;
+            if (!content.body.trim()) {
+                if (hasAttachments) await sendAttachments();
+                return;
+            }
 
             // clear composer first so the user doesn't actually see the delay of attach URL preview image files
             clearComposerAndPushHistory();
             attachUrlPreviews(urlPreviewSnapshot, content);
+
+            // Send the attachments first so the message text lands beneath them in the timeline.
+            if (hasAttachments) await sendAttachments();
 
             if (SettingsStore.getValue("Performance.addSendMessageTimingMetadata")) {
                 decorateStartSendingTime(content);
@@ -494,6 +510,8 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
             }
         } else {
             clearComposerAndPushHistory();
+            // A slash command or quick reaction still leaves the staged files to send.
+            if (hasAttachments) await sendAttachments();
         }
     }
 

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -584,6 +584,10 @@
         "warning": "Warning"
     },
     "composer": {
+        "attachments_animated_format": "%(format)s (animated)",
+        "attachments_item_a11y": "%(fileName)s, attachment %(position)s of %(count)s. Use the arrow keys to reorder.",
+        "attachments_label": "Attachments to send",
+        "attachments_remove": "Remove attachment",
         "autocomplete": {
             "@room_description": "Notify the whole room",
             "command_a11y": "Command Autocomplete",

--- a/apps/web/src/models/ComposerAttachment.ts
+++ b/apps/web/src/models/ComposerAttachment.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import { _t } from "../languageHandler";
+import { fileSize } from "../utils/FileUtils";
+import { blobIsAnimated, mayBeAnimated } from "../utils/Image";
+import { imageFormatLabel, sniffVideoCodec, videoContainerLabel } from "../utils/MediaFormat";
+
+export type ComposerAttachmentKind = "image" | "video" | "file";
+
+let nextAttachmentId = 0;
+
+/**
+ * A file staged in the composer. Nothing is uploaded until the message is sent.
+ */
+export class ComposerAttachment {
+    public readonly id: string;
+    public readonly kind: ComposerAttachmentKind;
+    /** Only set for kinds we can preview. */
+    public readonly previewUrl?: string;
+    /** Size, plus format details once they have been read off the file. */
+    public description: string;
+
+    public constructor(public readonly file: File) {
+        this.id = `mx_composer_attachment_${nextAttachmentId++}`;
+        this.kind = kindForMimeType(file.type);
+        this.description = humanSize(file.size);
+        if (this.kind !== "file") {
+            this.previewUrl = URL.createObjectURL(file);
+        }
+    }
+
+    public get name(): string {
+        return this.file.name || _t("common|attachment");
+    }
+
+    public get size(): number {
+        return this.file.size;
+    }
+
+    /**
+     * Read format details off the file, e.g. "1.2 MB - JPEG". Resolves true if the
+     * description changed, so the caller knows to re-render.
+     */
+    public async loadDescription(): Promise<boolean> {
+        const details = await this.formatDetails();
+        if (!details) return false;
+
+        const description = `${humanSize(this.size)} - ${details}`;
+        if (description === this.description) return false;
+        this.description = description;
+        return true;
+    }
+
+    private async formatDetails(): Promise<string | undefined> {
+        switch (this.kind) {
+            case "image": {
+                const format = imageFormatLabel(this.file.type);
+                if (!format) return undefined;
+                if (mayBeAnimated(this.file.type) && (await blobIsAnimated(this.file))) {
+                    return _t("composer|attachments_animated_format", { format });
+                }
+                return format;
+            }
+            case "video": {
+                const container = videoContainerLabel(this.file.type, this.name);
+                const codec = await sniffVideoCodec(this.file);
+                if (!container) return codec;
+                return codec ? `${container}/${codec}` : container;
+            }
+            default:
+                return undefined;
+        }
+    }
+
+    /** Object URLs live until revoked, so every dropped attachment must be disposed. */
+    public dispose(): void {
+        if (this.previewUrl) {
+            URL.revokeObjectURL(this.previewUrl);
+        }
+    }
+}
+
+function humanSize(bytes: number): string {
+    return fileSize(bytes, { base: 2, standard: "jedec" });
+}
+
+function kindForMimeType(mimeType: string): ComposerAttachmentKind {
+    if (mimeType.startsWith("image/")) return "image";
+    if (mimeType.startsWith("video/")) return "video";
+    return "file";
+}

--- a/apps/web/src/utils/MediaFormat.ts
+++ b/apps/web/src/utils/MediaFormat.ts
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+// Format labels for files staged in the composer. Image formats come from the mime type;
+// nothing exposes a video's codec, so that is read out of the container headers.
+
+import { logger as rootLogger } from "matrix-js-sdk/src/logger";
+
+const logger = rootLogger.getChild("MediaFormat");
+
+const SNIFF_CHUNK_SIZE = 512 * 1024;
+
+const IMAGE_FORMAT_LABELS: Record<string, string> = {
+    "image/jpeg": "JPEG",
+    "image/jpg": "JPEG",
+    "image/png": "PNG",
+    "image/apng": "APNG",
+    "image/gif": "GIF",
+    "image/webp": "WebP",
+    "image/avif": "AVIF",
+    "image/svg+xml": "SVG",
+    "image/bmp": "BMP",
+    "image/x-icon": "ICO",
+    "image/tiff": "TIFF",
+    "image/heic": "HEIC",
+    "image/heif": "HEIF",
+};
+
+const VIDEO_CONTAINER_LABELS: Record<string, string> = {
+    "video/mp4": "mp4",
+    "video/quicktime": "mov",
+    "video/webm": "webm",
+    "video/x-matroska": "mkv",
+    "video/x-msvideo": "avi",
+    "video/mpeg": "mpeg",
+    "video/ogg": "ogv",
+    "video/3gpp": "3gp",
+    "video/x-flv": "flv",
+};
+
+// Sample entry formats found in the stsd box.
+const MP4_CODEC_LABELS: Record<string, string> = {
+    avc1: "h264",
+    avc3: "h264",
+    hev1: "h265",
+    hvc1: "h265",
+    av01: "av1",
+    vp09: "vp9",
+    vp08: "vp8",
+    mp4v: "mpeg4",
+    s263: "h263",
+};
+
+const MATROSKA_CODEC_LABELS: Record<string, string> = {
+    "V_VP8": "vp8",
+    "V_VP9": "vp9",
+    "V_AV1": "av1",
+    "V_MPEG4/ISO/AVC": "h264",
+    "V_MPEGH/ISO/HEVC": "h265",
+    "V_MPEG4/ISO/ASP": "mpeg4",
+    "V_MPEG2": "mpeg2",
+    "V_THEORA": "theora",
+};
+
+export function imageFormatLabel(mimeType: string): string {
+    const known = IMAGE_FORMAT_LABELS[mimeType.toLowerCase()];
+    if (known) return known;
+    return subtypeFallback(mimeType);
+}
+
+export function videoContainerLabel(mimeType: string, fileName: string): string {
+    const known = VIDEO_CONTAINER_LABELS[mimeType.toLowerCase()];
+    if (known) return known;
+
+    const extension = fileName.split(".").pop();
+    if (extension && extension !== fileName && extension.length <= 5) {
+        return extension.toLowerCase();
+    }
+    return subtypeFallback(mimeType);
+}
+
+function subtypeFallback(mimeType: string): string {
+    const subtype = mimeType.split("/")[1];
+    if (!subtype) return "";
+    return subtype.replace(/^x-/, "").toUpperCase();
+}
+
+/**
+ * Read the container headers to work out which video codec a file holds, e.g. "h264".
+ * Resolves undefined if the container is unsupported or the codec cannot be found.
+ */
+export async function sniffVideoCodec(file: File): Promise<string | undefined> {
+    try {
+        const head = new Uint8Array(await file.slice(0, SNIFF_CHUNK_SIZE).arrayBuffer());
+
+        if (isMatroska(head)) {
+            return findMatroskaCodec(head);
+        }
+
+        if (isIsoBaseMedia(head)) {
+            const fromHead = findMp4Codec(head);
+            if (fromHead) return fromHead;
+            // Files not written for streaming keep moov at the end.
+            if (file.size > SNIFF_CHUNK_SIZE) {
+                const tail = new Uint8Array(await file.slice(Math.max(0, file.size - SNIFF_CHUNK_SIZE)).arrayBuffer());
+                return findMp4CodecUnaligned(tail);
+            }
+        }
+    } catch (e) {
+        logger.warn("Failed to sniff video codec", e);
+    }
+    return undefined;
+}
+
+function readFourCc(bytes: Uint8Array, offset: number): string {
+    return String.fromCharCode(bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3]);
+}
+
+function isIsoBaseMedia(bytes: Uint8Array): boolean {
+    return bytes.length > 12 && readFourCc(bytes, 4) === "ftyp";
+}
+
+function isMatroska(bytes: Uint8Array): boolean {
+    // EBML magic, shared by Matroska and WebM.
+    return bytes.length > 4 && bytes[0] === 0x1a && bytes[1] === 0x45 && bytes[2] === 0xdf && bytes[3] === 0xa3;
+}
+
+const MP4_CONTAINER_BOXES = new Set(["moov", "trak", "mdia", "minf", "stbl"]);
+
+function findMp4Codec(bytes: Uint8Array, start = 0, end = bytes.length): string | undefined {
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    let offset = start;
+
+    while (offset + 8 <= end) {
+        let size = view.getUint32(offset);
+        const type = readFourCc(bytes, offset + 4);
+        let headerSize = 8;
+
+        if (size === 1) {
+            // 64-bit size follows the type.
+            if (offset + 16 > end) break;
+            size = Number(view.getBigUint64(offset + 8));
+            headerSize = 16;
+        } else if (size === 0) {
+            size = end - offset;
+        }
+
+        if (size < headerSize) break;
+
+        if (type === "stsd") {
+            // Skip version+flags, entry count and the sample entry size to reach the format.
+            const formatOffset = offset + headerSize + 8 + 4;
+            if (formatOffset + 4 > end) return undefined;
+            // Muxers often put the audio track first, so skip anything that is not a known
+            // video codec rather than reporting it as one.
+            const known = MP4_CODEC_LABELS[readFourCc(bytes, formatOffset)];
+            if (known) return known;
+        }
+
+        if (MP4_CONTAINER_BOXES.has(type)) {
+            const found = findMp4Codec(bytes, offset + headerSize, Math.min(offset + size, end));
+            if (found) return found;
+        }
+
+        offset += size;
+    }
+
+    return undefined;
+}
+
+/**
+ * Parse a buffer that does not start on a box boundary, as happens when slicing the tail of
+ * a file, by scanning for the moov type and stepping back over its size field.
+ */
+function findMp4CodecUnaligned(bytes: Uint8Array): string | undefined {
+    for (let i = 4; i + 8 <= bytes.length; i++) {
+        // "moov"
+        if (bytes[i] !== 0x6d || bytes[i + 1] !== 0x6f || bytes[i + 2] !== 0x6f || bytes[i + 3] !== 0x76) continue;
+        const found = findMp4Codec(bytes, i - 4, bytes.length);
+        if (found) return found;
+    }
+    return undefined;
+}
+
+// Scans for the CodecID element rather than doing a full EBML parse.
+function findMatroskaCodec(bytes: Uint8Array): string | undefined {
+    for (let i = 0; i < bytes.length - 2; i++) {
+        if (bytes[i] !== 0x86) continue;
+
+        // Only the single-byte length form is plausible for a codec string.
+        const length = bytes[i + 1] & 0x7f;
+        if (!(bytes[i + 1] & 0x80) || length < 2 || length > 30 || i + 2 + length > bytes.length) continue;
+
+        let value = "";
+        for (let j = 0; j < length; j++) {
+            value += String.fromCharCode(bytes[i + 2 + j]);
+        }
+
+        if (!value.startsWith("V_")) continue;
+        return MATROSKA_CODEC_LABELS[value] ?? value.slice(2).toLowerCase();
+    }
+    return undefined;
+}

--- a/apps/web/src/viewmodels/room/RoomUploadViewModel.tsx
+++ b/apps/web/src/viewmodels/room/RoomUploadViewModel.tsx
@@ -45,11 +45,14 @@ import { Action } from "../../dispatcher/actions";
 import type { ComposerInsertFilesPayload } from "../../dispatcher/payloads/ComposerInsertFilePayload";
 import { useDispatcher } from "../../hooks/useDispatcher";
 import type { ActionPayload } from "../../dispatcher/payloads";
+import { ComposerAttachment } from "../../models/ComposerAttachment";
 
 const logger = rootLogger.getChild("RoomUploadViewModel");
 
 interface RoomUploadViewSnapshot extends UploadButtonViewSnapshot {
     mayDragAndDropFile: boolean;
+    /** Files staged in the composer, not yet uploaded. */
+    attachments: ComposerAttachment[];
 }
 
 export class RoomUploadViewModel
@@ -57,6 +60,8 @@ export class RoomUploadViewModel
     implements UploadButtonViewActions
 {
     private readonly uploadSelectFns = new Map<string, ComposerApiFileUploadOption["onSelected"]>();
+    /** Serialises the file reads behind attachment descriptions. */
+    private describeQueue: Promise<void> = Promise.resolve();
     public constructor(
         private readonly room: Room,
         private readonly client: MatrixClient,
@@ -72,6 +77,7 @@ export class RoomUploadViewModel
             {
                 options: [],
                 mayDragAndDropFile: false,
+                attachments: [],
             },
         );
         // Initial check.
@@ -140,45 +146,135 @@ export class RoomUploadViewModel
         if (!this.checkCanUpload()) {
             return;
         }
-        const { roomId } = this.room;
-        logger.info("initiateViaInputFiles for", roomId);
         if (!files?.length) return;
-
-        try {
-            await ContentMessages.sharedInstance().sendContentListToRoom(
-                Array.from(files),
-                roomId,
-                this.threadRelation,
-                this.replyToEvent,
-                this.client,
-                this.timelineRenderingType,
-            );
-        } catch (ex) {
-            logger.warn("Failed to handle file upload transfer", ex);
-        }
+        this.stageFiles(Array.from(files));
     };
 
     public initiateViaDataTransfer = async (dataTransfer: DataTransfer): Promise<void> => {
         if (!this.checkCanUpload()) {
             return;
         }
-        const { roomId } = this.room;
-        logger.info("initiateViaDataTransfer for", roomId);
         if (!dataTransfer.files?.length) return;
+        this.stageFiles(Array.from(dataTransfer.files));
+    };
 
+    /** Add files to the composer. They are not uploaded until the message is sent. */
+    public stageFiles(files: File[]): void {
+        logger.info(`Staging ${files.length} attachment(s) for`, this.room.roomId);
+        const staged = files.map((file) => new ComposerAttachment(file));
+        this.snapshot.merge({
+            attachments: [...this.snapshot.current.attachments, ...staged],
+        });
+        // Warm the media config now so that sending does not stall behind a modal spinner.
+        ContentMessages.sharedInstance().prefetchMediaConfig(this.client);
+        this.queueDescriptions(staged);
+        this.dispatcher.dispatch({
+            action: Action.FocusSendMessageComposer,
+            context: this.timelineRenderingType,
+        });
+    }
+
+    /**
+     * Describing an image reads the whole file, so run them one at a time rather than
+     * holding a dropped folder of them in memory at once.
+     */
+    private queueDescriptions(staged: ComposerAttachment[]): void {
+        this.describeQueue = staged.reduce(
+            (queue, attachment) => queue.then(() => this.loadDescription(attachment)),
+            this.describeQueue,
+        );
+    }
+
+    private async loadDescription(attachment: ComposerAttachment): Promise<void> {
+        // It may have been removed or sent while it sat in the queue.
+        if (this.isDisposed || !this.snapshot.current.attachments.includes(attachment)) return;
+
+        let changed = false;
         try {
-            await ContentMessages.sharedInstance().sendContentListToRoom(
-                Array.from(dataTransfer.files),
-                roomId,
+            changed = await attachment.loadDescription();
+        } catch (ex) {
+            logger.warn("Failed to describe attachment", ex);
+            return;
+        }
+        if (!changed || this.isDisposed || !this.snapshot.current.attachments.includes(attachment)) return;
+        this.snapshot.merge({ attachments: [...this.snapshot.current.attachments] });
+    }
+
+    public moveAttachment = (id: string, toIndex: number): void => {
+        const attachments = this.snapshot.current.attachments;
+        const fromIndex = attachments.findIndex((attachment) => attachment.id === id);
+        const clamped = Math.max(0, Math.min(toIndex, attachments.length - 1));
+        if (fromIndex === -1 || fromIndex === clamped) return;
+
+        const reordered = [...attachments];
+        const [moved] = reordered.splice(fromIndex, 1);
+        reordered.splice(clamped, 0, moved);
+        this.snapshot.merge({ attachments: reordered });
+    };
+
+    public removeAttachment = (id: string): void => {
+        const remaining: ComposerAttachment[] = [];
+        for (const attachment of this.snapshot.current.attachments) {
+            if (attachment.id === id) {
+                attachment.dispose();
+            } else {
+                remaining.push(attachment);
+            }
+        }
+        this.snapshot.merge({ attachments: remaining });
+    };
+
+    public get hasAttachments(): boolean {
+        return this.snapshot.current.attachments.length > 0;
+    }
+
+    /**
+     * Upload and send every staged attachment as its own event, in order. Resolves once
+     * they have all been sent, so a trailing text message lands beneath them.
+     */
+    public sendStagedAttachments = async (opts: { includeReply?: boolean } = {}): Promise<boolean> => {
+        const attachments = this.snapshot.current.attachments;
+        if (!attachments.length) return false;
+
+        // Clear first so the composer empties immediately and the files cannot be sent twice.
+        this.snapshot.merge({ attachments: [] });
+
+        let sent = false;
+        try {
+            sent = await ContentMessages.sharedInstance().sendContentListToRoom(
+                attachments.map((attachment) => attachment.file),
+                this.room.roomId,
                 this.threadRelation,
-                this.replyToEvent,
+                opts.includeReply === false ? undefined : this.replyToEvent,
                 this.client,
                 this.timelineRenderingType,
+                // The staging area already showed the user what they are about to send.
+                { skipConfirmation: true },
             );
         } catch (ex) {
-            logger.warn("Failed to handle drag and drop data transfer", ex);
+            logger.warn("Failed to send staged attachments", ex);
         }
+
+        if (!sent) {
+            // The user backed out or it failed, so put the files back rather than dropping
+            // a selection they would have to pick from disk again.
+            logger.info("Staged attachments were not sent; restoring them to the composer");
+            this.snapshot.merge({ attachments: [...attachments, ...this.snapshot.current.attachments] });
+            return false;
+        }
+
+        for (const attachment of attachments) {
+            attachment.dispose();
+        }
+        return true;
     };
+
+    public dispose(): void {
+        for (const attachment of this.snapshot.current.attachments) {
+            attachment.dispose();
+        }
+        super.dispose();
+    }
 
     public onUploadOptionSelected = (type: ComposerApiFileUploadOption["type"]): void => {
         const fn = this.uploadSelectFns.get(type);

--- a/apps/web/test/unit-tests/ContentMessages-test.ts
+++ b/apps/web/test/unit-tests/ContentMessages-test.ts
@@ -23,6 +23,7 @@ import { createTestClient, flushPromises, mkEvent } from "../test-utils";
 import { BlurhashEncoder } from "../../src/BlurhashEncoder";
 import Modal from "../../src/Modal";
 import ErrorDialog from "../../src/components/views/dialogs/ErrorDialog";
+import UploadConfirmDialog from "../../src/components/views/dialogs/UploadConfirmDialog";
 import { _t } from "../../src/languageHandler";
 
 jest.mock("matrix-encrypt-attachment", () => ({ encryptAttachment: jest.fn().mockResolvedValue({}) }));
@@ -315,6 +316,66 @@ describe("ContentMessages", () => {
                     description: _t("upload_failed_size", { fileName: "fileName" }),
                 }),
             );
+            dialogSpy.mockRestore();
+        });
+    });
+
+    describe("sendContentListToRoom", () => {
+        const roomId = "!roomId:server";
+
+        beforeEach(() => {
+            mocked(doMaybeLocalRoomAction).mockImplementation(
+                <T>(roomId: string, fn: (actualRoomId: string) => Promise<T>) => fn(roomId),
+            );
+            mocked(client.getMediaConfig).mockResolvedValue({});
+            mocked(client.uploadContent).mockResolvedValue({ content_uri: "mxc://server/file" });
+        });
+
+        it("resolves only once every file has actually been sent", async () => {
+            // Regression: it used to resolve as soon as the uploads were kicked off, so a
+            // message sent straight afterwards landed above the files instead of below them.
+            const files = [new File([], "one.txt"), new File([], "two.txt")];
+
+            await contentMessages.sendContentListToRoom(files, roomId, undefined, undefined, client, undefined, {
+                skipConfirmation: true,
+            });
+
+            expect(client.sendMessage).toHaveBeenCalledTimes(2);
+        });
+
+        it("skips the upload confirmation dialog when asked to", async () => {
+            const dialogSpy = jest.spyOn(Modal, "createDialog");
+
+            await contentMessages.sendContentListToRoom(
+                [new File([], "one.txt")],
+                roomId,
+                undefined,
+                undefined,
+                client,
+                undefined,
+                { skipConfirmation: true },
+            );
+
+            expect(dialogSpy).not.toHaveBeenCalledWith(UploadConfirmDialog, expect.anything(), expect.anything());
+            dialogSpy.mockRestore();
+        });
+
+        it("does not show the media config spinner once the config is prefetched", async () => {
+            contentMessages.prefetchMediaConfig(client);
+            await flushPromises();
+            const dialogSpy = jest.spyOn(Modal, "createDialog");
+
+            await contentMessages.sendContentListToRoom(
+                [new File([], "one.txt")],
+                roomId,
+                undefined,
+                undefined,
+                client,
+                undefined,
+                { skipConfirmation: true },
+            );
+
+            expect(dialogSpy).not.toHaveBeenCalled();
             dialogSpy.mockRestore();
         });
     });

--- a/apps/web/test/unit-tests/components/views/rooms/ComposerAttachments-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/ComposerAttachments-test.tsx
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import React from "react";
+import { act, fireEvent, render, screen } from "jest-matrix-react";
+import userEvent from "@testing-library/user-event";
+import { type MatrixClient, type Room } from "matrix-js-sdk/src/matrix";
+
+import type { MockedObject } from "jest-mock";
+import { ComposerAttachments } from "../../../../../src/components/views/rooms/ComposerAttachments";
+import { RoomUploadContext, RoomUploadViewModel } from "../../../../../src/viewmodels/room/RoomUploadViewModel";
+import { TimelineRenderingType } from "../../../../../src/contexts/RoomContext";
+import { MatrixDispatcher } from "../../../../../src/dispatcher/dispatcher";
+import { mkStubRoom, stubClient } from "../../../../test-utils";
+
+// Card width plus the gap between cards.
+const SLOT = 192;
+
+/**
+ * jsdom implements no PointerEvent, so fireEvent.pointerDown drops button/clientX/pointerId
+ * entirely. Build the event by hand instead so the handlers see what a browser would send.
+ */
+function firePointer(element: Element, type: string, props: Record<string, number>): void {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    Object.assign(event, props);
+    fireEvent(element, event);
+}
+
+describe("ComposerAttachments", () => {
+    let vm: RoomUploadViewModel;
+
+    beforeEach(() => {
+        const client = stubClient() as MockedObject<MatrixClient>;
+        const room = mkStubRoom("!room", undefined, undefined) as MockedObject<Room>;
+        vm = new RoomUploadViewModel(
+            room,
+            client,
+            TimelineRenderingType.Room,
+            new MatrixDispatcher(),
+            undefined,
+            undefined,
+            () => {},
+        );
+    });
+
+    function renderTray(): void {
+        render(
+            <RoomUploadContext.Provider value={vm}>
+                <ComposerAttachments />
+            </RoomUploadContext.Provider>,
+        );
+    }
+
+    it("renders nothing when no files are staged", () => {
+        const { container } = render(
+            <RoomUploadContext.Provider value={vm}>
+                <ComposerAttachments />
+            </RoomUploadContext.Provider>,
+        );
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it("shows a card per staged file", () => {
+        act(() =>
+            vm.stageFiles([
+                { name: "cat.png", size: 1024, type: "image/png" } as File,
+                { name: "notes.pdf", size: 2048, type: "application/pdf" } as File,
+            ]),
+        );
+        renderTray();
+
+        expect(screen.getByText("cat.png")).toBeInTheDocument();
+        expect(screen.getByText("notes.pdf")).toBeInTheDocument();
+        expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    });
+
+    it("removes a file when its delete button is clicked", async () => {
+        act(() =>
+            vm.stageFiles([
+                { name: "cat.png", size: 1024, type: "image/png" } as File,
+                { name: "dog.png", size: 1024, type: "image/png" } as File,
+            ]),
+        );
+        renderTray();
+
+        await userEvent.click(screen.getAllByRole("button", { name: "Remove attachment" })[0]);
+
+        expect(screen.queryByText("cat.png")).not.toBeInTheDocument();
+        expect(screen.getByText("dog.png")).toBeInTheDocument();
+        expect(vm.getSnapshot().attachments).toHaveLength(1);
+    });
+
+    it("keeps the delete button visible without hovering", () => {
+        act(() => vm.stageFiles([{ name: "cat.png", size: 1024, type: "image/png" } as File]));
+        renderTray();
+
+        expect(screen.getByRole("button", { name: "Remove attachment" })).toBeVisible();
+    });
+
+    /** jsdom lays nothing out, so give the cards a believable 180px-wide row. */
+    function stubLayout(): HTMLElement[] {
+        const items = screen.getAllByRole("listitem");
+        items.forEach((item, index) => {
+            Object.defineProperty(item, "offsetLeft", { value: index * SLOT, configurable: true });
+            // Not implemented by jsdom, and the component captures the pointer on drag.
+            item.setPointerCapture = jest.fn();
+        });
+        return items;
+    }
+
+    function stageTwo(): void {
+        act(() =>
+            vm.stageFiles([
+                { name: "first.png", size: 1024, type: "image/png" } as File,
+                { name: "second.png", size: 1024, type: "image/png" } as File,
+            ]),
+        );
+    }
+
+    it("reorders when a card is dragged past its neighbour", () => {
+        stageTwo();
+        renderTray();
+        const [first] = stubLayout();
+
+        firePointer(first, "pointerdown", { button: 0, pointerId: 1, clientX: 0, clientY: 0 });
+        firePointer(first, "pointermove", { pointerId: 1, clientX: SLOT, clientY: 0 });
+        firePointer(first, "pointerup", { pointerId: 1, clientX: SLOT, clientY: 0 });
+
+        expect(vm.getSnapshot().attachments.map((a) => a.name)).toEqual(["second.png", "first.png"]);
+    });
+
+    it("eases the released card from where it was let go to its new slot", () => {
+        stageTwo();
+        renderTray();
+        const [first] = stubLayout();
+
+        firePointer(first, "pointerdown", { button: 0, pointerId: 1, clientX: 0, clientY: 0 });
+        // Past the midpoint, so it takes the next slot, but stops half a slot short of it.
+        firePointer(first, "pointermove", { pointerId: 1, clientX: SLOT / 2, clientY: 6 });
+        firePointer(first, "pointerup", { pointerId: 1, clientX: SLOT / 2, clientY: 6 });
+
+        expect(vm.getSnapshot().attachments.map((a) => a.name)).toEqual(["second.png", "first.png"]);
+        // Pinned where the pointer left it, ready to transition the rest of the way.
+        expect(first.style.transform).toEqual(`translate(${-SLOT / 2}px, 6px)`);
+        expect(first.style.transition).not.toContain("transform");
+        expect(first.style.transition).toContain("box-shadow");
+    });
+
+    it("does not animate the cards that were only shuffled aside", () => {
+        stageTwo();
+        renderTray();
+        const [first, second] = stubLayout();
+
+        firePointer(first, "pointerdown", { button: 0, pointerId: 1, clientX: 0, clientY: 0 });
+        firePointer(first, "pointermove", { pointerId: 1, clientX: SLOT, clientY: 0 });
+        firePointer(first, "pointerup", { pointerId: 1, clientX: SLOT, clientY: 0 });
+
+        // The reorder already put it where its transform was showing it, so animating the
+        // transform would fling it across the row.
+        expect(second.style.transition).not.toContain("transform");
+        expect(second.style.transform).toEqual("");
+    });
+
+    it("keeps a dragged card within the row", () => {
+        stageTwo();
+        renderTray();
+        const [first] = stubLayout();
+
+        firePointer(first, "pointerdown", { button: 0, pointerId: 1, clientX: 0, clientY: 0 });
+        // Yanked far past the end of the row and well below it.
+        firePointer(first, "pointermove", { pointerId: 1, clientX: SLOT * 20, clientY: 500 });
+
+        // Clamped to the last slot horizontally, and to a slight lift vertically.
+        expect(first.style.transform).toEqual(`translate(${SLOT}px, 10px)`);
+    });
+
+    it("leaves the order alone when the card is not dragged far enough", () => {
+        stageTwo();
+        renderTray();
+        const [first] = stubLayout();
+
+        firePointer(first, "pointerdown", { button: 0, pointerId: 1, clientX: 0, clientY: 0 });
+        // A third of a slot is not past the midpoint.
+        firePointer(first, "pointermove", { pointerId: 1, clientX: SLOT / 3, clientY: 0 });
+        firePointer(first, "pointerup", { pointerId: 1, clientX: SLOT / 3, clientY: 0 });
+
+        expect(vm.getSnapshot().attachments.map((a) => a.name)).toEqual(["first.png", "second.png"]);
+    });
+
+    it("does not start a drag from the delete button", () => {
+        stageTwo();
+        renderTray();
+        stubLayout();
+
+        const deleteButton = screen.getAllByRole("button", { name: "Remove attachment" })[0];
+        firePointer(deleteButton, "pointerdown", { button: 0, pointerId: 1, clientX: 0, clientY: 0 });
+        firePointer(deleteButton, "pointermove", { pointerId: 1, clientX: SLOT, clientY: 0 });
+        firePointer(deleteButton, "pointerup", { pointerId: 1, clientX: SLOT, clientY: 0 });
+
+        expect(vm.getSnapshot().attachments.map((a) => a.name)).toEqual(["first.png", "second.png"]);
+    });
+
+    it("reorders with the arrow keys", () => {
+        stageTwo();
+        renderTray();
+        const [first] = stubLayout();
+
+        fireEvent.keyDown(first, { key: "ArrowRight" });
+
+        expect(vm.getSnapshot().attachments.map((a) => a.name)).toEqual(["second.png", "first.png"]);
+    });
+
+    it("does not move the first card further left", () => {
+        stageTwo();
+        renderTray();
+        const [first] = stubLayout();
+
+        fireEvent.keyDown(first, { key: "ArrowLeft" });
+
+        expect(vm.getSnapshot().attachments.map((a) => a.name)).toEqual(["first.png", "second.png"]);
+    });
+});

--- a/apps/web/test/unit-tests/utils/MediaFormat-test.ts
+++ b/apps/web/test/unit-tests/utils/MediaFormat-test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 Element Creations Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+import { imageFormatLabel, sniffVideoCodec, videoContainerLabel } from "../../../src/utils/MediaFormat";
+
+function box(type: string, payload: Uint8Array): Uint8Array<ArrayBuffer> {
+    const out = new Uint8Array(8 + payload.length);
+    new DataView(out.buffer).setUint32(0, out.length);
+    for (let i = 0; i < 4; i++) out[4 + i] = type.charCodeAt(i);
+    out.set(payload, 8);
+    return out;
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array<ArrayBuffer> {
+    const total = parts.reduce((sum, part) => sum + part.length, 0);
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const part of parts) {
+        out.set(part, offset);
+        offset += part.length;
+    }
+    return out;
+}
+
+function ascii(text: string): Uint8Array<ArrayBuffer> {
+    return new Uint8Array([...text].map((c) => c.charCodeAt(0)));
+}
+
+function trak(fourCc: string): Uint8Array<ArrayBuffer> {
+    const sampleEntry = box(fourCc, new Uint8Array(8));
+    const stsd = box("stsd", concat(new Uint8Array([0, 0, 0, 0, 0, 0, 0, 1]), sampleEntry));
+    return box("trak", box("mdia", box("minf", box("stbl", stsd))));
+}
+
+/** Minimal ISO base media file whose tracks name the given codecs, in order. */
+function mp4WithTracks(fourCcs: string[], leading: Uint8Array = new Uint8Array(0)): File {
+    const moov = box("moov", concat(...fourCcs.map(trak)));
+    const ftyp = box("ftyp", ascii("isom"));
+    return new File([concat(ftyp, leading, moov)], "clip.mp4", { type: "video/mp4" });
+}
+
+function mp4WithCodec(fourCc: string, leading: Uint8Array = new Uint8Array(0)): File {
+    return mp4WithTracks([fourCc], leading);
+}
+
+/** Minimal EBML stream carrying a CodecID element. */
+function matroskaWithCodec(codecId: string): File {
+    const header = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3, 0x01, 0x02, 0x03, 0x04]);
+    const codec = concat(new Uint8Array([0x86, 0x80 | codecId.length]), ascii(codecId));
+    return new File([concat(header, codec)], "clip.mkv", { type: "video/x-matroska" });
+}
+
+describe("MediaFormat", () => {
+    describe("imageFormatLabel", () => {
+        it.each([
+            ["image/jpeg", "JPEG"],
+            ["image/png", "PNG"],
+            ["image/gif", "GIF"],
+            ["image/webp", "WebP"],
+            ["image/avif", "AVIF"],
+            ["image/svg+xml", "SVG"],
+        ])("labels %s as %s", (mimeType, expected) => {
+            expect(imageFormatLabel(mimeType)).toEqual(expected);
+        });
+
+        it("falls back to the mime subtype for unknown types", () => {
+            expect(imageFormatLabel("image/x-nonsense")).toEqual("NONSENSE");
+        });
+    });
+
+    describe("videoContainerLabel", () => {
+        it.each([
+            ["video/mp4", "mp4"],
+            ["video/quicktime", "mov"],
+            ["video/webm", "webm"],
+            ["video/x-matroska", "mkv"],
+        ])("labels %s as %s", (mimeType, expected) => {
+            expect(videoContainerLabel(mimeType, "clip")).toEqual(expected);
+        });
+
+        it("falls back to the file extension when the mime type is unhelpful", () => {
+            expect(videoContainerLabel("application/octet-stream", "holiday.mkv")).toEqual("mkv");
+        });
+    });
+
+    describe("sniffVideoCodec", () => {
+        it.each([
+            ["avc1", "h264"],
+            ["hvc1", "h265"],
+            ["av01", "av1"],
+            ["vp09", "vp9"],
+        ])("reads %s out of an mp4 as %s", async (fourCc, expected) => {
+            expect(await sniffVideoCodec(mp4WithCodec(fourCc))).toEqual(expected);
+        });
+
+        it.each([
+            ["V_VP9", "vp9"],
+            ["V_AV1", "av1"],
+            ["V_MPEG4/ISO/AVC", "h264"],
+            ["V_MPEGH/ISO/HEVC", "h265"],
+        ])("reads %s out of a matroska file as %s", async (codecId, expected) => {
+            expect(await sniffVideoCodec(matroskaWithCodec(codecId))).toEqual(expected);
+        });
+
+        it("skips the audio track when it comes first", async () => {
+            // QuickTime and many muxers write the audio trak first.
+            expect(await sniffVideoCodec(mp4WithTracks(["mp4a", "avc1"]))).toEqual("h264");
+        });
+
+        it("returns undefined when no track holds a video codec", async () => {
+            expect(await sniffVideoCodec(mp4WithTracks(["mp4a"]))).toBeUndefined();
+        });
+
+        it("finds moov even when it trails a large mdat", async () => {
+            // Files not written for streaming keep moov at the end, past the sniff window.
+            const mdat = box("mdat", new Uint8Array(600 * 1024));
+            expect(await sniffVideoCodec(mp4WithCodec("avc1", mdat))).toEqual("h264");
+        });
+
+        it("returns undefined for a container it cannot parse", async () => {
+            const file = new File([new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])], "clip.avi", { type: "video/x-msvideo" });
+            expect(await sniffVideoCodec(file)).toBeUndefined();
+        });
+
+        it("returns undefined rather than throwing on a truncated mp4", async () => {
+            const file = new File([concat(box("ftyp", ascii("isom")), ascii("moov"))], "clip.mp4", {
+                type: "video/mp4",
+            });
+            expect(await sniffVideoCodec(file)).toBeUndefined();
+        });
+    });
+});

--- a/apps/web/test/viewmodels/room/RoomUploadViewModel-test.tsx
+++ b/apps/web/test/viewmodels/room/RoomUploadViewModel-test.tsx
@@ -6,10 +6,15 @@
  */
 import React from "react";
 import { type IEventRelation, type MatrixClient, type Room, RoomEvent } from "matrix-js-sdk/src/matrix";
-import { render } from "jest-matrix-react";
+import { act, render, screen } from "jest-matrix-react";
+import { useViewModel } from "@element-hq/web-shared-components";
 
 import type { MockedObject } from "jest-mock";
-import { RoomUploadContextProvider, RoomUploadViewModel } from "../../../src/viewmodels/room/RoomUploadViewModel";
+import {
+    RoomUploadContextProvider,
+    RoomUploadViewModel,
+    useRoomUploadViewModel,
+} from "../../../src/viewmodels/room/RoomUploadViewModel";
 import { getRoomContext, mkEvent, mkStubRoom, stubClient } from "../../test-utils";
 import { TimelineRenderingType } from "../../../src/contexts/RoomContext";
 import defaultDispatcher, { MatrixDispatcher } from "../../../src/dispatcher/dispatcher";
@@ -20,6 +25,11 @@ import { ScopedRoomContextProvider } from "../../../src/contexts/ScopedRoomConte
 import { Action } from "../../../src/dispatcher/actions";
 import MatrixClientContext from "../../../src/contexts/MatrixClientContext";
 const sendContentListToRoomSpy = jest.spyOn(ContentMessages.sharedInstance(), "sendContentListToRoom");
+
+function StagedAttachmentNames(): React.ReactNode {
+    const { attachments } = useViewModel(useRoomUploadViewModel());
+    return <p data-testid="staged">{attachments.map((attachment) => attachment.name).join(", ")}</p>;
+}
 
 describe("RoomUploadViewModel", () => {
     let client: MockedObject<MatrixClient>;
@@ -117,8 +127,8 @@ describe("RoomUploadViewModel", () => {
             await vm.initiateViaInputFiles([] as unknown as FileList);
             expect(dis.dispatch).not.toHaveBeenCalled();
         });
-        it("uploads with correct context", async () => {
-            sendContentListToRoomSpy.mockResolvedValue(undefined);
+        it("stages files rather than sending them immediately", async () => {
+            sendContentListToRoomSpy.mockResolvedValue(true);
             const vm = new RoomUploadViewModel(
                 room,
                 client,
@@ -128,10 +138,6 @@ describe("RoomUploadViewModel", () => {
                 undefined,
                 () => {},
             );
-            const replyEvent = mkEvent({ event: true, type: "anything", user: "anyone", content: {} });
-            vm.setReplyToEvent(replyEvent);
-            const threadRelation: IEventRelation = { key: "foo" };
-            vm.setThreadRelation(threadRelation);
             const fileList = [
                 {
                     name: "fake.png",
@@ -140,14 +146,9 @@ describe("RoomUploadViewModel", () => {
                 },
             ] as unknown as FileList;
             await vm.initiateViaInputFiles(fileList);
-            expect(sendContentListToRoomSpy).toHaveBeenCalledWith(
-                fileList,
-                room.roomId,
-                threadRelation,
-                replyEvent,
-                client,
-                TimelineRenderingType.Thread,
-            );
+            expect(sendContentListToRoomSpy).not.toHaveBeenCalled();
+            expect(vm.getSnapshot().attachments).toHaveLength(1);
+            expect(vm.getSnapshot().attachments[0].name).toEqual("fake.png");
         });
     });
 
@@ -179,8 +180,8 @@ describe("RoomUploadViewModel", () => {
             await vm.initiateViaDataTransfer({ files: [] as unknown as FileList } as DataTransfer);
             expect(dis.dispatch).not.toHaveBeenCalled();
         });
-        it("uploads with correct context", async () => {
-            sendContentListToRoomSpy.mockResolvedValue(undefined);
+        it("stages files rather than sending them immediately", async () => {
+            sendContentListToRoomSpy.mockResolvedValue(true);
             const vm = new RoomUploadViewModel(
                 room,
                 client,
@@ -190,10 +191,6 @@ describe("RoomUploadViewModel", () => {
                 undefined,
                 () => {},
             );
-            const replyEvent = mkEvent({ event: true, type: "anything", user: "anyone", content: {} });
-            vm.setReplyToEvent(replyEvent);
-            const threadRelation: IEventRelation = { key: "foo" };
-            vm.setThreadRelation(threadRelation);
             const files = [
                 {
                     name: "fake.png",
@@ -202,25 +199,151 @@ describe("RoomUploadViewModel", () => {
                 },
             ] as unknown as FileList;
             await vm.initiateViaDataTransfer({ files } as DataTransfer);
+            expect(sendContentListToRoomSpy).not.toHaveBeenCalled();
+            expect(vm.getSnapshot().attachments).toHaveLength(1);
+        });
+    });
+
+    describe("staged attachments", () => {
+        const file = { name: "fake.png", size: 1024, type: "image/png" } as File;
+
+        function mkViewModel(): RoomUploadViewModel {
+            return new RoomUploadViewModel(
+                room,
+                client,
+                TimelineRenderingType.Thread,
+                dis,
+                undefined,
+                undefined,
+                () => {},
+            );
+        }
+
+        it("sends staged attachments with the correct context", async () => {
+            sendContentListToRoomSpy.mockResolvedValue(true);
+            const vm = mkViewModel();
+            const replyEvent = mkEvent({ event: true, type: "anything", user: "anyone", content: {} });
+            vm.setReplyToEvent(replyEvent);
+            const threadRelation: IEventRelation = { key: "foo" };
+            vm.setThreadRelation(threadRelation);
+
+            vm.stageFiles([file]);
+            await vm.sendStagedAttachments();
+
             expect(sendContentListToRoomSpy).toHaveBeenCalledWith(
-                files,
+                [file],
                 room.roomId,
                 threadRelation,
                 replyEvent,
                 client,
                 TimelineRenderingType.Thread,
+                { skipConfirmation: true },
             );
+            expect(vm.getSnapshot().attachments).toHaveLength(0);
+        });
+
+        it("keeps the files staged when the send is abandoned", async () => {
+            // e.g. the user cancelled the "file too big" dialog, so nothing was sent.
+            sendContentListToRoomSpy.mockResolvedValue(false);
+            const vm = mkViewModel();
+            vm.stageFiles([file]);
+
+            await expect(vm.sendStagedAttachments()).resolves.toBe(false);
+
+            expect(vm.getSnapshot().attachments).toHaveLength(1);
+            expect(vm.getSnapshot().attachments[0].name).toEqual("fake.png");
+            // Still usable, so its preview must not have been revoked.
+            expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+        });
+
+        it("keeps files staged when sending throws", async () => {
+            sendContentListToRoomSpy.mockRejectedValue(new Error("boom"));
+            const vm = mkViewModel();
+            vm.stageFiles([file]);
+
+            await expect(vm.sendStagedAttachments()).resolves.toBe(false);
+
+            expect(vm.getSnapshot().attachments).toHaveLength(1);
+        });
+
+        it("puts restored files back ahead of anything staged since", async () => {
+            sendContentListToRoomSpy.mockImplementation(async () => {
+                // Something else lands in the composer while the send is in flight.
+                vm.stageFiles([{ ...file, name: "later.png" } as File]);
+                return false;
+            });
+            const vm = mkViewModel();
+            vm.stageFiles([file]);
+
+            await vm.sendStagedAttachments();
+
+            expect(vm.getSnapshot().attachments.map((a) => a.name)).toEqual(["fake.png", "later.png"]);
+        });
+
+        it("omits the reply when the caller is sending its own message below", async () => {
+            sendContentListToRoomSpy.mockResolvedValue(true);
+            const vm = mkViewModel();
+            vm.setReplyToEvent(mkEvent({ event: true, type: "anything", user: "anyone", content: {} }));
+            vm.stageFiles([file]);
+
+            await vm.sendStagedAttachments({ includeReply: false });
+
+            expect(sendContentListToRoomSpy).toHaveBeenCalledWith(
+                [file],
+                room.roomId,
+                undefined,
+                undefined,
+                client,
+                TimelineRenderingType.Thread,
+                { skipConfirmation: true },
+            );
+        });
+
+        it("appends to the existing staged files", () => {
+            const vm = mkViewModel();
+            vm.stageFiles([file]);
+            vm.stageFiles([file]);
+            expect(vm.getSnapshot().attachments).toHaveLength(2);
+            expect(vm.hasAttachments).toBe(true);
+        });
+
+        it("removes a staged file and revokes its preview", () => {
+            const vm = mkViewModel();
+            vm.stageFiles([file, { ...file, name: "other.png" } as File]);
+            const [first] = vm.getSnapshot().attachments;
+
+            vm.removeAttachment(first.id);
+
+            expect(vm.getSnapshot().attachments).toHaveLength(1);
+            expect(vm.getSnapshot().attachments[0].name).toEqual("other.png");
+            expect(URL.revokeObjectURL).toHaveBeenCalledWith(first.previewUrl);
+        });
+
+        it("does nothing when there is nothing staged", async () => {
+            const vm = mkViewModel();
+            await vm.sendStagedAttachments();
+            expect(sendContentListToRoomSpy).not.toHaveBeenCalled();
+        });
+
+        it("revokes previews of files still staged on dispose", () => {
+            const vm = mkViewModel();
+            vm.stageFiles([file]);
+            const [staged] = vm.getSnapshot().attachments;
+
+            vm.dispose();
+
+            expect(URL.revokeObjectURL).toHaveBeenCalledWith(staged.previewUrl);
         });
     });
 
     describe("RoomUploadContextProvider", () => {
-        it("uploads when called via module API", async () => {
-            sendContentListToRoomSpy.mockResolvedValue(undefined);
+        it("stages files when called via module API", async () => {
+            sendContentListToRoomSpy.mockResolvedValue(true);
             render(
                 <MatrixClientContext.Provider value={client}>
                     <ScopedRoomContextProvider {...getRoomContext(room, {})}>
                         <RoomUploadContextProvider>
-                            <p>Any child</p>
+                            <StagedAttachmentNames />
                         </RoomUploadContextProvider>
                     </ScopedRoomContextProvider>
                 </MatrixClientContext.Provider>,
@@ -232,22 +355,18 @@ describe("RoomUploadViewModel", () => {
                     type: "image/png",
                 },
             ] as File[];
-            defaultDispatcher.dispatch(
-                {
-                    action: Action.ComposerFileInsert,
-                    files,
-                    timelineRenderingType: TimelineRenderingType.Room,
-                } satisfies ComposerInsertFilesPayload,
-                true,
+            act(() =>
+                defaultDispatcher.dispatch(
+                    {
+                        action: Action.ComposerFileInsert,
+                        files,
+                        timelineRenderingType: TimelineRenderingType.Room,
+                    } satisfies ComposerInsertFilesPayload,
+                    true,
+                ),
             );
-            expect(sendContentListToRoomSpy).toHaveBeenCalledWith(
-                files,
-                room.roomId,
-                undefined,
-                undefined,
-                client,
-                TimelineRenderingType.Room,
-            );
+            expect(sendContentListToRoomSpy).not.toHaveBeenCalled();
+            expect(await screen.findByTestId("staged")).toHaveTextContent("fake.png");
         });
     });
 });


### PR DESCRIPTION
## Problem
The current implementation of file upload is quite limiting and doesn't have proper UI for handing multi-file uploads, or any way managing files before the sending them.

## Solution in this PR
Message composer now have a list of files shown before sending them, like in Discord. It allows to re-order files before sending them, and of course allows sending multiple media/files at once (currently, due to protocol limitations, we send all files as separate messages, but it could be changed, when multiple files in a single event protocol will be mainline). 

Files, that are added to the "sending list" in the message compositor also have additional information shown: 
- file name
- file size
- video container+codec (shown only on videos, sniffed)
- is blob animated (check if it is a GIF, animated-PNG/animated-WEBP)

Also this allows to begin work on other features: like spoilers or image editor.

## Showcase

[Video.webm](https://github.com/user-attachments/assets/65d124b4-d13f-44f4-8004-863d35718ac9)

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)