### PR TITLE
Update the pinned message banner when a pinned message is edited

### DIFF
--- a/apps/web/src/hooks/usePinnedEvents.ts
+++ b/apps/web/src/hooks/usePinnedEvents.ts
@@ -16,6 +16,7 @@ import {
     RelationType,
     EventTimeline,
     type MatrixClient,
+    type IRoomTimelineData,
 } from "matrix-js-sdk/src/matrix";
 import { logger } from "matrix-js-sdk/src/logger";
 
@@ -180,27 +181,53 @@ async function fetchPinnedEvent(room: Room, pinnedEventId: string, cli: MatrixCl
 export function useFetchedPinnedEvents(room: Room, pinnedEventIds: string[]): Array<MatrixEvent> {
     const cli = useMatrixClientContext();
 
-    // Editing a pinned message leaves the pinned ids untouched, so nothing here would change and
-    // the pinned event would keep rendering its original content. Count the edits that land on a
-    // pinned event and refetch on each one.
-    const [editCount, setEditCount] = useState(0);
-    useTypedEventEmitter(room, RoomEvent.Timeline, (ev: MatrixEvent) => {
-        const relation = ev.getRelation();
-        if (relation?.rel_type !== RelationType.Replace || !relation.event_id) return;
-        if (!pinnedEventIds.includes(relation.event_id)) return;
-        setEditCount((count) => count + 1);
-    });
+    // Editing a pinned message leaves the pinned ids untouched, and a pinned event fetched from
+    // the server only carries the edits that existed when it was fetched, so a later edit would go
+    // unnoticed. Collect the edits landing on a pinned event, keyed by the event they replace.
+    const [edits, setEdits] = useState(new Map<string, MatrixEvent>());
+    useTypedEventEmitter(
+        room,
+        RoomEvent.Timeline,
+        (
+            event: MatrixEvent,
+            _room: Room | undefined,
+            _toStartOfTimeline: boolean | undefined,
+            removed: boolean,
+            data: IRoomTimelineData,
+        ): void => {
+            // A backfilled edit can be older than the one already applied, so only live ones count.
+            if (removed || !data.liveEvent) return;
 
-    const events = useAsyncMemo(
+            const relation = event.getRelation();
+            if (relation?.rel_type !== RelationType.Replace) return;
+
+            const editedEventId = relation.event_id;
+            if (!editedEventId || !pinnedEventIds.includes(editedEventId)) return;
+            setEdits((edits) => new Map(edits).set(editedEventId, event));
+        },
+    );
+
+    const fetchedEvents = useAsyncMemo(
         () => {
             const fetchPromises = pinnedEventIds.map((eventId) => () => fetchPinnedEvent(room, eventId, cli));
             // Fetch the pinned events in batches of 10
             return batch(fetchPromises, 10);
         },
-        [cli, room, pinnedEventIds, editCount],
+        [cli, room, pinnedEventIds],
         [],
     );
-    return filterBoolean(events);
+    const events = useMemo(() => filterBoolean(fetchedEvents), [fetchedEvents]);
+
+    // Replacing an event notifies whatever is rendering it, which is what refreshes the banner and
+    // the pinned messages card, so it has to happen after the render rather than during it.
+    useEffect(() => {
+        for (const event of events) {
+            const edit = edits.get(event.getId()!);
+            if (edit) event.makeReplaced(edit);
+        }
+    }, [events, edits]);
+
+    return events;
 }
 
 /**

--- a/apps/web/src/hooks/usePinnedEvents.ts
+++ b/apps/web/src/hooks/usePinnedEvents.ts
@@ -180,13 +180,24 @@ async function fetchPinnedEvent(room: Room, pinnedEventId: string, cli: MatrixCl
 export function useFetchedPinnedEvents(room: Room, pinnedEventIds: string[]): Array<MatrixEvent> {
     const cli = useMatrixClientContext();
 
+    // Editing a pinned message leaves the pinned ids untouched, so nothing here would change and
+    // the pinned event would keep rendering its original content. Count the edits that land on a
+    // pinned event and refetch on each one.
+    const [editCount, setEditCount] = useState(0);
+    useTypedEventEmitter(room, RoomEvent.Timeline, (ev: MatrixEvent) => {
+        const relation = ev.getRelation();
+        if (relation?.rel_type !== RelationType.Replace || !relation.event_id) return;
+        if (!pinnedEventIds.includes(relation.event_id)) return;
+        setEditCount((count) => count + 1);
+    });
+
     const events = useAsyncMemo(
         () => {
             const fetchPromises = pinnedEventIds.map((eventId) => () => fetchPinnedEvent(room, eventId, cli));
             // Fetch the pinned events in batches of 10
             return batch(fetchPromises, 10);
         },
-        [cli, room, pinnedEventIds],
+        [cli, room, pinnedEventIds, editCount],
         [],
     );
     return filterBoolean(events);

--- a/apps/web/test/unit-tests/hooks/usePinnedEvents-test.tsx
+++ b/apps/web/test/unit-tests/hooks/usePinnedEvents-test.tsx
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 hayaksi1
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import React, { type PropsWithChildren } from "react";
+import { renderHook, waitFor } from "jest-matrix-react";
+import { EventType, type MatrixClient, MatrixEvent, RelationType, Room } from "matrix-js-sdk/src/matrix";
+
+import { useFetchedPinnedEvents } from "../../../src/hooks/usePinnedEvents";
+import MatrixClientContext from "../../../src/contexts/MatrixClientContext";
+import { stubClient } from "../../test-utils";
+
+describe("useFetchedPinnedEvents", () => {
+    const roomId = "!room:server";
+    const userId = "@alice:server";
+    const pinnedEventId = "$pinned:server";
+
+    let client: MatrixClient;
+    let room: Room;
+    // Stable identity: the hook memoises on this array, so a fresh literal per render would
+    // refetch forever.
+    const pinnedIds = [pinnedEventId];
+
+    const makeEvent = (id: string, content: object): MatrixEvent =>
+        new MatrixEvent({
+            type: EventType.RoomMessage,
+            sender: userId,
+            room_id: roomId,
+            event_id: id,
+            origin_server_ts: 0,
+            content,
+        });
+
+    const edit = (targetId: string, id: string): MatrixEvent =>
+        makeEvent(id, {
+            "msgtype": "m.text",
+            "body": "* edited",
+            "m.new_content": { msgtype: "m.text", body: "edited" },
+            "m.relates_to": { rel_type: RelationType.Replace, event_id: targetId },
+        });
+
+    const wrapper = ({ children }: PropsWithChildren): React.JSX.Element => (
+        <MatrixClientContext.Provider value={client}>{children}</MatrixClientContext.Provider>
+    );
+
+    beforeEach(() => {
+        client = stubClient();
+        room = new Room(roomId, client, userId);
+        // The pinned event is deliberately not in the local timeline, so every recomputation has
+        // to go to the server and is therefore countable.
+        jest.spyOn(client, "fetchRoomEvent").mockResolvedValue(
+            makeEvent(pinnedEventId, { msgtype: "m.text", body: "original" }).event as never,
+        );
+        jest.spyOn(client, "relations").mockResolvedValue({ events: [] });
+    });
+
+    it("refetches the pinned events when one of them is edited", async () => {
+        const { result } = renderHook(() => useFetchedPinnedEvents(room, pinnedIds), { wrapper });
+        await waitFor(() => expect(result.current).toHaveLength(1));
+        expect(client.fetchRoomEvent).toHaveBeenCalledTimes(1);
+
+        room.addLiveEvents([edit(pinnedEventId, "$edit:server")], { addToState: false });
+
+        await waitFor(() => expect(client.fetchRoomEvent).toHaveBeenCalledTimes(2));
+    });
+
+    it("does not refetch when an event that is not pinned is edited", async () => {
+        const { result } = renderHook(() => useFetchedPinnedEvents(room, pinnedIds), { wrapper });
+        await waitFor(() => expect(result.current).toHaveLength(1));
+
+        room.addLiveEvents([edit("$somethingElse:server", "$edit2:server")], { addToState: false });
+
+        // Wait long enough that a refetch would have landed, then confirm none did.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(client.fetchRoomEvent).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/web/test/unit-tests/hooks/usePinnedEvents-test.tsx
+++ b/apps/web/test/unit-tests/hooks/usePinnedEvents-test.tsx
@@ -6,7 +6,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import React, { type PropsWithChildren } from "react";
-import { renderHook, waitFor } from "jest-matrix-react";
+import { act, renderHook, waitFor } from "jest-matrix-react";
 import { EventType, type MatrixClient, MatrixEvent, RelationType, Room } from "matrix-js-sdk/src/matrix";
 
 import { useFetchedPinnedEvents } from "../../../src/hooks/usePinnedEvents";
@@ -49,32 +49,36 @@ describe("useFetchedPinnedEvents", () => {
     beforeEach(() => {
         client = stubClient();
         room = new Room(roomId, client, userId);
-        // The pinned event is deliberately not in the local timeline, so every recomputation has
-        // to go to the server and is therefore countable.
+        // The pinned event is deliberately not in the local timeline, so the hook holds a copy of
+        // its own that nothing else keeps up to date.
         jest.spyOn(client, "fetchRoomEvent").mockResolvedValue(
             makeEvent(pinnedEventId, { msgtype: "m.text", body: "original" }).event as never,
         );
         jest.spyOn(client, "relations").mockResolvedValue({ events: [] });
     });
 
-    it("refetches the pinned events when one of them is edited", async () => {
+    it("gives the edited content for a pinned event that is edited", async () => {
         const { result } = renderHook(() => useFetchedPinnedEvents(room, pinnedIds), { wrapper });
         await waitFor(() => expect(result.current).toHaveLength(1));
-        expect(client.fetchRoomEvent).toHaveBeenCalledTimes(1);
+        expect(result.current[0].getContent().body).toBe("original");
 
-        room.addLiveEvents([edit(pinnedEventId, "$edit:server")], { addToState: false });
+        act(() => {
+            room.addLiveEvents([edit(pinnedEventId, "$edit:server")], { addToState: false });
+        });
 
-        await waitFor(() => expect(client.fetchRoomEvent).toHaveBeenCalledTimes(2));
+        await waitFor(() => expect(result.current[0].getContent().body).toBe("edited"));
     });
 
-    it("does not refetch when an event that is not pinned is edited", async () => {
+    it("leaves a pinned event alone when a different event is edited", async () => {
         const { result } = renderHook(() => useFetchedPinnedEvents(room, pinnedIds), { wrapper });
         await waitFor(() => expect(result.current).toHaveLength(1));
 
-        room.addLiveEvents([edit("$somethingElse:server", "$edit2:server")], { addToState: false });
+        act(() => {
+            room.addLiveEvents([edit("$somethingElse:server", "$edit2:server")], { addToState: false });
+        });
 
-        // Wait long enough that a refetch would have landed, then confirm none did.
+        // Wait long enough that an edit would have been applied, then confirm none was.
         await new Promise((resolve) => setTimeout(resolve, 50));
-        expect(client.fetchRoomEvent).toHaveBeenCalledTimes(1);
+        expect(result.current[0].getContent().body).toBe("original");
     });
 });


### PR DESCRIPTION
The pinned events are fetched from a memo keyed on the pinned event ids, and editing a pinned message leaves those ids untouched. Nothing invalidated the memo, so the banner and the pinned messages card went on rendering the original text while the timeline showed the edit.

`useFetchedPinnedEvents` now watches the timeline for `m.replace` relations and, when one lands on an event that is currently pinned, applies it to the copy it holds. An edit to any other event is ignored, and no refetch is involved — the replacement is the same mechanism the SDK uses for events it already has in the timeline. Only live edits count, since a backfilled one can be older than the edit already applied.

Applying it runs in an effect rather than in the memo because replacing an event notifies whatever is rendering it, and that must not happen during a render.

Tests: two cases in a new `usePinnedEvents-test.tsx` — one asserting the hook hands back the edited content for an edit to a pinned event, one asserting it does not for an unrelated edit. The first fails on the unpatched code.

Fixes #27978

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
