### PR TITLE
Use prebuilt seshat instead of building every time

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -270,21 +270,27 @@ jobs:
         uses: ./.github/workflows/build_desktop_linux.yaml
         strategy:
             matrix:
-                sqlcipher: [system, static]
+                # We only ever ship static sqlcipher builds (see build_desktop_and_deploy.yaml) —
+                # system/dynamic sqlcipher is exercised cheaply by check_desktop_native instead,
+                # rather than a full desktop build+Playwright pass for a variant nobody ships.
                 arch: [amd64, arm64]
                 runAllTests:
                     - ${{ needs.prepare.outputs.run-all-desktop == 'true' }}
                 exclude:
-                    # We ship static sqlcipher builds, so delegate testing the system builds to the merge queue
-                    - runAllTests: false
-                      sqlcipher: system
-                    # Additionally skip arm64 system builds on PRs, as the amd64 test is enough for a smoke test and includes the screenshot tests
+                    # Skip arm64 builds on PRs, as the amd64 test is enough for a smoke test and includes the screenshot tests
                     - runAllTests: false
                       arch: arm64
         with:
-            sqlcipher: ${{ matrix.sqlcipher }}
+            sqlcipher: static
             arch: ${{ matrix.arch }}
             blob_report: true
+
+    # Cheap, non-flaky check that the pinned matrix-seshat version has a
+    # working prebuilt for every arch/sqlcipher combo hak needs — doesn't
+    # depend on the webapp build, so it runs independently of prepare/prepare_ed.
+    check_desktop_native:
+        name: "Desktop native module check"
+        uses: ./.github/workflows/check_desktop_native.yaml
 
     build_ed_macos:
         needs: [prepare, prepare_ed]
@@ -306,6 +312,7 @@ jobs:
             - build_ed_windows
             - build_ed_linux
             - build_ed_macos
+            - check_desktop_native
         if: always()
         runs-on: ubuntu-24.04
         steps:

--- a/.github/workflows/build_desktop_windows.yaml
+++ b/.github/workflows/build_desktop_windows.yaml
@@ -183,12 +183,6 @@ jobs:
                   rm webapp.asar
                   pnpm asar pack config-edit/ webapp.asar
 
-            - name: Set up sqlcipher macros
-              if: steps.cache.outputs.cache-hit != 'true' && contains(inputs.arch, 'arm')
-              shell: pwsh
-              run: |
-                  echo "NCC=${{ github.workspace }}\scripts\cl.bat" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
             - name: Set up build tools
               if: steps.cache.outputs.cache-hit != 'true'
               uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0

--- a/.github/workflows/check_desktop_native.yaml
+++ b/.github/workflows/check_desktop_native.yaml
@@ -1,0 +1,57 @@
+# Verifies that the pinned matrix-seshat version has a working prebuilt for
+# each platform/arch/sqlcipher variant hak needs to build Element Desktop,
+# without a full Electron + Playwright desktop build.
+#
+# Deliberately doesn't install a Rust toolchain: if a prebuilt is missing or
+# broken, hak's build step falls back to compiling from source, which fails
+# loudly here (no cargo/rustc present) rather than silently masking a missing
+# prebuilt behind a real (slow, flaky) compile.
+on:
+    workflow_call:
+
+permissions: {} # No permissions required
+
+jobs:
+    check:
+        name: matrix-seshat (${{ matrix.arch }}, sqlcipher ${{ matrix.sqlcipher }})
+        runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
+        strategy:
+            fail-fast: false
+            matrix:
+                arch: [amd64, arm64]
+                sqlcipher: [static, system]
+        env:
+            SQLCIPHER_BUNDLED: ${{ matrix.sqlcipher == 'static' && '1' || '' }}
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+              with:
+                  persist-credentials: false
+
+            - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+              with:
+                  node-version-file: apps/desktop/.node-version
+                  cache: "pnpm"
+
+            - name: Install deps
+              working-directory: apps/desktop
+              run: pnpm install --frozen-lockfile --filter element-desktop
+
+            - name: Fetch matrix-seshat
+              working-directory: apps/desktop
+              run: node scripts/hak/index.ts fetch matrix-seshat
+
+            - name: Build matrix-seshat (should use the published prebuilt, not compile from source)
+              working-directory: apps/desktop
+              run: node scripts/hak/index.ts build matrix-seshat
+              env:
+                  # Authenticates the release metadata lookup, raising the
+                  # GitHub API rate limit from 60/hour to 5000/hour.
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Verify the prebuilt loads under Electron
+              working-directory: apps/desktop
+              run: |
+                  set -eu
+                  node_file=$(find .hak/matrix-seshat -name index.node)
+                  ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron -e "require('$(realpath "$node_file")'); console.log('matrix-seshat loaded OK')"

