### PR TITLE
Scale a pill's avatar with the font size setting

### DIFF
--- a/apps/web/res/css/views/elements/_Pill.pcss
+++ b/apps/web/res/css/views/elements/_Pill.pcss
@@ -60,6 +60,20 @@ Please see LICENSE files in the repository root for full details.
         min-width: $font-16px; /* ensure the avatar is not compressed */
         user-select: text;
         vertical-align: top;
+
+        /* The avatar has to be asked for at a fixed 16px because that same number builds its
+           thumbnail URL, so it cannot simply be given a rem size. Everything else in the pill is
+           rem-based and grows with the font size setting, which left the image sitting in the corner
+           of a larger round hole. Compound sizes the avatar box, the image inside it and the fallback
+           letter from this one custom property, and sets it inline, so !important is what it takes to
+           scale all three with the rest of the pill. */
+        --cpd-avatar-size: $font-16px !important;
+    }
+
+    /* The image also carries the requested size as width and height attributes, which would hold it
+       short of its own box once that box has grown. */
+    .mx_BaseAvatar img {
+        block-size: auto;
     }
 
     .mx_Pill_text {
@@ -80,22 +94,23 @@ Please see LICENSE files in the repository root for full details.
         background-color: $link-external;
         box-sizing: border-box;
         color: $background;
-        height: 16px;
+        height: $font-16px;
         padding: 1px;
-        width: 16px;
+        width: $font-16px;
         border-radius: 50%;
     }
 
     .mx_Pill_UserIcon {
         box-sizing: border-box;
         color: $secondary-content;
-        height: 16px;
-        width: 16px;
+        height: $font-16px;
+        width: $font-16px;
     }
 
+    /* A space pill is squared off on the avatar side, so its corners have to follow the avatar. */
     &.mx_SpacePill {
-        border-top-left-radius: 8px;
-        border-bottom-left-radius: 8px;
-        padding-left: 4px;
+        border-top-left-radius: $font-8px;
+        border-bottom-left-radius: $font-8px;
+        padding-left: 0.25em;
     }
 }


### PR DESCRIPTION
A pill's padding, line height and corner radius are all written in rem, so they grow with the
font size setting. The avatar inside it cannot be: the size it is asked for is also the size of
the thumbnail requested from the server, so it is a fixed 16px. Raising the setting therefore
stretched the avatar's box — the pill gives it a rem-based `min-width` — while the image, the
fallback letter and the link/user icon variants stayed at 16px, leaving them sitting in the corner
of a larger round hole.

Compound sizes the avatar's box, the image inside it and the fallback letter from a single
`--cpd-avatar-size` custom property which it sets inline, so overriding that property within the
pill scales all three together. The image also needs its height freeing, because it carries the
size it was requested at as an HTML attribute. The two icon variants and the squared-off corners
of a space pill move to the same rem-based value so that the whole pill grows as one thing.

At the default font size the value resolves to exactly 16px — `--cpd-font-size-root` is `1rem` —
so nothing moves for anyone who has not changed the setting, and no screenshot baselines change.

CSS-only, so there is no unit-test home. Measured in Chrome at a 21px root font size, which is the
setting the issue reports: before, the avatar's box is 21×21 with a 16×16 image inside it and the
fallback letter drawn at 9px with a 14px line height; after, the box and the image are both 21×21
and the letter is 11.8px on 19px. `Pill-test.tsx` still passes with its 13 snapshots unchanged.

Fixes #26396

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
