### PR TITLE
Stop a formatted message losing a level of ampersand escaping

### DIFF
--- a/apps/web/src/HtmlUtils.tsx
+++ b/apps/web/src/HtmlUtils.tsx
@@ -379,7 +379,12 @@ function analyseEvent(content: IContent, highlights?: string[], opts: EventRende
             let unsafeBody = formattedBody!;
 
             if (opts.linkify) {
-                unsafeBody = linkifyHtml(unsafeBody);
+                // linkify decodes entities while tokenising but only puts < and > back, so a body
+                // comes out of it one level of ampersand escaping short: `&amp;amp;` returns as
+                // `&amp;`, and a code block reading `&gtk::Label` renders as `>k::Label`. The plain
+                // text branch below escapes its body before linkifying it for exactly this reason;
+                // a formatted body is already escaped, so top the level back up first.
+                unsafeBody = linkifyHtml(unsafeBody.replace(/&/g, "&amp;"));
             }
 
             safeBody = sanitizeHtml(unsafeBody, sanitizeParams);

--- a/apps/web/test/unit-tests/HtmlUtils-test.tsx
+++ b/apps/web/test/unit-tests/HtmlUtils-test.tsx
@@ -9,6 +9,7 @@ Please see LICENSE files in the repository root for full details.
 import React, { type ReactElement } from "react";
 import { render, screen } from "jest-matrix-react";
 import parse from "html-react-parser";
+import { type IContent } from "matrix-js-sdk/src/matrix";
 
 import { bodyToHtml, bodyToNode, formatEmojis, sanitizedHtmlNode, topicToHtml } from "../../src/HtmlUtils";
 import SettingsStore from "../../src/settings/SettingsStore";
@@ -215,6 +216,42 @@ describe("bodyToHtml", () => {
                 [],
             );
             expect(html).toMatchSnapshot();
+        });
+    });
+
+    describe("escaped entities in a formatted body", () => {
+        function formatted(formattedBody: string): IContent {
+            return {
+                body: "irrelevant",
+                msgtype: "m.text",
+                formatted_body: formattedBody,
+                format: "org.matrix.custom.html",
+            };
+        }
+
+        // Rendering the result is what shows the bug: the browser decodes the string one more time,
+        // so a body which is short of a level of escaping loses characters on screen.
+        function renderedText(formattedBody: string): string {
+            const el = document.createElement("div");
+            el.innerHTML = bodyToHtml(formatted(formattedBody), [], { linkify: true });
+            return el.textContent!;
+        }
+
+        it("keeps an escaped ampersand which is itself the start of an entity", () => {
+            expect(renderedText("literal &amp;amp; <code>&amp;amp;</code>")).toEqual("literal &amp; &amp;");
+        });
+
+        it("does not turn an ampersand in a code block into the character it could have started", () => {
+            expect(renderedText("<pre><code>&amp;gtk::Label</code></pre>")).toEqual("&gtk::Label");
+        });
+
+        it("leaves a numeric character reference alone", () => {
+            expect(renderedText("<p>&#38;lt;</p>")).toEqual("&lt;");
+        });
+
+        it("still linkifies a URL whose query string contains an escaped ampersand", () => {
+            const html = bodyToHtml(formatted("<p>https://example.org/?a=1&amp;b=2</p>"), [], { linkify: true });
+            expect(html).toContain('href="https://example.org/?a=1&amp;b=2"');
         });
     });
 });


### PR DESCRIPTION
A formatted body is handed to linkify before it is sanitised. Linkify decodes HTML entities as it tokenises, but the serialiser it uses only escapes `<` and `>` on the way back out — never `&`. Every formatted message therefore comes out of that step one level of ampersand escaping short, and the browser then decodes what is left one more time than it should.

Two reports of the same defect: a message written as `&amp;amp;` displays as `&amp;` rather than the literal text, and a code block containing `&gtk::Label` renders as `>k::Label`, because the surviving `&gt` is read as the character it starts even without its semicolon.

The plain text branch of the same function already escapes its body before linkifying it, which is why only formatted messages were affected. A formatted body arrives escaped, so it is now topped back up by one level before linkify eats one, and comes out saying exactly what it said going in. Sanitisation is untouched, and so is link detection — an ampersand inside a URL's query string survives the round trip and the link is still found. No existing snapshot moved.

Tests: an escaped entity, an ampersand inside a code block and a numeric character reference each render as written, and a URL whose query contains an escaped ampersand is still linkified.

Fixes #31438
Fixes #31694

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
