### PR TITLE
Show one notification for a message which highlights you

### DIFF
--- a/apps/web/src/Notifier.ts
+++ b/apps/web/src/Notifier.ts
@@ -506,7 +506,13 @@ export default class Notifier extends TypedEventEmitter<keyof EmittedEvents, Emi
         if (!data.liveEvent || !!toStartOfTimeline) return; // only notify for new things, not old.
         if (!this.isSyncing) return; // don't alert for any messages initially
         if (ev.getSender() === this.sdkContext.client.getUserId()) return;
-        if (data.timeline.getTimelineSet().threadListType !== null) return; // Ignore events on the thread list generated timelines
+        const timelineSet = data.timeline.getTimelineSet();
+        if (timelineSet.threadListType !== null) return; // Ignore events on the thread list generated timelines
+        // A message which highlights us in an unencrypted room is put on the global notification
+        // timeline as well as on its own room's, and the client re-emits from both, so without this
+        // the same event is announced twice. The room's copy is the one to keep: it arrives whether
+        // or not the event highlights, and in an encrypted room it is the only one there is.
+        if (timelineSet === this.sdkContext.client.getNotifTimelineSet()) return;
 
         this.sdkContext.client.decryptEventIfNeeded(ev);
 

--- a/apps/web/test/unit-tests/Notifier-test.ts
+++ b/apps/web/test/unit-tests/Notifier-test.ts
@@ -17,6 +17,8 @@ import {
     MatrixEvent,
     SyncState,
     type AccountDataEvents,
+    type EventTimeline,
+    type EventTimelineSet,
 } from "matrix-js-sdk/src/matrix";
 import { waitFor } from "jest-matrix-react";
 import { CallMembership, type SessionMembershipData, type MatrixRTCSession } from "matrix-js-sdk/src/matrixrtc";
@@ -135,6 +137,7 @@ describe("Notifier", () => {
             decryptEventIfNeeded: jest.fn(),
             getRoom: jest.fn(),
             getPushActionsForEvent: jest.fn(),
+            getNotifTimelineSet: jest.fn().mockReturnValue(null),
             // Mock required because TextForEvent now evaluates supportsVoip for RTCNotification to trigger OS popups.
             // The true/false value is arbitrary here, as this test only verifies the in-app toast creation, not the OS text output.
             supportsVoip: jest.fn().mockReturnValue(true),
@@ -236,6 +239,22 @@ describe("Notifier", () => {
 
             expect(MockPlatform.displayNotification).not.toHaveBeenCalled();
             expect(MockPlatform.loudNotification).not.toHaveBeenCalled();
+        });
+
+        it("only notifies once for a highlight which also lands on the notification timeline", () => {
+            // A highlight in an unencrypted room is added to the global notification timeline as
+            // well as to its own room's, and the client re-emits from both.
+            const notifTimelineSet = { threadListType: null } as unknown as EventTimelineSet;
+            mockClient.getNotifTimelineSet.mockReturnValue(notifTimelineSet);
+
+            mockClient!.emit(ClientEvent.Sync, SyncState.Syncing, null);
+            emitLiveEvent(event);
+            mockClient!.emit(RoomEvent.Timeline, event, testRoom, false, false, {
+                liveEvent: true,
+                timeline: { getTimelineSet: () => notifTimelineSet } as unknown as EventTimeline,
+            });
+
+            expect(MockPlatform.displayNotification).toHaveBeenCalledTimes(1);
         });
 
         it("does not create notifications for non-live events (scrollback)", () => {


### PR DESCRIPTION
A message which both notifies and highlights — a mention, your display name, `@room` — is added to the client's global notification timeline during sync as well as to its own room's live timeline. The client re-emits `RoomEvent.Timeline` from both sets, and the notifier only skipped the thread list's generated timelines, so the same event reached it twice and raised two identical desktop notifications.

The notifier now ignores the notification timeline as well, leaving the room's own copy to do the work. That is the right copy to keep: it arrives whether or not the event highlights, and in an encrypted room it is the only one there is — at sync time an encrypted event is still `m.room.encrypted`, evaluates to no highlight, and is never added to the notification set, which is exactly why encrypted rooms never showed the problem.

The events added to the notification set are the same list the room is given, so nothing is lost by dropping that copy; there is no case where an event reaches the notification timeline without reaching its room's.

Tests: an event delivered on both timelines notifies once.

Fixes #34253

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
