### PR TITLE
Fix recovery key verification when 4S key info is unavailable

### DIFF
--- a/apps/web/src/components/structures/auth/CompleteSecurity.test.tsx
+++ b/apps/web/src/components/structures/auth/CompleteSecurity.test.tsx
@@ -147,4 +147,27 @@ describe("CompleteSecurity", () => {
             screen.getByRole("heading", { name: "Are you sure you want to reset your digital identity?" }),
         ).toBeInTheDocument();
     });
+
+    it("Allows verifying with recovery key when has4SKeys is true but keyInfo is null", async () => {
+        // Regression test for #34721: when 4S exists but the cross-signing master key
+        // info couldn't be fetched (isStored returned null), the "Use recovery key"
+        // button should still be shown based on has4SKeys.
+        const store = new SetupEncryptionStore();
+        vi.spyOn(store, "fetchKeyInfo").mockImplementation(async () => {
+            store.keyInfo = null;
+            store.has4SKeys = true;
+            store.hasDevicesToVerifyAgainst = false;
+            store.phase = Phase.Intro;
+            store.emit("update");
+        });
+        vi.spyOn(SetupEncryptionStore, "sharedInstance").mockReturnValue(store);
+        await act(() => render(<CompleteSecurity onFinished={() => {}} />));
+
+        // lostKeys() should be false because has4SKeys means recovery is possible
+        expect(store.lostKeys()).toBe(false);
+        // "Use recovery key" should be shown because has4SKeys is true
+        expect(screen.getByRole("button", { name: "Use recovery key" })).toBeInTheDocument();
+        // "Use another device" should NOT be shown
+        expect(screen.queryByRole("button", { name: "Use another device" })).not.toBeInTheDocument();
+    });
 });

--- a/apps/web/src/components/structures/auth/SetupEncryptionBody.tsx
+++ b/apps/web/src/components/structures/auth/SetupEncryptionBody.tsx
@@ -180,7 +180,7 @@ export default class SetupEncryptionBody extends React.Component<IProps, IState>
             }
 
             let useRecoveryKeyButton;
