### PR TITLE
Sort member list entries by name when the client has no presence data for them

### DIFF
--- a/apps/web/src/stores/MemberListStore.ts
+++ b/apps/web/src/stores/MemberListStore.ts
@@ -215,8 +215,8 @@ export class MemberListStore {
                 return idx === -1 ? order.length : idx; // unknown states at the end
             };
 
-            const idxA = presenceIndex(userA!.currentlyActive ? "active" : userA!.presence);
-            const idxB = presenceIndex(userB!.currentlyActive ? "active" : userB!.presence);
+            const idxA = presenceIndex(userA.currentlyActive ? "active" : userA.presence);
+            const idxB = presenceIndex(userB.currentlyActive ? "active" : userB.presence);
             if (idxA !== idxB) {
                 return idxA - idxB;
             }
@@ -228,8 +228,8 @@ export class MemberListStore {
         }
 
         // Third by last active
-        if (showPresence && userA!.getLastActiveTs() !== userB!.getLastActiveTs()) {
-            return userB!.getLastActiveTs() - userA!.getLastActiveTs();
+        if (showPresence && userA.getLastActiveTs() !== userB.getLastActiveTs()) {
+            return userB.getLastActiveTs() - userA.getLastActiveTs();
         }
 
         // Fourth by name (alphabetical)

--- a/apps/web/src/stores/MemberListStore.ts
+++ b/apps/web/src/stores/MemberListStore.ts
@@ -199,11 +199,12 @@ export class MemberListStore {
         const userA = memberA.user;
         const userB = memberB.user;
 
-        if (!userA && !userB) return 0;
-        if (userA && !userB) return -1;
-        if (!userA && userB) return 1;
+        // A member the client has no User for has no presence and no last-active time, but its
+        // power level and name are still known. Returning 0 for every such pair left the whole
+        // list in whatever order it was built in, which reads as random.
+        if (!!userA !== !!userB) return userA ? -1 : 1;
 
-        const showPresence = this.isPresenceEnabled();
+        const showPresence = this.isPresenceEnabled() && !!userA && !!userB;
 
         // First by presence
         if (showPresence) {

--- a/apps/web/test/unit-tests/stores/MemberListStore-test.ts
+++ b/apps/web/test/unit-tests/stores/MemberListStore-test.ts
@@ -124,6 +124,22 @@ describe("MemberListStore", () => {
         ]);
     });
 
+    it("sorts by name when the client has no user for any of the members", async () => {
+        const doris = "@doris:bar";
+        addMember(room, bob, KnownMembership.Join);
+        addMember(room, charlie, KnownMembership.Join);
+        addMember(room, doris, KnownMembership.Join, "AAAAA");
+        setPowerLevels(room, {
+            users_default: 10,
+        });
+        // Lazy loading means the client may hold no User for a member at all, which is the only
+        // thing that ever populates RoomMember.user.
+        mocked(client.getUser).mockReturnValue(null);
+
+        const { joined } = await store.loadMemberList(roomId);
+        expect(joined.map((m) => m.userId)).toEqual([doris, alice, bob, charlie]);
+    });
+
     it("filters based on a search query", async () => {
         const mice = "@mice:bar";
         const zorro = "@zorro:bar";


### PR DESCRIPTION
`MemberListStore.sortMembers` returned 0 as soon as neither member had a `User` object, which is the normal state for a lazily loaded member the client has never otherwise seen. Every such pair compared equal, so the sort left the list in whatever order it was built in and members of the same rank appeared in no order at all.

A missing `User` only means presence and last-active time are unknown; power level and display name still are. Those steps now run regardless, and only the presence comparisons are skipped rather than short-circuiting the whole comparison. The non-null assertions in the presence branch became redundant once the guard turned into an aliased boolean, so they are gone.

Tests: a case in `MemberListStore-test.ts` with `getUser` returning null throughout, asserting alphabetical order; it fails on the unpatched comparator.

Fixes #29380

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
