### PR TITLE
macOS Fix: Can't change homeserver on login or press the logout button on the splash/loading srceen

### DIFF
--- a/apps/desktop/src/macos-titlebar.test.ts
+++ b/apps/desktop/src/macos-titlebar.test.ts
@@ -66,6 +66,15 @@ describe("buildTitleBarCss", () => {
         expect(css).not.toContain("aria-hidden");
     });
 
+    it("does not turn whole screens into drag regions (#34661)", () => {
+        // Regression guard: these screens cover the window, and the controls drawn on them keep the
+        // default app-region of `none` — so they never subtract from the region and their clicks
+        // become window drags instead. That left the device verification screen and the splash
+        // screen's sign-out button reachable only by keyboard. The band is the drag handle.
+        expect(css).not.toMatch(/\.mx_AuthPage[^{]*\{[^}]*-webkit-app-region:\s*drag/);
+        expect(css).not.toMatch(/\.mx_MatrixChat_splash[^{]*\{[^}]*-webkit-app-region:\s*drag/);
+    });
+
     it("keeps floating portal overlays clickable within the band", () => {
         // Compound menus/tooltips render in body-level portals and can open anywhere, incl. the band.
         expect(css).toMatch(/\[data-radix-popper-content-wrapper\][^{]*\{[^}]*-webkit-app-region:\s*no-drag/);

--- a/apps/desktop/src/macos-titlebar.ts
+++ b/apps/desktop/src/macos-titlebar.ts
@@ -63,27 +63,6 @@ export function buildTitleBarCss(): string {
                 -webkit-app-region: no-drag;
             }
 
-            /* Mark the splash screen as a drag handle */
-            .mx_MatrixChat_splash {
-                -webkit-app-region: drag;
-            }
-            /* Exclude the splash buttons from being drag handles */
-            .mx_MatrixChat_splashButtons {
-                -webkit-app-region: no-drag;
-            }
-
-            /* Mark the background as a drag handle */
-            .mx_AuthPage {
-                -webkit-app-region: drag;
-            }
-            /* Exclude the main content elements from being drag handles */
-            .mx_AuthPage .mx_AuthPage_modalContent,
-            .mx_AuthPage .mx_AuthPage_modalBlur,
-            .mx_AuthPage .mx_AuthFooter > *,
-            .mx_AuthPage .mx_Dropdown_menu {
-                -webkit-app-region: no-drag;
-            }
-
             /* The image lightbox covers the whole window, including the title bar band; keep its
                sender info clear of the traffic lights, and let its header double as a drag handle */
             .mx_ImageView_info_wrapper {


### PR DESCRIPTION
Fixes #34661

In #34419 I flipped from draggable backgrounds to a single draggable title bar. Drag regions
steal te mouse clicks, so the old approach needed a long list of `no-drag` exclusions to keep things
clickable. I removed those exclusions but forgot to remove two of the draggable backgrounds,
so the auth page and the splash screen were still drag regions with nothing excluded.