### PR TITLE
Say a message could not be decrypted in the room list rather than why

### DIFF
--- a/apps/web/src/stores/message-preview/previews/MessageEventPreview.ts
+++ b/apps/web/src/stores/message-preview/previews/MessageEventPreview.ts
@@ -19,6 +19,17 @@ export class MessageEventPreview implements Preview {
     public getTextFor(event: MatrixEvent, tagId?: TagID, isThread?: boolean): string | null {
         let eventContent = event.getContent();
 
+        if (event.isDecryptionFailure()) {
+            // An event which failed to decrypt is given a body describing the failure, in English
+            // and in terms only a developer would recognise. Say the same thing the timeline says
+            // instead. Returning nothing is not an option: the preview would then fall back to an
+            // older message and present it as the latest one.
+            const text = _t("timeline|decryption_failure|unable_to_decrypt");
+            const roomId = event.getRoomId();
+            if (isThread || isSelf(event) || (roomId && !shouldPrefixMessagesIn(roomId, tagId))) return text;
+            return _t("event_preview|m.text", { senderName: getSenderName(event), message: text });
+        }
+
         if (event.isRelation(RelationType.Replace)) {
             // It's an edit, generate the preview on the new text
             eventContent = event.getContent()["m.new_content"];

--- a/apps/web/test/unit-tests/stores/message-preview/previews/MessageEventPreview-test.ts
+++ b/apps/web/test/unit-tests/stores/message-preview/previews/MessageEventPreview-test.ts
@@ -31,6 +31,22 @@ describe("MessageEventPreview", () => {
             expect(preview.getTextFor(event)).toBeNull();
         });
 
+        it("when called with an undecryptable event should return the same wording as the timeline", () => {
+            const event = mkEvent({
+                event: true,
+                content: {
+                    msgtype: "m.bad.encrypted",
+                    body: "** Unable to decrypt: The sender's device has not sent us the keys for this message. **",
+                },
+                user: userId,
+                room: "!room:example.com",
+                type: "m.room.message",
+            });
+            jest.spyOn(event, "isDecryptionFailure").mockReturnValue(true);
+
+            expect(preview.getTextFor(event)).toBe(`${userId}: Unable to decrypt message`);
+        });
+
         it("when called with an event with empty body should return null", () => {
             const event = mkEvent({
                 event: true,


### PR DESCRIPTION
When decryption fails the SDK substitutes a message event whose body describes the failure, so the
room list previewer saw an ordinary `m.room.message` and rendered its body verbatim. The result was
a preview reading `** Unable to decrypt: The sender's device has not sent us the keys for this
message. **` — untranslated, and phrased for whoever is reading a log rather than for the person
looking at their room list.

The previewer now recognises a decryption failure and uses the wording the timeline already shows
for one, which exists in the translations and needs no new string. The sender prefix, thread and
self cases are applied to it exactly as they are to a normal message.

The preview deliberately still says something rather than returning nothing. An empty preview makes
the store walk back through earlier events, which would put a stale message in the room list as
though it were the most recent one.

Tests: a case in `MessageEventPreview-test.ts` for an event reporting a decryption failure; it fails
without the change.

Fixes #27659

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
