### PR TITLE
Load the right translations for languages named after a region

### DIFF
--- a/apps/desktop/src/language-helper.test.ts
+++ b/apps/desktop/src/language-helper.test.ts
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 hayaksi1
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { expect, describe, it, beforeEach, vi } from "vitest";
+import { fs as memfs, vol } from "memfs";
+import counterpart from "counterpart";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+vi.mock("node:fs", () => ({ default: memfs }));
+vi.mock("node:fs/promises", () => ({ default: memfs.promises }));
+
+const { AppLocalization } = await import("./language-helper.js");
+const stringsDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "i18n", "strings");
+
+// Named the way the app is really built: a region which repeats the language, one which does not, and
+// a script subtag whose case does not survive being upper-cased.
+const strings = {
+    [path.join(stringsDir, "en_EN.json")]: JSON.stringify({ greeting: "Hello" }),
+    [path.join(stringsDir, "de_DE.json")]: JSON.stringify({ greeting: "Hallo" }),
+    [path.join(stringsDir, "mg_MG.json")]: JSON.stringify({ greeting: "Salama" }),
+    [path.join(stringsDir, "pt_BR.json")]: JSON.stringify({ greeting: "Olá" }),
+    [path.join(stringsDir, "zh_Hans.json")]: JSON.stringify({ greeting: "你好" }),
+    [path.join(stringsDir, "fr.json")]: JSON.stringify({ greeting: "Bonjour" }),
+};
+
+const store = { has: () => false, get: () => undefined, set: vi.fn() };
+
+const localization = (): InstanceType<typeof AppLocalization> =>
+    new AppLocalization({ components: [], store: store as never });
+
+describe("AppLocalization", () => {
+    beforeEach(() => {
+        vol.reset();
+        vol.fromJSON(strings);
+    });
+
+    describe("fetchTranslationJson", () => {
+        it.each([
+            ["de", "Hallo"],
+            ["mg", "Salama"],
+            ["pt-br", "Olá"],
+            ["zh-hans", "你好"],
+            ["fr", "Bonjour"],
+            ["en", "Hello"],
+        ])("loads the strings the web app asks for by the key '%s'", (locale, greeting) => {
+            expect(localization().fetchTranslationJson(locale)).toEqual({ greeting });
+        });
+
+        it("returns nothing for a language which was not built in", () => {
+            expect(localization().fetchTranslationJson("cy")).toEqual({});
+        });
+    });
+
+    describe("setAppLocale", () => {
+        it("skips a preference with no strings and settles on the next one", () => {
+            localization().setAppLocale(["cy", "de"]);
+
+            expect(counterpart.getLocale()).toBe("de");
+        });
+
+        it("falls back to English when none of the preferences have strings", () => {
+            localization().setAppLocale(["cy", "eo"]);
+
+            expect(counterpart.getLocale()).toBe("en");
+        });
+    });
+});

--- a/apps/desktop/src/language-helper.ts
+++ b/apps/desktop/src/language-helper.ts
@@ -7,6 +7,7 @@ Please see LICENSE files in the repository root for full details.
 
 import counterpart from "counterpart";
 import { type TranslationKey as TKey } from "matrix-web-i18n";
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -17,6 +18,30 @@ import type Store from "./store.js";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const FALLBACK_LOCALE = "en";
+
+const STRINGS_DIR = path.join(__dirname, "i18n", "strings");
+
+/**
+ * Index the strings files the app was built with by the language key the web app names them with.
+ *
+ * The web app derives those keys from these same file names — lower cased, `_` becoming `-`, and the
+ * region dropped where it only repeats the language — so deriving them from the files here is what
+ * keeps the two ends agreeing. Guessing a file name back from a key cannot: `de` and `mg` would have
+ * to become `de_DE` and `mg_MG`, and `zh-hans` would have to become `zh_Hans` rather than `zh_HANS`,
+ * which is a different file wherever the filesystem cares about case.
+ *
+ * @returns The strings file to load for each language key, keyed as the web app keys them.
+ */
+function getStringsFiles(): Map<string, string> {
+    const files = new Map<string, string>();
+    for (const file of fs.readdirSync(STRINGS_DIR)) {
+        if (!file.endsWith(".json")) continue;
+        const parts = path.basename(file, ".json").toLowerCase().split("_");
+        const key = parts.length === 2 && parts[0] === parts[1] ? parts[0] : parts.join("-");
+        files.set(key, file);
+    }
+    return files;
+}
 
 type TranslationKey = TKey<typeof EN>;
 
