### PR TITLE
Fix mistaken reference to element_call.disable in docs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -400,8 +400,8 @@ The VoIP and Jitsi options are:
       the app, removing the ability to enable legacy 1:1 calls or Jitsi calls.
       It is a misconfiguration if its set to true while `element_call.disable` is also true!
       Defaults to `false`.
-    - `disabled`: A boolean flag specifying whether Element Call should be disabled.
-      If it is disabled `element_call.use_exclusively` has no effect!
+    - `disable`: A boolean flag specifying whether Element Call should be disabled.
+      If `true`, `element_call.use_exclusively` has no effect!
       Defaults to `false`.
     - `brand`: Optional name for the app. Defaults to `Element Call`. This is
       used throughout the application in various strings/locations.


### PR DESCRIPTION
The actual name that is respected by the app is `disable`, not `disabled`.