### PR TITLE
Turn a completed emoji shortcode into its emoji as you type

### DIFF
--- a/apps/web/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/apps/web/src/components/views/rooms/BasicMessageComposer.tsx
@@ -11,7 +11,7 @@ import React, { type JSX, createRef, type ClipboardEvent, type SyntheticEvent } 
 import { type Room, type MatrixEvent } from "matrix-js-sdk/src/matrix";
 import EMOTICON_REGEX from "emojibase-regex/emoticon";
 import { logger } from "matrix-js-sdk/src/logger";
-import { EMOTICON_TO_EMOJI } from "@matrix-org/emojibase-bindings";
+import { EMOJI, EMOTICON_TO_EMOJI, type Emoji } from "@matrix-org/emojibase-bindings";
 import { isLinkable } from "@element-hq/web-shared-components";
 
 import type EditorModel from "../../../editor/model";
@@ -47,6 +47,16 @@ import { SDKContext } from "../../../contexts/SDKContext.ts";
 // matches emoticons which follow the start of a line or whitespace
 const REGEX_EMOTICON_WHITESPACE = new RegExp("(?:^|\\s)(" + EMOTICON_REGEX.source + ")\\s|:^$");
 export const REGEX_EMOTICON = new RegExp("(?:^|\\s)(" + EMOTICON_REGEX.source + ")$");
