### PR TITLE
Enlarge an emoji-only message which arrives wrapped in HTML

### DIFF
--- a/apps/web/src/HtmlUtils.tsx
+++ b/apps/web/src/HtmlUtils.tsx
@@ -423,7 +423,10 @@ export function bodyToNode(content: IContent, highlights?: string[], opts: Event
 
     let emojiBody = false;
     if (!opts.disableBigEmoji && eventInfo.bodyHasEmoji) {
-        const contentBody = eventInfo.safeBody ?? eventInfo.strippedBody;
+        // Look at the text the message renders as rather than the markup carrying it. A message
+        // bridged in from elsewhere, or sent with /html, arrives wrapped in a paragraph or a span,
+        // and those tags alone were enough to stop it counting as a message of nothing but emoji.
+        const contentBody = eventInfo.safeBody !== undefined ? getHtmlText(eventInfo.safeBody) : eventInfo.strippedBody;
         let contentBodyTrimmed = contentBody !== undefined ? contentBody.trim() : "";
 
         // Remove zero width joiner, zero width spaces and other spaces in body

--- a/apps/web/test/unit-tests/HtmlUtils-test.tsx
+++ b/apps/web/test/unit-tests/HtmlUtils-test.tsx
@@ -257,6 +257,29 @@ describe("bodyToNode", () => {
         expect(asFragment()).toMatchSnapshot();
     });
 
+    it("should generate big emoji for an emoji-only message wrapped in HTML", () => {
+        const { className } = bodyToNode({
+            body: "🥰",
+            format: "org.matrix.custom.html",
+            // What a bridge, or /html, sends for a message with nothing in it but an emoji.
+            formatted_body: "<p>🥰</p>",
+            msgtype: "m.text",
+        });
+
+        expect(className).toContain("mx_EventTile_bigEmoji");
+    });
+
+    it("should not generate big emoji for a pill named with an emoji", () => {
+        const { className } = bodyToNode({
+            body: "Yay",
+            format: "org.matrix.custom.html",
+            formatted_body: '<a href="https://matrix.to/#/@yay:example.org">🥰</a>',
+            msgtype: "m.text",
+        });
+
+        expect(className).not.toContain("mx_EventTile_bigEmoji");
+    });
+
     it("should generate big emoji for an emoji-only reply to a message", () => {
         const { className, formattedBody } = bodyToNode(
             {


### PR DESCRIPTION
Whether a message counts as nothing but emoji is decided by matching `BIGEMOJI_REGEX` against the
sanitised HTML rather than against the text that HTML renders as. A single emoji inside a paragraph —
which is how a bridge, or `/html`, sends one — fails the match on its own tags and stays at reading
size, which is what #22009 shows. In practice only a message with no formatted body at all, or one
whose formatted body happened to be bare text, was ever enlarged.

The match now runs over the text of the sanitised HTML, via the `getHtmlText` helper already in this
file. `<p>🥰</p>`, `<em>🥰</em>` and `<span data-mx-color="#f00">🥰</span>` are all enlarged now, and
anything whose rendered text is not purely emoji still is not.

The guard which stops a pill being enlarged is untouched, and still works for the reason it always
did: a pill's text may well be only emoji, but its formatted body carries the permalink and is caught
by the check for `http:`/`https:`. There is a test for that alongside the new one so the two stay
honest about each other.

Fixes #22009

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)