### PR TITLE
Clear the old room's notifications when marking an upgraded room as read

### DIFF
--- a/apps/web/src/utils/notifications.ts
+++ b/apps/web/src/utils/notifications.ts
@@ -17,6 +17,8 @@ import {
     type EmptyObject,
     EventType,
 } from "matrix-js-sdk/src/matrix";
+import { KnownMembership } from "matrix-js-sdk/src/types";
+import { logger } from "matrix-js-sdk/src/logger";
 import { type IndicatorIcon } from "@vector-im/compound-web";
 
 import SettingsStore from "../settings/SettingsStore";
@@ -83,6 +85,47 @@ export function localNotificationsAreSilenced(cli: MatrixClient): boolean {
 }
 
 /**
+ * Mark the room this one was upgraded from as read, if there is one.
+ *
+ * A room's badge folds in the highlight count of its predecessor (see
+ * `RoomNotifs.getUnreadNotificationCount`), so clearing only this room would leave behind a count
+ * the user has no way to reach: the predecessor is normally hidden from the room list once it has
+ * been replaced, and it comes back on the next sync anyway unless a receipt reaches the server.
+ *
+ * This is supplementary to marking the room itself as read, so a failure here is logged rather than
+ * propagated — the caller has already been told the room is read.
+ *
+ * @param room - the room whose predecessor should be marked as read
+ * @param client - the client to send the receipt with
+ */
+async function clearPredecessorNotification(room: Room, client: MatrixClient): Promise<void> {
+    const predecessor = room.findPredecessor(SettingsStore.getValue("feature_dynamic_room_predecessors"));
+    const oldRoom = predecessor?.roomId ? client.getRoom(predecessor.roomId) : null;
+    if (!oldRoom) return;
+
+    const lastEvent = oldRoom.getLastLiveEvent();
+    // A room we have left will not be sent to us with notification counts again, so zeroing them
+    // locally is enough; one we are still in needs a receipt or the server will re-send them.
+    if (lastEvent && oldRoom.getMyMembership() === KnownMembership.Join) {
+        const receiptType = SettingsStore.getValue("sendReadReceipts", oldRoom.roomId)
+            ? ReceiptType.Read
+            : ReceiptType.ReadPrivate;
+        try {
+            await client.sendReadReceipt(lastEvent, receiptType, true);
+        } catch (error) {
+            logger.warn("Failed to mark the predecessor room as read", { roomId: oldRoom.roomId, error });
+        }
+    }
+
+    oldRoom.setUnreadNotificationCount(NotificationCountType.Highlight, 0);
+    oldRoom.setUnreadNotificationCount(NotificationCountType.Total, 0);
+    for (const thread of oldRoom.getThreads()) {
+        oldRoom.setThreadUnreadNotificationCount(thread.id, NotificationCountType.Highlight, 0);
+        oldRoom.setThreadUnreadNotificationCount(thread.id, NotificationCountType.Total, 0);
+    }
+}
+
+/**
  * Mark a room as read
  * @param room
  * @param client
@@ -92,6 +135,7 @@ export async function clearRoomNotification(room: Room, client: MatrixClient): P
     const lastEvent = room.getLastLiveEvent();
 
     await setMarkedUnreadState(room, client, false);
+    await clearPredecessorNotification(room, client);
 
     try {
         if (lastEvent) {

--- a/apps/web/test/unit-tests/utils/notifications-test.ts
+++ b/apps/web/test/unit-tests/utils/notifications-test.ts
@@ -14,6 +14,7 @@ import {
     ReceiptType,
     type AccountDataEvents,
 } from "matrix-js-sdk/src/matrix";
+import { KnownMembership } from "matrix-js-sdk/src/types";
 import { type Mocked, mocked } from "jest-mock-vitest-adapter";
 
 import {
@@ -162,6 +163,58 @@ describe("notifications", () => {
                 await clearRoomNotification(room, client);
             }).rejects.toEqual({ error: 42 });
             expect(room.getUnreadNotificationCount(NotificationCountType.Total)).toBe(0);
+        });
+
+        describe("when the room replaces an older one", () => {
+            const OLD_ROOM_ID = "!old:example.org";
+            let oldRoom: Room;
+            let oldMessage: MatrixEvent;
+
+            beforeEach(() => {
+                oldRoom = new Room(OLD_ROOM_ID, client, USER_ID);
+                oldMessage = mkMessage({
+                    event: true,
+                    room: OLD_ROOM_ID,
+                    user: USER_ID,
+                    msg: "Older",
+                });
+                oldRoom.addLiveEvents([oldMessage], { addToState: true });
+                // The predecessor's highlights are folded into this room's badge, so they have to be
+                // cleared from here or the user is left with a count they cannot reach
+                oldRoom.setUnreadNotificationCount(NotificationCountType.Highlight, 3);
+                jest.spyOn(room, "findPredecessor").mockReturnValue({ roomId: OLD_ROOM_ID });
+                jest.spyOn(client, "getRoom").mockImplementation((roomId) => (roomId === OLD_ROOM_ID ? oldRoom : null));
+            });
+
+            it("marks the replaced room as read too", async () => {
+                oldRoom.updateMyMembership(KnownMembership.Join);
+
+                await clearRoomNotification(room, client);
+
+                expect(sendReadReceiptSpy).toHaveBeenCalledWith(oldMessage, ReceiptType.Read, true);
+                expect(oldRoom.getUnreadNotificationCount(NotificationCountType.Highlight)).toBe(0);
+            });
+
+            it("clears the counts without a receipt when the replaced room has been left", async () => {
+                oldRoom.updateMyMembership(KnownMembership.Leave);
+
+                await clearRoomNotification(room, client);
+
+                expect(sendReadReceiptSpy).not.toHaveBeenCalledWith(oldMessage, ReceiptType.Read, true);
+                expect(oldRoom.getUnreadNotificationCount(NotificationCountType.Highlight)).toBe(0);
+            });
+
+            it("still marks this room as read when the replaced room cannot be", async () => {
+                oldRoom.updateMyMembership(KnownMembership.Join);
+                sendReadReceiptSpy.mockImplementation(async (event: MatrixEvent) => {
+                    if (event === oldMessage) throw new Error("no receipt for you");
+                    return {};
+                });
+
+                await clearRoomNotification(room, client);
+
+                expect(sendReadReceiptSpy).toHaveBeenCalledWith(message, ReceiptType.Read, true);
+            });
         });
 
         describe("when sendReadReceipts setting is disabled", () => {


### PR DESCRIPTION
A room's badge folds in the highlight count of the room it replaced: `getUnreadNotificationCount` adds the predecessor's highlights to whichever count it was asked for, so an upgraded room can carry a badge that none of its own events account for. Marking the room as read only ever touched the room itself, so that part of the badge survives, and once a room has been replaced its predecessor is normally out of the room list entirely — which leaves the user a count with no affordance anywhere that clears it.

Marking a room as read now reaches its predecessor too. Where we are still joined it sends the same unthreaded receipt, because zeroing the counts locally would last only until the next sync told us about them again; where we have left, the server will not send those counts again, so clearing them locally is enough on its own. A failure there is logged rather than propagated — the caller has already been told this room is read, and the predecessor is supplementary to that.

Dropping the fold-in would have been the smaller change, but it looks deliberate: it is there so a mention from the room's previous life survives the upgrade. The affordance is the half that was missing, so that is the half this changes. Threads in the predecessor are cleared alongside its room counts, matching what the room's own reset already does.

Tests: three cases in `notifications-test.ts` covering a joined predecessor, a left one, and a predecessor whose receipt fails. The first two fail on `develop` and pass here.

Related to #24392

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
