### PR TITLE
Stop an unread room jumping above the room just opened from the keyboard

### DIFF
--- a/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
+++ b/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
@@ -691,7 +691,12 @@ export class RoomListViewModel
      * @returns The modified sections array with sticky positioning applied
      */
     private applyStickyRoom(isRoomChange: boolean, roomId: string | null | undefined): Section[] {
-        const sections = this.roomsResult.sections;
+        // Ask the store rather than reading `this.roomsResult`: the sections held there have already
+        // had a previous sticky adjustment written into them, so using them as the baseline would
+        // measure the newly opened room against a list in which the room just left is still pinned,
+        // and record its position one slot too low.
+        const filterKeys = this.activeFilter !== undefined ? [this.activeFilter] : undefined;
+        const sections = RoomListStoreV3.instance.getSortedRoomsInActiveSpace(filterKeys).sections;
 
         // When opening another room, the index should obviously change
         if (!roomId || isRoomChange) return sections;

--- a/apps/web/test/viewmodels/room-list/RoomListViewModel-test.ts
+++ b/apps/web/test/viewmodels/room-list/RoomListViewModel-test.ts
@@ -361,6 +361,56 @@ describe("RoomListViewModel", () => {
             expect(viewModel.getSnapshot().sections[0].roomIds[1]).toBe("!room2:server");
         });
 
+        it("should measure a newly opened room against the store order, not the previous pin", async () => {
+            viewModel = new RoomListViewModel({
+                client: matrixClient,
+                spaceStore: SDKContextClass.instance.spaceStore,
+                roomViewStore: SDKContextClass.instance.roomViewStore,
+            });
+
+            // Open the room at the top of the list.
+            jest.spyOn(SDKContextClass.instance.roomViewStore, "getRoomId").mockReturnValue("!room1:server");
+            dispatcher.dispatch({ action: Action.ActiveRoomChanged, newRoomId: "!room1:server" });
+            await flushPromises();
+            expect(viewModel.getSnapshot().roomListState.activeRoomIndex).toBe(0);
+
+            // Reading it demotes it in the store, but sticky keeps it where the user is looking.
+            jest.spyOn(RoomListStoreV3.instance, "getSortedRoomsInActiveSpace").mockReturnValue({
+                spaceId: "home",
+                sections: [{ tag: CHATS_TAG, rooms: [room2, room3, room1] }],
+            });
+            RoomListStoreV3.instance.emit(RoomListStoreV3Event.ListsUpdate);
+            expect(viewModel.getSnapshot().sections[0].roomIds).toEqual([
+                "!room1:server",
+                "!room2:server",
+                "!room3:server",
+            ]);
+
+            // Moving to the next room down has to fall back to the store's order, in which the room
+            // being left is last. Reusing the pinned order would record room2 at index 1.
+            jest.spyOn(SDKContextClass.instance.roomViewStore, "getRoomId").mockReturnValue("!room2:server");
+            dispatcher.dispatch({
+                action: Action.ActiveRoomChanged,
+                oldRoomId: "!room1:server",
+                newRoomId: "!room2:server",
+            });
+            await flushPromises();
+            expect(viewModel.getSnapshot().sections[0].roomIds).toEqual([
+                "!room2:server",
+                "!room3:server",
+                "!room1:server",
+            ]);
+            expect(viewModel.getSnapshot().roomListState.activeRoomIndex).toBe(0);
+
+            // So when room2 is read in turn, the still-unread room3 does not jump above it.
+            jest.spyOn(RoomListStoreV3.instance, "getSortedRoomsInActiveSpace").mockReturnValue({
+                spaceId: "home",
+                sections: [{ tag: CHATS_TAG, rooms: [room3, room2, room1] }],
+            });
+            RoomListStoreV3.instance.emit(RoomListStoreV3Event.ListsUpdate);
+            expect(viewModel.getSnapshot().roomListState.activeRoomIndex).toBe(0);
+        });
+
         it("should not apply sticky behavior when user changes rooms", async () => {
             viewModel = new RoomListViewModel({
                 client: matrixClient,


### PR DESCRIPTION
The sticky room calculation took its baseline from the sections held on the view model, but those
sections are where the result of the previous calculation is written back. On a room change the
baseline was therefore a list in which the room being left was still pinned to the place the user
had been looking at, even though the store had already demoted it for being read. The position
recorded for the newly opened room was one slot too low, so when its own read receipt landed the
sticky logic left it there and a still-unread room sorted above it. Moving down the list with the
keyboard then landed on an already-read room and needed a press back up, which is the down-up-down-up
pattern in the report.

The baseline now comes from the store, which is the unadjusted order by definition. On the list
update path this is the same value that was just fetched, so only the room change, section collapse
and reorder paths change behaviour.

Tests: a case in `RoomListViewModel-test.ts` walking the reported sequence — open the top room, let
it demote, move to the next room — asserting the resulting order; it fails without the change.

Fixes #34125

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
