### PR TITLE
Name a video by its filename rather than its caption

### DIFF
--- a/apps/web/src/viewmodels/message-body/VideoBodyViewModel.ts
+++ b/apps/web/src/viewmodels/message-body/VideoBodyViewModel.ts
@@ -239,8 +239,11 @@ export class VideoBodyViewModel
 
         return {
             state: VideoBodyViewState.READY,
-            videoLabel: content.body,
-            videoTitle: content.body,
+            // With a filename present the body is a caption rather than the name of the file, so
+            // naming the video by its body puts the caption in the hover text and the accessible
+            // name where the filename belongs.
+            videoLabel: content.filename || content.body,
+            videoTitle: content.filename || content.body,
             maxWidth,
             maxHeight,
             aspectRatio,

--- a/apps/web/test/viewmodels/message-body/VideoBodyViewModel-test.ts
+++ b/apps/web/test/viewmodels/message-body/VideoBodyViewModel-test.ts
@@ -442,6 +442,20 @@ describe("VideoBodyViewModel", () => {
         expect(vm.getSnapshot().src).toBe("data:video/mp4,");
     });
 
+    it("names the video by its filename rather than its caption", () => {
+        const vm = createVm({
+            mxEvent: createEvent({
+                body: "a caption",
+                content: { filename: "holiday.mp4" },
+            }),
+        });
+
+        vm.setMediaVisible(true);
+
+        expect(vm.getSnapshot().videoTitle).toBe("holiday.mp4");
+        expect(vm.getSnapshot().videoLabel).toBe("holiday.mp4");
+    });
+
     it("does not emit for unchanged targeted setters", () => {
         const event = createEvent();
         const onPreviewClick = jest.fn();


### PR DESCRIPTION
A video message that carries a `filename` uses its `body` as a caption. `VideoBodyViewModel` set both `videoTitle`, which becomes the player's `title`, and `videoLabel`, which becomes its `aria-label`, from the body — so the caption ended up as the hover text and as the accessible name, where the name of the file belongs.

Both now prefer the filename and fall back to the body, leaving messages without a filename, where the body *is* the filename, unchanged.

Tests: a case in `VideoBodyViewModel-test.ts` with a caption and a filename asserting both fields; it fails on the unpatched code.

Fixes #31117

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
