### PR TITLE
Say an identity server is needed when inviting an email address without one

### DIFF
--- a/apps/web/src/components/views/dialogs/InviteDialog.test.tsx
+++ b/apps/web/src/components/views/dialogs/InviteDialog.test.tsx
@@ -329,6 +329,18 @@ describe("InviteDialog", () => {
         expect(input).toHaveValue(bobbob);
     });
 
+    it("should ask for an identity server rather than inviting an email without one", async () => {
+        const onFinished = vi.fn();
+        render(<InviteDialog kind={InviteKind.Invite} roomId={roomId} onFinished={onFinished} />);
+
+        await enterIntoSearchField(aliceEmail);
+        await userEvent.click(screen.getByRole("button", { name: "Invite" }));
+
+        expect(screen.getByText(/Use an identity server to invite by email/)).toBeInTheDocument();
+        expect(mockClient.invite).not.toHaveBeenCalled();
+        expect(onFinished).not.toHaveBeenCalled();
+    });
+
     it("should allow to invite multiple emails to a room", async () => {
         render(<InviteDialog kind={InviteKind.Invite} roomId={roomId} onFinished={vi.fn()} />);
 
@@ -479,6 +491,9 @@ describe("InviteDialog", () => {
 
     describe("when inviting a user whose cryptographic identity we do not know", () => {
         beforeEach(() => {
+            // An email address can only be invited through an identity server, so these cases
+            // need one configured before they get as far as the identity warning.
+            mockClient.getIdentityServerUrl.mockReturnValue("https://identity-server");
             vi.mocked(mockClient.getCrypto()!.getUserVerificationStatus).mockImplementation(async (u) => {
                 return new UserVerificationStatus(false, false, false, false);
             });

--- a/apps/web/src/components/views/dialogs/InviteDialog.tsx
+++ b/apps/web/src/components/views/dialogs/InviteDialog.tsx
@@ -394,6 +394,23 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         return newTargets;
     }
 
+    /**
+     * An email address can only be invited through an identity server, so without one there is
+     * nothing to send. Raising the identity server prompt says that; letting the invite run
+     * produces an error about the homeserver or the one-at-a-time limit, neither of which is why
+     * it failed.
+     *
+     * @param targets - The members the user is about to invite.
+     * @returns true if the prompt was raised and the caller should stop.
+     */
+    private promptForIdentityServerIfNeeded(targets: Member[]): boolean {
+        if (this.state.canUseIdentityServer || !SettingsStore.getValue(UIFeature.IdentityServer)) return false;
+        if (!this.hasFilterAtLeastOneEmail() && !targets.some((t) => t instanceof ThreepidMember)) return false;
+
+        this.setState({ busy: false, tryingIdentityServer: true });
+        return true;
+    }
+
     private startDm = async (): Promise<void> => {
         this.setBusy(true);
 
@@ -1158,6 +1175,8 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         this.setBusy(true);
 
         const targets = this.convertFilter();
+        if (this.promptForIdentityServerIfNeeded(targets)) return;
+
         const unknownIdentityUsers: Member[] = [];
         const cli = MatrixClientPeg.safeGet();
         const crypto = cli.getCrypto();


### PR DESCRIPTION
An email address can only be invited through an identity server, but the invite dialog let the attempt run without one. It failed somewhere further down and reported whatever came back — the homeserver's error, or the note that invites by email can only be sent one at a time, which is baffling when only one address was entered. The dialog already has an identity server prompt; it simply never appeared on this path.

`onGoButtonPressed` now raises that prompt, before the cryptographic identity check, whenever the pending invite includes an email address and no identity server is configured. With an identity server present nothing about the flow changes.

Two existing identity-warning tests invited an email address without mocking an identity server. They now mock one, since without it that invite could never have been sent in the first place.

Tests: a case in `InviteDialog.test.tsx` asserting the prompt appears and no invite is issued; it fails on the unpatched code.

Fixes #33186

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
