### PR TITLE
Mark a plain text export as UTF-8 so Windows reads it correctly

### DIFF
--- a/apps/web/src/utils/exportUtils/PlainTextExport.ts
+++ b/apps/web/src/utils/exportUtils/PlainTextExport.ts
@@ -18,6 +18,11 @@ import { haveRendererForEvent } from "../../events/EventTileFactory";
 import SettingsStore from "../../settings/SettingsStore";
 import { formatFullDate } from "../../DateUtils";
 
+// A file with no byte order mark leaves the reader to guess its encoding, and the text editors and
+// spreadsheet tools people open an export in on Windows guess the system code page rather than
+// UTF-8, turning every emoji and every non-Latin name into mojibake.
+const UTF8_BOM = "\uFEFF";
+
 export default class PlainTextExporter extends Exporter {
     protected totalSize: number;
     protected mediaOmitText: string;
@@ -139,11 +144,11 @@ export default class PlainTextExporter extends Exporter {
         const text = await this.createOutput(res);
 
         if (this.files.length) {
-            this.addFile("export.txt", new Blob([text]));
+            this.addFile("export.txt", new Blob([UTF8_BOM + text], { type: "text/plain;charset=utf-8" }));
             await this.downloadZIP();
         } else {
             const fileName = this.destinationFileName;
-            this.downloadPlainText(fileName, text);
+            this.downloadPlainText(fileName, UTF8_BOM + text);
         }
 
         const exportEnd = performance.now();

--- a/apps/web/test/unit-tests/utils/exportUtils/PlainTextExport-test.ts
+++ b/apps/web/test/unit-tests/utils/exportUtils/PlainTextExport-test.ts
@@ -8,10 +8,15 @@ Please see LICENSE files in the repository root for full details.
 
 import { MatrixEvent, type Room } from "matrix-js-sdk/src/matrix";
 
+import { mocked } from "jest-mock-vitest-adapter";
+import { saveAs } from "file-saver";
+
 import { createTestClient, mkStubRoom, REPEATABLE_DATE } from "../../../test-utils";
 import { ExportType, type IExportOptions } from "../../../../src/utils/exportUtils/exportUtils";
 import PlainTextExporter from "../../../../src/utils/exportUtils/PlainTextExport";
 import SettingsStore from "../../../../src/settings/SettingsStore";
+
+jest.mock("file-saver", () => ({ saveAs: jest.fn() }));
 
 class TestablePlainTextExporter extends PlainTextExporter {
     public async testCreateOutput(events: MatrixEvent[]): Promise<string> {
@@ -32,6 +37,18 @@ describe("PlainTextExport", () => {
             maxSize: 50000000,
         };
         stubRoom = mkStubRoom("!myroom:example.org", roomName, client);
+    });
+
+    it("should start the exported file with a UTF-8 byte order mark", async () => {
+        const exporter = new PlainTextExporter(stubRoom, ExportType.Timeline, stubOptions, () => {});
+
+        await exporter.export();
+
+        // Asserted as bytes rather than as text: the mark is what a reader looks at to know the
+        // encoding, so what matters is that those three bytes lead the file.
+        const saved = mocked(saveAs).mock.calls[0][0] as Blob;
+        const bytes = new Uint8Array(await saved.arrayBuffer());
+        expect(Array.from(bytes.slice(0, 3))).toEqual([0xef, 0xbb, 0xbf]);
     });
 
     it("should have an Element-branded destination file name", () => {


### PR DESCRIPTION
A plain text export is written as UTF-8 but carries nothing to say so, so a reader has to guess the
encoding. Notepad, Excel and most other Windows tools guess the system code page instead, which
turns every emoji and every non-Latin name in the transcript into mojibake. The report calls the
file ANSI; the bytes are really UTF-8, but from the reader's side the two are indistinguishable.

The plain text exporter now writes a byte order mark ahead of the transcript, on both the single
file and the zipped path, and labels the blob with the charset. The HTML export already declares its
encoding in a meta tag and needs nothing, and the JSON export is deliberately left alone because a
byte order mark would break parsers reading it back.

Tests: a case in `PlainTextExport-test.ts` asserting the exported file opens with the three bytes of
the mark; it fails without the change.

Fixes #28786

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
