### PR TITLE
Record the mentions a rich text message makes

### DIFF
--- a/apps/web/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
+++ b/apps/web/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
@@ -7,7 +7,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { richToPlain, plainToRich } from "@vector-im/matrix-wysiwyg";
-import { type IContent, type IEventRelation, MatrixEvent, MsgType } from "matrix-js-sdk/src/matrix";
+import { type IContent, type IEventRelation, type IMentions, MatrixEvent, MsgType } from "matrix-js-sdk/src/matrix";
 import {
     type ReplacementEvent,
     type RoomMessageEventContent,
@@ -31,10 +31,75 @@ function attachRelation(content: IContent, relation?: IEventRelation): void {
     }
 }
 
+/**
+ * Fill in the mentions the message makes, in the form MSC3952 asks for.
+ *
+ * The composer marks its pills up with `data-mention-type`, and that markup is present in its
+ * output whether or not the message is being sent as formatted text — unlike the body, which has
+ * had the pills flattened back down to plain text by the time it is built.
+ *
+ * @param content - The event content being assembled, which is modified in place.
+ * @param message - The composer's own output for the message being sent.
+ * @param sender - The Matrix ID of the sender, who is never mentioned by their own message, if known.
+ * @param replyToEvent - The event being replied to, whose sender is mentioned, if this is a reply.
+ * @param editedEvent - The event being edited, if this is an edit.
+ */
+function attachMentions(
+    content: RoomMessageTextEventContent & ReplacementEvent<RoomMessageTextEventContent>,
+    message: string,
+    sender: string | undefined,
+    replyToEvent: MatrixEvent | undefined,
+    editedEvent: MatrixEvent | undefined,
+): void {
+    // The property is always present, even when empty, so that legacy push rules stay disabled.
+    const mentions: IMentions = (content["m.mentions"] = {});
+
+    const userMentions = new Set<string>();
+    let roomMention = false;
+
+    if (replyToEvent) {
+        userMentions.add(replyToEvent.sender!.userId);
+    }
+
+    const document = new DOMParser().parseFromString(message, "text/html");
+    for (const mention of document.querySelectorAll("a[data-mention-type]")) {
+        const mentionType = mention.getAttribute("data-mention-type");
+        if (mentionType === "at-room") {
+            roomMention = true;
+        } else if (mentionType === "user") {
+            const href = mention.getAttribute("href");
+            const userId = href && parsePermalink(href)?.userId;
+            if (userId) userMentions.add(userId);
+        }
+        // A room pill links to a room rather than mentioning anybody, so it is left alone.
+    }
+
+    if (sender) userMentions.delete(sender);
+
+    if (editedEvent) {
+        // The replacement says who the message mentions now; the fallback says who has newly been
+        // mentioned by it, so that editing does not notify everyone in it a second time.
+        const newMentions: IMentions = (content["m.new_content"]["m.mentions"] = {});
+        if (userMentions.size) newMentions.user_ids = [...userMentions];
+        if (roomMention) newMentions.room = true;
+
+        const previousMentions = editedEvent.getContent()["m.mentions"];
+        if (Array.isArray(previousMentions?.user_ids)) {
+            previousMentions.user_ids.forEach((userId: string) => userMentions.delete(userId));
+        }
+        if (previousMentions?.room) roomMention = false;
+    }
+
+    if (userMentions.size) mentions.user_ids = [...userMentions];
+    if (roomMention) mentions.room = true;
+}
+
 interface CreateMessageContentParams {
     relation?: IEventRelation;
     replyToEvent?: MatrixEvent;
     editedEvent?: MatrixEvent;
+    /** The Matrix ID of the sender, so that they are not recorded as mentioning themselves. */
+    sender?: string;
 }
 
 const isMatrixEvent = (e: MatrixEvent | undefined): e is MatrixEvent => e instanceof MatrixEvent;
