### PR TITLE
Stay in the space when previewing a room it offered

### DIFF
--- a/apps/web/src/stores/spaces/SpaceStore.test.ts
+++ b/apps/web/src/stores/spaces/SpaceStore.test.ts
@@ -70,6 +70,8 @@ const room1 = "!room1:server";
 const room2 = "!room2:server";
 const room3 = "!room3:server";
 const room4 = "!room4:server";
+/** Listed by space1 but never joined, as a room being previewed from the space's hierarchy is. */
+const previewRoom = "!preview:server";
 const videoRoomPrivate = "!videoRoomPrivate:server";
 const videoRoomPublic = "!videoRoomPublic:server";
 const space1 = "!space1:server";
@@ -1095,7 +1097,7 @@ describe("SpaceStore", () => {
     describe("space auto switching tests", () => {
         beforeEach(async () => {
             [room1, room2, room3, orphan1].forEach(mkRoom);
-            mkSpace(space1, [room1, room2, room3]);
+            mkSpace(space1, [room1, room2, room3, previewRoom]);
             mkSpace(space2, [room1, room2]);
 
             const cliRoom2 = client.getRoom(room2)!;
@@ -1133,6 +1135,14 @@ describe("SpaceStore", () => {
             viewRoom(room2);
             store.setActiveSpace(space2, false);
             viewRoom(room3);
+            expect(store.activeSpace).toBe(space1);
+        });
+
+        it("stays put when previewing a room the space lists but we have not joined", async () => {
+            viewRoom(room1);
+            store.setActiveSpace(space1, false);
+            // space1 lists this room, but it was never joined, so it is not one of the space's rooms.
+            viewRoom(previewRoom);
             expect(store.activeSpace).toBe(space1);
         });
 

--- a/apps/web/src/stores/spaces/SpaceStore.ts
+++ b/apps/web/src/stores/spaces/SpaceStore.ts
@@ -877,8 +877,32 @@ export default class SpaceStore extends AsyncStoreWithClient<EmptyObject> {
         }
     };
 
+    /**
+     * Whether the active space lists the given room as one of its children, joined or not.
+     *
+     * {@link getChildren} keeps only the children we are a member of, so a room being previewed from
+     * the space it was found in does not count as being in that space, even though the space says it
+     * is.
+     *
+     * @param roomId - The room being viewed.
+     * @returns True if the active space declares this room as a child.
+     */
+    private isChildOfActiveSpace(roomId: string): boolean {
+        if (isMetaSpace(this.activeSpace)) return false;
+        const child = this.matrixClient
+            ?.getRoom(this.activeSpace)
+            ?.currentState.getStateEvents(EventType.SpaceChild, roomId);
+        // Same test {@link getChildren} makes of a child event: a removed child has no via at all.
+        return !!child?.getContent().via;
+    }
+
     private switchToRelatedSpace = (roomId: string): void => {
         if (this.suggestedRooms.find((r) => r.room_id === roomId)) return;
+
+        // Previewing a room from the space that offered it should leave the user where they are, the
+        // same as it does for a suggested room. Without this the room belongs to no space we know of
+        // and they are taken to Home for looking.
+        if (this.isChildOfActiveSpace(roomId)) return;
 
         // try to find the canonical parent first
         let parent: SpaceKey | undefined = this.getCanonicalParent(roomId)?.roomId;


### PR DESCRIPTION
Previewing a room from a space's directory that you have not joined switches you to the Home
metaspace, so exploring a space throws you out of it.

`switchSpaceIfNeeded` asks `isRoomInSpace`, which is answered from the space's flattened room set,
and that set comes from `getChildren` — which keeps only the children you are a member of. A room
being previewed is not one, so `switchToRelatedSpace` runs and works through its options: the room
has no `m.space.parent` (child rooms normally carry none, and you have not joined it to read its
state anyway), no root space contains it for the same membership reason, and no metaspace claims it
— so it falls through to `goToFirstSpace()` and lands on Home.

Suggested rooms already have an exception for exactly this, added when the sibling issue was fixed.
This extends the same reasoning to any room the active space lists as a child, joined or not: the
space having offered the room is reason enough to leave the user where they are. Rooms reached from
anywhere else still switch to whichever space holds them.

The child test matches the one `getChildren` makes, so a child that has been removed — its `via`
gone — does not count.

Fixes #26026

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
