### PR TITLE
fix test using private field

### DIFF
--- a/apps/web/src/settings/controllers/FallbackIceServerController.test.ts
+++ b/apps/web/src/settings/controllers/FallbackIceServerController.test.ts
@@ -48,13 +48,13 @@ describe("FallbackIceServerController", () => {
         MatrixClientBackedController.matrixClient = client;
         expect(controller.settingDisabled).toBeFalsy();
 
-        const wn = {
+        const wellKnown = {
             "io.element.voip": {
                 disable_fallback_ice: true,
             },
         };
-        vi.spyOn(client, "getClientWellKnown").mockResolvedValue(wn);
-        client.emit(ClientEvent.ClientWellKnown, wn);
+        vi.spyOn(client, "getClientWellKnown").mockResolvedValue(wellKnown);
+        client.emit(ClientEvent.ClientWellKnown, wellKnown);
 
         expect(controller.settingDisabled).toBeTruthy();
     });

--- a/apps/web/src/settings/controllers/FallbackIceServerController.test.ts
+++ b/apps/web/src/settings/controllers/FallbackIceServerController.test.ts
@@ -48,12 +48,13 @@ describe("FallbackIceServerController", () => {
         MatrixClientBackedController.matrixClient = client;
         expect(controller.settingDisabled).toBeFalsy();
 
-        client["clientWellKnown"] = {
+        const wn = {
             "io.element.voip": {
                 disable_fallback_ice: true,
             },
         };
-        client.emit(ClientEvent.ClientWellKnown, client["clientWellKnown"]);
+        vi.spyOn(client, "getClientWellKnown").mockResolvedValue(wn);
+        client.emit(ClientEvent.ClientWellKnown, wn);
 
         expect(controller.settingDisabled).toBeTruthy();
     });


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Fix a test using an non-public API that is breaking a downstream refactoring
https://github.com/matrix-org/matrix-js-sdk/pull/5470


## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