@@ -66,7 +91,7 @@ export class AppLocalization {
     private readonly store: Store;
 
     public constructor({ components = [], store }: { components: Component[]; store: Store }) {
-        counterpart.registerTranslations(FALLBACK_LOCALE, this.fetchTranslationJson("en_EN"));
+        counterpart.registerTranslations(FALLBACK_LOCALE, this.fetchTranslationJson(FALLBACK_LOCALE));
         counterpart.setFallbackLocale(FALLBACK_LOCALE);
         counterpart.setSeparator("|");
 
@@ -83,22 +108,15 @@ export class AppLocalization {
         this.resetLocalizedUI();
     }
 
-    // Format language strings from normalized form to non-normalized form (e.g. en-gb to en_GB)
-    private denormalize(locale: string): string {
-        if (locale === "en") {
-            locale = "en_EN";
-        }
-        const parts = locale.split("-");
-        if (parts.length > 1) {
-            parts[1] = parts[1].toUpperCase();
-        }
-        return parts.join("_");
-    }
-
     public fetchTranslationJson(locale: string): Record<string, string> {
         try {
             console.log("Fetching translation json for locale: " + locale);
-            return loadJsonFile(__dirname, "i18n", "strings", `${this.denormalize(locale)}.json`);
+            const file = getStringsFiles().get(locale.toLowerCase());
+            if (!file) {
+                console.log(`No translation json for locale: '${locale}'`);
+                return {};
+            }
+            return loadJsonFile(STRINGS_DIR, file);
         } catch (e) {
             console.log(`Could not fetch translation json for locale: '${locale}'`, e);
             return {};
@@ -114,13 +132,15 @@ export class AppLocalization {
 
         const chosenLocale = locales.find((locale) => {
             const translations = this.fetchTranslationJson(locale);
-            if (translations !== null) {
-                counterpart.registerTranslations(locale, translations);
-            }
-            return !!translations;
+            // Nothing to register means nothing to show. Settling on the locale anyway would leave
+            // the menus in English while the app claimed to be in the chosen language, so move on to
+            // the next preference instead.
+            if (Object.keys(translations).length === 0) return false;
+            counterpart.registerTranslations(locale, translations);
+            return true;
         });
 
-        counterpart.setLocale(chosenLocale!);
+        counterpart.setLocale(chosenLocale ?? FALLBACK_LOCALE);
         this.store.set(AppLocalization.STORE_KEY, locales);
 
         this.resetLocalizedUI();


### PR DESCRIPTION
The desktop app works the file name for a language back out of the key the web app sends it, and
that guess only holds for some of them. German arrives as `de`, because the region repeats the
language, and the guess leaves it as `de.json` when the file is `de_DE.json` — which is exactly the
"Could not fetch translation json for locale: 'de'" in #32123. Malagasy fails the same way, and
simplified and traditional Chinese arrive as `zh-hans` / `zh-hant` and are upper-cased into
`zh_HANS.json` rather than `zh_Hans.json`. Anyone using one of those four gets English menus.

Rather than guessing the file name back, the strings files the app was built with are now indexed
under the keys the web app names them with, derived from the file names by the same rule the web app
uses when it builds `languages.json`. The two ends then agree by construction, including for
whatever is added later.

A language with nothing to load is also no longer treated as a successful choice. It used to be,
because the empty result was truthy, so the app settled on it and showed English under a locale
claiming otherwise instead of moving on to the next preference.

Tests: a new suite covering each shape of language name, a language which was not built in, and both
fallback paths.

Fixes #32123

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)