### PR TITLE
Show an error message if resetting identity takes too long

### DIFF
--- a/apps/web/src/components/structures/auth/CompleteSecurity.test.tsx
+++ b/apps/web/src/components/structures/auth/CompleteSecurity.test.tsx
@@ -16,6 +16,8 @@ import { stubClient } from "test-utils";
 import CompleteSecurity from "./CompleteSecurity";
 import { Phase, SetupEncryptionStore } from "../../../stores/SetupEncryptionStore";
 import SdkConfig from "../../../SdkConfig";
+import { sleep } from "matrix-js-sdk/src/utils";
+import { MatrixClientPeg } from "../../../MatrixClientPeg";
 
 class MockSetupEncryptionStore extends EventEmitter {
     public phase: Phase = Phase.Intro;
@@ -96,6 +98,26 @@ describe("CompleteSecurity", () => {
         // Then the reset identity dialog appears
         expect(screen.getByRole("heading", { name: "You need to reset your digital identity" })).toBeInTheDocument();
         expect(panel.getByRole("button", { name: "Continue" })).toBeInTheDocument();
+    });
+
+    it("Shows an error if reset times out", async () => {
+        const client = MatrixClientPeg.safeGet();
+
+        // Given reset will freeze forever when we do it
+        client.getCrypto()!.resetEncryption = vi.fn().mockImplementation(() => sleep(20000));
+        const store = new SetupEncryptionStore();
+        vi.spyOn(SetupEncryptionStore, "sharedInstance").mockReturnValue(store);
+        const panel = await act(() => render(<CompleteSecurity onFinished={() => {}} resetTimeoutMs={1} />));
+
+        // When we hit reset, then continue
+        await act(async () => panel.getByRole("button", { name: "Can't confirm?" }).click());
+        await act(async () => panel.getByRole("button", { name: "Continue" }).click());
+
+        // And wait more than the timeout
+        await sleep(10);
+
+        // Then an error dialog appears
+        expect(screen.getByRole("heading", { name: "Identity reset failed" })).toBeInTheDocument();
     });
 
     it("Allows verifying with another device if one is available", async () => {

--- a/apps/web/src/components/structures/auth/CompleteSecurity.tsx
+++ b/apps/web/src/components/structures/auth/CompleteSecurity.tsx
@@ -22,6 +22,10 @@ import { E2EStatus } from "../../../utils/ShieldUtils.ts";
 
 interface IProps {
     onFinished: () => void;
+
+    // How long to wait for an identity reset before we assume it failed.
+    // Default: 5000ms.
+    resetTimeoutMs?: number;
 }
 
 interface IState {
@@ -109,7 +113,11 @@ export default class CompleteSecurity extends React.Component<IProps, IState> {
                             {skipButton}
                         </h1>
                         <div className="mx_CompleteSecurity_body">
-                            <SetupEncryptionBody onFinished={this.props.onFinished} allowLogout={true} />
+                            <SetupEncryptionBody
+                                onFinished={this.props.onFinished}
+                                allowLogout={true}
+                                resetTimeoutMs={this.props.resetTimeoutMs}
+                            />
                         </div>
                     </CompleteSecurityBody>
                 </Glass>

--- a/apps/web/src/components/structures/auth/SetupEncryptionBody.tsx
+++ b/apps/web/src/components/structures/auth/SetupEncryptionBody.tsx
@@ -44,6 +44,11 @@ interface IProps {
      * Defaults to `false` if omitted.
      */
     allowLogout?: boolean;
+
+    // How long to wait for an identity reset before we assume it failed.
+    //
+    // Defaults to 5000ms if omitted.
+    resetTimeoutMs?: number;
 }
 
 interface IState {
@@ -138,6 +143,7 @@ export default class SetupEncryptionBody extends React.Component<IProps, IState>
                 const store = SetupEncryptionStore.sharedInstance();
                 store.done();
             },
+            resetTimeoutMs: this.props.resetTimeoutMs,
             onFail: (failureReason) => {
                 logger.error(`Failed to reset identity: ${failureReason}`);
 

--- a/apps/web/src/components/structures/auth/SetupEncryptionBody.tsx
+++ b/apps/web/src/components/structures/auth/SetupEncryptionBody.tsx
@@ -29,6 +29,8 @@ import ExternalLink from "../../views/elements/ExternalLink";
 import dispatcher from "../../../dispatcher/dispatcher";
 import E2EIcon from "../../views/rooms/E2EIcon.tsx";
 import { E2EStatus } from "../../../utils/ShieldUtils.ts";
+import ErrorDialog from "../../views/dialogs/ErrorDialog.tsx";
+import SdkConfig from "../../../SdkConfig.ts";
 
 interface IProps {
     onFinished: () => void;
@@ -135,6 +137,21 @@ export default class SetupEncryptionBody extends React.Component<IProps, IState>
                 this.props.onFinished();
                 const store = SetupEncryptionStore.sharedInstance();
                 store.done();
+            },
+            onFail: (failureReason) => {
+                logger.error(`Failed to reset identity: ${failureReason}`);
+
+                Modal.createDialog(ErrorDialog, {
+                    title: _t("error_reset_failed"),
+                    description: _t("error_reset_failed_description", undefined, {
+                        issueLink: (label: string) => (
+                            <a href={SdkConfig.get().feedback.new_issue_url} target="_blank" rel="noreferrer noopener">
+                                {label}
+                            </a>
+                        ),
+                    }),
+                    button: _t("action|ok"),
+                });
             },
             variant: store.lostKeys() ? "no_verification_method" : "confirm",
         });

--- a/apps/web/src/components/views/dialogs/ResetIdentityDialog.tsx
+++ b/apps/web/src/components/views/dialogs/ResetIdentityDialog.tsx
@@ -24,6 +24,11 @@ interface ResetIdentityDialogProps {
      */
     onReset: () => void;
 
+    // How long to wait for an identity reset before we assume it failed.
+    //
+    // Defaults to 5000ms if omitted.
+    resetTimeoutMs?: number;
+
     /**
      * Called when the identity reset fails (before onFinished is called).
      */
@@ -38,7 +43,13 @@ interface ResetIdentityDialogProps {
 /**
  * The dialog for resetting the identity of the current user.
  */
-export function ResetIdentityDialog({ onFinished, onReset, onFail, variant }: ResetIdentityDialogProps): JSX.Element {
+export function ResetIdentityDialog({
+    onFinished,
+    onReset,
+    resetTimeoutMs,
+    onFail,
+    variant,
+}: ResetIdentityDialogProps): JSX.Element {
     const matrixClient = MatrixClientPeg.safeGet();
 
     const onResetWrapper = (): void => {
@@ -57,6 +68,7 @@ export function ResetIdentityDialog({ onFinished, onReset, onFail, variant }: Re
         <MatrixClientContext.Provider value={matrixClient}>
             <ResetIdentityBody
                 onReset={onResetWrapper}
+                resetTimeoutMs={resetTimeoutMs}
                 onFail={onFailWrapper}
                 onCancelClick={onFinished}
                 variant={variant}

--- a/apps/web/src/components/views/dialogs/ResetIdentityDialog.tsx
+++ b/apps/web/src/components/views/dialogs/ResetIdentityDialog.tsx
@@ -25,6 +25,11 @@ interface ResetIdentityDialogProps {
     onReset: () => void;
 
     /**
+     * Called when the identity reset fails (before onFinished is called).
+     */
+    onFail: (failureReason: string) => void;
+
+    /**
      * Which variant of this dialog to show.
      */
     variant: ResetIdentityBodyVariant;
@@ -33,17 +38,29 @@ interface ResetIdentityDialogProps {
 /**
  * The dialog for resetting the identity of the current user.
  */
-export function ResetIdentityDialog({ onFinished, onReset, variant }: ResetIdentityDialogProps): JSX.Element {
+export function ResetIdentityDialog({ onFinished, onReset, onFail, variant }: ResetIdentityDialogProps): JSX.Element {
     const matrixClient = MatrixClientPeg.safeGet();
 
-    const onResetWrapper: () => void = () => {
+    const onResetWrapper = (): void => {
         onReset();
         // Close the dialog
         onFinished();
     };
+
+    const onFailWrapper = (reason: string): void => {
+        onFail(reason);
+        // Close the dialog
+        onFinished();
+    };
+
     return (
         <MatrixClientContext.Provider value={matrixClient}>
-            <ResetIdentityBody onReset={onResetWrapper} onCancelClick={onFinished} variant={variant} />
+            <ResetIdentityBody
+                onReset={onResetWrapper}
+                onFail={onFailWrapper}
+                onCancelClick={onFinished}
+                variant={variant}
+            />
         </MatrixClientContext.Provider>
     );
 }

--- a/apps/web/src/components/views/settings/encryption/ResetIdentityBody.tsx
+++ b/apps/web/src/components/views/settings/encryption/ResetIdentityBody.tsx
@@ -17,12 +17,18 @@ import { uiAuthCallback } from "../../../../CreateCrossSigning";
 import { EncryptionCardButtons } from "./EncryptionCardButtons";
 import { EncryptionCardEmphasisedContent } from "./EncryptionCardEmphasisedContent";
 import { useMatrixClientContext } from "../../../../contexts/MatrixClientContext";
+import { timeout } from "../../../../utils/promise";
 
 interface ResetIdentityBodyProps {
     /**
      * Called when the identity is reset.
      */
     onReset: () => void;
+
+    // How long to wait for an identity reset before we assume it failed.
+    //
+    // Defaults to 5000ms if omitted.
+    resetTimeoutMs?: number;
 
     /**
      * Called when the identity reset fails.
@@ -65,7 +71,13 @@ export type ResetIdentityBodyVariant = "compromised" | "forgot" | "sync_failed" 
  *
  * Used by {@link ResetIdentityPanel}.
  */
-export function ResetIdentityBody({ onCancelClick, onReset, onFail, variant }: ResetIdentityBodyProps): JSX.Element {
+export function ResetIdentityBody({
+    onCancelClick,
+    onReset,
+    resetTimeoutMs,
+    onFail,
+    variant,
+}: ResetIdentityBodyProps): JSX.Element {
     const matrixClient = useMatrixClientContext();
 
     // After the user clicks "Continue", we disable the button so it can't be
@@ -75,25 +87,27 @@ export function ResetIdentityBody({ onCancelClick, onReset, onFail, variant }: R
     async function onClick(): Promise<void> {
         setInProgress(true);
 
-        const timeoutPromise = new Promise((_resolve, reject) => {
-            // If resetEncryption takes longer than 5 seconds, return a failure.
-            setTimeout(() => reject(new Error("Timed out")), 5000);
-        });
+        try {
+            const timedOut = "timed_out";
+            const result = await timeout(doOnClick(), timedOut, resetTimeoutMs ?? 5000);
 
+            if (result === timedOut) {
+                onFail("Timed out");
+            } else {
+                onReset();
+            }
+        } catch (e: any) {
+            onFail(e.toString());
+        }
+    }
+
+    async function doOnClick(): Promise<void> {
         const crypto = matrixClient.getCrypto();
         if (!crypto) {
-            onFail("Crypto is not set up");
-            return;
+            throw new Error("Crypto is not set up");
         }
 
-        const resetEncryptionPromise = crypto.resetEncryption((makeRequest) =>
-            uiAuthCallback(matrixClient, makeRequest),
-        );
-
-        await Promise.race([timeoutPromise, resetEncryptionPromise]).then(
-            () => onReset(),
-            (error_) => onFail(error_.toString()),
-        );
+        await crypto.resetEncryption((makeRequest) => uiAuthCallback(matrixClient, makeRequest));
     }
 
     return (

--- a/apps/web/src/components/views/settings/encryption/ResetIdentityBody.tsx
+++ b/apps/web/src/components/views/settings/encryption/ResetIdentityBody.tsx
@@ -17,6 +17,7 @@ import { uiAuthCallback } from "../../../../CreateCrossSigning";
 import { EncryptionCardButtons } from "./EncryptionCardButtons";
 import { EncryptionCardEmphasisedContent } from "./EncryptionCardEmphasisedContent";
 import { useMatrixClientContext } from "../../../../contexts/MatrixClientContext";
+import {reject} from "lodash";
 
 interface ResetIdentityBodyProps {
     /**
@@ -77,7 +78,7 @@ export function ResetIdentityBody({ onCancelClick, onReset, onFail, variant }: R
 
         const timeoutPromise = new Promise((_resolve, reject) => {
             // If resetEncryption takes longer than 5 seconds, return a failure.
-            setTimeout(() => reject("Timed out"), 5000);
+            setTimeout(() => reject(new Error("Timed out")), 5000);
         });
 
         const crypto = matrixClient.getCrypto();
@@ -92,7 +93,7 @@ export function ResetIdentityBody({ onCancelClick, onReset, onFail, variant }: R
 
         await Promise.race([timeoutPromise, resetEncryptionPromise]).then(
             () => onReset(),
-            (failureReason) => onFail(failureReason),
+            (error_) => onFail(error_.toString()),
         );
     }
 

--- a/apps/web/src/components/views/settings/encryption/ResetIdentityBody.tsx
+++ b/apps/web/src/components/views/settings/encryption/ResetIdentityBody.tsx
@@ -80,9 +80,13 @@ export function ResetIdentityBody({ onCancelClick, onReset, onFail, variant }: R
             setTimeout(() => reject("Timed out"), 5000);
         });
 
-        const resetEncryptionPromise = matrixClient
-            .getCrypto()
-            ?.resetEncryption((makeRequest) => uiAuthCallback(matrixClient, makeRequest));
+        const crypto = matrixClient.getCrypto();
+        if (!crypto) {
+            onFail("Crypto is not set up");
+            return;
+        }
+
+        const resetEncryptionPromise = crypto.resetEncryption((makeRequest) => uiAuthCallback(matrixClient, makeRequest));
 
         await Promise.race([timeoutPromise, resetEncryptionPromise]).then(
             () => onReset(),

--- a/apps/web/src/components/views/settings/encryption/ResetIdentityBody.tsx
+++ b/apps/web/src/components/views/settings/encryption/ResetIdentityBody.tsx
@@ -25,6 +25,11 @@ interface ResetIdentityBodyProps {
     onReset: () => void;
 
     /**
+     * Called when the identity reset fails.
+     */
+    onFail: (failureReason: string) => void;
+
+    /**
      * Called when the cancel button is clicked.
      */
     onCancelClick: () => void;
@@ -60,21 +65,29 @@ export type ResetIdentityBodyVariant = "compromised" | "forgot" | "sync_failed" 
  *
  * Used by {@link ResetIdentityPanel}.
  */
-export function ResetIdentityBody({ onCancelClick, onReset, variant }: ResetIdentityBodyProps): JSX.Element {
+export function ResetIdentityBody({ onCancelClick, onReset, onFail, variant }: ResetIdentityBodyProps): JSX.Element {
     const matrixClient = useMatrixClientContext();
 
     // After the user clicks "Continue", we disable the button so it can't be
     // clicked again, and warn the user not to close the window.
     const [inProgress, setInProgress] = useState(false);
 
-    async function onClick() {
+    async function onClick(): Promise<void> {
         setInProgress(true);
 
-        await matrixClient
+        const timeoutPromise = new Promise((_resolve, reject) => {
+            // If resetEncryption takes longer than 5 seconds, return a failure.
+            setTimeout(() => reject("Timed out"), 5000);
+        });
+
+        const resetEncryptionPromise = matrixClient
             .getCrypto()
             ?.resetEncryption((makeRequest) => uiAuthCallback(matrixClient, makeRequest));
 
-        onReset();
+        await Promise.race([timeoutPromise, resetEncryptionPromise]).then(
+            () => onReset(),
+            (failureReason) => onFail(failureReason),
+        );
     }
 
     return (
@@ -94,11 +107,7 @@ export function ResetIdentityBody({ onCancelClick, onReset, variant }: ResetIden
                 {variant === "compromised" && <span>{_t("settings|encryption|advanced|breadcrumb_warning")}</span>}
             </EncryptionCardEmphasisedContent>
             <EncryptionCardButtons>
-                <Button
-                    destructive={true}
-                    disabled={inProgress}
-                    onClick={onClick}
-                >
+                <Button destructive={true} disabled={inProgress} onClick={onClick}>
                     {inProgress ? (
                         <>
                             <InlineSpinner /> {_t("settings|encryption|advanced|reset_in_progress")}

--- a/apps/web/src/components/views/settings/encryption/ResetIdentityBody.tsx
+++ b/apps/web/src/components/views/settings/encryption/ResetIdentityBody.tsx
@@ -67,6 +67,16 @@ export function ResetIdentityBody({ onCancelClick, onReset, variant }: ResetIden
     // clicked again, and warn the user not to close the window.
     const [inProgress, setInProgress] = useState(false);
 
+    async function onClick() {
+        setInProgress(true);
+
+        await matrixClient
+            .getCrypto()
+            ?.resetEncryption((makeRequest) => uiAuthCallback(matrixClient, makeRequest));
+
+        onReset();
+    }
+
     return (
         <EncryptionCard Icon={ErrorIcon} destructive={true} title={titleForVariant(variant)}>
             <EncryptionCardEmphasisedContent>
@@ -87,13 +97,7 @@ export function ResetIdentityBody({ onCancelClick, onReset, variant }: ResetIden
                 <Button
                     destructive={true}
                     disabled={inProgress}
-                    onClick={async () => {
-                        setInProgress(true);
-                        await matrixClient
-                            .getCrypto()
-                            ?.resetEncryption((makeRequest) => uiAuthCallback(matrixClient, makeRequest));
-                        onReset();
-                    }}
+                    onClick={onClick}
                 >
                     {inProgress ? (
                         <>

--- a/apps/web/src/components/views/settings/encryption/ResetIdentityBody.tsx
+++ b/apps/web/src/components/views/settings/encryption/ResetIdentityBody.tsx
@@ -17,7 +17,6 @@ import { uiAuthCallback } from "../../../../CreateCrossSigning";
 import { EncryptionCardButtons } from "./EncryptionCardButtons";
 import { EncryptionCardEmphasisedContent } from "./EncryptionCardEmphasisedContent";
 import { useMatrixClientContext } from "../../../../contexts/MatrixClientContext";
-import {reject} from "lodash";
 
 interface ResetIdentityBodyProps {
     /**

--- a/apps/web/src/components/views/settings/encryption/ResetIdentityBody.tsx
+++ b/apps/web/src/components/views/settings/encryption/ResetIdentityBody.tsx
@@ -86,7 +86,9 @@ export function ResetIdentityBody({ onCancelClick, onReset, onFail, variant }: R
             return;
         }
 
-        const resetEncryptionPromise = crypto.resetEncryption((makeRequest) => uiAuthCallback(matrixClient, makeRequest));
+        const resetEncryptionPromise = crypto.resetEncryption((makeRequest) =>
+            uiAuthCallback(matrixClient, makeRequest),
+        );
 
         await Promise.race([timeoutPromise, resetEncryptionPromise]).then(
             () => onReset(),

--- a/apps/web/src/components/views/settings/encryption/ResetIdentityPanel.tsx
+++ b/apps/web/src/components/views/settings/encryption/ResetIdentityPanel.tsx
@@ -18,6 +18,11 @@ interface ResetIdentityPanelProps {
     onReset: () => void;
 
     /**
+     * Called if the identity reset fails.
+     */
+    onFail: (failureReason: string) => void;
+
+    /**
      * Called when the cancel button is clicked or when we go back in the breadcrumbs.
      */
     onCancelClick: () => void;
@@ -33,7 +38,7 @@ interface ResetIdentityPanelProps {
  *
  * A thin wrapper around {@link ResetIdentityBody}, just adding breadcrumbs.
  */
-export function ResetIdentityPanel({ onCancelClick, onReset, variant }: ResetIdentityPanelProps): JSX.Element {
+export function ResetIdentityPanel({ onCancelClick, onReset, onFail, variant }: ResetIdentityPanelProps): JSX.Element {
     return (
         <>
             <Breadcrumb
@@ -42,7 +47,7 @@ export function ResetIdentityPanel({ onCancelClick, onReset, variant }: ResetIde
                 pages={[_t("settings|encryption|title"), _t("settings|encryption|advanced|breadcrumb_page")]}
                 onPageClick={onCancelClick}
             />
-            <ResetIdentityBody onReset={onReset} onCancelClick={onCancelClick} variant={variant} />
+            <ResetIdentityBody onReset={onReset} onFail={onFail} onCancelClick={onCancelClick} variant={variant} />
         </>
     );
 }

--- a/apps/web/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.tsx
@@ -26,6 +26,8 @@ import { KeyStoragePanel } from "../../encryption/KeyStoragePanel";
 import { DeleteKeyStoragePanel } from "../../encryption/DeleteKeyStoragePanel";
 import { DeviceListener, CurrentDeviceEvents, type DeviceState } from "../../../../../device-listener";
 import { useKeyStoragePanelViewModel } from "../../../../viewmodels/settings/encryption/KeyStoragePanelViewModel";
+import ErrorDialog from "../../../dialogs/ErrorDialog";
+import SdkConfig from "../../../../../SdkConfig";
 
 /**
  * The state in the encryption settings tab.
@@ -143,6 +145,23 @@ export function EncryptionUserSettingsTab({ initialState = "main" }: Readonly<Pr
                     variant={findResetVariant(state)}
                     onCancelClick={() => setState("main")}
                     onReset={() => setState("main")}
+                    onFail={() => {
+                        Modal.createDialog(ErrorDialog, {
+                            title: _t("error_reset_failed"),
+                            description: _t("error_reset_failed_description", undefined, {
+                                issueLink: (label: string) => (
+                                    <a
+                                        href={SdkConfig.get().feedback.new_issue_url}
+                                        target="_blank"
+                                        rel="noreferrer noopener"
+                                    >
+                                        {label}
+                                    </a>
+                                ),
+                            }),
+                            button: _t("action|ok"),
+                        });
+                    }}
                 />
             );
             break;

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -1147,6 +1147,8 @@
         "error_loading_user_profile": "Could not load user profile",
         "forget_room_failed": "Failed to forget room %(errCode)s"
     },
+    "error_reset_failed": "Identity reset failed",
+    "error_reset_failed_description": "Something went wrong while resetting your digital identity. Please try again and <issueLink>submit a bug report</issueLink> if the problem persists.",
     "error_user_not_logged_in": "User is not logged in",
     "event_preview": {
         "m.call.answer": {

--- a/apps/web/test/unit-tests/components/views/dialogs/security/ResetIdentityDialog-test.tsx
+++ b/apps/web/test/unit-tests/components/views/dialogs/security/ResetIdentityDialog-test.tsx
@@ -26,7 +26,10 @@ describe("ResetIdentityDialog", () => {
 
         const onFinished = jest.fn();
         const onReset = jest.fn();
-        const dialog = render(<ResetIdentityDialog onFinished={onFinished} onReset={onReset} variant="compromised" />);
+        const onFail = jest.fn();
+        const dialog = render(
+            <ResetIdentityDialog onFinished={onFinished} onReset={onReset} onFail={onFail} variant="compromised" />,
+        );
 
         await act(async () => dialog.getByRole("button", { name: "Continue" }).click());
 
@@ -41,7 +44,10 @@ describe("ResetIdentityDialog", () => {
 
         const onFinished = jest.fn();
         const onReset = jest.fn();
-        const dialog = render(<ResetIdentityDialog onFinished={onFinished} onReset={onReset} variant="compromised" />);
+        const onFail = jest.fn();
+        const dialog = render(
+            <ResetIdentityDialog onFinished={onFinished} onReset={onReset} onFail={onFail} variant="compromised" />,
+        );
 
         await act(async () => dialog.getByRole("button", { name: "Cancel" }).click());
 

--- a/apps/web/test/unit-tests/components/views/settings/encryption/ResetIdentityPanel-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/encryption/ResetIdentityPanel-test.tsx
@@ -25,8 +25,9 @@ describe("<ResetIdentityPanel />", () => {
         const user = userEvent.setup();
 
         const onReset = jest.fn();
+        const onFail = jest.fn();
         const { asFragment } = render(
-            <ResetIdentityPanel variant="compromised" onReset={onReset} onCancelClick={jest.fn()} />,
+            <ResetIdentityPanel variant="compromised" onReset={onReset} onFail={onFail} onCancelClick={jest.fn()} />,
             withClientContextRenderOptions(matrixClient),
         );
         expect(asFragment()).toMatchSnapshot();
@@ -48,8 +49,9 @@ describe("<ResetIdentityPanel />", () => {
 
     it("should display the 'forgot recovery key' variant correctly", async () => {
         const onReset = jest.fn();
+        const onFail = jest.fn();
         const { asFragment } = render(
-            <ResetIdentityPanel variant="forgot" onReset={onReset} onCancelClick={jest.fn()} />,
+            <ResetIdentityPanel variant="forgot" onReset={onReset} onFail={onFail} onCancelClick={jest.fn()} />,
             withClientContextRenderOptions(matrixClient),
         );
         expect(asFragment()).toMatchSnapshot();
@@ -57,8 +59,9 @@ describe("<ResetIdentityPanel />", () => {
 
     it("should display the 'sync failed' variant correctly", async () => {
         const onReset = jest.fn();
+        const onFail = jest.fn();
         const { asFragment } = render(
-            <ResetIdentityPanel variant="sync_failed" onReset={onReset} onCancelClick={jest.fn()} />,
+            <ResetIdentityPanel variant="sync_failed" onReset={onReset} onFail={onFail} onCancelClick={jest.fn()} />,
             withClientContextRenderOptions(matrixClient),
         );
         expect(asFragment()).toMatchSnapshot();


### PR DESCRIPTION
Exposes the error that is happening in https://github.com/element-hq/element-web/issues/34642 but doesn't fix it:

If we take longer than 5 seconds to reset identity, we show this:

<img width="685" height="289" alt="image" src="https://github.com/user-attachments/assets/0e92c303-eb57-4220-8172-0b2c1b5006c1" />

and log this:

```
Failed to reset identity: Timed out
```

... which is better than what we did before, which was to freeze forever on the "resetting digital identity" screen.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
