### PR TITLE
Answer the authentication challenge some homeservers send when changing a password

### DIFF
--- a/apps/web/src/components/views/settings/ChangePassword.tsx
+++ b/apps/web/src/components/views/settings/ChangePassword.tsx
@@ -7,7 +7,8 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import React from "react";
-import { type MatrixClient } from "matrix-js-sdk/src/matrix";
+import { type MatrixClient, MatrixError } from "matrix-js-sdk/src/matrix";
+import { AuthType, type IAuthData } from "matrix-js-sdk/src/interactive-auth";
 
 import Field from "../elements/Field";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
@@ -50,6 +51,20 @@ interface IState {
     oldPassword: string;
     newPassword: string;
     newPasswordConfirm: string;
+}
+
+/**
+ * Whether the given error is a user-interactive authentication challenge which the current password
+ * on its own is enough to answer.
+ *
+ * @param err - The error the homeserver rejected the request with.
+ * @returns True if the challenge carries a session and offers a flow of nothing but a password stage.
+ */
+function isPasswordOnlyChallenge(err: unknown): err is MatrixError {
+    if (!(err instanceof MatrixError) || err.httpStatus !== 401) return false;
+    const challenge = err.data as IAuthData;
+    if (typeof challenge.session !== "string") return false;
+    return !!challenge.flows?.some((flow) => flow.stages.length === 1 && flow.stages[0] === AuthType.Password);
 }
 
 export default class ChangePassword extends React.Component<IProps, IState> {
@@ -95,6 +110,16 @@ export default class ChangePassword extends React.Component<IProps, IState> {
         });
 
         cli.setPassword(authDict, newPassword, false)
+            .catch((err) => {
+                // The spec has the client open a session with an unauthenticated request and answer the
+                // challenge in a second one. Sending the credentials straight away saves a round trip and
+                // is what most homeservers accept, but a homeserver is free to ignore an auth object which
+                // carries no session and reply with a challenge of its own. We are still holding the
+                // password at that point, so answer the challenge rather than leaving the user looking at
+                // a bare 401. Anything else the server might ask for we genuinely cannot supply here.
+                if (!isPasswordOnlyChallenge(err)) throw err;
+                return cli.setPassword({ ...authDict, session: err.data.session }, newPassword, false);
+            })
             .then(
                 () => {
                     if (this.props.shouldAskForEmail) {

--- a/apps/web/test/unit-tests/components/views/settings/ChangePassword-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/ChangePassword-test.tsx
@@ -10,6 +10,7 @@ import React from "react";
 import { render, screen, waitFor } from "jest-matrix-react";
 import userEvent from "@testing-library/user-event";
 import { mocked } from "jest-mock";
+import { MatrixError } from "matrix-js-sdk/src/matrix";
 
 import ChangePassword from "../../../../../src/components/views/settings/ChangePassword";
 import { stubClient } from "../../../../test-utils";
@@ -51,23 +52,25 @@ describe("<ChangePassword />", () => {
         await expect(screen.findByText("Passwords don't match")).resolves.toBeInTheDocument();
     });
 
-    it("should call MatrixClient::setPassword with expected parameters", async () => {
-        const cli = stubClient();
-        mocked(cli.setPassword).mockResolvedValue({});
-
+    /** Fill in a valid password change and submit it, returning the callbacks the form was given. */
+    async function submitPasswordChange(): Promise<{ onFinished: jest.Mock; onError: jest.Mock }> {
         const onFinished = jest.fn();
         const onError = jest.fn();
         const { getByLabelText, getByText } = render(<ChangePassword onFinished={onFinished} onError={onError} />);
 
-        const currentPasswordField = getByLabelText("Current password");
-        await userEvent.type(currentPasswordField, "CurrentPassword1234");
-
-        const newPasswordField = getByLabelText("New Password");
-        await userEvent.type(newPasswordField, "$%newPassword1234");
-        const confirmPasswordField = getByLabelText("Confirm password");
-        await userEvent.type(confirmPasswordField, "$%newPassword1234");
-
+        await userEvent.type(getByLabelText("Current password"), "CurrentPassword1234");
+        await userEvent.type(getByLabelText("New Password"), "$%newPassword1234");
+        await userEvent.type(getByLabelText("Confirm password"), "$%newPassword1234");
         await userEvent.click(getByText("Change Password"));
+
+        return { onFinished, onError };
+    }
+
+    it("should call MatrixClient::setPassword with expected parameters", async () => {
+        const cli = stubClient();
+        mocked(cli.setPassword).mockResolvedValue({});
+
+        const { onFinished } = await submitPasswordChange();
 
         await waitFor(() => {
             expect(cli.setPassword).toHaveBeenCalledWith(
@@ -84,5 +87,40 @@ describe("<ChangePassword />", () => {
             );
         });
         expect(onFinished).toHaveBeenCalled();
+    });
+
+    it("changes the password when the server answers with a password challenge", async () => {
+        const cli = stubClient();
+        // A homeserver which ignores an auth object with no session and starts a fresh flow instead.
+        mocked(cli.setPassword)
+            .mockRejectedValueOnce(
+                new MatrixError(
+                    { session: "sessionId", flows: [{ stages: ["m.login.password"] }], completed: [] },
+                    401,
+                ),
+            )
+            .mockResolvedValueOnce({});
+
+        const { onFinished, onError } = await submitPasswordChange();
+
+        await waitFor(() => expect(onFinished).toHaveBeenCalled());
+        expect(cli.setPassword).toHaveBeenLastCalledWith(
+            expect.objectContaining({ session: "sessionId", password: "CurrentPassword1234" }),
+            "$%newPassword1234",
+            false,
+        );
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("reports a challenge the current password cannot answer", async () => {
+        const cli = stubClient();
+        const error = new MatrixError({ session: "sessionId", flows: [{ stages: ["m.login.sso"] }] }, 401);
+        mocked(cli.setPassword).mockRejectedValue(error);
+
+        const { onFinished, onError } = await submitPasswordChange();
+
+        await waitFor(() => expect(onError).toHaveBeenCalledWith(error));
+        expect(cli.setPassword).toHaveBeenCalledTimes(1);
+        expect(onFinished).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Changing a password sends the current one and the new one together in a single request, with an
`auth` object that carries no session. The spec has the client open a user-interactive authentication
session with an unauthenticated request first and answer the challenge in a second one, so a
homeserver is entitled to ignore that auth object and reply with a challenge of its own. Element
treated the reply as a failure and put a raw `MatrixError: [401] Unknown message` in front of the
user, who was then unable to change their password at all.

The single request stays. It is one round trip rather than two, and every homeserver which accepts it
carries on exactly as before. What changes is the failure path: a 401 which offers a flow of nothing
but a password stage is now answered with the same credentials plus the session the server has just
handed out, which is the second half of the flow the spec describes.

A challenge asking for anything else — SSO, a registration token, a second stage — is still reported
rather than retried, because the password on its own genuinely cannot satisfy it and guessing at a
retry would only hide the real reason. Wiring the full interactive-auth dialog in behind this form is
a larger change and is deliberately left out.

Fixes #33179

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)