### PR TITLE
Notify when you are invited to a room

### DIFF
--- a/apps/web/src/Notifier.ts
+++ b/apps/web/src/Notifier.ts
@@ -24,6 +24,7 @@ import {
     TypedEventEmitter,
 } from "matrix-js-sdk/src/matrix";
 import { logger } from "matrix-js-sdk/src/logger";
+import { KnownMembership } from "matrix-js-sdk/src/types";
 import { type PermissionChanged as PermissionChangedEvent } from "@matrix-org/analytics-events/types/typescript/PermissionChanged";
 import { type SessionMembershipData, type IRTCNotificationContent } from "matrix-js-sdk/src/matrixrtc";
 
@@ -159,6 +160,10 @@ export default class Notifier extends TypedEventEmitter<keyof EmittedEvents, Emi
     // they're decrypted until we decide whether to notify for them
     // or not
     private pendingEncryptedEventIds: string[] = [];
+
+    // Rooms we have been invited to during the sync response currently being applied, to notify
+    // about once it has been: see notifyForPendingInvites.
+    private pendingInviteRoomIds = new Set<string>();
 
     private toolbarHidden?: boolean;
     private isSyncing?: boolean;
@@ -340,6 +345,7 @@ export default class Notifier extends TypedEventEmitter<keyof EmittedEvents, Emi
 
     public start(): void {
         this.sdkContext.client!.on(RoomEvent.Timeline, this.onEvent);
+        this.sdkContext.client!.on(RoomEvent.MyMembership, this.onMyMembership);
         this.sdkContext.client!.on(RoomEvent.Receipt, this.onRoomReceipt);
         this.sdkContext.client!.on(MatrixEventEvent.Decrypted, this.onEventDecrypted);
         this.sdkContext.client!.on(ClientEvent.Sync, this.onSyncStateChange);
@@ -349,9 +355,11 @@ export default class Notifier extends TypedEventEmitter<keyof EmittedEvents, Emi
 
     public stop(): void {
         this.sdkContext.client?.removeListener(RoomEvent.Timeline, this.onEvent);
+        this.sdkContext.client?.removeListener(RoomEvent.MyMembership, this.onMyMembership);
         this.sdkContext.client?.removeListener(RoomEvent.Receipt, this.onRoomReceipt);
         this.sdkContext.client?.removeListener(MatrixEventEvent.Decrypted, this.onEventDecrypted);
         this.sdkContext.client?.removeListener(ClientEvent.Sync, this.onSyncStateChange);
+        this.pendingInviteRoomIds = new Set();
         this.isSyncing = false;
     }
 
@@ -483,6 +491,8 @@ export default class Notifier extends TypedEventEmitter<keyof EmittedEvents, Emi
     public onSyncStateChange = (state: SyncState, prevState: SyncState | null, data?: SyncStateData): void => {
         if (!this.sdkContext.client) return;
         if (state === SyncState.Syncing) {
+            // The sync response which carried them has been applied by the time this fires.
+            this.notifyForPendingInvites();
             this.isSyncing = true;
         } else if (state === SyncState.Stopped || state === SyncState.Error) {
             this.isSyncing = false;
@@ -523,6 +533,46 @@ export default class Notifier extends TypedEventEmitter<keyof EmittedEvents, Emi
 
         this.evaluateEvent(ev);
     };
+
+    /**
+     * Note a room we have been invited to, to be notified about once the sync response it arrived
+     * in has been applied. An invite arrives as stripped state rather than as a timeline event, so
+     * {@link onEvent} never sees it and the `.m.rule.invite_for_me` push rule — which the
+     * notification settings still expose as "When I'm invited to a room" — went unheard.
+     *
+     * Membership is reported once per transition, whereas the stripped state itself is re-delivered
+     * on every sync that carries the invite, so this is the signal which fires exactly once.
+     */
+    private onMyMembership = (room: Room, membership: string): void => {
+        if (!this.isSyncing) return; // don't alert for invites which were already pending at startup
+        if (membership !== KnownMembership.Invite) return;
+
+        this.pendingInviteRoomIds.add(room.roomId);
+    };
+
+    /**
+     * Notify about the invites noted by {@link onMyMembership} during the sync response which has
+     * just been applied. Waiting for the response to land matters twice over: a room invited to for
+     * the first time is not in the store yet while the membership change is being emitted, and a
+     * single response can carry an invite the user has already accepted elsewhere, whose membership
+     * only settles on join once the whole response has been read.
+     */
+    private notifyForPendingInvites(): void {
+        const cli = this.sdkContext.client;
+        const roomIds = this.pendingInviteRoomIds;
+        this.pendingInviteRoomIds = new Set();
+        if (!cli) return;
+
+        for (const roomId of roomIds) {
+            const room = cli.getRoom(roomId);
+            if (room?.getMyMembership() !== KnownMembership.Invite) continue;
+
+            const ev = room.currentState.getStateEvents(EventType.RoomMember, cli.getSafeUserId());
+            if (!ev || ev.getSender() === cli.getUserId()) continue;
+
+            this.evaluateEvent(ev);
+        }
+    }
 
     private onEventDecrypted = (ev: MatrixEvent): void => {
         // 'decrypted' means the decryption process has finished: it may have failed,

--- a/apps/web/test/unit-tests/Notifier-test.ts
+++ b/apps/web/test/unit-tests/Notifier-test.ts
@@ -18,6 +18,7 @@ import {
     SyncState,
     type AccountDataEvents,
 } from "matrix-js-sdk/src/matrix";
+import { KnownMembership } from "matrix-js-sdk/src/types";
 import { waitFor } from "jest-matrix-react";
 import { CallMembership, type SessionMembershipData, type MatrixRTCSession } from "matrix-js-sdk/src/matrixrtc";
 import { randomUUID } from "node:crypto";
@@ -320,6 +321,112 @@ describe("Notifier", () => {
             expect(MockPlatform.displayNotification).toHaveBeenCalled();
             // without noisy
             expect(MockPlatform.loudNotification).not.toHaveBeenCalled();
+        });
+
+        describe("room invites", () => {
+            // An invite arrives as stripped state rather than as a timeline event, so it reaches the
+            // room's state without ever passing through the live timeline.
+            const inviteRoomWith = (sender: string, membership = KnownMembership.Invite): Room => {
+                const room = new Room("!invite:server.org", mockClient, mockClient.getSafeUserId());
+                room.currentState.setStateEvents([
+                    new MatrixEvent({
+                        sender,
+                        type: EventType.RoomMember,
+                        state_key: userId,
+                        room_id: room.roomId,
+                        content: { membership: KnownMembership.Invite },
+                    }),
+                ]);
+                room.updateMyMembership(membership);
+                return room;
+            };
+
+            // A room invited to for the first time only reaches the store once the whole sync
+            // response has been applied, which is after the membership change is announced.
+            const beInvited = (room: Room, previous?: string): void => {
+                mockClient.getRoom.mockImplementation((id) => (id === room.roomId ? null : testRoom));
+                mockClient!.emit(RoomEvent.MyMembership, room, room.getMyMembership(), previous);
+                mockClient.getRoom.mockImplementation((id) => (id === room.roomId ? room : testRoom));
+            };
+
+            const syncCompletes = (): void => {
+                mockClient!.emit(ClientEvent.Sync, SyncState.Syncing, SyncState.Syncing);
+            };
+
+            beforeEach(() => {
+                // Put the notifier past its startup sync, where invites are deliberately ignored.
+                mockClient!.emit(ClientEvent.Sync, SyncState.Syncing, null);
+            });
+
+            it("notifies when we are invited to a room", () => {
+                const room = inviteRoomWith("@alice:server.org");
+
+                beInvited(room);
+                syncCompletes();
+
+                expect(MockPlatform.displayNotification).toHaveBeenCalled();
+                expect(MockPlatform.loudNotification).toHaveBeenCalled();
+            });
+
+            it("notifies once, however many syncs redeliver the invite", () => {
+                const room = inviteRoomWith("@alice:server.org");
+
+                beInvited(room);
+                syncCompletes();
+                syncCompletes();
+
+                expect(MockPlatform.displayNotification).toHaveBeenCalledTimes(1);
+            });
+
+            it("does not notify for invites which were already pending before syncing started", () => {
+                notifier.stop();
+                notifier.start();
+                const room = inviteRoomWith("@alice:server.org");
+
+                beInvited(room);
+                syncCompletes();
+
+                expect(MockPlatform.displayNotification).not.toHaveBeenCalled();
+            });
+
+            it("does not notify for an invite we accepted elsewhere in the same sync", () => {
+                // A gappy sync can announce the invite and the join we already made from another
+                // device in one response, leaving us joined by the time it has been applied.
+                const room = inviteRoomWith("@alice:server.org", KnownMembership.Join);
+
+                beInvited(room, KnownMembership.Leave);
+                syncCompletes();
+
+                expect(MockPlatform.displayNotification).not.toHaveBeenCalled();
+            });
+
+            it("does not notify when we join a room", () => {
+                const room = inviteRoomWith("@alice:server.org", KnownMembership.Join);
+
+                beInvited(room, KnownMembership.Invite);
+                syncCompletes();
+
+                expect(MockPlatform.displayNotification).not.toHaveBeenCalled();
+            });
+
+            it("does not notify for an invite we sent to ourselves", () => {
+                const room = inviteRoomWith(userId);
+
+                beInvited(room);
+                syncCompletes();
+
+                expect(MockPlatform.displayNotification).not.toHaveBeenCalled();
+            });
+
+            it("does not notify when the invite does not have a notify push action", () => {
+                mockClient.getPushActionsForEvent.mockReturnValue({ notify: false, tweaks: {} });
+                const room = inviteRoomWith("@alice:server.org");
+
+                beInvited(room);
+                syncCompletes();
+
+                expect(MockPlatform.displayNotification).not.toHaveBeenCalled();
+            });
         });
     });
 


### PR DESCRIPTION
Being invited to a room produced no notification of any kind — no popup, no sound — however the
"When I'm invited to a room" setting was configured. `Notifier` learns about events from
`RoomEvent.Timeline`, but an invite never reaches a timeline: it arrives as stripped state, which
the SDK writes into the room's state without any live timeline event. `evaluateEvent` was therefore
never called for an invite, and the `.m.rule.invite_for_me` push rule that the settings still offer
was never consulted. This dates from the change that moved the listener off `ClientEvent.Event` to
stop notifying for events which are not messages.

`Notifier` now notes the rooms whose membership turns to invite and evaluates them once that sync
response has been applied. Membership is chosen over the stripped state itself because it is
reported once per transition, whereas the state is re-delivered by every sync that carries the
invite; waiting for the response to land is what makes the notification arrive at all, since a room
invited to for the first time is not in the store yet while its membership change is announced.
Re-reading the membership at that point also keeps a gappy sync — one carrying both the invite and
the join the user already made elsewhere — from announcing an invite they have accepted. Invites
already pending when the app started stay silent, as messages do, and an invite the user sent
themselves is ignored.

Tests: an invite notifies once with a sound and only once however many syncs follow, and no
notification is shown for an invite accepted elsewhere in the same sync, one pending before syncing
started, a join, an invite sent to oneself, or an invite whose push rule does not notify.

Fixes #31759

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
