### PR TITLE
Let the unshifted plus key zoom back in on desktop

### DIFF
--- a/apps/desktop/src/vectormenu.test.ts
+++ b/apps/desktop/src/vectormenu.test.ts
@@ -47,6 +47,18 @@ describe("buildMenuTemplate", () => {
             expect(menu.items[0].label).toBe("ChatApp");
         });
 
+        it("should bind zooming in to the unshifted key as well as the shifted one", () => {
+            const menu = buildMenuTemplate();
+
+            const viewMenu = menu.items.find((item) => item.label === "view_menu|view")!;
+            const viewSubmenu = viewMenu.submenu as unknown as MenuItemConstructorOptions[];
+            const zoomInAccelerators = viewSubmenu
+                .filter((item) => item.role === "zoomIn")
+                .map((item) => item.accelerator);
+
+            expect(zoomInAccelerators).toContain("CmdOrCtrl+=");
+        });
+
         it("should include expected `help` menu", () => {
             const menu = buildMenuTemplate();
 

--- a/apps/desktop/src/vectormenu.ts
+++ b/apps/desktop/src/vectormenu.ts
@@ -71,6 +71,15 @@ export function buildMenuTemplate(): Menu {
                     visible: false,
                 },
                 {
+                    // The zoomIn role only binds the shifted "+", so the key people actually reach
+                    // for to undo a zoom out does nothing. Zooming out has no such gap, which is how
+                    // someone ends up stuck at a smaller size: the menu bar is hidden until Alt is
+                    // pressed, so the View menu is not there to fall back on either.
+                    role: "zoomIn",
+                    accelerator: "CmdOrCtrl+=",
+                    visible: false,
+                },
+                {
                     role: "zoomOut",
                     accelerator: "CmdOrCtrl+NumSub",
                     visible: false,


### PR DESCRIPTION
Electron's `zoomIn` role binds the shifted `+` only. Zooming out is bound to a key that needs no modifier, so `Ctrl+-` works while the combination people actually press to undo it does not. The View menu does list Zoom In and Actual Size, but the menu bar is hidden until Alt is pressed, so someone who shrank the app once was left at that size with nothing visible to undo it — and because the zoom level is remembered between runs, restarting did not help either.

Zooming in now also answers to the unshifted key, added the same way the numeric keypad bindings already present were added and for the same reason. The visible View menu entries are unchanged, so nothing moves or gains a duplicate, and no other shortcut in the app wanted that combination.

This does not change how zoom is stored or reset; `Ctrl+0` for Actual Size already worked and is left alone.

Tests: the View menu offers a zoom in accelerator for the unshifted key on each platform.

Fixes #33151

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
