### PR TITLE
Validate scheme of bundled URL preview links

### DIFF
--- a/apps/web/src/utils/UrlPreviewFetcher.test.ts
+++ b/apps/web/src/utils/UrlPreviewFetcher.test.ts
@@ -266,15 +266,15 @@ describe("UrlPreviewFetcher", () => {
         it("should fall back to the matched_url when there is no title", () => {
             const { fetcher } = getFetcher();
             const preview = fetcher.previewFromBundle({ matched_url: "https://example.org/page" });
-            expect(preview.title).toEqual("https://example.org/page");
-            expect(preview.showTooltipOnLink).toBe(false);
+            expect(preview!.title).toEqual("https://example.org/page");
+            expect(preview!.showTooltipOnLink).toBe(false);
         });
 
         it("should set showTooltipOnLink when tooltips are enabled and title differs from the URL", () => {
             const { client } = getFetcher();
             const fetcher = new UrlPreviewFetcher(client as unknown as MatrixClient, 0, true);
             const preview = fetcher.previewFromBundle(BASIC_BUNDLE);
-            expect(preview.showTooltipOnLink).toBe(true);
+            expect(preview!.showTooltipOnLink).toBe(true);
         });
 
         // Unlike fetchPreview, the tooltip flag is computed against the raw og:title rather than
@@ -284,7 +284,7 @@ describe("UrlPreviewFetcher", () => {
             const { client } = getFetcher();
             const fetcher = new UrlPreviewFetcher(client as unknown as MatrixClient, 0, true);
             const preview = fetcher.previewFromBundle({ matched_url: "https://example.org/page" });
-            expect(preview.showTooltipOnLink).toBe(true);
+            expect(preview!.showTooltipOnLink).toBe(true);
         });
 
         it("should not set showTooltipOnLink when tooltips are enabled but og:title equals the URL", () => {
@@ -294,14 +294,14 @@ describe("UrlPreviewFetcher", () => {
                 "matched_url": "https://example.org/page",
                 "og:title": "https://example.org/page",
             });
-            expect(preview.showTooltipOnLink).toBe(false);
+            expect(preview!.showTooltipOnLink).toBe(false);
         });
 
         it("should include the image when all image fields are present", () => {
             const { fetcher, client } = getFetcher();
             mockMedia(client);
             const preview = fetcher.previewFromBundle(IMAGE_BUNDLE);
-            expect(preview.image).toEqual({
+            expect(preview!.image).toEqual({
                 imageThumb: "https://example.org/image/thumb",
                 imageFull: "https://example.org/image/src",
                 imageType: "image/png",
@@ -323,7 +323,7 @@ describe("UrlPreviewFetcher", () => {
             const { fetcher, client } = getFetcher();
             mockMedia(client);
             const preview = fetcher.previewFromBundle({ ...IMAGE_BUNDLE, ...override });
-            expect(preview.image).toBeUndefined();
+            expect(preview!.image).toBeUndefined();
         });
 
         it("should omit the image when the media mxc URL is malformed", () => {
@@ -332,9 +332,9 @@ describe("UrlPreviewFetcher", () => {
             // eslint-disable-next-line no-restricted-properties
             client.mxcUrlToHttp.mockReturnValue(null);
             const preview = fetcher.previewFromBundle(IMAGE_BUNDLE);
-            expect(preview.image).toBeUndefined();
+            expect(preview!.image).toBeUndefined();
             // The rest of the preview is still returned.
-            expect(preview.title).toEqual("Bundled title");
+            expect(preview?.title).toEqual("Bundled title");
         });
 
         it("should compute the siteName from the matched_url hostname", () => {
@@ -343,7 +343,27 @@ describe("UrlPreviewFetcher", () => {
                 ...BASIC_BUNDLE,
                 matched_url: "https://sub.example.com:8443/some/path?q=1",
             });
-            expect(preview.siteName).toEqual("sub.example.com");
+            expect(preview?.siteName).toEqual("sub.example.com");
+        });
+
+        it.each([
+            "",
+            null,
+            true,
+            123,
+            "javascript:execute_me",
+            "data:evil",
+            "mailto:foo@bar",
+            "x-http://not-real",
+            "htttps://still-not-real",
+        ])("should reject '%s'", (url) => {
+            const { fetcher } = getFetcher();
+            const preview = fetcher.previewFromBundle({
+                ...BASIC_BUNDLE,
+                "og:url": url as string,
+                "matched_url": url as string,
+            });
+            expect(preview).toBeNull();
         });
     });
 });

--- a/apps/web/src/utils/UrlPreviewFetcher.ts
+++ b/apps/web/src/utils/UrlPreviewFetcher.ts
@@ -211,11 +211,26 @@ export class UrlPreviewFetcher {
     /*
      * Convert an MSC4095 URL preview bundle item to a UrlPreview
      */
-    public previewFromBundle(single: UnstableBundledUrlPreviewSingle): UrlPreview {
+    public previewFromBundle(single: UnstableBundledUrlPreviewSingle): UrlPreview | null {
+        // The bundle and its `matched_url` come from the message sender and are therefore
+        // untrusted (unlike the homeserver-fetched preview path, whose link originates from the
+        // linkified message body). Only allow http(s) URLs so that a malicious sender cannot
+        // supply a `javascript:`/`data:` (or otherwise unsafe) URL that would then be rendered as
+        // the preview link's `href`, and so that a malformed URL cannot throw while rendering.
+        let matchedUrl: URL;
+        try {
+            matchedUrl = new URL(single.matched_url);
+        } catch {
+            return null;
+        }
+        if (matchedUrl.protocol !== "http:" && matchedUrl.protocol !== "https:") {
+            return null;
+        }
+
         const preview: UrlPreview = {
             link: single.matched_url,
             title: single["og:title"] ?? single.matched_url,
-            siteName: new URL(single.matched_url).hostname,
+            siteName: matchedUrl.hostname,
             showTooltipOnLink: !!(single.matched_url !== single["og:title"] && this.showTooltips),
             description: single["og:description"],
             ogUrl: single["og:url"],


### PR DESCRIPTION
### What / why

`UrlPreviewFetcher.previewFromBundle()` builds a URL preview from an MSC4095 bundled preview object (`com.beeper.linkpreviews`). Unlike the homeserver-fetched preview path - whose `link` originates from the linkified message body and is therefore already constrained to `http(s)` - the bundled object is supplied verbatim by the **message sender** and is fully attacker-controlled. This path is used to render previews without contacting the homeserver (e.g. in encrypted rooms) and is gated behind the `feature_msc4095_url_preview_bundle` lab.

The sender-provided `matched_url` was used with no validation:

- It was passed straight through as `preview.link`, which the preview component renders as the anchor `href` (`<Text as="a" href={link} ...>` in `LinkPreview`). A value such as `javascript:...` or `data:...` therefore ends up as a clickable link target. React does not sanitise `href`, so the dangerous scheme is rendered as-is.
- It was passed to `new URL(single.matched_url)` for the site-name/host. A malformed value throws a `TypeError`, and because the call happens inside `.map(...)` during preview computation the throw is uncaught, breaking rendering of the previews.

### The fix

Parse `matched_url` once inside `previewFromBundle()` and return `null` unless it is a valid `http:`/`https:` URL. The single caller already discards `null` entries (`previews.filter((p) => !!p)`) and its array is already typed to allow `null`, so no other changes are needed. The parsed `URL` is reused for `siteName`, removing the second unguarded `new URL(...)` call.

This mirrors the trust boundary the fetch path already relies on and keeps unsafe schemes and malformed URLs out of the rendered preview.

### Checklist

- Type: Defect
- No user-facing string or behaviour change for legitimate `http(s)` previews.
