### PR TITLE
Always pad the minutes of a duration if the hours place is occupied

### DIFF
--- a/packages/shared-components/src/audio/Clock/Clock.stories.tsx
+++ b/packages/shared-components/src/audio/Clock/Clock.stories.tsx
@@ -31,6 +31,6 @@ export const LotOfSeconds: Story = {
 export const SingleDigitMinutes: Story = {
     args: {
         seconds: 100,
-        minutesMaxLength: 1,
+        minutesMinLength: 1,
     },
 };

--- a/packages/shared-components/src/audio/Clock/Clock.tsx
+++ b/packages/shared-components/src/audio/Clock/Clock.tsx
@@ -21,17 +21,17 @@ export interface Props extends Pick<HTMLProps<HTMLSpanElement>, "aria-live" | "r
      * The number of positions to pad the minutes part.
      *
      * @example
-     * If minutesMaxLength = 1, the clock will show 5:31 instead of 05:31.
+     * If minutesMinLength = 1, the clock will show 5:31 instead of 05:31.
      */
-    minutesMaxLength?: number;
+    minutesMinLength?: number;
 
     /**
      * The number of positions to pad the hour part.
      *
      * @example
-     * If hoursMaxLength = 1, the clock will show 1:05:31 instead of 01:05:31.
+     * If hoursMinLength = 1, the clock will show 1:05:31 instead of 01:05:31.
      */
-    hoursMaxLength?: number;
+    hoursMinLength?: number;
 }
 
 /**
@@ -44,7 +44,7 @@ export interface Props extends Pick<HTMLProps<HTMLSpanElement>, "aria-live" | "r
  * <Clock seconds={125} />
  * ```
  */
