### PR TITLE
Stop a deleted voice message playing when another one finishes

### DIFF
--- a/apps/web/src/audio/PlaybackQueue.ts
+++ b/apps/web/src/audio/PlaybackQueue.ts
@@ -106,6 +106,27 @@ export class PlaybackQueue {
         playback.clockInfo.liveData.onUpdate((clock) => this.onPlaybackClock(playback, mxEvent, clock));
     }
 
+    /**
+     * Forget everything the queue knows about an event, for when its playback is about to be destroyed.
+     *
+     * A destroyed Playback still holds its decoded audio and will play if it is asked to, but it has
+     * dropped its listeners by then, so nothing would show it playing and nothing could stop it. The
+     * queue must therefore not be left holding one as somewhere to continue to.
+     *
+     * @param mxEvent - The event whose playback is going away.
+     */
+    public dequeue(mxEvent: MatrixEvent): void {
+        const eventId = mxEvent.getId()!;
+        this.playbacks.delete(eventId);
+        this.playbackIdOrder = this.playbackIdOrder.filter((id) => id !== eventId);
+        this.recentFullPlays.delete(eventId);
+        if (this.currentPlaybackId === eventId) {
+            // Whatever was playing has gone away, so there is nothing left for the next message that
+            // stops to treat as its predecessor.
+            this.currentPlaybackId = null;
+        }
+    }
+
     private onPlaybackStateChange(playback: Playback, mxEvent: MatrixEvent, newState: PlaybackState): void {
         // Remember where the user got to in playback
         const wasLastPlaying = this.currentPlaybackId === mxEvent.getId();

--- a/apps/web/src/components/views/messages/MAudioBody.tsx
+++ b/apps/web/src/components/views/messages/MAudioBody.tsx
@@ -68,7 +68,12 @@ export default class MAudioBody extends React.PureComponent<IBodyProps, IState> 
 
     protected onMount(playback: Playback): void {}
 
+    protected onUnmount(): void {}
+
     public componentWillUnmount(): void {
+        // Before the destroy, so that anything still holding this playback can let go of it while it
+        // is in one piece.
+        this.onUnmount();
         this.state.playback?.destroy();
     }
 

--- a/apps/web/src/components/views/messages/MVoiceMessageBody.tsx
+++ b/apps/web/src/components/views/messages/MVoiceMessageBody.tsx
@@ -23,13 +23,19 @@ export default class MVoiceMessageBody extends MAudioBody {
     public static contextType = RoomContext;
     declare public context: React.ContextType<typeof RoomContext>;
 
+    private playbackQueue?: PlaybackQueue;
+
     protected onMount(playback: Playback): void {
         if (isVoiceMessage(this.props.mxEvent)) {
-            PlaybackQueue.forRoom(this.props.mxEvent.getRoomId()!, this.context.roomViewStore).unsortedEnqueue(
-                this.props.mxEvent,
-                playback,
-            );
+            this.playbackQueue = PlaybackQueue.forRoom(this.props.mxEvent.getRoomId()!, this.context.roomViewStore);
+            this.playbackQueue.unsortedEnqueue(this.props.mxEvent, playback);
         }
+    }
+
+    protected onUnmount(): void {
+        // The queue is the one kept from onMount rather than looked up again: unmounting can happen on
+        // the way out of the session, and forRoom() reaches for a client which may already be gone.
+        this.playbackQueue?.dequeue(this.props.mxEvent);
     }
 
     // A voice message is an audio file but rendered in a special way.

--- a/apps/web/test/unit-tests/audio/MockedPlayback.ts
+++ b/apps/web/test/unit-tests/audio/MockedPlayback.ts
@@ -55,5 +55,6 @@ export class MockedPlayback extends EventEmitter {
     public prepare = vi.fn().mockResolvedValue(undefined);
     public skipTo = vi.fn();
     public toggle = vi.fn();
+    public play = vi.fn().mockResolvedValue(undefined);
     public destroy = vi.fn().mockResolvedValue(undefined);
 }

--- a/apps/web/test/unit-tests/audio/PlaybackQueue-test.ts
+++ b/apps/web/test/unit-tests/audio/PlaybackQueue-test.ts
@@ -21,9 +21,24 @@ describe("PlaybackQueue", () => {
     beforeEach(() => {
         mockRoom = {
             getMember: jest.fn(),
+            // Reached for when a message finishes and the queue looks for the next voice message to
+            // continue with; an empty timeline means there is nothing to continue to.
+            getLiveTimeline: jest.fn().mockReturnValue({ getEvents: () => [] }),
         } as unknown as Mocked<Room>;
         playbackQueue = new PlaybackQueue(mockRoom, SDKContextClass.instance.roomViewStore);
     });
+
+    /**
+     * Enqueue a playback for an event id and hand back both, ready to be driven through states.
+     */
+    const enqueue = (eventId: string): { mxEvent: Mocked<MatrixEvent>; playback: MockedPlayback } => {
+        const mxEvent = {
+            getId: jest.fn().mockReturnValue(eventId),
+        } as unknown as Mocked<MatrixEvent>;
+        const playback = new MockedPlayback(PlaybackState.Stopped, 0, 0);
+        playbackQueue.unsortedEnqueue(mxEvent, playback as unknown as Mocked<Playback>);
+        return { mxEvent, playback };
+    };
 
     it.each([
         [PlaybackState.Playing, true],
@@ -64,6 +79,34 @@ describe("PlaybackQueue", () => {
         mockPlayback.emit(UPDATE_EVENT as any, PlaybackState.Stopped);
 
         expect(mockPlayback.skipTo).toHaveBeenCalledWith(1);
+    });
+
+    it("does not play a message which has been dequeued when the one after it finishes", () => {
+        const deleted = enqueue("$deleted:bar");
+        const other = enqueue("$other:bar");
+
+        // The deleted message plays, then the user starts another one, which leaves the deleted one
+        // sitting in the queue as the message to fall back to.
+        deleted.playback.emit(UPDATE_EVENT as any, PlaybackState.Playing);
+        other.playback.emit(UPDATE_EVENT as any, PlaybackState.Playing);
+
+        // Redaction unmounts the tile, which lets the queue go before destroying the playback.
+        playbackQueue.dequeue(deleted.mxEvent);
+
+        other.playback.emit(UPDATE_EVENT as any, PlaybackState.Stopped);
+
+        expect(deleted.playback.play).not.toHaveBeenCalled();
+    });
+
+    it("plays the message before it when the one after finishes", () => {
+        const first = enqueue("$first:bar");
+        const second = enqueue("$second:bar");
+
+        first.playback.emit(UPDATE_EVENT as any, PlaybackState.Playing);
+        second.playback.emit(UPDATE_EVENT as any, PlaybackState.Playing);
+        second.playback.emit(UPDATE_EVENT as any, PlaybackState.Stopped);
+
+        expect(first.playback.play).toHaveBeenCalled();
     });
 
     it("should ignore the nullish clock state when loading", () => {


### PR DESCRIPTION
The playback queue remembers every voice message it is handed and never forgets one. Deleting a
message unmounts its tile, which destroys the playback, but the queue keeps the entry — so when the
next message finishes and the queue looks for somewhere to continue, it finds the deleted one and
plays it. A destroyed playback still holds its decoded audio, and it has dropped its listeners by
then, so nothing shows it playing and nothing short of restarting the app stops it. That is the
"impossible to stop besides exiting the app" in #32024.

The queue now has a dequeue to match its enqueue, and the tile calls it on the way out, before the
playback is destroyed. The message is dropped from the order and from the recent plays as well as
from the lookup, so the queue carries on to the next live voice message rather than stopping at a
gap where the deleted one was.

The tile holds on to the queue it enqueued into rather than looking it up again at unmount:
unmounting also happens on the way out of a session, and the lookup reaches for a client which may
be gone by then.

Tests: the message before a finished one is still played, and one which has been dequeued is not.

Fixes #32024

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)