### PR TITLE
Resolve a room pill's alias to the upgraded room, not its predecessor

### DIFF
--- a/apps/web/src/components/views/rooms/wysiwyg_composer/utils/autocomplete.ts
+++ b/apps/web/src/components/views/rooms/wysiwyg_composer/utils/autocomplete.ts
@@ -11,6 +11,7 @@ import { type MatrixClient, type Room } from "matrix-js-sdk/src/matrix";
 
 import { type ICompletion } from "../../../../../autocomplete/Autocompleter";
 import * as Avatar from "../../../../../Avatar";
+import { findRoomByAlias } from "../../../../../utils/room/findRoomByAlias";
 
 /**
  * Builds the query for the `<Autocomplete />` component from the rust suggestion. This
@@ -50,9 +51,7 @@ export function getRoomFromCompletion(completion: ICompletion, client: MatrixCli
     } else if (!aliasFromCompletion.startsWith("#")) {
         roomToReturn = client.getRoom(aliasFromCompletion);
     } else {
-        roomToReturn = client.getRooms().find((r) => {
-            return r.getCanonicalAlias() === aliasFromCompletion || r.getAltAliases().includes(aliasFromCompletion);
-        });
+        roomToReturn = findRoomByAlias(client, aliasFromCompletion);
     }
 
     return roomToReturn ?? null;

--- a/apps/web/src/editor/model.test.ts
+++ b/apps/web/src/editor/model.test.ts
@@ -6,6 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+// @vitest-environment happy-dom
+
 import { describe, it, expect } from "vitest";
 
 import EditorModel from "./model";

--- a/apps/web/src/editor/parts.ts
+++ b/apps/web/src/editor/parts.ts
@@ -19,6 +19,7 @@ import defaultDispatcher from "../dispatcher/dispatcher";
 import { Action } from "../dispatcher/actions";
 import SettingsStore from "../settings/SettingsStore";
 import { getFirstGrapheme, graphemeSegmenter } from "../utils/strings";
+import { findRoomByAlias } from "../utils/room/findRoomByAlias";
 
 const REGIONAL_EMOJI_SEPARATOR = String.fromCodePoint(0x200b);
 
@@ -630,9 +631,7 @@ export class PartCreator {
         if (roomId || alias[0] !== "#") {
             room = this.client.getRoom(roomId || alias) ?? undefined;
         } else {
-            room = this.client.getRooms().find((r) => {
-                return r.getCanonicalAlias() === alias || r.getAltAliases().includes(alias);
-            });
+            room = findRoomByAlias(this.client, alias) ?? undefined;
         }
         return new RoomPillPart(alias, room ? room.name : alias, room);
     }

--- a/apps/web/src/editor/range.test.ts
+++ b/apps/web/src/editor/range.test.ts
@@ -6,6 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+// @vitest-environment happy-dom
+
 import { describe, it, expect } from "vitest";
 
 import EditorModel from "./model";

--- a/apps/web/src/hooks/usePermalinkTargetRoom.ts
+++ b/apps/web/src/hooks/usePermalinkTargetRoom.ts
@@ -12,6 +12,7 @@ import { useEffect, useState } from "react";
 import { PillType } from "../components/views/elements/PillType";
 import { MatrixClientPeg } from "../MatrixClientPeg";
 import { type PermalinkParts } from "../utils/permalinks/PermalinkConstructor";
+import { findRoomByAlias } from "../utils/room/findRoomByAlias";
 
 /**
  * Tries to determine the initial room.
@@ -53,11 +54,7 @@ const determineInitialRoom = (
 const findRoom = (roomIdOrAlias: string): Room | null => {
     const client = MatrixClientPeg.safeGet();
 
-    return roomIdOrAlias[0] === "#"
-        ? (client.getRooms().find((r) => {
-              return r.getCanonicalAlias() === roomIdOrAlias || r.getAltAliases().includes(roomIdOrAlias);
-          }) ?? null)
-        : client.getRoom(roomIdOrAlias);
+    return roomIdOrAlias[0] === "#" ? findRoomByAlias(client, roomIdOrAlias) : client.getRoom(roomIdOrAlias);
 };
 
 /**

--- a/apps/web/src/utils/room/findRoomByAlias.test.ts
+++ b/apps/web/src/utils/room/findRoomByAlias.test.ts
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 hayaksi1
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+// @vitest-environment happy-dom
+
+import { vi, describe, it, expect } from "vitest";
+import { Room } from "matrix-js-sdk/src/matrix";
+import { getMockClientWithEventEmitter, mockClientMethodsUser, mkRoomCanonicalAliasEvent } from "test-utils";
+
+import { findRoomByAlias } from "./findRoomByAlias";
+
+describe("findRoomByAlias()", () => {
+    const userId = "@alice:server.org";
+    const alias = "#room:server.org";
+    const client = getMockClientWithEventEmitter({
+        ...mockClientMethodsUser(userId),
+        getRooms: vi.fn(),
+        getVisibleRooms: vi.fn(),
+    });
+
+    const mkRoomWithAlias = (roomId: string, canonical: boolean): Room => {
+        const room = new Room(roomId, client, userId);
+        room.currentState.setStateEvents([mkRoomCanonicalAliasEvent(userId, roomId, canonical ? alias : "")]);
+        if (!canonical) vi.spyOn(room, "getAltAliases").mockReturnValue([alias]);
+        return room;
+    };
+
+    it("returns the room the alias points at", () => {
+        const room = mkRoomWithAlias("!room:server.org", true);
+        client.getVisibleRooms.mockReturnValue([room]);
+        expect(findRoomByAlias(client, alias)).toBe(room);
+    });
+
+    it("matches an alternative alias too", () => {
+        const room = mkRoomWithAlias("!room:server.org", false);
+        client.getVisibleRooms.mockReturnValue([room]);
+        expect(findRoomByAlias(client, alias)).toBe(room);
+    });
+
+    it("prefers the upgraded room over the predecessor which still carries the alias", () => {
+        const oldRoom = mkRoomWithAlias("!old:server.org", true);
+        const newRoom = mkRoomWithAlias("!new:server.org", true);
+        client.getRooms.mockReturnValue([oldRoom, newRoom]);
+        client.getVisibleRooms.mockReturnValue([newRoom]);
+        expect(findRoomByAlias(client, alias)).toBe(newRoom);
+    });
+
+    it("returns null when no room carries the alias", () => {
+        client.getVisibleRooms.mockReturnValue([mkRoomWithAlias("!room:server.org", true)]);
+        expect(findRoomByAlias(client, "#other:server.org")).toBeNull();
+    });
+});

--- a/apps/web/src/utils/room/findRoomByAlias.ts
+++ b/apps/web/src/utils/room/findRoomByAlias.ts
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 hayaksi1
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { type MatrixClient, type Room } from "matrix-js-sdk/src/matrix";
+
+import SettingsStore from "../../settings/SettingsStore";
+
+/**
+ * Find the room a known alias belongs to, skipping rooms which have been upgraded away from.
+ *
+ * After a room upgrade both the old and the new room can still carry the same alias in their
+ * state, and the old room is usually stored first, so a plain search over every room would keep
+ * resolving the alias to the room the user has left behind.
+ *
+ * @param client - The client whose rooms to search.
+ * @param alias - The canonical or alternative alias to look for.
+ * @returns The room carrying the alias, or null if none of the visible rooms does.
+ */
+export function findRoomByAlias(client: MatrixClient, alias: string): Room | null {
+    return (
+        client
+            .getVisibleRooms(SettingsStore.getValue("feature_dynamic_room_predecessors"))
+            .find((room) => room.getCanonicalAlias() === alias || room.getAltAliases().includes(alias)) ?? null
+    );
+}

