### PR TITLE
Move through spotlight results a page at a time with page up and down

### DIFF
--- a/apps/web/src/accessibility/KeyboardShortcuts.ts
+++ b/apps/web/src/accessibility/KeyboardShortcuts.ts
@@ -141,6 +141,8 @@ export enum KeyBindingAction {
     Delete = "KeyBinding.delete",
     Home = "KeyBinding.home",
     End = "KeyBinding.end",
+    PageUp = "KeyBinding.pageUp",
+    PageDown = "KeyBinding.pageDown",
     ArrowLeft = "KeyBinding.arrowLeft",
     ArrowUp = "KeyBinding.arrowUp",
     ArrowRight = "KeyBinding.arrowRight",
@@ -266,6 +268,8 @@ export const CATEGORIES: Record<CategoryName, ICategory> = {
             KeyBindingAction.Delete,
             KeyBindingAction.Home,
             KeyBindingAction.End,
+            KeyBindingAction.PageUp,
+            KeyBindingAction.PageDown,
             KeyBindingAction.ArrowLeft,
             KeyBindingAction.ArrowUp,
             KeyBindingAction.ArrowRight,
@@ -696,6 +700,16 @@ export const KEYBOARD_SHORTCUTS: IKeyboardShortcuts = {
     [KeyBindingAction.End]: {
         default: {
             key: Key.END,
+        },
+    },
+    [KeyBindingAction.PageUp]: {
+        default: {
+            key: Key.PAGE_UP,
+        },
+    },
+    [KeyBindingAction.PageDown]: {
+        default: {
+            key: Key.PAGE_DOWN,
         },
     },
     [KeyBindingAction.ArrowLeft]: {

--- a/apps/web/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
+++ b/apps/web/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
@@ -107,6 +107,24 @@ interface IProps {
     onFinished(this: void): void;
 }
 
+/**
+ * How many results a page up or down should move by, worked out from how many results of the size of
+ * the current one fit in the visible list.
+ *
+ * Results differ in height — a public room with its details is taller than a person — so this measures
+ * the one the selection is on rather than assuming an average, and falls back to a single step while
+ * nothing has been laid out.
+ *
+ * @param container - The scrolling list of results.
+ * @param result - The result the selection is currently on.
+ * @returns How many results to move by, never fewer than one.
+ */
+function resultsPerPage(container: HTMLElement | null, result: HTMLElement): number {
+    const resultHeight = result.offsetHeight;
+    if (!container || !resultHeight) return 1;
+    return Math.max(1, Math.floor(container.clientHeight / resultHeight));
+}
+
 function nodeIsForRecentlyViewed(node?: HTMLElement): boolean {
     return node?.id?.startsWith("mx_SpotlightDialog_button_recentlyViewed_") === true;
 }
@@ -1145,6 +1163,26 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
         );
     }
 
+    /**
+     * The options the up and down keys move between. Everything is a stop, except that the recently
+     * viewed row counts as a single one until the selection is actually inside it.
+     *
+     * @param activeNode - The option the selection is currently on.
+     * @returns The options to move between, in the order they appear.
+     */
+    const verticalNodes = (activeNode: HTMLElement): HTMLElement[] => {
+        const nodes = rovingContext.state.nodes;
+        if (query || filter !== null) return nodes;
+
+        // If the current selection is not in the recently viewed row then only include the
+        // first recently viewed so that is the target when the user is switching into recently viewed.
+        const keptRecentlyViewedRef = nodeIsForRecentlyViewed(activeNode)
+            ? activeNode
+            : nodes.find(nodeIsForRecentlyViewed);
+        // exclude all other recently viewed items from the list so up/down arrows skip them
+        return nodes.filter((ref) => ref === keptRecentlyViewedRef || !nodeIsForRecentlyViewed(ref));
+    };
+
     const onDialogKeyDown = (ev: KeyboardEvent | React.KeyboardEvent): void => {
         const navigationAction = getKeyBindingsManager().getNavigationAction(ev);
         switch (navigationAction) {
@@ -1169,22 +1207,31 @@ const SpotlightDialog: React.FC<IProps> = ({ initialText = "", initialFilter = n
                 ev.preventDefault();
 
                 if (rovingContext.state.activeNode && rovingContext.state.nodes.length > 0) {
-                    let nodes = rovingContext.state.nodes;
-                    if (!query && filter === null) {
-                        // If the current selection is not in the recently viewed row then only include the
-                        // first recently viewed so that is the target when the user is switching into recently viewed.
-                        const keptRecentlyViewedRef = nodeIsForRecentlyViewed(rovingContext.state.activeNode)
-                            ? rovingContext.state.activeNode
-                            : nodes.find(nodeIsForRecentlyViewed);
-                        // exclude all other recently viewed items from the list so up/down arrows skip them
-                        nodes = nodes.filter((ref) => ref === keptRecentlyViewedRef || !nodeIsForRecentlyViewed(ref));
-                    }
-
+                    const nodes = verticalNodes(rovingContext.state.activeNode);
                     const idx = nodes.indexOf(rovingContext.state.activeNode);
                     node = findNextSiblingElement(
                         nodes,
                         idx + (accessibilityAction === KeyBindingAction.ArrowUp ? -1 : 1),
                     );
+                }
+                break;
+
+            case KeyBindingAction.PageUp:
+            case KeyBindingAction.PageDown:
+                ev.stopPropagation();
+                ev.preventDefault();
+
+                if (rovingContext.state.activeNode && rovingContext.state.nodes.length > 0) {
+                    const nodes = verticalNodes(rovingContext.state.activeNode);
+                    const idx = nodes.indexOf(rovingContext.state.activeNode);
+                    const page = resultsPerPage(scrollContainerRef.current, rovingContext.state.activeNode);
+                    // Clamped to the ends, so a page which overshoots still lands on the last result
+                    // rather than on nothing at all.
+                    const target =
+                        accessibilityAction === KeyBindingAction.PageUp
+                            ? Math.max(0, idx - page)
+                            : Math.min(nodes.length - 1, idx + page);
+                    node = findNextSiblingElement(nodes, target);
                 }
                 break;
 

--- a/apps/web/test/unit-tests/components/views/dialogs/SpotlightDialog-test.tsx
+++ b/apps/web/test/unit-tests/components/views/dialogs/SpotlightDialog-test.tsx
@@ -702,6 +702,66 @@ describe("Spotlight Dialog", () => {
         });
     });
 
+    describe("page up and down", () => {
+        beforeAll(() => {
+            // jsdom lays nothing out, and the roving index passes over any node whose offsetParent
+            // is null, so without this every result looks hidden and nothing moves at all.
+            Object.defineProperty(HTMLElement.prototype, "offsetParent", {
+                configurable: true,
+                get() {
+                    return this.parentElement;
+                },
+            });
+        });
+
+        afterAll(() => {
+            Reflect.deleteProperty(HTMLElement.prototype, "offsetParent");
+        });
+
+        it("should move the selection by a page of results", async () => {
+            const rooms = Array.from({ length: 12 }, (_, i) => mkRoom(mockedClient, `!spotlight${i}:example.com`));
+            mocked(mockedClient.getVisibleRooms).mockReturnValue(rooms);
+            // Five results of this height fit in a list this tall.
+            jest.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(40);
+            jest.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(200);
+
+            const { container } = render(<SpotlightDialog initialText="spotlight" onFinished={() => null} />);
+            jest.advanceTimersByTime(200);
+            await flushPromisesWithFakeTimers();
+
+            const selectedIndex = (): number =>
+                Array.from(container.querySelectorAll("li.mx_SpotlightDialog_option")).findIndex(
+                    (option) => option.getAttribute("aria-selected") === "true",
+                );
+            const dialog = container.querySelector(".mx_SpotlightDialog")!;
+
+            expect(selectedIndex()).toBe(0);
+
+            fireEvent.keyDown(dialog, { key: "PageDown" });
+            expect(selectedIndex()).toBe(5);
+
+            fireEvent.keyDown(dialog, { key: "PageUp" });
+            expect(selectedIndex()).toBe(0);
+        });
+
+        it("should stop at the last result rather than moving nowhere", async () => {
+            const rooms = Array.from({ length: 3 }, (_, i) => mkRoom(mockedClient, `!spotlight${i}:example.com`));
+            mocked(mockedClient.getVisibleRooms).mockReturnValue(rooms);
+            // A list far taller than it has results to put in it, so one page overshoots the end.
+            jest.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(40);
+            jest.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(4000);
+
+            const { container } = render(<SpotlightDialog initialText="spotlight" onFinished={() => null} />);
+            jest.advanceTimersByTime(200);
+            await flushPromisesWithFakeTimers();
+
+            const options = container.querySelectorAll("li.mx_SpotlightDialog_option");
+            fireEvent.keyDown(container.querySelector(".mx_SpotlightDialog")!, { key: "PageDown" });
+
+            expect(options[options.length - 1]).toHaveAttribute("aria-selected", "true");
+        });
+    });
+
     describe("metaspaces", () => {
         beforeEach(() => {
             jest.spyOn(SDKContextClass.instance.spaceStore, "enabledMetaSpaces", "get").mockReturnValue([


### PR DESCRIPTION
Reaching a result well down the spotlight list means holding an arrow key, one result per press. #21256
asks for page up and down instead, and suggests moving by half or a whole page.

A press now moves by however many results of the current one's height fit in the visible list, so the
selection moves by about what the list moves. Results differ in height — a public room with its details
is taller than a person — so it measures the result the selection is on rather than assuming an
average, and falls back to a single step while nothing has been laid out yet. A jump past either end
lands on the first or last result rather than on nothing, which is what would otherwise happen since
the roving index searches forward from the index it is given.

The keys are registered as accessibility bindings beside home and end, which means they can be rebound
like any other. Like those two they carry no display name, so nothing new appears in the keyboard
shortcuts settings list. The node filtering that up and down already did — treating the recently viewed
row as a single stop until the selection is inside it — is now a named function shared by both cases
instead of being written out twice.

Fixes #21256

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)