### PR TITLE
Wire up recent emoji to user status emoji picker

### DIFF
--- a/apps/web/src/viewmodels/status/SetStatusViewModel.test.ts
+++ b/apps/web/src/viewmodels/status/SetStatusViewModel.test.ts
@@ -24,6 +24,12 @@ import { Action } from "../../dispatcher/actions";
 import { UserTab } from "../../components/views/dialogs/UserTab";
 import { OwnProfileStore } from "../../stores/OwnProfileStore";
 import { UPDATE_EVENT } from "../../stores/AsyncStore";
+import * as recent from "../../emojipicker/recent";
+
+vi.mock("../../emojipicker/recent", () => ({
+    add: vi.fn(),
+    get: vi.fn(),
+}));
 
 const STATUS: MatrixUserStatus = { emoji: "🧪", text: "Testing" };
 
@@ -43,6 +49,7 @@ describe("SetStatusViewModel", () => {
             setExtendedProfileProperty: vi.fn().mockResolvedValue(undefined),
         });
         vi.mocked(mockOwnProfileStoreInstance).userStatus = undefined;
+        vi.mocked(recent.get).mockReturnValue([]);
     });
 
     afterEach(() => {
@@ -58,6 +65,12 @@ describe("SetStatusViewModel", () => {
     it("initialises snapshot with undefined when no status is set", () => {
         const vm = new SetStatusViewModel({ client, ownProfileStore: mockOwnProfileStoreInstance });
         expect(vm.getSnapshot().userStatus).toBeUndefined();
+    });
+
+    it("initialises snapshot from the recently used emojis", () => {
+        vi.mocked(recent.get).mockReturnValue(["🧪", "🦎"]);
+        const vm = new SetStatusViewModel({ client, ownProfileStore: mockOwnProfileStoreInstance });
+        expect(vm.getSnapshot().recentEmojis).toEqual(["🧪", "🦎"]);
     });
 
     it("updates the snapshot when OwnProfileStore emits an update", () => {
@@ -116,6 +129,25 @@ describe("SetStatusViewModel", () => {
             expect(vm.getSnapshot().userStatus).toEqual(newStatus);
 
             await waitFor(() => expect(vm.getSnapshot().userStatus).toEqual(STATUS));
+        });
+    });
+
+    describe("recordRecentEmoji", () => {
+        it("records the emoji as recently used", () => {
+            const vm = new SetStatusViewModel({ client, ownProfileStore: mockOwnProfileStoreInstance });
+            vm.recordRecentEmoji("🎉");
+            expect(recent.add).toHaveBeenCalledWith("🎉");
+        });
+
+        it("updates the snapshot with the new list of recent emojis", () => {
+            vi.mocked(recent.get).mockReturnValue(["🧪"]);
+            const vm = new SetStatusViewModel({ client, ownProfileStore: mockOwnProfileStoreInstance });
+            expect(vm.getSnapshot().recentEmojis).toEqual(["🧪"]);
+
+            vi.mocked(recent.get).mockReturnValue(["🎉", "🧪"]);
+            vm.recordRecentEmoji("🎉");
+
+            expect(vm.getSnapshot().recentEmojis).toEqual(["🎉", "🧪"]);
         });
     });
 

--- a/apps/web/src/viewmodels/status/SetStatusViewModel.ts
+++ b/apps/web/src/viewmodels/status/SetStatusViewModel.ts
@@ -15,6 +15,7 @@ import {
 } from "@element-hq/web-shared-components";
 
 import { clearAllUserStatus, setUserStatus } from "../../utils/userStatus";
+import * as recent from "../../emojipicker/recent";
 import { UPDATE_EVENT } from "../../stores/AsyncStore";
 import dis from "../../dispatcher/dispatcher";
 import { UserTab } from "../../components/views/dialogs/UserTab";
@@ -36,6 +37,10 @@ export class SetStatusViewModel
     public constructor(props: SetStatusViewModelProps) {
         super(props, {
             userStatus: props.ownProfileStore.userStatus,
+            // This is a one-time snapshot and we manually update when we add an emoji.
+            // It could have a listener for when an emoji gets added but in practice, this
+            // would be the only way a recent could possibly get added while the view is mounted.
+            recentEmojis: recent.get(),
         });
 
         this.disposables.trackListener(props.ownProfileStore, UPDATE_EVENT, this.onProfileStoreUpdate);
@@ -53,6 +58,12 @@ export class SetStatusViewModel
             this.snapshot.merge({ userStatus: oldStatus });
             logger.warn("Failed to set user status", err);
         });
+    };
+
+    public recordRecentEmoji = (unicode: string): void => {
+        recent.add(unicode);
+        // Manually update the list of recent emojis as we know we've just added one.
+        this.snapshot.merge({ recentEmojis: recent.get() });
     };
 
     public clearStatus = (): void => {

--- a/packages/shared-components/src/status/CustomStatusView.test.tsx
+++ b/packages/shared-components/src/status/CustomStatusView.test.tsx
@@ -73,4 +73,25 @@ describe("CustomStatusView", () => {
 
         expect(onSave).toHaveBeenCalledWith({ emoji: "😇", text: "Angelic" });
     });
+
+    it("offers the recently used emoji in the picker", async () => {
+        render(<CustomStatusView onSave={vi.fn()} onCancel={vi.fn()} recentEmojis={["😇"]} />);
+
+        await userEvent.click(screen.getByRole("button", { name: "Choose Emoji" }));
+        await waitFor(() => expect(screen.getByLabelText("Emoji picker")).toBeInTheDocument());
+
+        expect(await screen.findByRole("heading", { name: "Frequently Used" })).toBeInTheDocument();
+    });
+
+    it("records the chosen emoji as recently used", async () => {
+        const onRecordRecentEmoji = vi.fn();
+        render(<CustomStatusView onSave={vi.fn()} onCancel={vi.fn()} onRecordRecentEmoji={onRecordRecentEmoji} />);
+
+        await userEvent.click(screen.getByRole("button", { name: "Choose Emoji" }));
+        await waitFor(() => expect(screen.getByLabelText("Emoji picker")).toBeInTheDocument());
+
+        await userEvent.click(await screen.findByText("😇"));
+
+        expect(onRecordRecentEmoji).toHaveBeenCalledWith("😇");
+    });
 });

--- a/packages/shared-components/src/status/CustomStatusView.tsx
+++ b/packages/shared-components/src/status/CustomStatusView.tsx
@@ -29,12 +29,28 @@ export interface CustomStatusViewProps {
      * "Cancel" while the text is empty.
      */
     onCancel: () => void;
+    /**
+     * Recently used emoji (unicode strings, most relevant first) to show in the
+     * picker's "Frequently Used" category. The category is hidden when empty or
+     * omitted.
+     */
+    recentEmojis?: string[];
+    /**
+     * Called with the chosen emoji unicode when it should be recorded as
+     * recently used.
+     */
+    onRecordRecentEmoji?: (unicode: string) => void;
 }
 
 /**
  * Editor for composing a custom user status text and choosing an emoji.
  */
-export function CustomStatusView({ onSave, onCancel }: CustomStatusViewProps): JSX.Element {
+export function CustomStatusView({
+    onSave,
+    onCancel,
+    recentEmojis,
+    onRecordRecentEmoji,
+}: CustomStatusViewProps): JSX.Element {
     const [emoji, setEmoji] = useState(DEFAULT_EMOJI);
     const [text, setText] = useState("");
     const [pickerOpen, setPickerOpen] = useState(false);
@@ -44,8 +60,7 @@ export function CustomStatusView({ onSave, onCancel }: CustomStatusViewProps): J
     const onChooseEmoji = useCallback((unicode: string): boolean => {
         setEmoji(unicode);
         setPickerOpen(false);
-        // Don't record custom-status emoji as recently used composer reactions.
-        return false;
+        return true;
     }, []);
 
     const commit = useCallback(() => {
@@ -99,6 +114,8 @@ export function CustomStatusView({ onSave, onCancel }: CustomStatusViewProps): J
             >
                 <EmojiPicker
                     onChoose={onChooseEmoji}
+                    recentEmojis={recentEmojis}
+                    onRecordRecent={onRecordRecentEmoji}
                     onFinished={() => setPickerOpen(false)}
                     showQuickReactions={false}
                 />

--- a/packages/shared-components/src/status/SetStatusView.tsx
+++ b/packages/shared-components/src/status/SetStatusView.tsx
@@ -32,6 +32,12 @@ export interface SetStatusViewSnapshot {
      * The current user status, or undefined if no status is set.
      */
     userStatus?: UserStatus;
+
+    /**
+     * Recently used emoji (unicode strings, most relevant first) to offer when
+     * choosing an emoji for a custom status.
+     */
+    recentEmojis?: string[];
 }
 
 export interface SetStatusViewActions {
@@ -51,6 +57,12 @@ export interface SetStatusViewActions {
      * Called when the user clears their current status.
      */
     clearStatus: () => void;
+
+    /**
+     * Called with the unicode of an emoji the user picked for a custom status,
+     * so it can be recorded as recently used.
+     */
+    recordRecentEmoji?: (unicode: string) => void;
 }
 
 export type SetStatusViewModel = ViewModel<SetStatusViewSnapshot, SetStatusViewActions>;
@@ -69,7 +81,7 @@ function StatusOption({ value }: { value: StatusValue }): React.ReactNode {
 }
 
 export function SetStatusView({ vm }: SetStatusViewProps): JSX.Element {
-    const { userStatus } = useViewModel(vm);
+    const { userStatus, recentEmojis } = useViewModel(vm);
     const [customMode, setCustomMode] = useState(false);
 
     const renderItem = useCallback((value: StatusValue | null): React.ReactNode => {
@@ -90,6 +102,8 @@ export function SetStatusView({ vm }: SetStatusViewProps): JSX.Element {
                     vm.setStatus(status);
                 }}
                 onCancel={() => setCustomMode(false)}
+                recentEmojis={recentEmojis}
+                onRecordRecentEmoji={vm.recordRecentEmoji}
             />
         );
     }


### PR DESCRIPTION
So recents are saved and displayed.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
