### PR TITLE
Stop escaping a plain text message which has no markdown in it when editing

### DIFF
--- a/apps/web/src/editor/deserialize.ts
+++ b/apps/web/src/editor/deserialize.ts
@@ -13,6 +13,7 @@ import { checkBlockNode } from "../HtmlUtils";
 import { getPrimaryPermalinkEntity } from "../utils/permalinks/Permalinks";
 import { type Part, type PartCreator, Type } from "./parts";
 import SdkConfig from "../SdkConfig";
+import Markdown from "../Markdown";
 import { textToHtmlRainbow } from "../utils/colour";
 import { stripPlainReply } from "../utils/Reply";
 
@@ -21,6 +22,21 @@ const LIST_TYPES = ["UL", "OL", "LI"];
 // Escapes all markup in the given text
 function escape(text: string): string {
     return text.replace(/[\\*_[\]`<]|^>/g, (match) => `\\${match}`);
+}
+
+/**
+ * Whether a body which was sent as plain text has to be escaped to survive a round trip through the
+ * composer. A body the markdown parser would leave alone comes back out of the composer unchanged
+ * whether or not it was escaped, so escaping it only adds backslashes the sender never typed.
+ *
+ * @param body - The plain text body of the event being opened for editing.
+ * @returns True if the body has to be escaped to be preserved.
+ */
+function needsEscaping(body: string): boolean {
+    // A backslash is markup in its own right once the body goes back through the parser, so a body
+    // containing one has to be escaped even when nothing else in it is markup.
+    if (body.includes("\\")) return true;
+    return !new Markdown(body).isPlainText();
 }
 
 // Finds the length of the longest backtick sequence in the given text, used for
@@ -300,7 +316,10 @@ export function parseEvent(event: MatrixEvent, pc: PartCreator, opts: IParseOpti
         if (event.replyEventId) {
             body = stripPlainReply(body);
         }
-        parts = parsePlainTextMessage(body, pc, opts);
+        parts = parsePlainTextMessage(body, pc, {
+            ...opts,
+            shouldEscape: opts.shouldEscape && needsEscaping(body),
+        });
     }
 
     if (isEmote && isRainbow) {

--- a/apps/web/test/unit-tests/editor/deserialize-test.ts
+++ b/apps/web/test/unit-tests/editor/deserialize-test.ts
@@ -95,6 +95,20 @@ describe("editor/deserialize", function () {
             expect(parts.length).toBe(1);
             expect(parts[0]).toStrictEqual({ type: "plain", text: "/spoiler broiler" });
         });
+        it("leaves text alone which markdown would not have touched", function () {
+            const parts = normalize(parseEvent(textMessage("path/to/_light.scss"), createPartCreator()));
+            expect(parts.length).toBe(1);
+            expect(parts[0]).toStrictEqual({ type: "plain", text: "path/to/_light.scss" });
+        });
+        it.each([
+            ["**bold**", "\\*\\*bold\\*\\*"],
+            ["a<del>b</del>c", "a\\<del>b\\</del>c"],
+            ["> quoted", "\\> quoted"],
+            ["C:\\Program Files", "C:\\\\Program Files"],
+        ])("still escapes %s, which markdown would have consumed", function (body, expected) {
+            const parts = normalize(parseEvent(textMessage(body), createPartCreator()));
+            expect(parts[0]).toStrictEqual({ type: "plain", text: expected });
+        });
     });
     describe("html messages", function () {
         it("inline styling", function () {


### PR DESCRIPTION
Opening a message for editing escaped every markdown character in it, whether or not the body would
ever have been read as markdown. A message reading `path/to/_light.scss` came back as
`path/to/\_light.scss`, and the backslash was not only cosmetic: saving writes the serialised text
straight into the body, so the edit shipped a backslash the sender never typed, and the body now
containing one made the serialiser attach a `formatted_body` to a message which previously had none.
It also made an untouched message compare as modified, so Save was enabled on an edit that changed
nothing.

A body the markdown parser would leave alone survives the composer unchanged whether or not it was
escaped, so the escaping is now applied only when the body actually needs it. A body containing a
backslash always does, since a backslash is markup itself on the way back through the parser. The
test for whether the body is plain is the same one the serialiser uses to decide whether to produce
HTML, so the two cannot disagree and the round trip stays byte identical.

Messages sent with formatting are untouched — the HTML path still escapes its text nodes as before.

Tests: cases in `deserialize-test.ts` for a body markdown would leave alone, plus bold, an inline
tag, a quote and a Windows path pinning the escaping that must stay; the first fails without the
change.

Fixes #22456

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
