### PR TITLE
Keep an IPv6 host readable in a markdown link

### DIFF
--- a/apps/web/src/Markdown.test.ts
+++ b/apps/web/src/Markdown.test.ts
@@ -172,5 +172,20 @@ describe("Markdown parser test", () => {
             const md = new Markdown(testString);
             expect(md.toHTML()).toEqual(expectedResult);
         });
+
+        it("keeps an IPv6 host readable so the link can be followed", () => {
+            const md = new Markdown("[test](https://[2a00:1450:4009:819::200e]/)");
+            expect(md.toHTML()).toContain('href="https://[2a00:1450:4009:819::200e]/"');
+        });
+
+        it("keeps an IPv6 host readable alongside a port and a query string", () => {
+            const md = new Markdown("[test](http://[::1]:8080/a?b=1)");
+            expect(md.toHTML()).toContain('href="http://[::1]:8080/a?b=1"');
+        });
+
+        it("leaves square brackets elsewhere in a URL encoded", () => {
+            const md = new Markdown("[test](https://example.org/a%5Bb%5D)");
+            expect(md.toHTML()).toContain('href="https://example.org/a%5Bb%5D"');
+        });
     });
 });

--- a/apps/web/src/Markdown.ts
+++ b/apps/web/src/Markdown.ts
@@ -18,6 +18,24 @@ const ALLOWED_HTML_TAGS = ["sub", "sup", "del", "s", "u", "br", "br/"];
 // These types of node are definitely text
 const TEXT_NODES = ["text", "softbreak", "linebreak", "paragraph", "document"];
 
+// The square brackets around an IPv6 host, once commonmark has percent-encoded them along with
+// everything else it normalises in a URL.
+const ENCODED_IPV6_HOST = /^([a-z][a-z0-9+.-]*:\/\/)%5b([0-9a-f:.]+)%5d/i;
+
+/**
+ * Undo the percent-encoding commonmark applies to the square brackets around an IPv6 host.
+ *
+ * Encoded brackets are not a host any browser will resolve, so the link renders but goes nowhere.
+ * Only those two characters are restored, and only when what sits between them looks like an
+ * address: the rest of commonmark's encoding is what makes its output safe to emit as an href.
+ *
+ * @param destination - The link destination as commonmark normalised it.
+ * @returns The destination with an IPv6 host readable again, unchanged if there is not one.
+ */
+function restoreIPv6Host(destination: string): string {
+    return destination.replace(ENCODED_IPV6_HOST, (_, scheme: string, address: string) => `${scheme}[${address}]`);
+}
+
 function isAllowedHtmlTag(node: commonmark.Node): boolean {
     if (!node.literal) {
         return false;
@@ -313,7 +331,7 @@ export default class Markdown {
         renderer.link = function (node, entering) {
             const attrs = this.attrs(node);
             if (entering && node.destination) {
-                attrs.push(["href", this.esc(node.destination)]);
+                attrs.push(["href", this.esc(restoreIPv6Host(node.destination))]);
                 if (node.title) {
                     attrs.push(["title", this.esc(node.title)]);
                 }


### PR DESCRIPTION
commonmark percent-encodes a link destination as it normalises it, and the square brackets around an IPv6 host go the same way as everything else — `https://[2a00:1450:4009:819::200e]/` becomes `https://%5B2a00:1450:4009:819::200e%5D/`. That is not a host any browser will resolve, so the message renders a link which then does nothing when clicked.

Those two brackets are now put back on the way into the `href`, and only when what sits between them looks like an address. Everything else commonmark encoded is left alone: that encoding is what makes the destination safe to emit as an attribute, and a square bracket anywhere else in a URL means something different and stays encoded.

The sanitiser downstream passes a bracketed host through untouched, so nothing further is needed on the render side.

This is the `[name](url)` form only. The bare-URL case from #8875 goes through linkify rather than commonmark and is not addressed here.

Tests: an IPv6 host survives on its own and with a port and query string, and brackets in a path stay encoded.

Fixes #28276

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
