### PR TITLE
Fetch the profile of a user opened from a link

### DIFF
--- a/apps/web/src/components/views/right_panel/UserInfo.tsx
+++ b/apps/web/src/components/views/right_panel/UserInfo.tsx
@@ -11,7 +11,15 @@ Please see LICENSE files in the repository root for full details.
 
 import React, { type JSX, type ReactNode, useContext, useEffect, useMemo, useState } from "react";
 import classNames from "classnames";
-import { type MatrixClient, type RoomMember, type Room, type User, type Device } from "matrix-js-sdk/src/matrix";
+import {
+    type MatrixClient,
+    RoomMember,
+    type Room,
+    type User,
+    type Device,
+    MatrixEvent,
+    EventType,
+} from "matrix-js-sdk/src/matrix";
 import { type UserVerificationStatus, type VerificationRequest, CryptoEvent } from "matrix-js-sdk/src/crypto-api";
 
 import Modal from "../../../Modal";
@@ -168,6 +176,51 @@ export const useDevices = (userId: string): IDevice[] | undefined | null => {
 
 export type Member = User | RoomMember;
 
+/**
+ * Fetch the profile of a member we were handed nothing but an ID for.
+ *
+ * The panel is usually opened from a room's member list, where the member already carries a display
+ * name and an avatar. It can also be opened by following a link to a user who is not in the room, and
+ * then all that is known about them is their ID, which leaves the header with nothing to render. The
+ * fetched profile is shaped into a RoomMember because that is the API the views below read it
+ * through. No membership is put on it, so nothing beyond the name and the avatar changes.
+ *
+ * @param member - The member the panel was opened for.
+ * @returns The member to render: the one that was passed in, or a profile-backed stand-in for it.
+ */
+const useMemberProfile = (member: Member): Member => {
+    const { userProfilesStore } = useContext(SDKContext);
+    const [profileMember, setProfileMember] = useState<RoomMember>();
+
+    // Anyone who came out of a room's state arrives with their profile already on them. A User does
+    // not: it is constructed from an ID alone and only filled in by a presence event, so it can be
+    // carrying nothing but the ID it was named after.
+    const needsProfile = !(member instanceof RoomMember) && (!member.avatarUrl || member.displayName === member.userId);
+    const { userId } = member;
+
+    useEffect(() => {
+        if (!needsProfile) return;
+
+        let cancelled = false;
+        userProfilesStore.getOrFetchProfile(userId).then((profile) => {
+            if (cancelled || !profile) return;
+
+            const memberWithProfile = new RoomMember("", userId);
+            memberWithProfile.setMembershipEvent(new MatrixEvent({ type: EventType.RoomMember, content: profile }));
+            setProfileMember(memberWithProfile);
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [needsProfile, userId, userProfilesStore]);
+
+    // The panel can be pointed at somebody else while a fetch is still in flight, so only a profile
+    // belonging to the member being rendered is used.
+    if (needsProfile && profileMember && profileMember.userId === userId) return profileMember;
+    return member;
+};
+
 interface IProps {
     user: Member;
     room?: Room;
@@ -181,7 +234,8 @@ const UserInfo: React.FC<IProps> = ({ user, room, onClose, phase = RightPanelPha
     const sdkContext = useContext(SDKContext);
 
     // fetch latest room member if we have a room, so we don't show historical information, falling back to user
-    const member = useMemo(() => (room ? room.getMember(user.userId) || user : user), [room, user]);
+    const roomMember = useMemo(() => (room ? room.getMember(user.userId) || user : user), [room, user]);
+    const member = useMemberProfile(roomMember);
 
     const isRoomEncrypted = useIsEncrypted(sdkContext.client!, room);
     const devices = useDevices(user.userId) ?? [];

--- a/apps/web/test/unit-tests/components/views/right_panel/UserInfo-test.tsx
+++ b/apps/web/test/unit-tests/components/views/right_panel/UserInfo-test.tsx
@@ -122,6 +122,9 @@ beforeEach(() => {
         doesServerSupportUnstableFeature: jest.fn().mockReturnValue(false),
         doesServerSupportExtendedProfiles: jest.fn().mockResolvedValue(false),
         getExtendedProfile: jest.fn().mockRejectedValue(new Error("Not supported")),
+        // Stands in for a user the homeserver has no profile for, which is what most of these tests
+        // are rendering.
+        getProfileInfo: jest.fn().mockResolvedValue(null),
         mxcUrlToHttp: jest.fn().mockReturnValue("mock-mxcUrlToHttp"),
         removeListener: jest.fn(),
         currentState: {
@@ -197,6 +200,25 @@ describe("<UserInfo />", () => {
         it("renders user info", () => {
             renderComponent();
             expect(screen.getByRole("heading", { name: defaultUserId })).toBeInTheDocument();
+        });
+
+        it("shows the name and avatar of a user we were only given the ID of", async () => {
+            mockClient.getProfileInfo.mockResolvedValue({
+                displayname: "Alice",
+                avatar_url: "mxc://example.com/alice",
+            });
+
+            renderComponent();
+
+            expect(await screen.findByText("Alice")).toBeInTheDocument();
+            expect(screen.getByTestId("avatar-img").querySelector("img")).toHaveAttribute("src", "mock-mxcUrlToHttp");
+        });
+
+        it("does not fetch a profile for a member who came from a room", async () => {
+            renderComponent({ user: new RoomMember(defaultRoomId, defaultUserId) });
+            await flushPromises();
+
+            expect(mockClient.getProfileInfo).not.toHaveBeenCalled();
         });
 
         describe.each([[ProfileKeyTimezone], [ProfileKeyMSC4175Timezone]])("timezone rendering (%s)", (profileKey) => {


### PR DESCRIPTION
Clicking a `matrix.to` link to a user that has not been pillified opens the right panel on a bare
`User`, built in `Linkify` from the ID in the link and nothing else. The panel then has nothing to
render that person with: `UserInfoHeaderView` reads the avatar and the display name through the
`RoomMember` API, and `MemberAvatar` only resolves a thumbnail for a member that has a `name`. So a
user who is not in the room being viewed — the case where `room.getMember()` cannot fill the gap —
came up with a letter for an avatar and their ID for a name.

`UserInfo` now fetches the profile of a member it was handed nothing to render, through
`UserProfilesStore`, which already caches profiles and swallows a failed lookup. The result is
shaped into a `RoomMember`, which is what `UserView` has long done for the same problem on the
`/#/user/` route, and is what the views below read the member through. No membership is put on the
stand-in, so nothing but the name and the avatar changes and the room-dependent controls behave as
they did. A profile that arrives after the panel has been pointed at someone else is discarded.

Fixes #20752

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
