### PR TITLE
Count messages, not events, when exporting the last N of them

### DIFF
--- a/apps/web/src/utils/exportUtils/Exporter.ts
+++ b/apps/web/src/utils/exportUtils/Exporter.ts
@@ -19,6 +19,7 @@ import { formatFullDateNoDay, formatFullDateNoDayISO } from "../../DateUtils";
 import { isVoiceMessage } from "../EventUtils";
 import { _t } from "../../languageHandler";
 import SdkConfig from "../../SdkConfig";
+import { haveRendererForEvent } from "../../events/EventTileFactory";
 
 type BlobFile = {
     name: string;
@@ -137,6 +138,27 @@ export default abstract class Exporter {
         return limit;
     }
 
+    /**
+     * Whether an event will appear in the export at all.
+     *
+     * Every exporter skips the events it has no renderer for — reactions, edits and redacted state
+     * events among them — so those cannot count towards the number of messages that was asked for.
+     *
+     * @param event - The event about to be exported.
+     * @returns Whether the export will contain it.
+     */
+    protected isRenderable(event: MatrixEvent): boolean {
+        return haveRendererForEvent(event, this.room.client, false);
+    }
+
+    private async decryptEvents(events: MatrixEvent[]): Promise<void> {
+        await Promise.all(
+            events
+                .filter((event) => event.isEncrypted())
+                .map((event) => this.room.client.decryptEventIfNeeded(event, { emit: false })),
+        );
+    }
+
     protected async getRequiredEvents(): Promise<MatrixEvent[]> {
         const eventMapper = this.room.client.getEventMapper();
 
@@ -145,10 +167,15 @@ export default abstract class Exporter {
         let events: MatrixEvent[] = [];
         if (this.exportType === ExportType.Timeline) {
             events = this.room.getLiveTimeline().getEvents();
+            await this.decryptEvents(events);
         } else {
-            let limit = this.getLimit();
-            while (limit) {
-                const eventsPerCrawl = Math.min(limit, 1000);
+            const limit = this.getLimit();
+            // Counted in events that will actually be written out rather than in events the server
+            // returns: asking for the last five messages of a room whose five most recent events are
+            // all reactions used to hand back an export with nothing in it.
+            let found = 0;
+            while (found < limit) {
+                const eventsPerCrawl = Math.min(limit - found, 1000);
                 const res = await this.room.client.createMessagesRequest(
                     this.room.roomId,
                     prevToken,
@@ -163,9 +190,10 @@ export default abstract class Exporter {
 
                 if (res.chunk.length === 0) break;
 
-                limit -= res.chunk.length;
-
                 const matrixEvents: MatrixEvent[] = res.chunk.map(eventMapper);
+                // Whether an encrypted event is one of the kinds that get skipped is only knowable
+                // once it has been decrypted, so this cannot wait until the crawl has finished.
+                await this.decryptEvents(matrixEvents);
 
                 for (const mxEv of matrixEvents) {
                     // if (this.exportOptions.startDate && mxEv.getTs() < this.exportOptions.startDate) {
@@ -173,13 +201,14 @@ export default abstract class Exporter {
                     //     limit = 0;
                     //     break;
                     // }
+                    if (this.isRenderable(mxEv)) found++;
                     events.push(mxEv);
                 }
 
                 if (this.exportType === ExportType.LastNMessages) {
                     this.updateProgress(
                         _t("export_chat|fetched_n_events_with_total", {
-                            count: events.length,
+                            count: found,
                             total: this.exportOptions.numberOfMessages,
                         }),
                     );
@@ -192,19 +221,13 @@ export default abstract class Exporter {
                 }
 
                 prevToken = res.end ?? null;
+                // With no token to carry on from, there is nothing older to ask for, and asking again
+                // from the start would hand back the newest events a second time.
+                if (prevToken === null) break;
             }
             // Reverse the events so that we preserve the order
             events.reverse();
         }
-
-        const decryptionPromises = events
-            .filter((event) => event.isEncrypted())
-            .map((event) => {
-                return this.room.client.decryptEventIfNeeded(event, { emit: false });
-            });
-
-        // Wait for all the events to get decrypted.
-        await Promise.all(decryptionPromises);
 
         for (let i = 0; i < events.length; i++) this.setEventMetadata(events[i]);
 

--- a/apps/web/src/utils/exportUtils/HtmlExport.tsx
+++ b/apps/web/src/utils/exportUtils/HtmlExport.tsx
@@ -29,7 +29,6 @@ import { type ExportType, type IExportOptions } from "./exportUtils";
 import MatrixClientContext from "../../contexts/MatrixClientContext";
 import getExportCSS from "./exportCSS";
 import { textForEvent } from "../../TextForEvent";
-import { haveRendererForEvent } from "../../events/EventTileFactory";
 import { SDKContext } from "../../contexts/SDKContext.ts";
 import { SDKContextClass } from "../../contexts/SDKContextClass";
 import { DateSeparatorViewModel } from "../../viewmodels/room/timeline/DateSeparatorViewModel";
@@ -446,7 +445,7 @@ export default class HTMLExporter extends Exporter {
                 true,
             );
             if (this.cancelled) return this.cleanUp();
-            if (!haveRendererForEvent(event, this.room.client, false)) continue;
+            if (!this.isRenderable(event)) continue;
 
             content += this.needsDateSeparator(event, prevEvent) ? this.getDateSeparator(event) : "";
             const shouldBeJoined =

--- a/apps/web/src/utils/exportUtils/JSONExport.ts
+++ b/apps/web/src/utils/exportUtils/JSONExport.ts
@@ -13,7 +13,6 @@ import Exporter from "./Exporter";
 import { formatFullDateNoDayNoTime } from "../../DateUtils";
 import { type ExportType, type IExportOptions } from "./exportUtils";
 import { _t } from "../../languageHandler";
-import { haveRendererForEvent } from "../../events/EventTileFactory";
 
 export default class JSONExporter extends Exporter {
     protected totalSize = 0;
@@ -81,7 +80,7 @@ export default class JSONExporter extends Exporter {
                 true,
             );
             if (this.cancelled) return this.cleanUp();
-            if (!haveRendererForEvent(event, this.room.client, false)) continue;
+            if (!this.isRenderable(event)) continue;
             this.messages.push(await this.getJSONString(event));
         }
         return this.createJSONString();

--- a/apps/web/src/utils/exportUtils/PlainTextExport.ts
+++ b/apps/web/src/utils/exportUtils/PlainTextExport.ts
@@ -14,7 +14,6 @@ import Exporter from "./Exporter";
 import { _t } from "../../languageHandler";
 import { type ExportType, type IExportOptions } from "./exportUtils";
 import { textForEvent } from "../../TextForEvent";
-import { haveRendererForEvent } from "../../events/EventTileFactory";
 import SettingsStore from "../../settings/SettingsStore";
 import { formatFullDate } from "../../DateUtils";
 
@@ -113,7 +112,7 @@ export default class PlainTextExporter extends Exporter {
                 true,
             );
             if (this.cancelled) return this.cleanUp();
-            if (!haveRendererForEvent(event, this.room.client, false)) continue;
+            if (!this.isRenderable(event)) continue;
             const textForEvent = await this.plainTextForEvent(event);
             content +=
                 textForEvent &&

--- a/apps/web/test/unit-tests/utils/exportUtils/HTMLExport-test.ts
+++ b/apps/web/test/unit-tests/utils/exportUtils/HTMLExport-test.ts
@@ -133,7 +133,7 @@ describe("HTMLExport", () => {
     function mockMessages(...events: IRoomEvent[]): void {
         client.createMessagesRequest.mockImplementation((_roomId, fromStr, limit = 30) => {
             const from = fromStr === null ? 0 : parseInt(fromStr);
-            const chunk = events.slice(from, limit);
+            const chunk = events.slice(from, from + limit);
             return Promise.resolve({
                 chunk,
                 start: from.toString(),
@@ -755,5 +755,44 @@ describe("HTMLExport", () => {
 
         const file = getMessageFile(exporter);
         expect(file).not.toBeUndefined();
+    });
+
+    it("should keep looking when the newest events are ones it cannot render", async () => {
+        // The three most recent events in the room are reactions, which no exporter writes out.
+        const reactions = [...Array(3)].map<IRoomEvent>((_, i) => ({
+            event_id: `$reaction${i}`,
+            type: EventType.Reaction,
+            sender: "@bob:example.com",
+            origin_server_ts: 10_000 + i * 1000,
+            content: {
+                "m.relates_to": { rel_type: RelationType.Annotation, event_id: "$message0", key: "🙂" },
+            },
+        }));
+        const messages = [...Array(3)].map<IRoomEvent>((_, i) => ({
+            event_id: `$message${i}`,
+            type: EventType.RoomMessage,
+            sender: "@bob:example.com",
+            origin_server_ts: 5_000 + i * 1000,
+            content: { msgtype: "m.text", body: `Message #${i}` },
+        }));
+        mockMessages(...reactions, ...messages);
+
+        const exporter = new HTMLExporter(
+            room,
+            ExportType.LastNMessages,
+            {
+                attachmentsIncluded: false,
+                maxSize: 1_024 * 1_024,
+                numberOfMessages: 3,
+            },
+            () => {},
+        );
+
+        await exporter.export();
+
+        const file = await getMessageFile(exporter).text();
+        expect(file).toContain("Message #0");
+        expect(file).toContain("Message #1");
+        expect(file).toContain("Message #2");
     });
 });


### PR DESCRIPTION
"Choose the amount of messages" paginated until it had that many **raw events** from
`/messages`: `limit -= res.chunk.length`, with every event in the chunk pushed. The exporters then
write out only what they have a renderer for — `PlainTextExport`, `HtmlExport` and `JSONExport` all
skip an event when `haveRendererForEvent` says no, which covers reactions, `m.replace` edits and
redacted state events. So a small number and a busy room could easily mean the newest N events are
all reactions, and the export comes out empty.

The crawl now counts the events that will actually be written and keeps asking for older ones until
it has as many as were requested. The count uses the very predicate the exporters apply, moved onto
the base class as `isRenderable` so the two cannot drift apart. Whether an encrypted event is one of
the skipped kinds is only knowable once it has been decrypted, so decryption moves from after the
crawl into it, one chunk at a time.

The loop also stops when the server stops offering an `end` token: it no longer has a raw count to
run down, and continuing with a null token would ask for the newest events all over again.

`mockMessages` in the tests was paginating with `events.slice(from, limit)`, treating a count as an
end index, which its own `end: from + limit` token contradicts. Fixed so a second page can be
fetched at all.

Fixes #31747

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
