### PR TITLE
Add a note that restricted-guests requires knocking to be enabled

### DIFF
--- a/modules/restricted-guests/README.md
+++ b/modules/restricted-guests/README.md
@@ -10,6 +10,8 @@ Supports the following configuration options under the configuration key `io.ele
 | guest_user_prefix         | string  | Prefix to apply to all guests registered via the module, defaults to `@guest-`.                                                                 |
 | skip_single_sign_on       | boolean | If true, the user will be forwarded to the login page instead of to the SSO login. This is only required if the home server has no SSO support. |
 
+## Knocking ("ask to join") has to be enabled
+
 In order to make the feature work, **knocking has to be enabled** via config.json
 
 ```
@@ -17,6 +19,9 @@ In order to make the feature work, **knocking has to be enabled** via config.jso
   "feature_ask_to_join": true
 }
 ```
+## Facilitating how users can obtain the room link
+
+If you want to make it more obvious to users how to copy the link, you can modify the link a user gets from "Copy link" in the right sidebar by using `permalink_prefix` in config.json. If you don't do that, users will have to copy the URL from the address bar.
 
 ## Copyright & License
 

--- a/modules/restricted-guests/README.md
+++ b/modules/restricted-guests/README.md
@@ -10,6 +10,14 @@ Supports the following configuration options under the configuration key `io.ele
 | guest_user_prefix         | string  | Prefix to apply to all guests registered via the module, defaults to `@guest-`.                                                                 |
 | skip_single_sign_on       | boolean | If true, the user will be forwarded to the login page instead of to the SSO login. This is only required if the home server has no SSO support. |
 
+In order to make the feature work, **knocking has to be enabled** via config.json
+
+```
+"features": {
+  "feature_ask_to_join": true
+}
+```
+
 ## Copyright & License
 
 Copyright (c) 2025 New Vector Ltd

--- a/modules/restricted-guests/README.md
+++ b/modules/restricted-guests/README.md
@@ -19,6 +19,7 @@ In order to make the feature work, **knocking has to be enabled** via config.jso
   "feature_ask_to_join": true
 }
 ```
+
 ## Facilitating how users can obtain the room link
 
 If you want to make it more obvious to users how to copy the link, you can modify the link a user gets from "Copy link" in the right sidebar by using `permalink_prefix` in config.json. If you don't do that, users will have to copy the URL from the address bar.


### PR DESCRIPTION
Just adding a note that knocking needs to be enabled for the restricted-guests module to work.
