### PR TITLE
Stop one finished sound from cutting off another

### DIFF
--- a/apps/web/src/audio/BackgroundAudio.test.ts
+++ b/apps/web/src/audio/BackgroundAudio.test.ts
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 hayaksi1
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { vi, describe, it, expect, beforeEach, type Mock } from "vitest";
+import fetchMock from "@fetch-mock/vitest";
+
+import { BackgroundAudio } from "./BackgroundAudio";
+import { createAudioContext } from "./compat";
+
+vi.mock("./compat", () => ({
+    createAudioContext: vi.fn(),
+}));
+
+describe("BackgroundAudio", () => {
+    let audioContext: {
+        createBufferSource: Mock;
+        decodeAudioData: Mock;
+        resume: Mock;
+        suspend: Mock;
+        destination: object;
+    };
+
+    /** The sources handed out by the mocked context, in the order they were created. */
+    let sources: Array<{ start: Mock; disconnect: Mock; onended?: () => void }>;
+
+    beforeEach(() => {
+        sources = [];
+        audioContext = {
+            createBufferSource: vi.fn().mockImplementation(() => {
+                const source = { start: vi.fn(), connect: vi.fn(), disconnect: vi.fn() };
+                sources.push(source);
+                return source;
+            }),
+            decodeAudioData: vi.fn().mockResolvedValue({}),
+            resume: vi.fn().mockResolvedValue(undefined),
+            suspend: vi.fn().mockResolvedValue(undefined),
+            destination: {},
+        };
+        vi.mocked(createAudioContext).mockReturnValue(audioContext as unknown as AudioContext);
+
+        // Every sound is fetched before it is decoded, and the decoding is mocked out above, so the
+        // bytes that come back never matter.
+        fetchMock.mockReset();
+        fetchMock.get("*", 200);
+    });
+
+    it("suspends the context once the sound has finished", async () => {
+        const audio = new BackgroundAudio();
+
+        await audio.play("sound.mp3");
+        expect(audioContext.suspend).not.toHaveBeenCalled();
+
+        sources[0].onended!();
+
+        expect(audioContext.suspend).toHaveBeenCalled();
+    });
+
+    it("keeps playing a sound that outlasts one started before it", async () => {
+        const audio = new BackgroundAudio();
+
+        await audio.play("first.mp3");
+        await audio.play("second.mp3");
+
+        // The first sound finishes while the second is still going.
+        sources[0].onended!();
+
+        expect(audioContext.suspend).not.toHaveBeenCalled();
+
+        sources[1].onended!();
+
+        expect(audioContext.suspend).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/web/src/audio/BackgroundAudio.ts
+++ b/apps/web/src/audio/BackgroundAudio.ts
@@ -18,6 +18,8 @@ const formatMap = {
 export class BackgroundAudio {
     private audioContext = createAudioContext();
     private sounds: Record<string, AudioBuffer> = {};
+    /** How many sounds started here are still going. */
+    private playing = 0;
 
     public async pickFormatAndPlay<F extends Array<keyof typeof formatMap>>(
         urlPrefix: string,
@@ -50,8 +52,16 @@ export class BackgroundAudio {
         source.connect(this.audioContext.destination);
 
         await this.audioContext.resume();
+        this.playing++;
         source.onended = () => {
-            this.audioContext.suspend();
+            source.disconnect();
+            this.playing--;
+            // Every sound played here shares the one context, which is suspended rather than closed so
+            // that it can be reused. Suspending it while another sound is still going would cut that
+            // one off mid-way and leave it to pick up again the next time anything is played.
+            if (this.playing === 0) {
+                this.audioContext.suspend();
+            }
         };
 
         source.start();

--- a/apps/web/test/unit-tests/audio/BackgroundAudio-test.ts
+++ b/apps/web/test/unit-tests/audio/BackgroundAudio-test.ts
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 hayaksi1
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { BackgroundAudio } from "../../../src/audio/BackgroundAudio";
+import { createAudioContext } from "../../../src/audio/compat";
+
+jest.mock("../../../src/audio/compat", () => ({
+    createAudioContext: jest.fn(),
+}));
+
+describe("BackgroundAudio", () => {
+    let audioContext: {
+        createBufferSource: jest.Mock;
+        decodeAudioData: jest.Mock;
+        resume: jest.Mock;
+        suspend: jest.Mock;
+        destination: object;
+    };
+
+    /** The sources handed out by the mocked context, in the order they were created. */
+    let sources: Array<{ start: jest.Mock; disconnect: jest.Mock; onended?: () => void }>;
+
+    beforeEach(() => {
+        sources = [];
+        audioContext = {
+            createBufferSource: jest.fn().mockImplementation(() => {
+                const source = { start: jest.fn(), connect: jest.fn(), disconnect: jest.fn() };
+                sources.push(source);
+                return source;
+            }),
+            decodeAudioData: jest.fn().mockResolvedValue({}),
+            resume: jest.fn().mockResolvedValue(undefined),
+            suspend: jest.fn().mockResolvedValue(undefined),
+            destination: {},
+        };
+        jest.mocked(createAudioContext).mockReturnValue(audioContext as unknown as AudioContext);
+
+        // Every sound is fetched before it is decoded, and the decoding is mocked out above.
+        global.fetch = jest.fn().mockResolvedValue({
+            status: 200,
+            arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+        }) as unknown as typeof global.fetch;
+    });
+
+    it("suspends the context once the sound has finished", async () => {
+        const audio = new BackgroundAudio();
+
+        await audio.play("sound.mp3");
+        expect(audioContext.suspend).not.toHaveBeenCalled();
+
+        sources[0].onended!();
+
+        expect(audioContext.suspend).toHaveBeenCalled();
+    });
+
+    it("keeps playing a sound that outlasts one started before it", async () => {
+        const audio = new BackgroundAudio();
+
+        await audio.play("first.mp3");
+        await audio.play("second.mp3");
+
+        // The first sound finishes while the second is still going.
+        sources[0].onended!();
+
+        expect(audioContext.suspend).not.toHaveBeenCalled();
+
+        sources[1].onended!();
+
+        expect(audioContext.suspend).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
`BackgroundAudio` plays every sound through one `AudioContext`, and suspends it rather than closing
it so that it can be reused. The `onended` handler suspended that shared context whenever *any*
source finished:

```ts
source.onended = () => {
    this.audioContext.suspend();
};
```

So a sound that started while an earlier one was still playing was cut off part of the way through.
Suspending is not stopping, either — the cut-off buffer stays where it is and carries on the next
time `resume()` is called, which is how a notification for one room ends up being heard later,
during a different one. `Notifier` and `LegacyCallHandler` each own an instance, so notification
sounds collide with each other and ring tones with each other.

The context is now suspended only once nothing this instance started is still running, and each
source is disconnected as it ends so nothing can be resumed from behind. A looping sound holds the
count up while it loops; stopping it fires `onended` as well, so the context is still suspended as
soon as everything has gone quiet.

Fixes #33969

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
