### PR TITLE
Leave the loading screen alone when a modal opens during startup

### DIFF
--- a/apps/web/src/components/structures/MatrixChat.test.tsx
+++ b/apps/web/src/components/structures/MatrixChat.test.tsx
@@ -752,6 +752,20 @@ describe("<MatrixChat />", () => {
         });
     });
 
+    describe("opening a modal while the app is still starting", () => {
+        it("leaves the loading screen alone rather than sending the user to the welcome page", () => {
+            // The dialog itself is not the point here, and it cannot mount without a client anyway.
+            vi.spyOn(Modal, "createDialog").mockReturnValue({} as any);
+            // Nothing is awaited between render and the dispatch below, so the app is still on its
+            // initial loading view — the spinner someone is staring at when they hit ctrl-comma.
+            getComponent();
+
+            defaultDispatcher.dispatch({ action: Action.ViewUserSettings }, true);
+
+            expect(defaultProps.onNewScreen).not.toHaveBeenCalledWith("welcome", expect.anything());
+        });
+    });
+
     describe("with an existing session", () => {
         const mockidb: Record<string, Record<string, string>> = {
             account: {

--- a/apps/web/src/components/structures/MatrixChat.tsx
+++ b/apps/web/src/components/structures/MatrixChat.tsx
@@ -1076,6 +1076,11 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
     }
 
     private viewSomethingBehindModal(): void {
+        // While the app is still starting there is nothing to put behind the modal yet, and sending
+        // the user to the welcome page would rewrite the URL out from under a session which is about
+        // to finish loading — leaving them on a half-started app they never asked to leave.
+        if (this.state.view === Views.LOADING || this.state.view === Views.PENDING_CLIENT_START) return;
+
         if (this.state.view !== Views.LOGGED_IN) {
             this.viewWelcome();
             return;


### PR DESCRIPTION
Opening settings, the room directory or the create-room dialog asks for something to be shown behind the modal, and anything not already logged in was sent to the welcome page. During startup that swaps the loading spinner out and rewrites the URL to `#/welcome`, so a session which was seconds away from being ready comes back behind a dialog on a half-started app the user never asked to leave. It is easy to hit: `Ctrl`/`Cmd+,` while staring at the spinner.

Nothing needs putting behind a modal while the app is still starting — the loading screen is already there, and the session which follows picks its own view once it is ready. Both starting views now leave things as they are, which is the first of the two outcomes the report asked for: the dialog opens over the launch screen instead of stranding the user.

Everything after startup is unchanged, including a genuinely logged-out user reaching the welcome page and a logged-in user with no room open reaching home.

Tests: opening settings while the app is loading does not navigate to the welcome screen.

Fixes #32004

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
