### PR TITLE
Include thread replies when exporting the current timeline

### DIFF
--- a/apps/web/src/utils/exportUtils/Exporter.ts
+++ b/apps/web/src/utils/exportUtils/Exporter.ts
@@ -137,6 +137,29 @@ export default abstract class Exporter {
         return limit;
     }
 
+    /**
+     * The events of the current timeline, in timestamp order.
+     *
+     * Thread replies are kept out of the room's live timeline, so reading that alone exports the
+     * thread roots and none of the conversation under them. The other export types go through
+     * `/messages`, which returns thread replies with everything else.
+     */
+    private getCurrentTimelineEvents(): MatrixEvent[] {
+        const events = [...this.room.getLiveTimeline().getEvents()];
+        const seen = new Set(events.map((ev) => ev.getId()));
+
+        for (const thread of this.room.getThreads()) {
+            for (const ev of thread.liveTimeline.getEvents()) {
+                // The root lives in both timelines.
+                if (seen.has(ev.getId())) continue;
+                seen.add(ev.getId());
+                events.push(ev);
+            }
+        }
+
+        return events.sort((a, b) => a.getTs() - b.getTs());
+    }
+
     protected async getRequiredEvents(): Promise<MatrixEvent[]> {
         const eventMapper = this.room.client.getEventMapper();
 
@@ -144,7 +167,7 @@ export default abstract class Exporter {
 
         let events: MatrixEvent[] = [];
         if (this.exportType === ExportType.Timeline) {
-            events = this.room.getLiveTimeline().getEvents();
+            events = this.getCurrentTimelineEvents();
         } else {
             let limit = this.getLimit();
             while (limit) {

--- a/apps/web/test/unit-tests/utils/exportUtils/PlainTextExport-test.ts
+++ b/apps/web/test/unit-tests/utils/exportUtils/PlainTextExport-test.ts
@@ -8,7 +8,7 @@ Please see LICENSE files in the repository root for full details.
 
 import { MatrixEvent, type Room } from "matrix-js-sdk/src/matrix";
 
-import { createTestClient, mkStubRoom, REPEATABLE_DATE } from "../../../test-utils";
+import { createTestClient, mkEvent, mkStubRoom, REPEATABLE_DATE } from "../../../test-utils";
 import { ExportType, type IExportOptions } from "../../../../src/utils/exportUtils/exportUtils";
 import PlainTextExporter from "../../../../src/utils/exportUtils/PlainTextExport";
 import SettingsStore from "../../../../src/settings/SettingsStore";
@@ -16,6 +16,10 @@ import SettingsStore from "../../../../src/settings/SettingsStore";
 class TestablePlainTextExporter extends PlainTextExporter {
     public async testCreateOutput(events: MatrixEvent[]): Promise<string> {
         return this.createOutput(events);
+    }
+
+    public async testGetRequiredEvents(): Promise<MatrixEvent[]> {
+        return this.getRequiredEvents();
     }
 }
 
@@ -32,6 +36,38 @@ describe("PlainTextExport", () => {
             maxSize: 50000000,
         };
         stubRoom = mkStubRoom("!myroom:example.org", roomName, client);
+    });
+
+    it("should export thread replies alongside the main timeline", async () => {
+        const mkMsg = (id: string, body: string, ts: number): MatrixEvent =>
+            mkEvent({
+                event: true,
+                id,
+                type: "m.room.message",
+                user: "@alice:example.org",
+                room: stubRoom.roomId,
+                content: { msgtype: "m.text", body },
+                ts,
+            });
+
+        const message = mkMsg("$message", "in the room", 1);
+        const threadRoot = mkMsg("$root", "thread root", 2);
+        const threadReply = mkMsg("$reply", "thread reply", 3);
+
+        stubRoom.currentState = {
+            getSentinelMember: () => null,
+        } as unknown as typeof stubRoom.currentState;
+        stubRoom.getLiveTimeline = jest.fn().mockReturnValue({ getEvents: () => [message, threadRoot] });
+        stubRoom.getThreads = jest.fn().mockReturnValue([
+            {
+                liveTimeline: { getEvents: () => [threadRoot, threadReply] },
+            },
+        ]);
+
+        const exporter = new TestablePlainTextExporter(stubRoom, ExportType.Timeline, stubOptions, () => {});
+        const events = await exporter.testGetRequiredEvents();
+
+        expect(events.map((e) => e.getId())).toEqual(["$message", "$root", "$reply"]);
     });
 
     it("should have an Element-branded destination file name", () => {


### PR DESCRIPTION
`Exporter.getRequiredEvents` reads the room's live timeline directly for the current-timeline range. Thread replies are deliberately kept out of that timeline, so the export contained every thread root and none of the conversation underneath it.

The timeline events and the events of every thread are now merged, deduplicated on the root that appears in both, and ordered by timestamp. The other export ranges go through `/messages`, which already returns thread replies alongside everything else, so only this range changes.

Tests: a case in `PlainTextExport-test.ts` asserting a thread reply appears in the exported event list in timestamp order; it fails on the unpatched code.

Fixes #27259

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
