### PR TITLE
Remember whether the space panel was left expanded

### DIFF
--- a/apps/web/src/components/views/spaces/SpacePanel.tsx
+++ b/apps/web/src/components/views/spaces/SpacePanel.tsx
@@ -362,7 +362,15 @@ const SpacePanel: React.FC = () => {
     const sdkContext = useContext(SDKContext);
     const client = sdkContext.client!;
     const [dragging, setDragging] = useState(false);
-    const [isPanelCollapsed, setPanelCollapsed] = useState(true);
+    const [isPanelCollapsed, setPanelCollapsedState] = useState(() =>
+        SettingsStore.getValue("Spaces.isPanelCollapsed"),
+    );
+    // Remember how the panel was left so that it comes back the same way, as the room list beside it
+    // already does. Expanding it is a deliberate act, not something to undo on every launch.
+    const setPanelCollapsed = useCallback((collapsed: boolean): void => {
+        setPanelCollapsedState(collapsed);
+        SettingsStore.setValue("Spaces.isPanelCollapsed", null, SettingLevel.DEVICE, collapsed);
+    }, []);
     const ref = useRef<HTMLDivElement>(null);
     useLayoutEffect(() => {
         if (ref.current) UIStore.instance.trackElementDimensions("SpacePanel", ref.current);

--- a/apps/web/src/settings/Settings.tsx
+++ b/apps/web/src/settings/Settings.tsx
@@ -332,6 +332,7 @@ export interface Settings {
     "RoomList.preferredSorting": IBaseSetting<SortingAlgorithm>;
     "RoomList.panelSize": IBaseSetting<number | null>;
     "RoomList.isPanelCollapsed": IBaseSetting<boolean>;
+    "Spaces.isPanelCollapsed": IBaseSetting<boolean>;
     "RoomList.showMessagePreview": IBaseSetting<boolean>;
     "RightPanel.phasesGlobal": IBaseSetting<IRightPanelForRoomStored | null>;
     "RightPanel.phases": IBaseSetting<IRightPanelForRoomStored | null>;
@@ -1214,6 +1215,10 @@ export const SETTINGS: Settings = {
     "RoomList.isPanelCollapsed": {
         supportedLevels: [SettingLevel.DEVICE],
         default: false,
+    },
+    "Spaces.isPanelCollapsed": {
+        supportedLevels: [SettingLevel.DEVICE],
+        default: true,
     },
     "RoomList.showMessagePreview": {
         supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS_WITH_CONFIG,

--- a/apps/web/test/unit-tests/components/views/spaces/SpacePanel-test.tsx
+++ b/apps/web/test/unit-tests/components/views/spaces/SpacePanel-test.tsx
@@ -21,6 +21,7 @@ import { TestSDKContext } from "../../../TestSDKContext.ts";
 import DMRoomMap from "../../../../../src/utils/DMRoomMap";
 import { type SpaceNotificationState } from "../../../../../src/stores/notifications/SpaceNotificationState";
 import SettingsStore from "../../../../../src/settings/SettingsStore";
+import { SettingLevel } from "../../../../../src/settings/SettingLevel";
 import UnwrappedSpacePanel from "../../../../../src/components/views/spaces/SpacePanel";
 import defaultDispatcher from "../../../../../src/dispatcher/dispatcher";
 import { Action } from "../../../../../src/dispatcher/actions";
@@ -208,6 +209,61 @@ describe("<SpacePanel />", () => {
         await waitFor(() => {
             // Menu exists outside the component due to Portals, so select it manually.
             expect(baseElement.querySelector("div[aria-label='User menu']")).toBeInTheDocument();
+        });
+    });
+
+    describe("remembering whether the panel was expanded", () => {
+        // The toggle button carries the expanded class only while the panel is open, which is the
+        // same thing the chevron's direction is driven from.
+        const isExpanded = (container: HTMLElement): boolean =>
+            !!container.querySelector(".mx_SpacePanel_toggleCollapse.expanded");
+
+        // Restore only these spies: the suite mocks MatrixClientPeg once in beforeAll, so a blanket
+        // restoreAllMocks here would log the following tests out.
+        let spies: jest.SpyInstance[] = [];
+
+        function mockCollapsedSetting(collapsed: boolean): void {
+            const originalGetValue = SettingsStore.getValue;
+            spies.push(
+                jest
+                    .spyOn(SettingsStore, "getValue")
+                    .mockImplementation((setting, ...args) =>
+                        setting === "Spaces.isPanelCollapsed" ? collapsed : originalGetValue(setting, ...args),
+                    ),
+            );
+        }
+
+        afterEach(() => {
+            spies.forEach((spy) => spy.mockRestore());
+            spies = [];
+        });
+
+        it("starts expanded when it was left expanded", () => {
+            mockCollapsedSetting(false);
+
+            const { container } = render(<SpacePanel />);
+
+            expect(isExpanded(container)).toBe(true);
+        });
+
+        it("starts collapsed when it was left collapsed", () => {
+            mockCollapsedSetting(true);
+
+            const { container } = render(<SpacePanel />);
+
+            expect(isExpanded(container)).toBe(false);
+        });
+
+        it("stores the new state when the panel is toggled", () => {
+            mockCollapsedSetting(true);
+            const setValue = jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
+            spies.push(setValue);
+            const { container } = render(<SpacePanel />);
+
+            fireEvent.click(container.querySelector(".mx_SpacePanel_toggleCollapse")!);
+
+            expect(isExpanded(container)).toBe(true);
+            expect(setValue).toHaveBeenCalledWith("Spaces.isPanelCollapsed", null, SettingLevel.DEVICE, false);
         });
     });
 });


### PR DESCRIPTION
The space panel's collapsed flag lived in component state initialised to `true`, so however it was left it came back narrow on the next launch. Expanding it is a deliberate act, and the room list immediately beside it has remembered its own collapsed state through `RoomList.isPanelCollapsed` for a while, so the two behaved inconsistently side by side.

The flag is now a device-level setting, `Spaces.isPanelCollapsed`, written whenever the panel is toggled — from the button or from the keyboard shortcut, which both go through the same setter — and read once when the panel mounts. It is declared next to `RoomList.isPanelCollapsed` and follows the same shape.

It defaults to collapsed, matching what the panel did before, so nobody who has never touched the toggle sees any change. The panel's width and the drag-and-drop reordering are untouched.

Tests: the panel mounts expanded or collapsed according to what was stored, and toggling writes the new value at device level.

Fixes #23172

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
