### PR TITLE
Stop a slash command running twice when enter is pressed again

### DIFF
--- a/apps/web/src/components/views/rooms/SendMessageComposer.tsx
+++ b/apps/web/src/components/views/rooms/SendMessageComposer.tsx
@@ -155,6 +155,8 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
     private model: EditorModel;
     private currentlyComposedEditorState: SerializedPart[] | null = null;
     private dispatcherRef?: string;
+    /** Whether a slash command typed into this composer is still running. */
+    private runningSlashCommand = false;
     private sendHistoryManager: SendHistoryManager;
 
     public constructor(props: ISendMessageComposerProps, context: React.ContextType<typeof RoomContext>) {
@@ -375,45 +377,58 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
         let content: RoomMessageEventContent | null = null;
 
         if (!containsEmote(model) && isSlashCommand(this.model)) {
-            const [cmd, args, commandText] = getSlashCommand(this.props.room.roomId, this.model);
-            if (cmd) {
-                const threadId =
-                    this.props.relation?.rel_type === THREAD_RELATION_TYPE.name ? this.props.relation?.event_id : null;
+            // A message clears the composer before it is sent, so pressing enter again finds nothing
+            // left to send. A command is awaited first and the composer still holds it, so without
+            // this the command would run a second time — /topic would set the topic twice.
+            if (this.runningSlashCommand) return;
+            this.runningSlashCommand = true;
+            try {
+                const [cmd, args, commandText] = getSlashCommand(this.props.room.roomId, this.model);
+                if (cmd) {
+                    const threadId =
+                        this.props.relation?.rel_type === THREAD_RELATION_TYPE.name
+                            ? this.props.relation?.event_id
+                            : null;
 
-                let commandSuccessful: boolean;
-                [content, commandSuccessful] = await runSlashCommand(
-                    MatrixClientPeg.safeGet(),
-                    cmd,
-                    args,
-                    this.props.room.roomId,
-                    threadId ?? null,
-                );
-                if (!commandSuccessful) {
-                    return; // errored
-                }
+                    let commandSuccessful: boolean;
+                    [content, commandSuccessful] = await runSlashCommand(
+                        MatrixClientPeg.safeGet(),
+                        cmd,
+                        args,
+                        this.props.room.roomId,
+                        threadId ?? null,
+                    );
+                    if (!commandSuccessful) {
+                        return; // errored
+                    }
 
-                if (
-                    content &&
-                    [CommandCategories.messages as string, CommandCategories.effects as string].includes(cmd.category)
-                ) {
-                    // Attach any mentions which might be contained in the command content.
-                    attachMentions(this.props.mxClient.getSafeUserId(), content, model, replyToEvent);
-                    attachRelation(content, this.props.relation);
-                    if (replyToEvent) {
-                        addReplyToMessageContent(content, replyToEvent);
+                    if (
+                        content &&
+                        [CommandCategories.messages as string, CommandCategories.effects as string].includes(
+                            cmd.category,
+                        )
+                    ) {
+                        // Attach any mentions which might be contained in the command content.
+                        attachMentions(this.props.mxClient.getSafeUserId(), content, model, replyToEvent);
+                        attachRelation(content, this.props.relation);
+                        if (replyToEvent) {
+                            addReplyToMessageContent(content, replyToEvent);
+                        }
+                    } else {
+                        shouldSend = false;
                     }
                 } else {
-                    shouldSend = false;
+                    const sendAnyway = await shouldSendAnyway(commandText);
+                    // re-focus the composer after QuestionDialog is closed
+                    dis.dispatch({
+                        action: Action.FocusAComposer,
+                        context: this.context.timelineRenderingType,
+                    });
+                    // if !sendAnyway bail to let the user edit the composer and try again
+                    if (!sendAnyway) return;
                 }
-            } else {
-                const sendAnyway = await shouldSendAnyway(commandText);
-                // re-focus the composer after QuestionDialog is closed
-                dis.dispatch({
-                    action: Action.FocusAComposer,
-                    context: this.context.timelineRenderingType,
-                });
-                // if !sendAnyway bail to let the user edit the composer and try again
-                if (!sendAnyway) return;
+            } finally {
+                this.runningSlashCommand = false;
             }
         }
 

--- a/apps/web/test/unit-tests/components/views/rooms/SendMessageComposer-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/SendMessageComposer-test.tsx
@@ -319,6 +319,23 @@ describe("<SendMessageComposer/>", () => {
             });
         });
 
+        it("only runs a slash command once when enter is pressed twice", async () => {
+            // Commands run against the client from the peg rather than the one passed as a prop.
+            const client = stubClient();
+            // Nothing resolves this, so the command is still running when the second enter arrives.
+            mocked(client.setRoomTopic).mockReturnValue(new Promise<never>(() => {}));
+
+            mockPlatformPeg({ overrideBrowserShortcuts: jest.fn().mockReturnValue(false) });
+            const { container } = getComponent();
+
+            addTextToComposer(container, "/topic Nice topic");
+            const composer = container.querySelector(".mx_SendMessageComposer")!;
+            fireEvent.keyDown(composer, { key: "Enter" });
+            fireEvent.keyDown(composer, { key: "Enter" });
+
+            await waitFor(() => expect(client.setRoomTopic).toHaveBeenCalledTimes(1));
+        });
+
         it("correctly sends a reply using a slash command", async () => {
             stubClient();
             mocked(doMaybeLocalRoomAction).mockImplementation(


### PR DESCRIPTION
`sendMessage` has no re-entrancy guard, and `onKeyDown` calls it on every send keybinding. For an
ordinary message that is harmless, because the composer is cleared *before* the send is awaited —
"clear composer first so the user doesn't actually see the delay" — so a second enter finds
`model.isEmpty` and returns.

A slash command is the other way round: `runSlashCommand` is awaited while the composer still holds
the text, and nothing is cleared until it resolves. A second enter during that window re-enters
`sendMessage` with the same model and runs the command again, so a slow `/topic` sets the topic
twice and the room shows two topic changes.

The composer now ignores a send while one of its own commands is still running. The flag is released
in a `finally`, so the paths that bail out early — a command that errored, an unrecognised command
the user chose not to send as a message, or anything that throws — all leave the composer usable.

Deliberately scoped to the command path: sending a message never waits, and holding a guard across
it would swallow the next message on a slow connection.

Fixes #29095

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
