### PR TITLE
Make styling for the user menu more specific

### DIFF
--- a/packages/shared-components/src/menus/UserMenu/UserMenu.module.css
+++ b/packages/shared-components/src/menus/UserMenu/UserMenu.module.css
@@ -26,8 +26,12 @@
         display: flex;
         flex-direction: column;
         gap: var(--cpd-space-2x);
+
         > * {
             margin: auto;
+        }
+
+        .constrainedText {
             max-width: 100%;
             overflow: hidden;
             text-overflow: ellipsis;

--- a/packages/shared-components/src/menus/UserMenu/UserMenu.tsx
+++ b/packages/shared-components/src/menus/UserMenu/UserMenu.tsx
@@ -171,13 +171,25 @@ export function UserMenuView({ vm, className }: UserMenuViewProps): JSX.Element 
             >
                 <section className={classNames(styles.profile, styles.profilePrimary)}>
                     {showAvatar && <Avatar id={userId} name={displayName} type="round" size="64px" src={avatarUrl} />}
-                    <Text className={styles.displayname} type="body" size="lg" weight="semibold" as="span">
+                    <Text
+                        className={classNames(styles.displayname, styles.constrainedText)}
+                        type="body"
+                        size="lg"
+                        weight="semibold"
+                        as="span"
+                    >
                         {displayName}
                     </Text>
                     {showUserStatus && <SetStatusView vm={setStatusViewModel} />}
                 </section>
                 <section className={classNames(styles.profile, styles.profileSecondary)}>
-                    <Text data-testid="userId" size="md" as="span" type="body" className={styles.userId}>
+                    <Text
+                        data-testid="userId"
+                        size="md"
+                        as="span"
+                        type="body"
+                        className={classNames(styles.userId, styles.constrainedText)}
+                    >
                         {userId}
                     </Text>
                     {manageAccountHref && (

--- a/packages/shared-components/src/menus/UserMenu/__snapshots__/UserMenu.test.tsx.snap
+++ b/packages/shared-components/src/menus/UserMenu/__snapshots__/UserMenu.test.tsx.snap
@@ -289,7 +289,7 @@ exports[`UserMenu > renders a menu without an avatar 1`] = `
         class="UserMenu-module_profile UserMenu-module_profilePrimary"
       >
         <span
-          class="_typography_6v6n8_153 _font-body-lg-semibold_6v6n8_74 UserMenu-module_displayname"
+          class="_typography_6v6n8_153 _font-body-lg-semibold_6v6n8_74 UserMenu-module_displayname UserMenu-module_constrainedText"
         >
           Sally Sanderson
         </span>
@@ -450,7 +450,7 @@ exports[`UserMenu > renders a menu without an avatar 1`] = `
         class="UserMenu-module_profile UserMenu-module_profileSecondary"
       >
         <span
-          class="_typography_6v6n8_153 _font-body-md-regular_6v6n8_50 UserMenu-module_userId"
+          class="_typography_6v6n8_153 _font-body-md-regular_6v6n8_50 UserMenu-module_userId UserMenu-module_constrainedText"
           data-testid="userId"
         >
           @person-name:homeserver.com
@@ -777,7 +777,7 @@ exports[`UserMenu > renders an open menu 1`] = `
           />
         </span>
         <span
-          class="_typography_6v6n8_153 _font-body-lg-semibold_6v6n8_74 UserMenu-module_displayname"
+          class="_typography_6v6n8_153 _font-body-lg-semibold_6v6n8_74 UserMenu-module_displayname UserMenu-module_constrainedText"
         >
           Sally Sanderson with a longer name
         </span>
@@ -938,7 +938,7 @@ exports[`UserMenu > renders an open menu 1`] = `
         class="UserMenu-module_profile UserMenu-module_profileSecondary"
       >
         <span
-          class="_typography_6v6n8_153 _font-body-md-regular_6v6n8_50 UserMenu-module_userId"
+          class="_typography_6v6n8_153 _font-body-md-regular_6v6n8_50 UserMenu-module_userId UserMenu-module_constrainedText"
           data-testid="userId"
         >
           @person-name:homeserver.com


### PR DESCRIPTION
The overflow: hidden etc were applied to all child elements rather than just text so was causing the status menu to be completely hidden. This applies those styles only to the text elements where they're needed (split out of the user status change for easier review).

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
