### PR TITLE
Keep hiding the membership changes you asked to hide when showing hidden events

### DIFF
--- a/apps/web/src/components/structures/MessagePanel.tsx
+++ b/apps/web/src/components/structures/MessagePanel.tsx
@@ -25,7 +25,7 @@ import {
     useCreateAutoDisposedViewModel,
 } from "@element-hq/web-shared-components";
 
-import shouldHideEvent from "../../shouldHideEvent";
+import shouldHideEvent, { isHiddenMemberEvent } from "../../shouldHideEvent";
 import { formatDate, wantsDateSeparator } from "../../DateUtils";
 import { MatrixClientPeg } from "../../MatrixClientPeg";
 import SettingsStore from "../../settings/SettingsStore";
@@ -496,7 +496,10 @@ export default class MessagePanel extends React.Component<IProps, IState> {
         }
 
         if (this.showHiddenEvents && !forceHideEvents) {
-            return true;
+            // Showing hidden events is about events with no tile of their own, not about the
+            // membership changes somebody has turned off in preferences. Turning it on used to
+            // bring those back too, quietly undoing a setting made somewhere else entirely.
+            return !isHiddenMemberEvent(mxEv, this.context);
         }
 
         if (!haveRendererForEvent(mxEv, MatrixClientPeg.safeGet(), this.showHiddenEvents)) {

--- a/apps/web/src/shouldHideEvent.ts
+++ b/apps/web/src/shouldHideEvent.ts
@@ -44,6 +44,35 @@ function memberEventDiff(ev: MatrixEvent): IDiff {
 }
 
 /**
+ * Determines whether the given event is a membership change the user has asked not to see.
+ *
+ * This is kept apart from {@link shouldHideEvent} so that the timeline can honour these three
+ * preferences even while hidden events are being shown. That setting is about events which have no
+ * tile of their own, not about membership changes somebody has deliberately turned off.
+ *
+ * @param ev - The event to test.
+ * @param ctx - An optional RoomContext to pull cached settings values from to avoid hitting the
+ *     settings store.
+ * @returns True if the event is a join, leave, avatar or display name change the user has hidden.
+ */
+export function isHiddenMemberEvent(ev: MatrixEvent, ctx?: IRoomState): boolean {
+    const eventDiff = memberEventDiff(ev);
+    if (!eventDiff.isMemberEvent) return false;
+
+    // Accessing the settings store directly can be expensive if done frequently,
+    // so we should prefer using cached values if a RoomContext is available
+    const isEnabled = ctx
+        ? (name: keyof IRoomState) => ctx[name]
+        : (name: SettingKey) => SettingsStore.getValue(name, ev.getRoomId());
+
+    if ((eventDiff.isJoin || eventDiff.isPart) && !isEnabled("showJoinLeaves")) return true;
+    if (eventDiff.isAvatarChange && !isEnabled("showAvatarChanges")) return true;
+    if (eventDiff.isDisplaynameChange && !isEnabled("showDisplaynameChanges")) return true;
+
+    return false;
+}
+
+/**
  * Determines whether the given event should be hidden from timelines.
  * @param ev The event
  * @param ctx An optional RoomContext to pull cached settings values from to avoid
@@ -67,13 +96,5 @@ export default function shouldHideEvent(ev: MatrixEvent, ctx?: IRoomState): bool
     // Hide replacement events since they update the original tile (if enabled)
     if (ev.isRelation(RelationType.Replace)) return true;
 
-    const eventDiff = memberEventDiff(ev);
-
-    if (eventDiff.isMemberEvent) {
-        if ((eventDiff.isJoin || eventDiff.isPart) && !isEnabled("showJoinLeaves")) return true;
-        if (eventDiff.isAvatarChange && !isEnabled("showAvatarChanges")) return true;
-        if (eventDiff.isDisplaynameChange && !isEnabled("showDisplaynameChanges")) return true;
-    }
-
-    return false;
+    return isHiddenMemberEvent(ev, ctx);
 }

--- a/apps/web/test/unit-tests/components/structures/MessagePanel-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/MessagePanel-test.tsx
@@ -691,6 +691,33 @@ describe("MessagePanel", function () {
         expect(els[0].getAttribute("data-scroll-tokens")?.split(",")).toHaveLength(3);
     });
 
+    it.each([[true], [false]])(
+        "should hide a display name change the user has turned off, with hidden events shown: %s",
+        (showHiddenEvents) => {
+            const events = [
+                TestUtilsMatrix.mkEvent({
+                    event: true,
+                    type: "m.room.member",
+                    room: "!room:id",
+                    user: "@user:id",
+                    skey: "@user:id",
+                    content: { membership: KnownMembership.Join, displayname: "New name" },
+                    prev_content: { membership: KnownMembership.Join, displayname: "Old name" },
+                    ts: 1,
+                }),
+            ];
+
+            const { container } = render(
+                getComponent({ events }, { showHiddenEvents, showDisplaynameChanges: false }),
+                clientAndSDKContextRenderOptions(client, sdkContext),
+            );
+
+            // Showing hidden events is about events with no tile of their own; it is not a way to
+            // undo a preference set elsewhere in the settings.
+            expect(container.getElementsByClassName("mx_EventTile")).toHaveLength(0);
+        },
+    );
+
     it("should handle large numbers of hidden events quickly", () => {
         // Increase the length of the loop here to test performance issues with
         // rendering


### PR DESCRIPTION
Turning on "Show hidden events in timeline" makes `shouldShowEvent` return true for everything it is
handed, which sweeps up the join, leave, avatar and display name changes that were switched off in
preferences. Somebody who had opted out of those and then went looking for state events gets the noise
back, with nothing to say why and no way to have one without the other — which is what #29245 reports.

The two settings are about different things. Hidden events are the ones with no tile of their own; the
membership settings are a deliberate choice about events which do have one, made in another part of
the settings entirely. The membership half of `shouldHideEvent` is now `isHiddenMemberEvent`, so the
timeline can keep honouring it while hidden events are being shown. `shouldHideEvent` itself is
unchanged in behaviour and simply calls the new function.

Everything else that "show hidden events" reveals is untouched: redactions, replacements, poll ends
and events with no renderer all still appear. The other half of the issue — wanting to see hidden
events *other than* membership changes — is what this gives you, since the membership filters now
apply on top rather than being overridden.

Fixes #29245

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)