### PR TITLE
Stop an image with a width shrinking inside a table cell

### DIFF
--- a/apps/web/res/css/views/rooms/_EventTile.pcss
+++ b/apps/web/res/css/views/rooms/_EventTile.pcss
@@ -839,6 +839,17 @@ $left-gutter: 64px;
         background-color: inherit !important;
     }
 
+    /* A width in percent counts for nothing while a table decides how wide its columns should be,
+    so an image sharing a row with a paragraph of text gets squeezed to a fraction of the size it
+    asked for before it is ever drawn. Inside a cell the image's own width has to speak for itself;
+    the max-width set alongside it still caps the result, and the table scrolls rather than clips.
+    The width being overridden is an inline one, hence the !important. Only images the sanitiser
+    produced sit directly inside a cell, so this leaves pill avatars alone. */
+    &.markdown-body td > img,
+    &.markdown-body th > img {
+        width: auto !important;
+    }
+
     .mx_EventTile_clamp & {
         -webkit-line-clamp: 2;
         -webkit-box-orient: vertical;


### PR DESCRIPTION
An image in message HTML is given the width its sender asked for as `width: 100%` under a `max-width` in pixels, so that it fills the box whatever size the thumbnail came back at. A table works out how wide its columns should be before it lays their contents out, and a width in percent counts for nothing while it does — so an image sharing a row with a paragraph of text is allotted almost no column at all and drawn at a fraction of the size it asked for.

Nothing the sanitiser can write into the inline style fixes this by itself. A width in pixels sizes the column correctly but then overflows a container narrower than the image, and wrapping it in `min()` or `clamp()` puts a percentage back in front of the table and collapses the column again. The width has to be out of the way where the table can see it, which only a rule scoped to a cell can do. The `max-width` beside it still caps the image, and these tables are already `overflow: auto`, so a wide one scrolls rather than clipping.

Measured against the real cascade (`github-markdown-css` plus the timeline's own rules), for the reporter's image asking for 163x230:

| context | before | after |
|---|---|---|
| paragraph, 800px wide | 163x230 | 163x230 |
| paragraph, 100px wide | 100x230 | 100x230 |
| table cell beside a paragraph, 800px | 40x56 | 163x230 |
| table cell beside a paragraph, 300px | 12x16 | 163x230 |

Only images the sanitiser produced sit directly inside a cell — a pill keeps its avatar inside the pill's anchor — so pill avatars measure the same size either way and are left alone.

Fixes #31624