@@ -42,7 +107,7 @@ const isMatrixEvent = (e: MatrixEvent | undefined): e is MatrixEvent => e instan
 export async function createMessageContent(
     message: string,
     isHTML: boolean,
-    { relation, replyToEvent, editedEvent }: CreateMessageContentParams,
+    { relation, replyToEvent, editedEvent, sender }: CreateMessageContentParams,
 ): Promise<RoomMessageEventContent> {
     const isEditing = isMatrixEvent(editedEvent);
 
@@ -92,8 +157,7 @@ export async function createMessageContent(
 
     const newRelation = isEditing ? { ...relation, rel_type: "m.replace", event_id: editedEvent.getId() } : relation;
 
-    // TODO Do we need to attach mentions here?
-    // TODO Handle editing?
+    attachMentions(content, message, sender, replyToEvent, isEditing ? editedEvent : undefined);
     attachRelation(content, newRelation);
 
     if (!isEditing && replyToEvent) {

--- a/apps/web/src/components/views/rooms/wysiwyg_composer/utils/message.ts
+++ b/apps/web/src/components/views/rooms/wysiwyg_composer/utils/message.ts
@@ -113,7 +113,7 @@ export async function sendMessage(
     }
 
     // if content is null, we haven't done any slash command processing, so generate some content
-    content ??= await createMessageContent(message, isHTML, params);
+    content ??= await createMessageContent(message, isHTML, { ...params, sender: mxClient.getSafeUserId() });
     attachUrlPreviews(urlPreviewSnapshot, content);
 
     // TODO replace emotion end of message ?
@@ -205,7 +205,7 @@ export async function editMessage(
         const position = this.model.positionForOffset(caret.offset, caret.atNodeEnd);
         this.editorRef.current?.replaceEmoticon(position, REGEX_EMOTICON);
     }*/
-    const editContent = await createMessageContent(html, true, { editedEvent });
+    const editContent = await createMessageContent(html, true, { editedEvent, sender: mxClient.getSafeUserId() });
     const newContent = editContent["m.new_content"]!;
 
     const shouldSend = true;

--- a/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/EditWysiwygComposer-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/EditWysiwygComposer-test.tsx
@@ -201,11 +201,13 @@ describe("EditWysiwygComposer", () => {
                 "body": `* foo bar`,
                 "format": "org.matrix.custom.html",
                 "formatted_body": `* foo bar`,
+                "m.mentions": {},
                 "m.new_content": {
-                    body: "foo bar",
-                    format: "org.matrix.custom.html",
-                    formatted_body: "foo bar",
-                    msgtype: "m.text",
+                    "body": "foo bar",
+                    "format": "org.matrix.custom.html",
+                    "formatted_body": "foo bar",
+                    "msgtype": "m.text",
+                    "m.mentions": {},
                 },
                 "m.relates_to": {
                     event_id: mockEvent.getId(),

--- a/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/utils/createMessageContent-test.ts
+++ b/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/utils/createMessageContent-test.ts
@@ -35,10 +35,11 @@ describe("createMessageContent", () => {
 
             // Then
             expect(content).toEqual({
-                body: "*__hello__ world*",
-                format: "org.matrix.custom.html",
-                formatted_body: message,
-                msgtype: "m.text",
+                "body": "*__hello__ world*",
+                "format": "org.matrix.custom.html",
+                "formatted_body": message,
+                "msgtype": "m.text",
+                "m.mentions": {},
             });
         });
 
@@ -56,6 +57,7 @@ describe("createMessageContent", () => {
                 "format": "org.matrix.custom.html",
                 "formatted_body": message,
                 "msgtype": "m.text",
+                "m.mentions": {},
                 "m.relates_to": {
                     event_id: "myFakeThreadId",
                     rel_type: "m.thread",
@@ -89,11 +91,13 @@ describe("createMessageContent", () => {
                 "format": "org.matrix.custom.html",
                 "formatted_body": `* ${message}`,
                 "msgtype": "m.text",
+                "m.mentions": {},
                 "m.new_content": {
-                    body: "*__hello__ world*",
-                    format: "org.matrix.custom.html",
-                    formatted_body: message,
-                    msgtype: "m.text",
+                    "body": "*__hello__ world*",
+                    "format": "org.matrix.custom.html",
+                    "formatted_body": message,
+                    "msgtype": "m.text",
+                    "m.mentions": {},
                 },
                 "m.relates_to": {
                     event_id: editedEvent.getId(),
@@ -146,6 +150,76 @@ describe("createMessageContent", () => {
 
             expect(content).toMatchObject({
                 body: "#test_room:element.io ",
+            });
+        });
+    });
+
+    describe("mentions", () => {
+        const userPill = (userId: string, name: string): string =>
+            `<a href="https://matrix.to/#/${userId}" contenteditable="false" data-mention-type="user">${name}</a>`;
+        const atRoomPill = `<a href="#" contenteditable="false" data-mention-type="at-room">@room</a>`;
+        const sender = "@me:element.io";
+
+        it("mentions a user who was pilled", async () => {
+            const content = await createMessageContent(`hey ${userPill("@bob:element.io", "Bob")}`, false, { sender });
+
+            expect(content["m.mentions"]).toEqual({ user_ids: ["@bob:element.io"] });
+        });
+
+        it("mentions the room when @room was used", async () => {
+            const content = await createMessageContent(`${atRoomPill} listen up`, false, { sender });
+
+            expect(content["m.mentions"]).toEqual({ room: true });
+        });
+
+        it("does not mention the sender for pilling themselves", async () => {
+            const content = await createMessageContent(userPill(sender, "Me"), false, { sender });
+
+            expect(content["m.mentions"]).toEqual({});
+        });
+
+        it("does not mention anybody for a link to a room", async () => {
+            const messageComposerState = `<a href="https://matrix.to/#/#test_room:element.io" contenteditable="false" data-mention-type="room">a test room</a>`;
+
+            const content = await createMessageContent(messageComposerState, false, { sender });
+
+            expect(content["m.mentions"]).toEqual({});
+        });
+
+        it("mentions the sender of an event being replied to", async () => {
+            const replyToEvent = mkEvent({
+                type: "m.room.message",
+                room: "myfakeroom",
+                user: "@alice:element.io",
+                content: { msgtype: "m.text", body: "First message" },
+                event: true,
+            });
+
+            const content = await createMessageContent("a reply", false, { replyToEvent, sender });
+
+            expect(content["m.mentions"]).toEqual({ user_ids: ["@alice:element.io"] });
+        });
+
+        it("only tells the fallback about someone the edited message did not already mention", async () => {
+            const editedEvent = mkEvent({
+                type: "m.room.message",
+                room: "myfakeroom",
+                user: sender,
+                content: {
+                    "msgtype": "m.text",
+                    "body": "First message",
+                    "m.mentions": { user_ids: ["@bob:element.io"] },
+                },
+                event: true,
+            });
+            const message = `${userPill("@bob:element.io", "Bob")} and ${userPill("@carol:element.io", "Carol")}`;
+
+            const content = await createMessageContent(message, false, { editedEvent, sender });
+
+            // Bob was already notified by the message being edited, so only Carol is new.
+            expect(content["m.mentions"]).toEqual({ user_ids: ["@carol:element.io"] });
+            expect(content["m.new_content"]!["m.mentions"]).toEqual({
+                user_ids: ["@bob:element.io", "@carol:element.io"],
             });
         });
     });

--- a/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/utils/message-test.ts
+++ b/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/utils/message-test.ts
@@ -159,10 +159,11 @@ describe("message", () => {
 
             // Then
             const expectedContent = {
-                body: "*__hello__ world*",
-                format: "org.matrix.custom.html",
-                formatted_body: "<i><b>hello</b> world</i>",
-                msgtype: "m.text",
+                "body": "*__hello__ world*",
+                "format": "org.matrix.custom.html",
+                "formatted_body": "<i><b>hello</b> world</i>",
+                "msgtype": "m.text",
+                "m.mentions": {},
             };
             expect(mockClient.sendMessage).toHaveBeenCalledWith("myfakeroom", null, expectedContent);
             expect(spyDispatcher).toHaveBeenCalledWith({ action: "message_sent" });
@@ -197,6 +198,8 @@ describe("message", () => {
                 "format": "org.matrix.custom.html",
                 "formatted_body": "<i><b>hello</b> world</i>",
                 "msgtype": "m.text",
+                // Replying to someone mentions them.
+                "m.mentions": { user_ids: ["myfakeuser2"] },
                 "m.relates_to": {
                     "m.in_reply_to": {
                         event_id: mockReplyEvent.getId(),
@@ -445,11 +448,13 @@ describe("message", () => {
             const expectedContent = {
                 "body": `* ${newMessage}`,
                 "formatted_body": `* ${newMessage}`,
+                "m.mentions": {},
                 "m.new_content": {
-                    body: "Replying to this new content",
-                    format: "org.matrix.custom.html",
-                    formatted_body: "Replying to this new content",
-                    msgtype: "m.text",
+                    "body": "Replying to this new content",
+                    "format": "org.matrix.custom.html",
+                    "formatted_body": "Replying to this new content",
+                    "msgtype": "m.text",
+                    "m.mentions": {},
                 },
                 "m.relates_to": {
                     event_id: mockEvent.getId(),


### PR DESCRIPTION
The rich text composer never filled in `m.mentions`, so mentioning someone from it sent an event with a pill the reader can see and nothing telling their client to notify them. Whether it was needed was left as an open question in a `TODO` next to where the relation is attached; it is needed, and the plain composer has done it since intentional mentions landed.

The composer marks its own pills with `data-mention-type`, and that markup is present in its output whether or not the message is being sent as formatted text. The body is the wrong thing to read here — by the time it is built the pills have already been flattened back down to plain text — so the mentions are collected from the composer's own output instead: a user pill by the ID in its permalink, `@room` by its type. A link to a room is not a mention of anybody and is left alone.

Replies mention the person being replied to, and the sender is never recorded as mentioning themselves. An edit puts the full set in the replacement and only the newly mentioned people in the fallback, matching what the plain composer does, so editing a message does not notify the same people a second time. `m.mentions` is now always present even when empty, which is what disables the legacy push rules — that is why several existing expectations in the tests gained an empty object.

This does not share code with the plain composer's `attachMentions`, which takes an `EditorModel` the rich text composer does not have. Making it usable from both would mean splitting the model walk out of it, which felt like more churn than this fix warrants.

Tests: a pill, `@room`, a reply, a self-mention, a room link, and an edit which adds one person to a message that already mentioned another.

Fixes #28383

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
