### PR TITLE
Show the promotion warning when your own power level comes from the room default

### DIFF
--- a/apps/web/src/components/viewmodels/right_panel/UserInfoPowerlevelViewModel.tsx
+++ b/apps/web/src/components/viewmodels/right_panel/UserInfoPowerlevelViewModel.tsx
@@ -67,8 +67,10 @@ export const useUserInfoPowerlevelViewModel = (user: RoomMember, room: Room): Us
             if (!powerLevelEvent) return;
 
             const myUserId = cli.getUserId();
-            const myPower = powerLevelEvent.getContent().users[myUserId || ""];
-            if (myPower && parseInt(myPower) <= powerLevel && myUserId !== target) {
+            // Read our own level off the member rather than the `users` map: the map omits anyone
+            // sitting on `users_default`, and omits room creators, who outrank everyone.
+            const myPower = myUserId ? room.getMember(myUserId)?.powerLevel : undefined;
+            if (myPower !== undefined && myPower <= powerLevel && myUserId !== target) {
                 const { finished } = Modal.createDialog(QuestionDialog, {
                     title: _t("common|warning"),
                     description: (
@@ -83,7 +85,7 @@ export const useUserInfoPowerlevelViewModel = (user: RoomMember, room: Room): Us
 
                 const [confirmed] = await finished;
                 if (!confirmed) return;
-            } else if (myUserId === target && myPower && parseInt(myPower) > powerLevel) {
+            } else if (myUserId === target && myPower !== undefined && myPower > powerLevel) {
                 // If we are changing our own PL it can only ever be decreasing, which we cannot reverse.
                 try {
                     if (!(await warnSelfDemote(room?.isSpaceRoom()))) return;

--- a/apps/web/src/components/viewmodels/right_panel/UserInfoPowerlevelViewModel.tsx
+++ b/apps/web/src/components/viewmodels/right_panel/UserInfoPowerlevelViewModel.tsx
@@ -67,8 +67,6 @@ export const useUserInfoPowerlevelViewModel = (user: RoomMember, room: Room): Us
             if (!powerLevelEvent) return;
 
             const myUserId = cli.getUserId();
-            // Read our own level off the member rather than the `users` map: the map omits anyone
-            // sitting on `users_default`, and omits room creators, who outrank everyone.
             const myPower = myUserId ? room.getMember(myUserId)?.powerLevel : undefined;
             if (myPower !== undefined && myPower <= powerLevel && myUserId !== target) {
                 const { finished } = Modal.createDialog(QuestionDialog, {

--- a/apps/web/test/unit-tests/components/viewmodels/right_panel/user_info/UserInfoPowerLevelsViewModel-test.ts
+++ b/apps/web/test/unit-tests/components/viewmodels/right_panel/user_info/UserInfoPowerLevelsViewModel-test.ts
@@ -109,6 +109,18 @@ describe("UserInfoAdminPowerlevelViewModel", () => {
         );
     };
 
+    /**
+     * Make `room.getMember` resolve levels the way the SDK does: an explicit `users` entry when there
+     * is one, otherwise `users_default`. Without this the room reports no members at all.
+     */
+    const mockMembersFrom = (content: { users?: Record<string, number>; users_default?: number }): void => {
+        mockRoom.getMember.mockImplementation((userId: string) => {
+            const member = new RoomMember(defaultRoomId, userId);
+            member.powerLevel = content.users?.[userId] ?? content.users_default ?? 0;
+            return member;
+        });
+    };
+
     afterEach(() => {
         jest.clearAllMocks();
     });
@@ -144,17 +156,16 @@ describe("UserInfoAdminPowerlevelViewModel", () => {
     });
 
     it("shows warning when promoting user to higher power level", async () => {
-        const powerLevelEvent = new MatrixEvent({
-            type: EventType.RoomPowerLevels,
-            content: {
-                users: {
-                    [defaultUserId]: startPowerLevel,
-                    [defaultMeId]: startPowerLevel,
-                },
-                users_default: 1,
+        const content = {
+            users: {
+                [defaultUserId]: startPowerLevel,
+                [defaultMeId]: startPowerLevel,
             },
-        });
+            users_default: 1,
+        };
+        const powerLevelEvent = new MatrixEvent({ type: EventType.RoomPowerLevels, content });
         mockRoom.currentState.getStateEvents.mockReturnValue(powerLevelEvent);
+        mockMembersFrom(content);
         mockClient.getUserId.mockReturnValue(defaultMeId);
 
         const { result } = renderComponentHook({ ...defaultProps, room: mockRoom }, mockClient);
@@ -166,14 +177,13 @@ describe("UserInfoAdminPowerlevelViewModel", () => {
     });
 
     it("shows warning when self-demoting", async () => {
-        const powerLevelEvent = new MatrixEvent({
-            type: EventType.RoomPowerLevels,
-            content: {
-                users: { [defaultMeId]: changedPowerLevel },
-                users_default: 1,
-            },
-        });
+        const content = {
+            users: { [defaultMeId]: changedPowerLevel },
+            users_default: 1,
+        };
+        const powerLevelEvent = new MatrixEvent({ type: EventType.RoomPowerLevels, content });
         mockRoom.currentState.getStateEvents.mockReturnValue(powerLevelEvent);
+        mockMembersFrom(content);
         mockClient.getUserId.mockReturnValue(defaultMeId);
 
         const { result } = renderComponentHook({ ...defaultProps, room: mockRoom, user: selfUser }, mockClient);
@@ -189,17 +199,16 @@ describe("UserInfoAdminPowerlevelViewModel", () => {
             finished: Promise.resolve([false]),
         }));
 
-        const powerLevelEvent = new MatrixEvent({
-            type: EventType.RoomPowerLevels,
-            content: {
-                users: {
-                    [defaultUserId]: startPowerLevel,
-                    "@me:example.com": startPowerLevel,
-                },
-                users_default: 1,
+        const content = {
+            users: {
+                [defaultUserId]: startPowerLevel,
+                "@me:example.com": startPowerLevel,
             },
-        });
+            users_default: 1,
+        };
+        const powerLevelEvent = new MatrixEvent({ type: EventType.RoomPowerLevels, content });
         mockRoom.currentState.getStateEvents.mockReturnValue(powerLevelEvent);
+        mockMembersFrom(content);
         mockClient.getUserId.mockReturnValue(defaultMeId);
 
         const { result } = renderComponentHook({ ...defaultProps, room: mockRoom }, mockClient);
@@ -208,6 +217,42 @@ describe("UserInfoAdminPowerlevelViewModel", () => {
 
         expect(Modal.createDialog).toHaveBeenCalled();
         expect(mockClient.setPowerLevel).not.toHaveBeenCalled();
+    });
+
+    it("shows warning when our own level comes from users_default", async () => {
+        // Nobody is listed in `users`, so both of us sit on `users_default`.
+        const content = { users: {}, users_default: startPowerLevel };
+        const powerLevelEvent = new MatrixEvent({ type: EventType.RoomPowerLevels, content });
+        mockRoom.currentState.getStateEvents.mockReturnValue(powerLevelEvent);
+        mockMembersFrom(content);
+        mockClient.getUserId.mockReturnValue(defaultMeId);
+
+        const { result } = renderComponentHook({ ...defaultProps, room: mockRoom }, mockClient);
+
+        await result.current.onPowerChange(startPowerLevel);
+
+        expect(Modal.createDialog).toHaveBeenCalled();
+        expect(mockClient.setPowerLevel).toHaveBeenCalled();
+    });
+
+    it("does not warn when we outrank the new level as a room creator", async () => {
+        const content = { users: { [defaultUserId]: startPowerLevel }, users_default: 1 };
+        const powerLevelEvent = new MatrixEvent({ type: EventType.RoomPowerLevels, content });
+        mockRoom.currentState.getStateEvents.mockReturnValue(powerLevelEvent);
+        mockRoom.getMember.mockImplementation((userId: string) => {
+            const member = new RoomMember(defaultRoomId, userId);
+            // Creators outrank every assignable level, so promoting to 100 cannot match us.
+            member.powerLevel = userId === defaultMeId ? Infinity : startPowerLevel;
+            return member;
+        });
+        mockClient.getUserId.mockReturnValue(defaultMeId);
+
+        const { result } = renderComponentHook({ ...defaultProps, room: mockRoom }, mockClient);
+
+        await result.current.onPowerChange(changedPowerLevel);
+
+        expect(Modal.createDialog).not.toHaveBeenCalled();
+        expect(mockClient.setPowerLevel).toHaveBeenCalled();
     });
 
     it("handles missing power level event", async () => {

--- a/apps/web/test/unit-tests/components/views/right_panel/user_info/UserInfoPowerLevels-test.tsx
+++ b/apps/web/test/unit-tests/components/views/right_panel/user_info/UserInfoPowerLevels-test.tsx
@@ -139,7 +139,10 @@ describe("<PowerLevelEditor />", () => {
             type: EventType.RoomPowerLevels,
             content: { users: { [defaultUserId]: startPowerLevel }, users_default: 1 },
         });
+        const self = new RoomMember(defaultRoomId, defaultUserId);
+        self.powerLevel = startPowerLevel;
         mockRoom.currentState.getStateEvents.mockReturnValue(powerLevelEvent);
+        mockRoom.getMember.mockReturnValue(self);
         mockClient.getSafeUserId.mockReturnValueOnce(defaultUserId);
         mockClient.getUserId.mockReturnValueOnce(defaultUserId);
         renderComponent({


### PR DESCRIPTION
Promoting somebody to your own level is irreversible, so a confirmation exists to catch it. It read
our level straight out of the power levels event's `users` map, which only lists people who have
been given a level individually.

Anyone sitting on `users_default` is absent from that map, so in a room whose default is 50 the
lookup came back `undefined`, the guard's leading truthiness test failed, and the promotion went
through with no confirmation at all — precisely the case the warning exists for. The same truthiness
test also discarded an explicit level of zero, and the map never lists room creators, who since room
version 12 outrank every assignable level.

Reading the level off our own `RoomMember` fixes all three: the SDK already resolves an explicit
entry, then `users_default`, then zero, and reports creators as `Infinity`. The comparison then needs
an explicit `undefined` check rather than a truthiness one so a legitimate zero still counts, and the
self-demotion branch is corrected the same way. This is also how the rest of the file reads a level —
`selectedPowerLevel` is seeded from `user.powerLevel`.

There is no issue for this; it turned up while reading #34299, which asks for unrelated wording
changes to the dialog this warning opens.

Tests: the existing cases had `room.getMember` returning `undefined` for everybody, which no real
room does, so they are given a stub that resolves levels the way the SDK does. Two cases are added:
our level coming from `users_default`, which fails without this change, and a creator, which
documents that an infinite level never matches a promotion.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
