### PR TITLE
Never show a message from an ignored user inside an event summary

### DIFF
--- a/apps/web/src/components/structures/grouper/MainGrouper.tsx
+++ b/apps/web/src/components/structures/grouper/MainGrouper.tsx
@@ -97,8 +97,11 @@ export class MainGrouper extends BaseGrouper {
             if (!hasText(ev, MatrixClientPeg.safeGet(), this.panel.showHiddenEvents)) return;
         }
         this.readMarker = this.readMarker || this.panel.readMarkerForEvent(ev.getId()!, ev === this.lastShownEvent);
-        if (!this.panel.showHiddenEvents && !shouldShow) {
-            // absorb hidden events to not split the summary
+        if (!shouldShow) {
+            // Absorb hidden events so they do not split the summary, but never render them. Once
+            // hidden events are being shown, shouldShowEvent() only returns false for an event
+            // filtered out of the timeline altogether — an ignored sender, or a message that
+            // belongs to a thread — and a developer setting must not bring those back.
             return;
         }
 

--- a/apps/web/test/unit-tests/components/structures/MessagePanel-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/MessagePanel-test.tsx
@@ -691,6 +691,38 @@ describe("MessagePanel", function () {
         expect(els[0].getAttribute("data-scroll-tokens")?.split(",")).toHaveLength(3);
     });
 
+    it("should not render a message from an ignored user when hidden events are shown", () => {
+        client.isUserIgnored.mockImplementation((userId: string) => userId === "@troll:id");
+        try {
+            const events = [
+                // Starts the summary off, and is the reason the ignored message is absorbed into it.
+                TestUtilsMatrix.mkEvent({
+                    event: true,
+                    type: "m.reaction",
+                    room: "!room:id",
+                    user: "@user:id",
+                    content: {},
+                    ts: 1,
+                }),
+                TestUtilsMatrix.mkMessage({
+                    event: true,
+                    room: "!room:id",
+                    user: "@troll:id",
+                    msg: "ignored message",
+                    ts: 2,
+                }),
+            ];
+            const { container } = render(
+                getComponent({ events }, { showHiddenEvents: true }),
+                clientAndSDKContextRenderOptions(client, sdkContext),
+            );
+
+            expect(within(container).queryByText("ignored message")).toBeNull();
+        } finally {
+            client.isUserIgnored.mockReturnValue(false);
+        }
+    });
+
     it("should handle large numbers of hidden events quickly", () => {
         // Increase the length of the loop here to test performance issues with
         // rendering


### PR DESCRIPTION
`MainGrouper.add` only refused to render an event the panel had filtered out while the "show hidden
events in timeline" developer setting was off. With the setting on, a message from an ignored user
was absorbed into the surrounding event summary and then rendered inside it, which is why it turned
up small and grey rather than disappearing — the summary styles every tile it contains one size
down.

`shouldShowEvent` applies the ignore check and the thread check before it consults that setting, so
once hidden events are being shown an event can only fail it for one of those two reasons. Neither
is something the developer setting is meant to override, so the grouper now declines to render any
filtered event and keeps absorbing it, which is what stops it splitting the summary in two.

Tests: a case in `MessagePanel-test.tsx` rendering an ignored user's message after a reaction with
hidden events shown, asserting the body is absent; it fails without the change.

Fixes #27984

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
