### PR TITLE
Follow a link inside a reply instead of jumping to the replied-to message

### DIFF
--- a/apps/web/src/components/views/rooms/ReplyTile.tsx
+++ b/apps/web/src/components/views/rooms/ReplyTile.tsx
@@ -67,11 +67,11 @@ export default class ReplyTile extends React.PureComponent<IProps> {
         // Following a link within a reply should not dispatch the `view_room` action
         // so that the browser can direct the user to the correct location
         // The exception being the link wrapping the reply
-        if (
-            clickTarget.tagName.toLowerCase() !== "a" ||
-            clickTarget.closest("a") === null ||
-            clickTarget === this.anchorElement.current
-        ) {
+        // Ask for the ENCLOSING anchor rather than testing the target itself: a link is regularly
+        // clicked on something nested inside it — the text of a pill, an emoji image, a bold run —
+        // and treating those as "not a link" swallowed the navigation.
+        const clickedAnchor = clickTarget.closest("a");
+        if (clickedAnchor === null || clickedAnchor === this.anchorElement.current) {
             // This allows the permalink to be opened in a new tab/window or copied as
             // matrix.to, but also for it to enable routing within Riot when clicked.
             e.preventDefault();

--- a/apps/web/test/unit-tests/components/views/rooms/ReplyTile-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/ReplyTile-test.tsx
@@ -13,6 +13,8 @@ import ReplyTile from "../../../../../src/components/views/rooms/ReplyTile";
 import { renderReplyTile } from "../../../../../src/events/EventTileFactory";
 import { VideoBodyFactory } from "../../../../../src/components/views/messages/MBodyFactory";
 import { mkEvent, stubClient } from "../../../../test-utils";
+import dis from "../../../../../src/dispatcher/dispatcher";
+import { Action } from "../../../../../src/dispatcher/actions";
 
 jest.mock("../../../../../src/events/EventTileFactory", () => {
     const actual = jest.requireActual("../../../../../src/events/EventTileFactory");
@@ -63,5 +65,53 @@ describe("ReplyTile", () => {
             }),
             false,
         );
+    });
+
+    describe("clicking a reply", () => {
+        const mkTextEvent = () =>
+            mkEvent({
+                event: true,
+                type: EventType.RoomMessage,
+                user: "@alice:server",
+                room: "!room:server",
+                id: "$text",
+                content: { body: "hello", msgtype: MsgType.Text },
+            });
+
+        // The quoted body is injected as markup rather than as JSX because React refuses to nest an
+        // anchor inside the anchor which wraps the whole tile, and the test setup turns that warning
+        // into a failure.
+        const renderWithBody = (html: string) => {
+            jest.mocked(renderReplyTile).mockReturnValue(
+                <div className="mx_EventTile_body" dangerouslySetInnerHTML={{ __html: html }} />,
+            );
+            return render(<ReplyTile mxEvent={mkTextEvent()} />);
+        };
+
+        const clickOn = (element: Element): MouseEvent => {
+            const click = new MouseEvent("click", { bubbles: true, cancelable: true });
+            element.dispatchEvent(click);
+            return click;
+        };
+
+        it("follows a link the click landed inside rather than jumping to the replied-to message", () => {
+            const dispatch = jest.spyOn(dis, "dispatch");
+            const { container } = renderWithBody('<a href="https://example.com/foo"><b id="inner">docs</b></a>');
+
+            const click = clickOn(container.querySelector("#inner")!);
+
+            expect(click.defaultPrevented).toBe(false);
+            expect(dispatch).not.toHaveBeenCalledWith(expect.objectContaining({ action: Action.ViewRoom }));
+        });
+
+        it("jumps to the replied-to message when the click was not on a link", () => {
+            const dispatch = jest.spyOn(dis, "dispatch");
+            const { container } = renderWithBody('<b id="plain">docs</b>');
+
+            const click = clickOn(container.querySelector("#plain")!);
+
+            expect(click.defaultPrevented).toBe(true);
+            expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ action: Action.ViewRoom }));
+        });
     });
 });


### PR DESCRIPTION
The whole quoted body of a reply is wrapped in the permalink to the message being replied to, so
`ReplyTile.onClick` has to tell a click on a link inside the quote from a click on the quote itself.
It did that by looking at the tag name of the element the click landed on, which is only an anchor
when the link contains nothing but bare text. Clicking anything nested inside a link — the text of a
mention pill, an emoji image, a bold or code run — looked like "not a link", so the navigation was
cancelled and the user was permalinked to the replied-to message instead.

The check now asks for the nearest enclosing anchor. Anything inside an inner link is left for the
browser, or for the pill's own handler, while a click on non-link content still resolves to the
anchor wrapping the tile and permalinks as before.

Tests: two cases in `ReplyTile-test.tsx` clicking a bold run inside a link and one with no link
around it, asserting the default action and the dispatch; the first fails without the change.

Fixes #26784

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
