### PR TITLE
Add a playwright test to check that key reset succeeds after it was previously interrupted

### DIFF
--- a/apps/web/playwright/e2e/crypto/crypto.spec.ts
+++ b/apps/web/playwright/e2e/crypto/crypto.spec.ts
@@ -170,6 +170,37 @@ test.describe("Cryptography", function () {
         expect(await keyStorageToggle.isChecked()).toBe(true);
     });
 
+    // When resetting identity is interrupted, it can be retried.
+    // ref: https://github.com/element-hq/element-web/issues/34642
+    test("Can reset identity if previous reset was interrupted", async ({ page, app, user: aliceCredentials }) => {
+        await app.client.bootstrapCrossSigning(aliceCredentials);
+
+        await enableKeyBackup(app);
+
+        // Wait for the cross signing keys to be uploaded
+        // Waiting for "Change the recovery key" button ensure that all the secrets are uploaded and cached locally
+        const encryptionTab = await app.settings.openUserSettings("Encryption");
+        await expect(encryptionTab.getByRole("button", { name: "Change recovery key" })).toBeVisible();
+
+        // Emulate a previous reset having been interrupted by setting the
+        // default 4S key to be empty
+        await app.client.setAccountData("m.secret_storage.default_key", {} as unknown as { key: string });
+
+        // Find "the Reset cryptographic identity" button
+        await encryptionTab.getByRole("button", { name: "Reset cryptographic identity" }).click();
+
+        // Confirm
+        await encryptionTab.getByRole("button", { name: "Continue" }).click();
+
+        // Enter the password.
+        await page.getByPlaceholder("Password").fill(aliceCredentials.password!);
+        await page.getByRole("button", { name: "Continue" }).click();
+
+        // We should be back to the main encryption tab, and it should indicate
+        // that there is no existing recovery key.
+        await expect(encryptionTab.getByRole("button", { name: "Get recovery key" })).toBeVisible();
+    });
+
     test(
         "creating a DM should work, being e2e-encrypted / user verification",
         { tag: "@screenshot" },


### PR DESCRIPTION
a test that https://github.com/element-hq/element-web/issues/34642 was fixed in js-sdk

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