-export function Clock({ seconds, className, minutesMaxLength, hoursMaxLength, ...rest }: Props): JSX.Element {
+export function Clock({ seconds, className, minutesMinLength, hoursMinLength, ...rest }: Props): JSX.Element {
     // Memoize current second to avoid recalculating the duration when seconds changes slightly (e.g. 1.2 -> 1.3)
     const currentSecond = useMemo(() => Math.floor(seconds), [seconds]);
     const duration = useMemo(() => calculateDuration(currentSecond), [currentSecond]);
@@ -57,8 +57,8 @@ export function Clock({ seconds, className, minutesMaxLength, hoursMaxLength, ..
             {...rest}
         >
             {formatSeconds(seconds, {
-                minutesMaxLength,
-                hoursMaxLength,
+                minutesMinLength,
+                hoursMinLength,
             })}
         </time>
     );

--- a/packages/shared-components/src/core/utils/DateUtils.test.ts
+++ b/packages/shared-components/src/core/utils/DateUtils.test.ts
@@ -22,6 +22,7 @@ describe("formatSeconds", () => {
         expect(formatSeconds(60 * 60 * 3 + 60 * 0 + 55)).toBe("03:00:55");
         expect(formatSeconds(60 * 60 * 3 + 60 * 31 + 0)).toBe("03:31:00");
         expect(formatSeconds(-(60 * 60 * 3 + 60 * 31 + 0))).toBe("-03:31:00");
+        expect(formatSeconds(60 * 60 * 1 + 60 * 3 + 0, { hoursMinLength: 1, minutesMinLength: 1 })).toBe("1:03:00");
     });
 
     it("correctly formats time without hours", () => {
@@ -29,6 +30,7 @@ describe("formatSeconds", () => {
         expect(formatSeconds(60 * 60 * 0 + 60 * 0 + 55)).toBe("00:55");
         expect(formatSeconds(60 * 60 * 0 + 60 * 31 + 0)).toBe("31:00");
         expect(formatSeconds(-(60 * 60 * 0 + 60 * 31 + 0))).toBe("-31:00");
+        expect(formatSeconds(60 * 60 * 0 + 60 * 3 + 0, { hoursMinLength: 1, minutesMinLength: 1 })).toBe("3:00");
     });
 });
 

--- a/packages/shared-components/src/core/utils/DateUtils.ts
+++ b/packages/shared-components/src/core/utils/DateUtils.ts
@@ -11,18 +11,18 @@
  */
 export function formatSeconds(
     inSeconds: number,
-    opts?: { hoursMaxLength?: number; minutesMaxLength?: number },
+    opts?: { hoursMinLength?: number; minutesMinLength?: number },
 ): string {
     const isNegative = inSeconds < 0;
     inSeconds = Math.abs(inSeconds);
 
     const hours = Math.floor(inSeconds / (60 * 60))
         .toFixed(0)
-        .padStart(opts?.hoursMaxLength ?? 2, "0");
+        .padStart(opts?.hoursMinLength ?? 2, "0");
 
     const minutes = Math.floor((inSeconds % (60 * 60)) / 60)
         .toFixed(0)
-        .padStart(opts?.minutesMaxLength ?? 2, "0");
+        .padStart(opts?.minutesMinLength ?? 2, "0");
 
     const seconds = Math.floor((inSeconds % (60 * 60)) % 60)
         .toFixed(0)

--- a/packages/shared-components/src/core/utils/DateUtils.ts
+++ b/packages/shared-components/src/core/utils/DateUtils.ts
@@ -16,21 +16,20 @@ export function formatSeconds(
     const isNegative = inSeconds < 0;
     inSeconds = Math.abs(inSeconds);
 
-    const hours = Math.floor(inSeconds / (60 * 60))
-        .toFixed(0)
-        .padStart(opts?.hoursMinLength ?? 2, "0");
+    const hoursMinLength = opts?.hoursMinLength ?? 2;
+    const hours = Math.floor(inSeconds / (60 * 60));
+    const hoursText = hours.toFixed(0).padStart(hoursMinLength, "0");
 
-    const minutes = Math.floor((inSeconds % (60 * 60)) / 60)
-        .toFixed(0)
-        .padStart(opts?.minutesMinLength ?? 2, "0");
+    const minutesMinLength = hours > 0 ? 2 : (opts?.minutesMinLength ?? 2);
+    const minutes = Math.floor((inSeconds % (60 * 60)) / 60);
+    const minutesText = minutes.toFixed(0).padStart(minutesMinLength, "0");
 
-    const seconds = Math.floor((inSeconds % (60 * 60)) % 60)
-        .toFixed(0)
-        .padStart(2, "0");
+    const seconds = Math.floor((inSeconds % (60 * 60)) % 60);
+    const secondsText = seconds.toFixed(0).padStart(2, "0");
 
     let output = "";
-    if (hours !== "00") output += `${hours}:`;
-    output += `${minutes}:${seconds}`;
+    if (hours > 0) output += `${hoursText}:`;
+    output += `${minutesText}:${secondsText}`;
 
     if (isNegative) {
         output = "-" + output;

--- a/packages/shared-components/src/room/timeline/event-tile/call/ongoing/components/Duration/DurationView.tsx
+++ b/packages/shared-components/src/room/timeline/event-tile/call/ongoing/components/Duration/DurationView.tsx
@@ -39,7 +39,7 @@ export function DurationView(props: Props): React.ReactNode {
 
     return (
         <div className={classes}>
-            (<Clock seconds={duration} minutesMinLength={1} className={classes} />)
+            (<Clock seconds={duration} hoursMinLength={1} minutesMinLength={1} className={classes} />)
         </div>
     );
 }

--- a/packages/shared-components/src/room/timeline/event-tile/call/ongoing/components/Duration/DurationView.tsx
+++ b/packages/shared-components/src/room/timeline/event-tile/call/ongoing/components/Duration/DurationView.tsx
@@ -39,7 +39,7 @@ export function DurationView(props: Props): React.ReactNode {
 
     return (
         <div className={classes}>
-            (<Clock seconds={duration} minutesMaxLength={1} className={classes} />)
+            (<Clock seconds={duration} minutesMinLength={1} className={classes} />)
         </div>
     );
 }


### PR DESCRIPTION
This fixes call durations showing up as '01:3:05' for calls which run for longer than an hour. Such a duration will now be correctly padded as '1:03:05'.

|Before|After|
|-|-|
|<img width="341" height="93" alt="Screenshot From 2026-08-18 12-58-35" src="https://github.com/user-attachments/assets/3a870c34-bd91-4f4e-9046-56a92acb82dd" />|<img width="341" height="93" alt="Screenshot From 2026-08-18 12-55-57" src="https://github.com/user-attachments/assets/45fbe98e-1429-4f34-acfa-4f9e4151eadc" />|

(I've also allowed the hours place of call durations to be one digit long, for consistency.)