### PR TITLE
Fix .well-known MatrixRTC transports fallback not kicking in for widgets

### DIFF
--- a/apps/web/src/stores/widgets/ElementWidgetDriver.ts
+++ b/apps/web/src/stores/widgets/ElementWidgetDriver.ts
@@ -758,7 +758,7 @@ export class ElementWidgetDriver extends WidgetDriver {
             // If the homeserver does not support the API, fall back to legacy well-known lookup.
             if (
                 e instanceof MatrixError &&
-                e.errcode === "M_NOT_FOUND" &&
+                e.errcode === "M_UNRECOGNIZED" &&
                 SdkConfig.get("enable_client_well_known_lookups")
             ) {
                 const wellKnown = await client.waitForClientWellKnown();

--- a/apps/web/test/unit-tests/stores/widgets/ElementWidgetDriver-test.ts
+++ b/apps/web/test/unit-tests/stores/widgets/ElementWidgetDriver-test.ts
@@ -462,7 +462,7 @@ describe("ElementWidgetDriver", () => {
                 return sdkConfigGet(key, altCaseName);
             });
             client.cachedRtcTransports.wait.mockRejectedValue(
-                new MatrixError({ errcode: "M_NOT_FOUND", error: "Not found" }, 404),
+                new MatrixError({ errcode: "M_UNRECOGNIZED", error: "Not found" }, 404),
             );
 
             await expect(driver.getRtcTransports()).rejects.toThrow();
@@ -492,7 +492,7 @@ describe("ElementWidgetDriver", () => {
                 return sdkConfigGet(key, altCaseName);
             });
             client.cachedRtcTransports.wait.mockRejectedValue(
-                new MatrixError({ errcode: "M_NOT_FOUND", error: "Not found" }, 404),
+                new MatrixError({ errcode: "M_UNRECOGNIZED", error: "Not found" }, 404),
             );
 
             const transports = [{ type: "livekit", livekit_service_url: "https://livekit-jwt.example.com" }];


### PR DESCRIPTION
This fallback code path was looking for the wrong error code (M_UNRECOGNIZED is the [correct code](https://spec.matrix.org/unstable/client-server-api/#common-error-codes) for endpoints that a server does not implement, and is what Synapse returns on the transports endpoint in practice when `msc4143_enabled` is `false`).

Closes https://github.com/element-hq/element-web/issues/34725