+
+const REGEX_SHORTCODE = /(?:^|[^\w:])(:[+\-\w]+:)$/;
+const SHORTCODE_TO_EMOJI = new Map<string, Emoji>();
+for (const emoji of EMOJI) {
+    for (const shortcode of emoji.shortcodes) {
+        if (!SHORTCODE_TO_EMOJI.has(`:${shortcode}:`)) SHORTCODE_TO_EMOJI.set(`:${shortcode}:`, emoji);
+    }
+}
+const EMOTICON_LOOKBACK = 9;
+const SHORTCODE_LOOKBACK = 64;
 
 const SURROUND_WITH_CHARACTERS = ['"', "_", "`", "'", "*", "~", "$"];
 const SURROUND_WITH_DOUBLE_CHARACTERS = new Map([
@@ -167,11 +177,24 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
     }
 
     public replaceEmoticon(caretPosition: DocumentPosition, regex: RegExp): number | undefined {
+        return this.replaceWithEmoji(caretPosition, regex, EMOTICON_TO_EMOJI, EMOTICON_LOOKBACK);
+    }
+
+    public replaceShortcode(caretPosition: DocumentPosition): number | undefined {
+        return this.replaceWithEmoji(caretPosition, REGEX_SHORTCODE, SHORTCODE_TO_EMOJI, SHORTCODE_LOOKBACK);
+    }
+
+    private replaceWithEmoji(
+        caretPosition: DocumentPosition,
+        regex: RegExp,
+        emojiByText: Map<string, Emoji>,
+        lookback: number,
+    ): number | undefined {
         const { model } = this.props;
         const range = model.startRange(caretPosition);
-        // expand range max 9 characters backwards from caretPosition,
+        // expand range max `lookback` characters backwards from caretPosition,
         // as a space to look for an emoticon
-        let n = 9;
+        let n = lookback;
         range.expandBackwardsWhile((index, offset) => {
             const part = model.parts[index];
             n -= 1;
@@ -184,12 +207,12 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
         if (emoticonMatch && (n >= 0 || emoticonMatch.index !== 0)) {
             const query = emoticonMatch[1];
             // variations of plaintext emoitcons(E.g. :P vs :p vs :-P) are handled upstream by the emojibase-bindings library
-            const data = EMOTICON_TO_EMOJI.get(query);
+            const data = emojiByText.get(query);
 
             if (data) {
                 const { partCreator } = model;
                 const firstMatch = emoticonMatch[0];
-                const moveStart = firstMatch[0] === " " ? 1 : 0;
+                const moveStart = firstMatch.indexOf(query);
 
                 // we need the range to only comprise of the emoticon
                 // because we'll replace the whole range with an emoji,
@@ -720,7 +743,10 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
 
     private transform = (documentPosition: DocumentPosition): void => {
         const shouldReplace = SettingsStore.getValue("MessageComposerInput.autoReplaceEmoji");
-        if (shouldReplace) this.replaceEmoticon(documentPosition, REGEX_EMOTICON_WHITESPACE);
+        if (!shouldReplace) return;
+        if (this.replaceEmoticon(documentPosition, REGEX_EMOTICON_WHITESPACE) === undefined) {
+            this.replaceShortcode(documentPosition);
+        }
     };
 
     public componentWillUnmount(): void {

--- a/apps/web/test/unit-tests/components/views/rooms/BasicMessageComposer-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/BasicMessageComposer-test.tsx
@@ -76,6 +76,7 @@ describe("BasicMessageComposer", () => {
             { before: ":D", after: "😄" },
             { before: ":3", after: "😽" },
             { before: "=-]", after: "🙂" },
+            { before: "line{shift>}{enter}{/shift}:)", after: "line\n🙂" },
         ];
         const input = screen.getByRole("textbox");
 
@@ -86,6 +87,55 @@ describe("BasicMessageComposer", () => {
             const transformedText = model.parts.map((part) => part.text).join("");
             expect(transformedText).toBe(after + " ");
         }
+    });
+
+    it("should resolve emoji shortcodes once they are closed", async () => {
+        jest.spyOn(SettingsStore, "getValue").mockImplementation((settingName: string) => {
+            return settingName === "MessageComposerInput.autoReplaceEmoji";
+        });
+        userEvent.setup();
+        const model = new EditorModel([], pc, renderer);
+        render(<BasicMessageComposer model={model} room={room} />, {
+            wrapper: ({ children }) => (
+                <SDKContext.Provider value={SDKContextClass.instance}>{children}</SDKContext.Provider>
+            ),
+        });
+
+        const transformations = [
+            { before: ":eyes:", after: "👀" },
+            { before: "hello :tada:", after: "hello 🎉" },
+            { before: "(:eyes:)", after: "(👀)" },
+            { before: ":smiling_face_with_smiling_eyes_and_hand_covering_mouth:", after: "🤭" },
+            { before: ":eyes: and :tada:", after: "👀 and 🎉" },
+            { before: "line{shift>}{enter}{/shift}:eyes:", after: "line\n👀" },
+
+            { before: ":notanemoji:", after: ":notanemoji:" },
+            { before: "10:30:", after: "10:30:" },
+            { before: "foo:eyes:", after: "foo:eyes:" },
+            { before: ":eyes", after: ":eyes" },
+        ];
+        const input = screen.getByRole("textbox");
+
+        for (const { before, after } of transformations) {
+            await userEvent.clear(input);
+            await userEvent.type(input, before);
+            const transformedText = model.parts.map((part) => part.text).join("");
+            expect(transformedText).toBe(after);
+        }
+    });
+
+    it("should leave emoji shortcodes alone when replacement is switched off", async () => {
+        jest.spyOn(SettingsStore, "getValue").mockImplementation(() => false);
+        userEvent.setup();
+        const model = new EditorModel([], pc, renderer);
+        render(<BasicMessageComposer model={model} room={room} />, {
+            wrapper: ({ children }) => (
+                <SDKContext.Provider value={SDKContextClass.instance}>{children}</SDKContext.Provider>
+            ),
+        });
+
+        await userEvent.type(screen.getByRole("textbox"), ":eyes:");
+        expect(model.parts.map((part) => part.text).join("")).toBe(":eyes:");
     });
 
     it("should not mangle shift-enter when the autocomplete is open", async () => {


### PR DESCRIPTION
Typing `:eyes:` in the composer left the literal shortcode in place unless you stopped to pick the
suggestion from the autocomplete. The plain text emoji replacement only knew ASCII emoticons like
`:-)` and looked at most nine characters back, so a shortcode closed with its second colon — how
Discord and Slack resolve them, and what this issue asks for (product-accepted in the thread) — was
never considered.

The composer now keeps a map of every shortcode the emoji data knows and, when the plain text emoji
replacement setting is on, resolves a shortcode the moment its closing colon is typed. The lookback
for that pass covers the longest shortcode in the data set. A shortcode only counts when it starts a
line or follows a non-word character, so `10:30:` and `foo:eyes:` are left alone while `(:eyes:)`
resolves inside its brackets, matching the example in the issue. The existing emoticon pass runs
first and is unchanged; the range start now moves past whatever preceded the match rather than only
past a space, which is what lets a bracket survive.

This sits behind the existing "Automatically replace plain text Emoji" setting because it is the
same kind of replacement and keeps the change opt-in for people who type literal shortcodes. If
product would rather have it on for everyone, that is a one-line change and I am happy to make it.

Tests: `BasicMessageComposer-test.tsx` types shortcodes with and without surrounding text and
brackets, the longest shortcode, and non-shortcodes that must stay put, plus the setting switched
off; the positive cases fail without the change.

Fixes #19178

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
