### PR TITLE
Send a rich text mention as a name in the plain text body

### DIFF
--- a/apps/web/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
+++ b/apps/web/src/components/views/rooms/wysiwyg_composer/utils/createMessageContent.ts
@@ -61,7 +61,10 @@ export async function createMessageContent(
 
     // if we're editing rich text, the message content is pure html
     // BUT if we're not, the message content will be plain text where we need to convert the mentions
-    const body = isHTML ? await richToPlain(message, false) : convertPlainTextToBody(message);
+    // Ask for the MESSAGE representation rather than the editor's own: the editor representation keeps
+    // a mention as the anchor that renders its pill, so a client which only reads the body would be
+    // shown that markup instead of the name the mention stands for.
+    const body = isHTML ? await richToPlain(message, true) : convertPlainTextToBody(message);
 
     const content = {
         msgtype: isEmote ? MsgType.Emote : MsgType.Text,

--- a/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/utils/createMessageContent-test.ts
+++ b/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/utils/createMessageContent-test.ts
@@ -42,6 +42,20 @@ describe("createMessageContent", () => {
             });
         });
 
+        it("Should name a mention in the body rather than repeat its markup", async () => {
+            // When
+            const mention = '<a href="https://matrix.to/#/@alice:example.org">Alice</a> hello';
+            const content = await createMessageContent(mention, true, {});
+
+            // Then
+            expect(content).toEqual({
+                body: "Alice hello",
+                format: "org.matrix.custom.html",
+                formatted_body: mention,
+                msgtype: "m.text",
+            });
+        });
+
         it("Should add relation to message", async () => {
             // When
             const relation = {


### PR DESCRIPTION
`createMessageContent` asked the rich text editor for the editor's own representation of the message
when building `content.body`. In that representation a mention is still the anchor which renders its
pill, so mentioning someone put `<a data-mention-type="user" href="https://matrix.to/#/@alice:…"
contenteditable="false">Alice</a>` into the plain text body. `formatted_body` was correct, so only
clients that read the body — bridges, notifications, anything without HTML support — saw the markup.

The body now asks for the message representation instead, in which a mention is flattened to the
name it stands for. The two representations differ only for mentions; emphasis, links, lists, code,
quotes and escaping are produced identically either way, so nothing else about the body moves.

The other caller of `richToPlain` stays on the editor representation. That one converts composer
state when switching the composer from rich text to plain text, where the pills have to survive.

Tests: a case in `createMessageContent-test.ts` asserting a mention becomes the person's name in
`body` while `formatted_body` keeps the anchor; it fails without the change.

Fixes #28516

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
