### PR TITLE
Stop offering a replaced room as somewhere to forward a message

### DIFF
--- a/apps/web/src/components/views/dialogs/ForwardDialog.tsx
+++ b/apps/web/src/components/views/dialogs/ForwardDialog.tsx
@@ -123,6 +123,12 @@ const Entry: React.FC<IEntryProps<any>> = ({ room, type, content, matrixClient: 
         if (!room.maySendMessage()) {
             disabled = true;
             title = _t("forward|no_perms_title");
+        } else if (room.currentState.getStateEvents(EventType.RoomTombstone, "")) {
+            // A tombstone leaves the power levels alone, so a superseded room still says we may send
+            // to it. The composer hides itself for exactly this reason, and forwarding was the one
+            // way left to post into a room the app otherwise treats as closed.
+            disabled = true;
+            title = _t("composer|room_upgraded_notice");
         }
     } else if (sendState === SendState.Sending) {
         className = "mx_ForwardList_sending";

--- a/apps/web/test/unit-tests/components/views/dialogs/ForwardDialog-test.tsx
+++ b/apps/web/test/unit-tests/components/views/dialogs/ForwardDialog-test.tsx
@@ -257,6 +257,32 @@ describe("ForwardDialog", () => {
         expect(secondButton.getAttribute("aria-disabled")).toBeFalsy();
     });
 
+    it("disables buttons for rooms which have been replaced", async () => {
+        const supersededRoom = mkStubRoom("a", "a", mockClient);
+        // A tombstone does not change the power levels, so the room still says we may send to it.
+        supersededRoom.currentState.getStateEvents = jest.fn((type, key) =>
+            type === EventType.RoomTombstone && key === ""
+                ? mkEvent({
+                      event: true,
+                      type: EventType.RoomTombstone,
+                      room: "a",
+                      user: aliceId,
+                      skey: "",
+                      content: { body: "This room has been replaced", replacement_room: "!b:example.org" },
+                  })
+                : null,
+        ) as unknown as typeof supersededRoom.currentState.getStateEvents;
+        const rooms = [supersededRoom, mkStubRoom("b", "b", mockClient)];
+
+        const { container } = mountForwardDialog(undefined, rooms);
+
+        const [firstButton, secondButton] = container.querySelectorAll<HTMLButtonElement>(".mx_ForwardList_sendButton");
+
+        expect(firstButton).toHaveAttribute("aria-disabled", "true");
+        expect(firstButton).toHaveAttribute("aria-label", "This room has been replaced and is no longer active.");
+        expect(secondButton).not.toHaveAttribute("aria-disabled");
+    });
+
     describe("Mention recalculation", () => {
         const roomId = "a";
         const sendClick = (container: HTMLElement): void =>


### PR DESCRIPTION
A tombstone does not touch the room's power levels, so `Room.maySendMessage()` still answers yes for a
room which has been replaced, and the forward dialog offered it like any other. Everywhere else in the
app treats such a room as closed — the composer takes itself away and shows "This room has been
replaced and is no longer active." — which left forwarding as the only remaining way to post into a
room nobody is reading, exactly as reported in #29244.

The send button is now disabled for a room carrying an `m.room.tombstone`, labelled with the same
sentence the composer uses, so the reason given is one the user has already met. The power-level check
next to it is unchanged; this is a second condition rather than a replacement, because the two refuse
for different reasons and deserve different wording.

The room is deliberately left in the list rather than filtered out of it: it is still worth being able
to open it from here, and a room disappearing from the forward list with no explanation is harder to
understand than a disabled button which says why.

Fixes #29244

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)