### PR TITLE
Stop notification states emitting an update when nothing has changed

### DIFF
--- a/apps/web/src/stores/notifications/NotificationState.test.ts
+++ b/apps/web/src/stores/notifications/NotificationState.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 hayaksi1
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+// @vitest-environment happy-dom
+
+import { describe, it, expect } from "vitest";
+
+import { type INotificationStateSnapshotParams, NotificationStateSnapshot } from "./NotificationState";
+import { NotificationLevel } from "./NotificationLevel";
+
+describe("NotificationStateSnapshot", () => {
+    const idleState: INotificationStateSnapshotParams = {
+        symbol: null,
+        count: 0,
+        level: NotificationLevel.None,
+        muted: false,
+        knocked: false,
+        invited: false,
+    };
+
+    it("reports no difference when nothing has changed", () => {
+        const snapshot = new NotificationStateSnapshot(idleState);
+
+        expect(snapshot.isDifferentFrom(idleState)).toBe(false);
+    });
+
+    it.each<[string, Partial<INotificationStateSnapshotParams>]>([
+        ["symbol", { symbol: "!" }],
+        ["count", { count: 1 }],
+        ["level", { level: NotificationLevel.Highlight }],
+        ["muted", { muted: true }],
+        ["knocked", { knocked: true }],
+        ["invited", { invited: true }],
+    ])("reports a difference when %s changes", (_field, change) => {
+        const snapshot = new NotificationStateSnapshot(idleState);
+
+        expect(snapshot.isDifferentFrom({ ...idleState, ...change })).toBe(true);
+    });
+});

--- a/apps/web/src/stores/notifications/NotificationState.ts
+++ b/apps/web/src/stores/notifications/NotificationState.ts
@@ -150,22 +150,23 @@ export class NotificationStateSnapshot {
         this.isInvitation = state.invited;
     }
 
+    /**
+     * Whether the given state differs from the one captured by this snapshot.
+     *
+     * @param other - the state to compare this snapshot against
+     * @returns true if any of the snapshotted fields has changed
+     */
     public isDifferentFrom(other: INotificationStateSnapshotParams): boolean {
-        const before = {
-            count: this.count,
-            symbol: this.symbol,
-            level: this.level,
-            muted: this.muted,
-            knocked: this.knocked,
-            is: this.isInvitation,
-        };
-        const after = {
-            count: other.count,
-            symbol: other.symbol,
-            level: other.level,
-            muted: other.muted,
-            knocked: other.knocked,
-        };
-        return JSON.stringify(before) !== JSON.stringify(after);
+        // Compare the fields directly rather than serialising two object literals. Keeping those
+        // literals in step by hand is what let the invited flag be captured on one side only, and
+        // an unpaired key makes the two serialisations differ for every possible input.
+        return (
+            this.count !== other.count ||
+            this.symbol !== other.symbol ||
+            this.level !== other.level ||
+            this.muted !== other.muted ||
+            this.knocked !== other.knocked ||
+            this.isInvitation !== other.invited
+        );
     }
 }

--- a/apps/web/src/stores/notifications/RoomNotificationState.test.ts
+++ b/apps/web/src/stores/notifications/RoomNotificationState.test.ts
@@ -95,6 +95,22 @@ describe("RoomNotificationState", () => {
         expect(listener).toHaveBeenCalled();
     });
 
+    it("does not update when a recomputation leaves the state unchanged", () => {
+        const roomNotifState = new RoomNotificationState(room, true);
+        const testEvent = {
+            getRoomId: () => room.roomId,
+        } as unknown as MatrixEvent;
+        room.getUnreadNotificationCount = vi.fn().mockReturnValue(1);
+        client.emit(MatrixEventEvent.Decrypted, testEvent);
+
+        // Only start listening once the count is already 1, so the second decryption recomputes
+        // exactly the state that is already published
+        const listener = vi.fn();
+        roomNotifState.addListener(NotificationStateEvents.Update, listener);
+        client.emit(MatrixEventEvent.Decrypted, testEvent);
+        expect(listener).not.toHaveBeenCalled();
+    });
+
     it("emits an Update event on marked unread room account data", () => {
         const roomNotifState = new RoomNotificationState(room, true);
         const listener = vi.fn();


### PR DESCRIPTION
`NotificationStateSnapshot.isDifferentFrom` decides whether a notification state has changed by serialising two object literals and comparing the strings. The literal describing the previous state carries an `is` key; the literal describing the new state has no matching entry. `JSON.stringify` therefore produces different strings for every possible pair of inputs, so `emitIfUpdated` announces an update on every recomputation, and `invited` — the field that key was meant to carry — is never compared at all.

That is not free. A room's notification state recomputes on every timeline event, receipt, redaction, local echo and decryption in that room, and each recomputation fans an update out to the room list item, to every space badge holding that room and to the summarised global state, each of which then recomputes and re-emits in turn.

Comparing the fields directly is what the serialisation was standing in for, so this does it directly. That restores the missing `invited` comparison and retires the failure mode with it — an unpaired key can no longer quietly defeat the whole comparison. Adding the missing key to the second literal would have been smaller, but it leaves the next field added exposed to exactly the same mistake.

No user-visible behaviour is intended to change: `RoomNotificationState` already listens for every input `determineUnreadState` reads, so states that genuinely change still emit.

Tests: new `NotificationState.test.ts` covering every snapshotted field, plus a `RoomNotificationState` case asserting no update is emitted when a recomputation lands on the state already published. Both fail on `develop` and pass here.

Related to #24392

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
