### PR TITLE
Cachebust languages.json

### DIFF
--- a/apps/web/src/test/setupLanguage.ts
+++ b/apps/web/src/test/setupLanguage.ts
@@ -45,7 +45,7 @@ export function setupLanguageMock() {
 
     fetchMock
         .get(
-            "end:/i18n/languages.json",
+            "end:/i18n/languages.json?*",
             {
                 en: "en_EN.json",
                 de: "de_DE.json",

--- a/apps/web/src/test/setupLanguage.ts
+++ b/apps/web/src/test/setupLanguage.ts
@@ -45,7 +45,7 @@ export function setupLanguageMock() {
 
     fetchMock
         .get(
-            "end:/i18n/languages.json?*",
+            "include:/i18n/languages.json?",
             {
                 en: "en_EN.json",
                 de: "de_DE.json",

--- a/apps/web/test/setup/setupLanguage.ts
+++ b/apps/web/test/setup/setupLanguage.ts
@@ -48,7 +48,7 @@ export function setupLanguageMock() {
     fetchMock.mockGlobal();
     fetchMock
         .get(
-            "end:/i18n/languages.json",
+            "end:/i18n/languages.json?*",
             {
                 en: "en_EN.json",
                 de: "de_DE.json",

--- a/apps/web/test/setup/setupLanguage.ts
+++ b/apps/web/test/setup/setupLanguage.ts
@@ -48,7 +48,7 @@ export function setupLanguageMock() {
     fetchMock.mockGlobal();
     fetchMock
         .get(
-            "end:/i18n/languages.json?*",
+            "include:/i18n/languages.json?",
             {
                 en: "en_EN.json",
                 de: "de_DE.json",

--- a/packages/shared-components/.storybook/main.ts
+++ b/packages/shared-components/.storybook/main.ts
@@ -88,7 +88,7 @@ const config: StorybookConfig = {
                     name: "language-middleware",
                     configureServer(server) {
                         server.middlewares.use((req, res, next) => {
-                            if (req.url === "/i18n/languages.json") {
+                            if (req.url?.split("?")[0] === "/i18n/languages.json") {
                                 // Dynamically generate a languages.json file based on what files are available
                                 res.setHeader("Content-Type", "application/json");
                                 res.end(JSON.stringify(languages));

--- a/packages/shared-components/src/core/i18n/i18n.tsx
+++ b/packages/shared-components/src/core/i18n/i18n.tsx
@@ -433,7 +433,8 @@ async function getLanguage(langPath: string): Promise<ICounterpartTranslation> {
 }
 
 export async function getLangsJson(): Promise<Languages> {
-    const url = i18nFolder + "languages.json";
+    const cachebust = Math.random().toString(16).slice(2);
+    const url = `${i18nFolder}languages.json?${cachebust}`;
 
     const res = await fetch(url, { method: "GET" });
 

--- a/packages/shared-components/src/core/i18n/i18n.tsx
+++ b/packages/shared-components/src/core/i18n/i18n.tsx
@@ -433,7 +433,7 @@ async function getLanguage(langPath: string): Promise<ICounterpartTranslation> {
 }
 
 export async function getLangsJson(): Promise<Languages> {
-    const cachebust = Math.random().toString(16).slice(2);
+    const cachebust = Date.now();
     const url = `${i18nFolder}languages.json?${cachebust}`;
 
     const res = await fetch(url, { method: "GET" });

--- a/packages/shared-components/src/test/setupTests.ts
+++ b/packages/shared-components/src/test/setupTests.ts
@@ -51,7 +51,7 @@ expect.addSnapshotSerializer({
 
 function setupLanguageMock(): void {
     fetchMock
-        .get("end:/i18n/languages.json?*", {
+        .get("include:/i18n/languages.json?", {
             en: "en_EN.json",
         })
         .get("end:en_EN.json", en);

--- a/packages/shared-components/src/test/setupTests.ts
+++ b/packages/shared-components/src/test/setupTests.ts
@@ -51,7 +51,7 @@ expect.addSnapshotSerializer({
 
 function setupLanguageMock(): void {
     fetchMock
-        .get("end:/i18n/languages.json", {
+        .get("end:/i18n/languages.json?*", {
             en: "en_EN.json",
         })
         .get("end:en_EN.json", en);


### PR DESCRIPTION
To avoid loading stale language files. The individual language files as hashbusted but the metadata file is not, and it is not feasible to do so.

