### PR TITLE
Fix soft crash when m.direct account data contains non-array values

### DIFF
--- a/apps/web/src/components/viewmodels/right_panel/RoomSummaryCardViewModel.ts
+++ b/apps/web/src/components/viewmodels/right_panel/RoomSummaryCardViewModel.ts
@@ -122,7 +122,7 @@ const useIsDirectMessage = (room: Room): boolean => {
 
     useEffect(() => {
         for (const [, dmRoomList] of Object.entries(directRoomsList)) {
-            if (dmRoomList.includes(room?.roomId ?? "")) {
+            if (Array.isArray(dmRoomList) && dmRoomList.includes(room?.roomId ?? "")) {
                 setDirectMessage(true);
                 break;
             }

--- a/apps/web/test/unit-tests/components/viewmodels/right_panel/RoomSummaryCardViewModel-test.ts
+++ b/apps/web/test/unit-tests/components/viewmodels/right_panel/RoomSummaryCardViewModel-test.ts
@@ -237,6 +237,20 @@ describe("useRoomSummaryCardViewModel", () => {
                 expect(result.current.isDirectMessage).toBe(false);
             });
         });
+
+        it("should handle malformed m.direct account data without crashing", async () => {
+            const directRoomsList = {
+                "@user:domain.com": "!not-an-array:domain.com" as any,
+                "@other:domain.com": null as any,
+            };
+            jest.spyOn(hooks, "useAccountData").mockReturnValue(directRoomsList);
+
+            const { result } = render();
+
+            await waitFor(() => {
+                expect(result.current.isDirectMessage).toBe(false);
+            });
+        });
     });
 
     describe("search input", () => {


### PR DESCRIPTION
## Summary

Adds `Array.isArray()` guard in `useIsDirectMessage` before calling `.includes()` on `m.direct` account data values. Prevents `TypeError: s.includes is not a function` React soft crash when `m.direct` contains malformed entries (string, null, or other non-array values instead of `string[]`).

## Context

Diagnosed from a rageshake (`react-soft-crash`, Element Desktop 1.12.24 on Windows). The crash reproduces deterministically when opening a room after a long sync reconnection (~17h sleep). During reconnection, a malformed `m.direct` account data entry causes `useIsDirectMessage` to call `.includes()` on a non-array value, crashing the `RoomSummaryCardView` render path.

The `m.direct` spec says values should be `string[]`, but real-world account data can contain non-array values (e.g. from older clients or corrupted state). The fix is a single `Array.isArray()` guard — no behavioral change for well-formed data.

## Testing strategy

1. Check out this branch
2. In a test account, set malformed `m.direct` account data (e.g. a string value instead of an array for one entry)
3. Open any room — before this fix, the right panel crashes with a soft crash; after, it renders normally
4. Run `pnpm test -- --testPathPattern=RoomSummaryCardViewModel` to verify the new and existing unit tests pass

```
Notes: Fix a crash when m.direct account data contains non-array values
```

Reviewer: please add the `T-Defect` label — I don't have permission to add labels. Thanks!

Signed-off-by: ahdzib-maya <noreply@ahdzib.maya>