-            if (store.keyInfo) {
+            if (store.keyInfo || store.has4SKeys) {
                 useRecoveryKeyButton = (
                     <Button kind="primary" onClick={this.onUsePassphraseClick}>
                         {_t("encryption|verification|use_recovery_key")}

--- a/apps/web/src/stores/SetupEncryptionStore.ts
+++ b/apps/web/src/stores/SetupEncryptionStore.ts
@@ -47,6 +47,10 @@ export class SetupEncryptionStore extends EventEmitter {
     // Descriptor of the key that the secrets we want are encrypted with
     public keyInfo: SecretStorage.SecretStorageKeyDescription | null = null;
     public hasDevicesToVerifyAgainst?: boolean;
+    // Whether a default 4S key exists in account data, checked via
+    // `secretStorage.hasKey()`. Used as a fallback to show the "Use recovery
+    // key" button even when `isStored("m.cross_signing.master")` returned null.
+    public has4SKeys?: boolean;
 
     public static sharedInstance(): SetupEncryptionStore {
         if (!window.mxSetupEncryptionStore) window.mxSetupEncryptionStore = new SetupEncryptionStore();
@@ -101,6 +105,11 @@ export class SetupEncryptionStore extends EventEmitter {
             this.keyId = Object.keys(keys)[0];
             this.keyInfo = keys[this.keyId];
         }
+
+        // Check whether a default 4S key exists in account data. This is used
+        // as a fallback to show the "Use recovery key" button even when we
+        // couldn't fetch the specific key info for the cross-signing master key.
+        this.has4SKeys = await cli.secretStorage.hasKey();
 
         const ownUserId = cli.getUserId()!;
         const ownDeviceId = cli.getDeviceId()!;
@@ -228,6 +237,6 @@ export class SetupEncryptionStore extends EventEmitter {
     }
 
     public lostKeys(): boolean {
-        return !this.hasDevicesToVerifyAgainst && !this.keyInfo;
+        return !this.hasDevicesToVerifyAgainst && !this.keyInfo && !this.has4SKeys;
     }
 }

--- a/apps/web/test/unit-tests/stores/SetupEncryptionStore-test.ts
+++ b/apps/web/test/unit-tests/stores/SetupEncryptionStore-test.ts
@@ -41,6 +41,7 @@ describe("SetupEncryptionStore", () => {
 
         mockSecretStorage = {
             isStored: jest.fn(),
+            hasKey: jest.fn().mockResolvedValue(false),
         } as unknown as Mocked<ServerSideSecretStorage>;
         Object.defineProperty(client, "secretStorage", { value: mockSecretStorage });
 
@@ -117,6 +118,42 @@ describe("SetupEncryptionStore", () => {
             setupEncryptionStore.start();
             await emitPromise(setupEncryptionStore, "update");
             expect(setupEncryptionStore.hasDevicesToVerifyAgainst).toBe(false);
+        });
+
+        it("should set has4SKeys when secret storage has keys", async () => {
+            mockSecretStorage.isStored.mockResolvedValue({ sskeyid: {} as SecretStorageKeyDescriptionAesV1 });
+            mockSecretStorage.hasKey.mockResolvedValue(true);
+            mockCrypto.getUserDeviceInfo.mockResolvedValue(new Map());
+
+            setupEncryptionStore.start();
+            await emitPromise(setupEncryptionStore, "update");
+
+            expect(setupEncryptionStore.has4SKeys).toBe(true);
+        });
+
+        it("should set has4SKeys to false when secret storage has no keys", async () => {
+            mockSecretStorage.isStored.mockResolvedValue(null);
+            mockSecretStorage.hasKey.mockResolvedValue(false);
+            mockCrypto.getUserDeviceInfo.mockResolvedValue(new Map());
+
+            setupEncryptionStore.start();
+            await emitPromise(setupEncryptionStore, "update");
+
+            expect(setupEncryptionStore.has4SKeys).toBe(false);
+        });
+
+        it("lostKeys should return false when has4SKeys is true even if keyInfo is null", async () => {
+            mockSecretStorage.isStored.mockResolvedValue(null);
+            mockSecretStorage.hasKey.mockResolvedValue(true);
+            mockCrypto.getUserDeviceInfo.mockResolvedValue(new Map());
+
+            setupEncryptionStore.start();
+            await emitPromise(setupEncryptionStore, "update");
+
+            expect(setupEncryptionStore.keyInfo).toBeNull();
+            expect(setupEncryptionStore.has4SKeys).toBe(true);
+            expect(setupEncryptionStore.hasDevicesToVerifyAgainst).toBe(false);
+            expect(setupEncryptionStore.lostKeys()).toBe(false);
         });
     });
 


### PR DESCRIPTION
## Fix recovery key verification when 4S key info is unavailable

Fixes #34721.

### Problem

When completing digital identity setup, the recovery-key option was not shown if:

* no other verified device was available, and
* `secretStorage.isStored("m.cross_signing.master")` returned `null`,
* even though a default 4S key was still present in account data.

This caused the flow to incorrectly treat the user's recovery options as unavailable.

### Solution

Use `secretStorage.hasKey()` to track whether the default 4S key exists.

The recovery-key option is now shown when either:

* the existing cross-signing key information is available, or
* a default 4S key is available.

`lostKeys()` was also updated so that the presence of a usable 4S recovery key prevents the user from being incorrectly treated as having lost their keys.

### Tests

Added regression coverage for the case where:

* `keyInfo` is `null`
* a default 4S key exists
* no other verified device is available

Also added store-level tests covering the new `has4SKeys` state and `lostKeys()` behavior.

### Validation

* TypeScript: passed, with unrelated pre-existing errors in `matrix-js-sdk/src/rendezvous/MSC4108SignInWithQR.ts`
* oxlint: passed
* `CompleteSecurity.test.tsx`: passed
* `SetupEncryptionStore-test.ts`: unable to run locally because the installed Node.js version is 22.15.0 while the Jest configuration requires Node.js >=22.18.0

No unrelated files or functionality were changed.
