### PR TITLE
Reverse a confirmed autocomplete with a single undo

### DIFF
--- a/apps/web/src/editor/model.test.ts
+++ b/apps/web/src/editor/model.test.ts
@@ -9,6 +9,7 @@ Please see LICENSE files in the repository root for full details.
 import { describe, it, expect } from "vitest";
 
 import EditorModel from "./model";
+import HistoryManager from "./history";
 import { createPartCreator, createRenderer, type MockAutoComplete } from "./__mocks__";
 import DocumentOffset from "./offset";
 import { type PillPart } from "./parts";
@@ -190,6 +191,43 @@ describe("editor/model", function () {
             expect(model.parts[0].text).toBe("hello ");
             expect(model.parts[1].type).toBe("user-pill");
             expect(model.parts[1].text).toBe("Alice");
+        });
+
+        it("reverses a confirmed completion with a single undo", function () {
+            const history = new HistoryManager();
+            const pc = createPartCreator([{ resourceId: "@alice", text: "Alice" } as PillPart]);
+            // Stands in for the composer, which pushes every update it is told about onto the
+            // undo stack.
+            const model: EditorModel = new EditorModel([pc.plain("hello ")], pc, (caret) =>
+                history.tryPush(model, caret),
+            );
+
+            model.update("hello @a", "insertText", new DocumentOffset(8, true));
+            history.ensureLastChangesPushed(model);
+            const autoComplete = model.autoComplete as unknown as MockAutoComplete;
+            autoComplete.tryComplete();
+            // Confirming a completion closes the autocomplete a second time, which is what used to
+            // put an identical second state on the undo stack.
+            autoComplete.close();
+
+            const undone = history.undo(model);
+            expect(undone).toBeTruthy();
+            expect(undone!.parts.map((p) => p.text)).toEqual(["hello ", "@a"]);
+        });
+
+        it("does not report the redundant close which follows a completion", function () {
+            const renderer = createRenderer();
+            const pc = createPartCreator([{ resourceId: "@alice", text: "Alice" } as PillPart]);
+            const model = new EditorModel([pc.plain("hello ")], pc, renderer);
+
+            model.update("hello @a", "insertText", new DocumentOffset(8, true));
+            const autoComplete = model.autoComplete as unknown as MockAutoComplete;
+            autoComplete.tryComplete();
+            expect(renderer.count).toBe(2);
+
+            autoComplete.close();
+
+            expect(renderer.count).toBe(2);
         });
 
         it("insert room pill", function () {

--- a/apps/web/src/editor/model.ts
+++ b/apps/web/src/editor/model.ts
@@ -262,6 +262,12 @@ export default class EditorModel {
     }
 
     private onAutoComplete = ({ replaceParts, close, range }: ICallback): void => {
+        // Confirming a completion closes the autocomplete twice: once as part of the completion and
+        // once more by the wrapper afterwards. Reporting the second one would have the history
+        // manager record a second, identical state, costing the user an extra undo to reverse one
+        // completion.
+        if (!replaceParts && close && !this._autoComplete) return;
+
         let pos: DocumentPosition | undefined;
         if (replaceParts) {
             const autoCompletePartIdx = this.autoCompletePartIdx || 0;


### PR DESCRIPTION
Confirming an autocomplete produces two model updates for one keystroke. The completion itself
replaces the range and closes the autocomplete, and then the wrapper closes it a second time. The
model reported that second close like any other change, and because it carries no input type and no
diff the history manager treats it as bulk input and always pushes, so one completion left two
identical states on the undo stack. The first ctrl+z appeared to do nothing and a second was needed
to get the typed text back.

The model now ignores a close which has nothing to replace and arrives when the autocomplete is
already gone. Every close that does something still reports as before: dismissing with escape, and
the fallback close when there was no selection to confirm, both run while the autocomplete is still
open.

Tests: two cases in `model.test.ts` — one asserting a single undo restores the typed text after a
completion, one that the redundant close causes no further render; both fail without the change.

Fixes #19524

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
