### PR TITLE
Leave a mentions-only room out of the application-wide unread indicator

### DIFF
--- a/apps/web/src/stores/notifications/RoomNotificationStateStore.ts
+++ b/apps/web/src/stores/notifications/RoomNotificationStateStore.ts
@@ -18,6 +18,8 @@ import { SummarizedNotificationState } from "./SummarizedNotificationState";
 import { isRoomVisible } from "../room-list-v3/isRoomVisible";
 import { PosthogAnalytics } from "../../PosthogAnalytics";
 import SettingsStore from "../../settings/SettingsStore";
+import { getRoomNotifsState, RoomNotifState } from "../../RoomNotifs";
+import { NotificationLevel } from "./NotificationLevel";
 
 export const UPDATE_STATUS_INDICATOR = Symbol("update-status-indicator");
 
@@ -117,7 +119,17 @@ export class RoomNotificationStateStore extends AsyncStoreWithClient<EmptyObject
         let numFavourites = 0;
         for (const room of visibleRooms) {
             if (isRoomVisible(room)) {
-                globalState.add(this.getRoomState(room));
+                const roomState = this.getRoomState(room);
+
+                // A room set to "mentions & keywords" has asked not to be told about ordinary
+                // traffic, and the app-level indicators this feeds - the asterisk in the page
+                // title and the dot on the tray icon - carry no room context to explain
+                // themselves. Its mere activity is therefore left out. Anything louder than
+                // activity is a mention, a marked-unread or an invite, and still counts.
+                const isActivityOnly = roomState.level === NotificationLevel.Activity;
+                if (!isActivityOnly || getRoomNotifsState(room.client, room.roomId) !== RoomNotifState.MentionsOnly) {
+                    globalState.add(roomState);
+                }
 
                 if (room.tags[DefaultTagID.Favourite] && !room.getType()) numFavourites++;
             }

--- a/apps/web/test/unit-tests/stores/RoomNotificationStateStore-test.ts
+++ b/apps/web/test/unit-tests/stores/RoomNotificationStateStore-test.ts
@@ -7,13 +7,15 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { mocked } from "jest-mock";
-import { ClientEvent, type MatrixClient, Room, SyncState } from "matrix-js-sdk/src/matrix";
+import { ClientEvent, type MatrixClient, PushRuleActionName, Room, SyncState } from "matrix-js-sdk/src/matrix";
 
 import { createTestClient, setupAsyncStoreWithClient } from "../../test-utils";
 import {
     RoomNotificationStateStore,
     UPDATE_STATUS_INDICATOR,
 } from "../../../src/stores/notifications/RoomNotificationStateStore";
+import { NotificationLevel } from "../../../src/stores/notifications/NotificationLevel";
+import { type RoomNotificationState } from "../../../src/stores/notifications/RoomNotificationState";
 import SettingsStore from "../../../src/settings/SettingsStore";
 import { MatrixDispatcher } from "../../../src/dispatcher/dispatcher";
 
@@ -106,6 +108,43 @@ describe("RoomNotificationStateStore", function () {
             // Then we check visible rooms, using the dynamic predecessor flag
             expect(client.getVisibleRooms).toHaveBeenCalledWith(true);
             expect(client.getVisibleRooms).not.toHaveBeenCalledWith(false);
+        });
+    });
+
+    describe("when a room is set to mentions & keywords", () => {
+        function fakeActivityRoom(level: NotificationLevel): Room {
+            const room = fakeRoom(0);
+            client.getRoomPushRule = jest.fn().mockReturnValue({
+                rule_id: room.roomId,
+                enabled: true,
+                default: false,
+                actions: [PushRuleActionName.DontNotify],
+            });
+            jest.spyOn(store, "getRoomState").mockReturnValue({
+                level,
+                symbol: null,
+                count: 0,
+                hasUnreadCount: true,
+            } as RoomNotificationState);
+            return room;
+        }
+
+        it("keeps its activity out of the global state", async () => {
+            const room = fakeActivityRoom(NotificationLevel.Activity);
+
+            mocked(client.getVisibleRooms).mockReturnValue([room]);
+            client.emit(ClientEvent.Sync, SyncState.Syncing, SyncState.Syncing);
+
+            expect(store.emit).not.toHaveBeenCalled();
+        });
+
+        it("still contributes a mention to the global state", async () => {
+            const room = fakeActivityRoom(NotificationLevel.Highlight);
+
+            mocked(client.getVisibleRooms).mockReturnValue([room]);
+            client.emit(ClientEvent.Sync, SyncState.Syncing, SyncState.Syncing);
+
+            expect(store.emit).toHaveBeenCalledWith(UPDATE_STATUS_INDICATOR, expect.anything(), "SYNCING");
         });
     });
 


### PR DESCRIPTION
`RoomNotificationStateStore` adds every visible room to the summarised state that drives the asterisk in the page title and the dot on the tray icon. `determineUnreadState` drops a muted room but not one set to mentions and keywords, so a busy room the user had deliberately quietened still reported plain activity and kept the whole client marked unread. The only escape was to mute the room outright and lose the mentions with it.

Activity from a mentions-only room no longer reaches the global summary. Anything louder still does — a mention, a marked-unread room and an invite all outrank activity — and the room's own entry in the room list is untouched, so no per-room context is lost.

Tests: two cases in `RoomNotificationStateStore-test.ts`, one asserting activity is excluded and one asserting a highlight from the same room still counts. The first fails on the unpatched code.

Fixes #32116

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
