### PR TITLE
Leave a virtualised list where it is when its scrollbar is grabbed

### DIFF
--- a/packages/shared-components/src/core/VirtualizedList/virtualized-list.test.tsx
+++ b/packages/shared-components/src/core/VirtualizedList/virtualized-list.test.tsx
@@ -9,6 +9,7 @@ import React, { type PropsWithChildren } from "react";
 import { render, screen, fireEvent, waitFor, act } from "@test-utils";
 import { VirtuosoMockContext } from "react-virtuoso";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { userEvent as browserUserEvent } from "vitest/browser";
 
 import { FlatVirtualizedList, type FlatVirtualizedListProps } from "./FlatVirtualizedList";
 import { GroupedVirtualizedList, type GroupedVirtualizedListProps } from "./GroupedVirtualizedList";
@@ -760,6 +761,72 @@ describe.each<ListTestVariant>([flatVariant, groupedVariant])("$name", (variant)
 
             // The first item should have been virtualised out of the DOM.
             expect(container.querySelector("[data-testid='row-0']")).toBeNull();
+        });
+
+        /**
+         * Virtuoso scrolls on a later frame than the focus which asked it to, so a test claiming
+         * the list did not move has to give it those frames first or it proves nothing.
+         */
+        const settle = async (): Promise<void> => {
+            await act(async () => {
+                for (let i = 0; i < 10; i++) {
+                    await new Promise((resolve) => requestAnimationFrame(resolve));
+                }
+            });
+        };
+
+        /** Wheel the list well past the tab stop, which leaves the tab stop where it was. */
+        const scrollAwayFromTheTabStop = async (listContainer: HTMLElement, container: Element): Promise<void> => {
+            await act(async () => {
+                listContainer.scrollTop = ITEM_HEIGHT * 25;
+                fireEvent.scroll(listContainer);
+            });
+            await waitFor(() => {
+                expect(container.querySelector("[data-testid='row-0']")).toBeNull();
+            });
+        };
+
+        it("should stay where the user scrolled to when the list is focused by pointer", async () => {
+            const { container } = renderRealVirtualizedList();
+            const listContainer = screen.getByRole("grid");
+            await waitFor(() => {
+                expect(screen.getByTestId("row-0")).toBeDefined();
+            });
+
+            // Driven through the browser rather than synthesised, because it is the browser's own
+            // idea of how focus last arrived that tells a grabbed scrollbar from a tab.
+            await browserUserEvent.click(screen.getByTestId("row-0"));
+            await scrollAwayFromTheTabStop(listContainer, container);
+
+            // Grabbing the scrollbar lands focus on the scroller itself rather than on an item.
+            await act(async () => {
+                listContainer.focus();
+            });
+            await settle();
+
+            expect(document.activeElement).toBe(listContainer);
+            expect(container.querySelector("[data-testid='row-0']")).toBeNull();
+        });
+
+        it("should bring the tab stop back into view when the list is focused from the keyboard", async () => {
+            const { container } = renderRealVirtualizedList();
+            const listContainer = screen.getByRole("grid");
+            await waitFor(() => {
+                expect(screen.getByTestId("row-0")).toBeDefined();
+            });
+            await scrollAwayFromTheTabStop(listContainer, container);
+
+            // Tabbing in: the keypress is what tells the browser the focus which follows is a
+            // keyboard one, and a tab stop the user cannot see is no use to them.
+            await browserUserEvent.keyboard("{Tab}");
+            await act(async () => {
+                listContainer.focus();
+            });
+
+            expect(document.activeElement).toBe(listContainer);
+            await waitFor(() => {
+                expect(screen.getByTestId("row-0")).toBeDefined();
+            });
         });
 
         it("should move focus from a focused child element to the scroller on keyboard navigation", async () => {

--- a/packages/shared-components/src/core/VirtualizedList/virtualized-list.ts
+++ b/packages/shared-components/src/core/VirtualizedList/virtualized-list.ts
@@ -409,7 +409,13 @@ export function useVirtualizedList<Item, Context>(
 
             setIsFocused(true);
             const index = keyToIndexMap.get(tabIndexKey);
+            // Grabbing the scrollbar focuses the list as well, and by grabbing it the user has said
+            // where they want to be — pulling the list back to the tab stop then fights the drag they
+            // are in the middle of. Focus arriving from the keyboard carries no scroll position of its
+            // own, so that is the case which still needs the tab stop brought into view.
+            const focusedFromKeyboard = e.target instanceof Element && e.target.matches(":focus-visible");
             if (
+                focusedFromKeyboard &&
                 index !== undefined &&
                 visibleRange &&
                 (index < visibleRange.startIndex || index > visibleRange.endIndex)


### PR DESCRIPTION
A virtualised list pulls its tab stop back into view whenever it is focused, so that tabbing into one never lands on a row the user cannot see. Grabbing the scrollbar focuses the list as well, so the list hauled itself back to the tab stop the moment the thumb was touched and only then followed the drag — the thumb visibly jumping to the top before it went where it had been told to go.

Focus arriving from the keyboard is the only kind that brings no scroll position of its own with it, and that is exactly what `:focus-visible` tells apart. A pointer has already said where it wants to be, so there is nothing left to work out.

Two things about the test are worth flagging, because both quietly make it prove nothing:

- the click and the tab are driven through the browser rather than synthesised, since `:focus-visible` reads the browser's own record of how focus last arrived, which a dispatched event does not set;
- it waits several frames before concluding the list stayed put, because Virtuoso scrolls on a later frame than the focus which asked it to, so an immediate assertion passes whatever the handler does.

Both new tests were checked against the fix rather than assumed: forcing the condition true fails the pointer test, forcing it false fails the keyboard one, and the full file passes as it stands.

Fixes #34422