### PR TITLE
Keep a list loose when a message is opened for editing

### DIFF
--- a/apps/web/src/editor/deserialize.ts
+++ b/apps/web/src/editor/deserialize.ts
@@ -17,6 +17,8 @@ import { textToHtmlRainbow } from "../utils/colour";
 import { stripPlainReply } from "../utils/Reply";
 
 const LIST_TYPES = ["UL", "OL", "LI"];
+/** What a nested list, or the continuation of a list item, is indented by. */
+const INDENT = " ".repeat(4);
 
 // Escapes all markup in the given text
 function escape(text: string): string {
@@ -43,6 +45,25 @@ export function longestBacktickSequence(text: string): number {
 
 function isListChild(n: Node): boolean {
     return LIST_TYPES.includes(n.parentNode?.nodeName || "");
+}
+
+/**
+ * Whether a node is one of several blocks making up a single list item, as opposed to a list item
+ * itself or a list nested inside one.
+ */
+function isListItemBlock(n: Node): boolean {
+    return n.parentNode?.nodeName === "LI" && !LIST_TYPES.includes(n.nodeName);
+}
+
+/**
+ * Whether a list was written with blank lines between its items. Markdown says so by giving each
+ * item a paragraph of its own rather than bare text, and a list that comes back without those blank
+ * lines is a tighter list than the one that was sent.
+ */
+function isLooseList(n: Node): boolean {
+    if (n.nodeName !== "UL" && n.nodeName !== "OL") return false;
+
+    return Array.from(n.childNodes).some((li) => Array.from(li.childNodes).some((child) => child.nodeName === "P"));
 }
 
 function parseAtRoomMentions(text: string, pc: PartCreator, opts: IParseOptions): Part[] {
@@ -143,10 +164,17 @@ function prefixLines(parts: Part[], prefix: string, pc: PartCreator): void {
 
 function parseChildren(n: Node, pc: PartCreator, opts: IParseOptions, mkListItem?: (li: Node) => Part[]): Part[] {
     let prev: ChildNode | undefined;
+    const loose = isLooseList(n);
     return Array.from(n.childNodes).flatMap((c) => {
         const parsed = parseNode(c, pc, opts, mkListItem);
         if (parsed.length && prev && (checkBlockNode(prev) || checkBlockNode(c))) {
-            if (isListChild(c)) {
+            if (isListItemBlock(c)) {
+                // An item made of more than one block is written as a blank line and an indented
+                // continuation. Run together on one line instead, the second block reads as more of
+                // the first when the message is parsed again.
+                prefixLines(parsed, INDENT, pc);
+                parsed.unshift(pc.newline(), pc.newline());
+            } else if (isListChild(c) && !loose) {
                 // Use tighter spacing within lists
                 parsed.unshift(pc.newline());
             } else {
@@ -212,7 +240,7 @@ function parseNode(n: Node, pc: PartCreator, opts: IParseOptions, mkListItem?: (
                 case "UL": {
                     const parts = parseChildren(n, pc, opts, (li) => [pc.plain("- "), ...parseChildren(li, pc, opts)]);
                     if (isListChild(n)) {
-                        prefixLines(parts, "    ", pc);
+                        prefixLines(parts, INDENT, pc);
                     }
                     return parts;
                 }
@@ -224,7 +252,7 @@ function parseNode(n: Node, pc: PartCreator, opts: IParseOptions, mkListItem?: (
                         return parts;
                     });
                     if (isListChild(n)) {
-                        prefixLines(parts, "    ", pc);
+                        prefixLines(parts, INDENT, pc);
                     }
                     return parts;
                 }

--- a/apps/web/test/unit-tests/editor/deserialize-test.ts
+++ b/apps/web/test/unit-tests/editor/deserialize-test.ts
@@ -250,6 +250,24 @@ describe("editor/deserialize", function () {
             expect(parts[3]).toStrictEqual({ type: "newline", text: "\n" });
             expect(parts[4]).toStrictEqual({ type: "plain", text: "3. Finish" });
         });
+        it("list items of several paragraphs", () => {
+            const html = "<ul><li><p>Oak</p><p>A kind of tree.</p></li></ul>";
+            const parts = normalize(parseEvent(htmlMessage(html), createPartCreator()));
+            expect(parts.length).toBe(4);
+            expect(parts[0]).toStrictEqual({ type: "plain", text: "- Oak" });
+            expect(parts[1]).toStrictEqual({ type: "newline", text: "\n" });
+            expect(parts[2]).toStrictEqual({ type: "newline", text: "\n" });
+            expect(parts[3]).toStrictEqual({ type: "plain", text: `${FOUR_SPACES}A kind of tree.` });
+        });
+        it("lists written with blank lines between the items", () => {
+            const html = "<ul><li><p>Oak</p></li><li><p>Spruce</p></li></ul>";
+            const parts = normalize(parseEvent(htmlMessage(html), createPartCreator()));
+            expect(parts.length).toBe(4);
+            expect(parts[0]).toStrictEqual({ type: "plain", text: "- Oak" });
+            expect(parts[1]).toStrictEqual({ type: "newline", text: "\n" });
+            expect(parts[2]).toStrictEqual({ type: "newline", text: "\n" });
+            expect(parts[3]).toStrictEqual({ type: "plain", text: "- Spruce" });
+        });
         it("nested unordered lists", () => {
             const html = "<ul><li>Oak<ul><li>Spruce<ul><li>Birch</li></ul></li></ul></li></ul>";
             const parts = normalize(parseEvent(htmlMessage(html), createPartCreator()));


### PR DESCRIPTION
Opening a message for editing converts its HTML back into markdown for the composer, and
`parseChildren` put a single line break between two blocks whenever either was inside a list. That
is right for a tight list, but it is the one thing that distinguishes a loose list from a tight one:

- a list item written as two paragraphs came back as `- Oak\nA kind of tree.`, which parses as a
  single run-on item;
- a list written with blank lines between its items came back as `- Oak\n- Spruce`, which parses as
  a tight list.

Either way, saving the edit sent a different list from the one that was being edited.

An item's continuation is now written after a blank line and indented like a nested list, and the
items of a list whose markup gives each of them a paragraph — which is how a markdown parser records
the blank lines between them — are separated by a blank line too. A list whose items are bare text
is unchanged, so tight lists keep their tighter spacing.

Checked against the `commonmark` parser the composer sends through. `<li><p>Oak</p><p>A kind of
tree.</p></li>` used to come back out as `<li>Oak\nA kind of tree.</li>`; it now round-trips to the
markup it started as, and so does a list with blank lines between its items.

Fixes #25952

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