--- a/apps/desktop/hak/matrix-seshat/build.ts
+++ b/apps/desktop/hak/matrix-seshat/build.ts
@@ -16,14 +16,51 @@ export default async function (hakEnv: HakEnv, moduleInfo: DependencyInfo): Prom
         env.CARGO_BUILD_TARGET = hakEnv.getTargetId();
     }
 
+    const sqlcipherVariant = hakEnv.wantsStaticSqlCipher() ? "static" : "dynamic";
+
+    // Via the package's own `download` script rather than invoking its
+    // underlying file directly, since that file's name/invocation is an
+    // implementation detail that can change between published versions —
+    // the npm script name is the stable contract. It has no dependencies of
+    // its own, so this can run before `yarn install` — if it finds a
+    // matching prebuilt we skip installing/building from source entirely.
+    console.log(
+        `Trying prebuilt matrix-seshat (${hakEnv.target.platform}-${hakEnv.target.arch}, ${sqlcipherVariant} sqlcipher)`,
+    );
+    try {
+        const downloadArgs = [
+            "run",
+            "download",
+            `--platform=${hakEnv.target.platform}`,
+            `--arch=${hakEnv.target.arch}`,
+            `--sqlcipher=${sqlcipherVariant}`,
+            "--no-fallback",
+        ];
+        // Raises the GitHub API rate limit for the release lookup from
+        // 60/hour to 5000/hour — matters in CI, where many workflows share
+        // a small pool of runner IPs against the unauthenticated limit.
+        if (process.env.GITHUB_TOKEN) {
+            downloadArgs.push(`--token=${process.env.GITHUB_TOKEN}`);
+        }
+        await hakEnv.spawn("yarn", downloadArgs, {
+            cwd: moduleInfo.moduleBuildDir,
+            env,
+            shell: true,
+        });
+        console.log("Using prebuilt matrix-seshat, skipping build from source");
+        return;
+    } catch {
+        console.log("No prebuilt matrix-seshat available, building from source");
+    }
+
     console.log("Running yarn install");
-    await hakEnv.spawn("yarn", ["install"], {
+    await hakEnv.spawn("yarn", ["install", "--ignore-scripts"], {
         cwd: moduleInfo.moduleBuildDir,
         env,
         shell: true,
     });
 
-    const buildTarget = hakEnv.wantsStaticSqlCipher() ? "build-bundled" : "build";
+    const buildTarget = sqlcipherVariant === "static" ? "build-bundled" : "build";
 
     console.log("Running yarn build");
     await hakEnv.spawn("yarn", ["run", buildTarget], {

--- a/apps/desktop/hak/matrix-seshat/check.ts
+++ b/apps/desktop/hak/matrix-seshat/check.ts
@@ -18,8 +18,6 @@ export default async function (hakEnv: HakEnv, moduleInfo: DependencyInfo): Prom
     if (hakEnv.isWin()) {
         tools.push(["perl", "--version"]); // for openssl configure
         tools.push(["nasm", "-v"]); // for openssl building
-        tools.push(["patch", "--version"]); // to patch sqlcipher Makefile.msc
-        tools.push(["nmake", "/?"]);
     } else {
         tools.push(["make", "--version"]);
     }

--- a/apps/desktop/scripts/cl.bat
+++ b/apps/desktop/scripts/cl.bat
@@ -1,7 +1,0 @@
-REM Batch file to aid in cross-compiling sqlcipher for Windows ARM64
-REM Full path should be passed to Makefile.msc as NCC env var
-
-setlocal
-call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %VSCMD_ARG_HOST_ARCH%
-cl.exe %*
-endlocal


### PR DESCRIPTION
Requires https://github.com/matrix-org/seshat/pull/184

This changes our process to use (as of yet, not released) prebuilt seshat modules rather than building our own, which hopefully saves a bit of CI flakiness.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
