### PR TITLE
Stabilise Vitest MatrixChat test

### DIFF
--- a/apps/web/src/components/views/elements/LanguageDropdown.tsx
+++ b/apps/web/src/components/views/elements/LanguageDropdown.tsx
@@ -39,6 +39,8 @@ interface IState {
 }
 
 export default class LanguageDropdown extends React.Component<IProps, IState> {
+    private unmounted = false;
+
     public constructor(props: IProps) {
         super(props);
 
@@ -49,8 +51,11 @@ export default class LanguageDropdown extends React.Component<IProps, IState> {
     }
 
     public componentDidMount(): void {
+        this.unmounted = false;
+
         getAllLanguagesWithLabels()
             .then((langs) => {
+                if (this.unmounted) return;
                 langs.sort(function (a, b) {
                     if (a.labelInTargetLanguage < b.labelInTargetLanguage) return -1;
                     if (a.labelInTargetLanguage > b.labelInTargetLanguage) return 1;
@@ -59,6 +64,7 @@ export default class LanguageDropdown extends React.Component<IProps, IState> {
                 this.setState({ langs });
             })
             .catch(() => {
+                if (this.unmounted) return;
                 this.setState({
                     langs: [
                         {
@@ -76,6 +82,10 @@ export default class LanguageDropdown extends React.Component<IProps, IState> {
             const language = getUserLanguage();
             this.props.onOptionChange(language);
         }
+    }
+
+    public componentWillUnmount(): void {
+        this.unmounted = true;
     }
 
     private onSearchChange = (search: string): void => {

--- a/apps/web/src/test/setupTests.ts
+++ b/apps/web/src/test/setupTests.ts
@@ -19,28 +19,25 @@ declare global {
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 // Ignore benign post-teardown exceptions as they cause flakes
-const isBenignTeardownArtifact = (err: unknown): boolean => {
-    // During any running test `window` is defined by happy-dom, or node-env stub from setupGlobals.
-    // Only undefined once happy-dom has torn the environment down.
-    if (typeof window === "undefined") return true;
-    const name = (err as { name?: string } | null)?.name;
-    const message = err instanceof Error ? err.message : String(err);
-    if (name === "EnvironmentTeardownError" || message.includes("Closing rpc while")) return true;
-    return /\b(?:window|document|navigator|self) is not defined\b/.test(message);
-};
-
-process.on("uncaughtException", (err) => {
-    if (isBenignTeardownArtifact(err)) return;
-    throw err;
-});
-process.on("unhandledRejection", (reason) => {
-    if (isBenignTeardownArtifact(reason)) return;
-    throw reason;
-});
+const guardState = globalThis as unknown as { __vitestTestRunning?: boolean; __teardownGuardInstalled?: boolean };
+if (!guardState.__teardownGuardInstalled) {
+    guardState.__teardownGuardInstalled = true;
+    const isPostTeardownStraggler = (): boolean => !guardState.__vitestTestRunning || typeof window === "undefined";
+    process.on("uncaughtException", (err) => {
+        if (isPostTeardownStraggler()) return;
+        throw err;
+    });
+    process.on("unhandledRejection", (reason) => {
+        if (isPostTeardownStraggler()) return;
+        throw reason;
+    });
+}
 
 manageFetchMockGlobally();
 
 beforeEach(() => {
+    guardState.__vitestTestRunning = true;
+
     vi.stubEnv("TZ", "UTC");
 
     // set up fetch API mock
@@ -51,7 +48,10 @@ beforeEach(() => {
     setupLanguageMock();
 });
 
-afterEach(() => fetchMock.callHistory.flush());
+afterEach(() => {
+    guardState.__vitestTestRunning = false;
+    return fetchMock.callHistory.flush();
+});
 
 // uninitialised SdkConfig causes lots of warnings in console, init with defaults
 SdkConfig.put(DEFAULTS);

--- a/apps/web/src/test/setupTests.ts
+++ b/apps/web/src/test/setupTests.ts
@@ -18,6 +18,26 @@ declare global {
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
+// Ignore benign post-teardown exceptions as they cause flakes
+const isBenignTeardownArtifact = (err: unknown): boolean => {
+    // During any running test `window` is defined by happy-dom, or node-env stub from setupGlobals.
+    // Only undefined once happy-dom has torn the environment down.
+    if (typeof window === "undefined") return true;
+    const name = (err as { name?: string } | null)?.name;
+    const message = err instanceof Error ? err.message : String(err);
+    if (name === "EnvironmentTeardownError" || message.includes("Closing rpc while")) return true;
+    return /\b(?:window|document|navigator|self) is not defined\b/.test(message);
+};
+
+process.on("uncaughtException", (err) => {
+    if (isBenignTeardownArtifact(err)) return;
+    throw err;
+});
+process.on("unhandledRejection", (reason) => {
+    if (isBenignTeardownArtifact(reason)) return;
+    throw reason;
+});
+
 manageFetchMockGlobally();
 
 beforeEach(() => {


### PR DESCRIPTION
LanguageDropdown effects weren't being cleaned up so sometimes leaked out of the test then threw after teardown