### PR TITLE
Show a desktop notification for reactions instead of only playing a sound

### DIFF
--- a/apps/web/src/Notifier.ts
+++ b/apps/web/src/Notifier.ts
@@ -209,6 +209,14 @@ export default class Notifier extends TypedEventEmitter<keyof EmittedEvents, Emi
         if (msgType && this.msgTypeHandlers.hasOwnProperty(msgType)) {
             return this.msgTypeHandlers[msgType](ev);
         }
+        if (ev.getType() === EventType.Reaction) {
+            // A reaction renders as an annotation rather than a timeline line, so TextForEvent
+            // has nothing for it. Without a body of our own the push rule still plays a sound
+            // while displayPopupNotification bails out, which reads as a silent-but-audible
+            // notification.
+            const key = ev.getRelation()?.key;
+            return key ? _t("notifier|m.reaction", { reaction: key }) : null;
+        }
         return TextForEvent.textForEvent(ev, this.sdkContext.client);
     }
 

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -1711,7 +1711,8 @@
         "mute_description": "You won't get any notifications"
     },
     "notifier": {
-        "m.key.verification.request": "%(name)s is requesting verification"
+        "m.key.verification.request": "%(name)s is requesting verification",
+        "m.reaction": "Reacted with %(reaction)s"
     },
     "onboarding": {
         "create_room": "Create a Group Chat",

--- a/apps/web/test/unit-tests/Notifier-test.ts
+++ b/apps/web/test/unit-tests/Notifier-test.ts
@@ -15,6 +15,7 @@ import {
     MsgType,
     type IContent,
     MatrixEvent,
+    RelationType,
     SyncState,
     type AccountDataEvents,
 } from "matrix-js-sdk/src/matrix";
@@ -333,6 +334,30 @@ describe("Notifier", () => {
             mockClient.setAccountData(accountDataEventKey, event!);
             notifier.displayPopupNotification(testEvent, testRoom);
             expect(MockPlatform.displayNotification).toHaveBeenCalledTimes(count);
+        });
+
+        it("should display a notification for a reaction", () => {
+            const reaction = mkEvent({
+                event: true,
+                type: EventType.Reaction,
+                user: mockClient.getSafeUserId(),
+                room: testRoom.roomId,
+                content: {
+                    "m.relates_to": {
+                        rel_type: RelationType.Annotation,
+                        event_id: "$target:example.org",
+                        key: "👍",
+                    },
+                },
+            });
+            notifier.displayPopupNotification(reaction, testRoom);
+            expect(MockPlatform.displayNotification).toHaveBeenCalledWith(
+                "@bob:example.org (!room1:server)",
+                "Reacted with 👍",
+                expect.any(String),
+                testRoom,
+                reaction,
+            );
         });
 
         it("should display a notification for a voice message", () => {


### PR DESCRIPTION
When a push rule notifies on an `m.reaction`, `Notifier.evaluateEvent` plays the sound and calls `displayPopupNotification`, but no banner ever appears. `notificationMessageForEvent` falls through to `TextForEvent`, which has no handler for reactions and returns an empty string, and `displayPopupNotification` returns early on the falsy body. The result is an alert sound with nothing on screen to explain it.

Reactions now get a notification body of their own, naming the key that was applied. The push rules still decide whether a reaction notifies at all — this only stops the banner being dropped once they have decided it does.

Tests: a case in `Notifier-test.ts` asserting `displayNotification` is called with the reaction body; it fails on the unpatched code.

Fixes #30800

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
