### PR TITLE
Point at the message search setting instead of the desktop app

### DIFF
--- a/apps/web/src/components/views/elements/SearchWarning.tsx
+++ b/apps/web/src/components/views/elements/SearchWarning.tsx
@@ -181,6 +181,37 @@ export default function SearchWarning({ isRoomEncrypted, kind, showLogo = true, 
         );
     }
 
+    // Seshat is right here and the user has only turned message search off, so sending them to the
+    // desktop app they are already running would be no help at all.
+    if (EventIndexPeg.supportIsInstalled()) {
+        return (
+            <div className="mx_SearchWarning">
+                {_t(
+                    kind === WarningKind.Files
+                        ? "seshat|warning_kind_files_disabled"
+                        : "seshat|warning_kind_search_disabled",
+                    {},
+                    {
+                        a: (sub) => (
+                            <AccessibleButton
+                                kind="link_inline"
+                                onClick={(evt: ButtonEvent) => {
+                                    evt.preventDefault();
+                                    dis.dispatch({
+                                        action: Action.ViewUserSettings,
+                                        initialTabId: UserTab.Security,
+                                    });
+                                }}
+                            >
+                                {sub}
+                            </AccessibleButton>
+                        ),
+                    },
+                )}
+            </div>
+        );
+    }
+
     const brand = SdkConfig.get("brand");
     const desktopBuilds = SdkConfig.getObject("desktop_builds");
 

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -2431,8 +2431,10 @@
         "reset_title": "Reset event store?",
         "warning_kind_files": "This version of %(brand)s does not support viewing some encrypted files",
         "warning_kind_files_app": "Use the <a>Desktop app</a> to see all encrypted files",
+        "warning_kind_files_disabled": "Turn on <a>message search</a> to see all encrypted files",
         "warning_kind_search": "This version of %(brand)s does not support searching encrypted messages",
         "warning_kind_search_app": "Use the <a>Desktop app</a> to search encrypted messages",
+        "warning_kind_search_disabled": "Turn on <a>message search</a> to search encrypted messages",
         "warning_kind_search_partial": "Results may be incomplete because your search index is still being built."
     },
     "setting": {

--- a/apps/web/test/unit-tests/components/views/elements/SearchWarning-test.tsx
+++ b/apps/web/test/unit-tests/components/views/elements/SearchWarning-test.tsx
@@ -105,6 +105,34 @@ describe("<SearchWarning />", () => {
         });
     });
 
+    describe("with seshat installed but message search turned off", () => {
+        beforeEach(() => {
+            EventIndexPeg.index = null;
+            jest.spyOn(EventIndexPeg, "supportIsInstalled").mockReturnValue(true);
+            // Available by default, and the very config that produced the wrong advice on desktop.
+            SdkConfig.put({
+                brand: "Element",
+                desktop_builds: { available: true, logo: "https://logo", url: "https://url" },
+            });
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it("points at the setting rather than the desktop app when searching", () => {
+            const { container } = render(<SearchWarning isRoomEncrypted={true} kind={WarningKind.Search} />);
+
+            expect(container.textContent).toEqual("Turn on message search to search encrypted messages");
+        });
+
+        it("points at the setting rather than the desktop app for files", () => {
+            const { container } = render(<SearchWarning isRoomEncrypted={true} kind={WarningKind.Files} />);
+
+            expect(container.textContent).toEqual("Turn on message search to see all encrypted files");
+        });
+    });
+
     describe("with the event index present", () => {
         const setIndex = (index: FakeEventIndex): void => {
             EventIndexPeg.index = index as unknown as EventIndex;


### PR DESCRIPTION
`SearchWarning` has four states for an encrypted room with no event index: the index is still being
built, it failed to initialise, this build cannot search, or `desktop_builds.available` is set and
the user is told to use the desktop app. There is no state for "you are on the desktop app, seshat
is installed, and you have turned message search off" — and `desktop_builds.available` defaults to
true, so that case fell into the last branch and told the user to use the app they were already
running. `FilePanel` renders the same component, so it offered the desktop app for encrypted files
in the same situation.

Seshat being installed is what distinguishes it, and `EventIndexPeg` already knows: `init()` records
`supportIsInstalled()` *before* it reads `enableEventIndexing`, so the flag stays true when the user
has turned indexing off. That case now offers to take them to the setting, reusing the route into
Security settings that the initialisation-failure branch above it already uses, and covering both
warning kinds so the file panel is fixed with it.

A browser has no indexing support at all, so `supportIsInstalled()` stays false there and the
existing advice is untouched.

Fixes #32132

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