--- a/apps/web/test/unit-tests/components/views/elements/Pill-test.tsx
+++ b/apps/web/test/unit-tests/components/views/elements/Pill-test.tsx
@@ -111,6 +111,7 @@ describe("<Pill>", () => {
         space1.name = "Space 1";
 
         client.getRooms.mockReturnValue([room1, room2, space1]);
+        client.getVisibleRooms.mockReturnValue([room1, room2, space1]);
         client.getRoom.mockImplementation((roomId: string) => {
             if (roomId === room1.roomId) return room1;
             if (roomId === room2.roomId) return room2;
@@ -184,6 +185,18 @@ describe("<Pill>", () => {
             url: permalinkPrefix + room1Alias,
         });
         expect(renderResult.asFragment()).toMatchSnapshot();
+    });
+
+    it("should resolve a room alias to the upgraded room rather than its predecessor", () => {
+        const oldRoom = new Room("!old:example.com", client, user1Id);
+        oldRoom.name = "Old Room";
+        oldRoom.currentState.setStateEvents([mkRoomCanonicalAliasEvent(user1Id, oldRoom.roomId, room1Alias)]);
+        client.getRooms.mockReturnValue([oldRoom, room1, room2, space1]);
+        client.getVisibleRooms.mockReturnValue([room1, room2, space1]);
+        renderPill({
+            url: permalinkPrefix + room1Alias,
+        });
+        expect(screen.getByText("Room 1")).toBeInTheDocument();
     });
 
     it("should render the expected pill for @room", () => {

--- a/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/utils/autocomplete-test.ts
+++ b/apps/web/test/unit-tests/components/views/rooms/wysiwyg_composer/utils/autocomplete-test.ts
@@ -81,13 +81,13 @@ describe("getRoomFromCompletion", () => {
         expect(mockClient.getRoom).toHaveBeenCalledWith(testCompletion);
     });
 
-    it("calls getRooms if no completionId is present and completion starts with #", () => {
+    it("searches the visible rooms if no completionId is present and completion starts with #", () => {
         const completionWithId = createMockRoomCompletion({ completion: "#hash" });
 
         const result = getRoomFromCompletion(completionWithId, mockClient);
 
         expect(mockClient.getRoom).not.toHaveBeenCalled();
-        expect(mockClient.getRooms).toHaveBeenCalled();
+        expect(mockClient.getVisibleRooms).toHaveBeenCalled();
 
         // in this case, because the mock client returns an empty array of rooms
         // from the call to get rooms, we'd expect the result to be null

--- a/apps/web/test/unit-tests/editor/mock.ts
+++ b/apps/web/test/unit-tests/editor/mock.ts
@@ -70,6 +70,7 @@ export function createPartCreator(completions: PillPart[] = []) {
     const room = new MockRoom() as unknown as Room;
     const client = {
         getRooms: vi.fn().mockReturnValue([]),
+        getVisibleRooms: vi.fn().mockReturnValue([]),
         getRoom: vi.fn().mockReturnValue(null),
     } as unknown as MatrixClient;
     return new PartCreator(room, client, autoCompleteCreator);


### PR DESCRIPTION
A room pill written as an alias is resolved by scanning every room the client knows for one whose
canonical or alternative alias matches, taking the first hit. After a room upgrade both the old and
the new room can keep the alias in their state, and the old room was stored first, so the pill kept
showing the name and avatar the room had before it was upgraded. The composer got it right while
typing because its autocomplete already skips rooms with a replacement and hands over the room id,
but the sent event only carries the alias, so the timeline pill re-resolved it to the old room —
which is the "correct while composing, wrong once sent" the issue describes.

The scan now lives in one `findRoomByAlias` helper which searches `getVisibleRooms()`, the same
call the autocomplete already makes, so a room that has been upgraded away from is skipped whenever
its successor is known. The timeline pill, the edit composer's pill and the rich text composer's
room lookup all go through it instead of each carrying its own copy of the loop. The `/part`
command keeps its own scan on purpose, since someone leaving a room by alias may well mean the old
one.

Tests: `findRoomByAlias.test.ts` covers canonical and alternative aliases and a predecessor still
carrying the alias; `Pill-test.tsx` renders an alias shared by an old and a new room and expects the
new room's name. Both fail without the change. Two editor suites gain the happy-dom pragma because
the helper reads the dynamic-predecessors setting.

Fixes #26934

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
