### PR TITLE
Update bundled URL preview implementation to reflect MSC updates

### DIFF
--- a/apps/web/src/utils/UrlPreviewFetcher.test.ts
+++ b/apps/web/src/utils/UrlPreviewFetcher.test.ts
@@ -230,6 +230,8 @@ describe("UrlPreviewFetcher", () => {
             "og:url": "https://example.org/canonical",
         };
 
+        const BASIC_BODY = "Check out https://example.org/page";
+
         const IMAGE_BUNDLE: UnstableBundledUrlPreviewSingle = {
             ...BASIC_BUNDLE,
             "og:image": IMAGE_MXC,
@@ -250,7 +252,7 @@ describe("UrlPreviewFetcher", () => {
 
         it("should map basic bundle fields without an image", () => {
             const { fetcher, client } = getFetcher();
-            const preview = fetcher.previewFromBundle(BASIC_BUNDLE);
+            const preview = fetcher.previewFromBundle(BASIC_BUNDLE, BASIC_BODY);
             expect(preview).toEqual({
                 link: "https://example.org/page",
                 title: "Bundled title",
@@ -265,7 +267,7 @@ describe("UrlPreviewFetcher", () => {
 
         it("should fall back to the matched_url when there is no title", () => {
             const { fetcher } = getFetcher();
-            const preview = fetcher.previewFromBundle({ matched_url: "https://example.org/page" });
+            const preview = fetcher.previewFromBundle({ matched_url: "https://example.org/page" }, BASIC_BODY);
             expect(preview!.title).toEqual("https://example.org/page");
             expect(preview!.showTooltipOnLink).toBe(false);
         });
@@ -273,7 +275,7 @@ describe("UrlPreviewFetcher", () => {
         it("should set showTooltipOnLink when tooltips are enabled and title differs from the URL", () => {
             const { client } = getFetcher();
             const fetcher = new UrlPreviewFetcher(client as unknown as MatrixClient, 0, true);
-            const preview = fetcher.previewFromBundle(BASIC_BUNDLE);
+            const preview = fetcher.previewFromBundle(BASIC_BUNDLE, BASIC_BODY);
             expect(preview!.showTooltipOnLink).toBe(true);
         });
 
@@ -283,24 +285,27 @@ describe("UrlPreviewFetcher", () => {
         it("should set showTooltipOnLink when tooltips are enabled and og:title is absent", () => {
             const { client } = getFetcher();
             const fetcher = new UrlPreviewFetcher(client as unknown as MatrixClient, 0, true);
-            const preview = fetcher.previewFromBundle({ matched_url: "https://example.org/page" });
+            const preview = fetcher.previewFromBundle({ matched_url: "https://example.org/page" }, BASIC_BODY);
             expect(preview!.showTooltipOnLink).toBe(true);
         });
 
         it("should not set showTooltipOnLink when tooltips are enabled but og:title equals the URL", () => {
             const { client } = getFetcher();
             const fetcher = new UrlPreviewFetcher(client as unknown as MatrixClient, 0, true);
-            const preview = fetcher.previewFromBundle({
-                "matched_url": "https://example.org/page",
-                "og:title": "https://example.org/page",
-            });
+            const preview = fetcher.previewFromBundle(
+                {
+                    "matched_url": "https://example.org/page",
+                    "og:title": "https://example.org/page",
+                },
+                BASIC_BODY,
+            );
             expect(preview!.showTooltipOnLink).toBe(false);
         });
 
         it("should include the image when all image fields are present", () => {
             const { fetcher, client } = getFetcher();
             mockMedia(client);
-            const preview = fetcher.previewFromBundle(IMAGE_BUNDLE);
+            const preview = fetcher.previewFromBundle(IMAGE_BUNDLE, BASIC_BODY);
             expect(preview!.image).toEqual({
                 imageThumb: "https://example.org/image/thumb",
                 imageFull: "https://example.org/image/src",
@@ -322,7 +327,7 @@ describe("UrlPreviewFetcher", () => {
         ])("should omit the image when image metadata is incomplete %s", (override) => {
             const { fetcher, client } = getFetcher();
             mockMedia(client);
-            const preview = fetcher.previewFromBundle({ ...IMAGE_BUNDLE, ...override });
+            const preview = fetcher.previewFromBundle({ ...IMAGE_BUNDLE, ...override }, BASIC_BODY);
             expect(preview!.image).toBeUndefined();
         });
 
@@ -331,7 +336,7 @@ describe("UrlPreviewFetcher", () => {
             // A malformed/unresolvable mxc yields no HTTP URL.
             // eslint-disable-next-line no-restricted-properties
             client.mxcUrlToHttp.mockReturnValue(null);
-            const preview = fetcher.previewFromBundle(IMAGE_BUNDLE);
+            const preview = fetcher.previewFromBundle(IMAGE_BUNDLE, BASIC_BODY);
             expect(preview!.image).toBeUndefined();
             // The rest of the preview is still returned.
             expect(preview?.title).toEqual("Bundled title");
@@ -339,10 +344,13 @@ describe("UrlPreviewFetcher", () => {
 
         it("should compute the siteName from the matched_url hostname", () => {
             const { fetcher } = getFetcher();
-            const preview = fetcher.previewFromBundle({
-                ...BASIC_BUNDLE,
-                matched_url: "https://sub.example.com:8443/some/path?q=1",
-            });
+            const preview = fetcher.previewFromBundle(
+                {
+                    ...BASIC_BUNDLE,
+                    matched_url: "https://sub.example.com:8443/some/path?q=1",
+                },
+                "Check out https://sub.example.com:8443/some/path?q=1",
+            );
             expect(preview?.siteName).toEqual("sub.example.com");
         });
 
@@ -358,11 +366,20 @@ describe("UrlPreviewFetcher", () => {
             "htttps://still-not-real",
         ])("should reject '%s'", (url) => {
             const { fetcher } = getFetcher();
-            const preview = fetcher.previewFromBundle({
-                ...BASIC_BUNDLE,
-                "og:url": url as string,
-                "matched_url": url as string,
-            });
+            const preview = fetcher.previewFromBundle(
+                {
+                    ...BASIC_BUNDLE,
+                    "og:url": url as string,
+                    "matched_url": url as string,
+                },
+                "Check out " + url,
+            );
+            expect(preview).toBeNull();
+        });
+
+        it("should reject urls not present in the event body", () => {
+            const { fetcher } = getFetcher();
+            const preview = fetcher.previewFromBundle(BASIC_BUNDLE, "No urls in here");
             expect(preview).toBeNull();
         });
     });

--- a/apps/web/src/utils/UrlPreviewFetcher.test.ts
+++ b/apps/web/src/utils/UrlPreviewFetcher.test.ts
@@ -266,15 +266,15 @@ describe("UrlPreviewFetcher", () => {
         it("should fall back to the matched_url when there is no title", () => {
             const { fetcher } = getFetcher();
             const preview = fetcher.previewFromBundle({ matched_url: "https://example.org/page" });
-            expect(preview.title).toEqual("https://example.org/page");
-            expect(preview.showTooltipOnLink).toBe(false);
+            expect(preview!.title).toEqual("https://example.org/page");
+            expect(preview!.showTooltipOnLink).toBe(false);
         });
 
         it("should set showTooltipOnLink when tooltips are enabled and title differs from the URL", () => {
             const { client } = getFetcher();
             const fetcher = new UrlPreviewFetcher(client as unknown as MatrixClient, 0, true);
             const preview = fetcher.previewFromBundle(BASIC_BUNDLE);
-            expect(preview.showTooltipOnLink).toBe(true);
+            expect(preview!.showTooltipOnLink).toBe(true);
         });
 
         // Unlike fetchPreview, the tooltip flag is computed against the raw og:title rather than
@@ -284,7 +284,7 @@ describe("UrlPreviewFetcher", () => {
             const { client } = getFetcher();
             const fetcher = new UrlPreviewFetcher(client as unknown as MatrixClient, 0, true);
             const preview = fetcher.previewFromBundle({ matched_url: "https://example.org/page" });
-            expect(preview.showTooltipOnLink).toBe(true);
+            expect(preview!.showTooltipOnLink).toBe(true);
         });
 
         it("should not set showTooltipOnLink when tooltips are enabled but og:title equals the URL", () => {
@@ -294,14 +294,14 @@ describe("UrlPreviewFetcher", () => {
                 "matched_url": "https://example.org/page",
                 "og:title": "https://example.org/page",
             });
-            expect(preview.showTooltipOnLink).toBe(false);
+            expect(preview!.showTooltipOnLink).toBe(false);
         });
 
         it("should include the image when all image fields are present", () => {
             const { fetcher, client } = getFetcher();
             mockMedia(client);
             const preview = fetcher.previewFromBundle(IMAGE_BUNDLE);
-            expect(preview.image).toEqual({
+            expect(preview!.image).toEqual({
                 imageThumb: "https://example.org/image/thumb",
                 imageFull: "https://example.org/image/src",
                 imageType: "image/png",
@@ -323,7 +323,7 @@ describe("UrlPreviewFetcher", () => {
             const { fetcher, client } = getFetcher();
             mockMedia(client);
             const preview = fetcher.previewFromBundle({ ...IMAGE_BUNDLE, ...override });
-            expect(preview.image).toBeUndefined();
+            expect(preview!.image).toBeUndefined();
         });
 
         it("should omit the image when the media mxc URL is malformed", () => {
@@ -332,9 +332,9 @@ describe("UrlPreviewFetcher", () => {
             // eslint-disable-next-line no-restricted-properties
             client.mxcUrlToHttp.mockReturnValue(null);
             const preview = fetcher.previewFromBundle(IMAGE_BUNDLE);
-            expect(preview.image).toBeUndefined();
+            expect(preview!.image).toBeUndefined();
             // The rest of the preview is still returned.
-            expect(preview.title).toEqual("Bundled title");
+            expect(preview?.title).toEqual("Bundled title");
         });
 
         it("should compute the siteName from the matched_url hostname", () => {
@@ -343,7 +343,27 @@ describe("UrlPreviewFetcher", () => {
                 ...BASIC_BUNDLE,
                 matched_url: "https://sub.example.com:8443/some/path?q=1",
             });
-            expect(preview.siteName).toEqual("sub.example.com");
+            expect(preview?.siteName).toEqual("sub.example.com");
+        });
+
+        it.each([
+            "",
+            null,
+            true,
+            123,
+            "javascript:execute_me",
+            "data:evil",
+            "mailto:foo@bar",
+            "x-http://not-real",
+            "htttps://still-not-real",
+        ])("should reject '%s'", (url) => {
+            const { fetcher } = getFetcher();
+            const preview = fetcher.previewFromBundle({
+                ...BASIC_BUNDLE,
+                "og:url": url as string,
+                "matched_url": url as string,
+            });
+            expect(preview).toBeNull();
         });
     });
 });

--- a/apps/web/src/utils/UrlPreviewFetcher.test.ts
+++ b/apps/web/src/utils/UrlPreviewFetcher.test.ts
@@ -250,9 +250,9 @@ describe("UrlPreviewFetcher", () => {
             });
         }
 
-        it("should map basic bundle fields without an image", () => {
+        it("should map basic bundle fields without an image", async () => {
             const { fetcher, client } = getFetcher();
-            const preview = fetcher.previewFromBundle(BASIC_BUNDLE, BASIC_BODY);
+            const preview = await fetcher.previewFromBundle(BASIC_BUNDLE, BASIC_BODY);
             expect(preview).toEqual({
                 link: "https://example.org/page",
                 title: "Bundled title",
@@ -265,34 +265,40 @@ describe("UrlPreviewFetcher", () => {
             expect(client.mxcUrlToHttp).not.toHaveBeenCalled();
         });
 
-        it("should fall back to the matched_url when there is no title", () => {
+        it("should fallback to the matched_url when there is no title", async () => {
             const { fetcher } = getFetcher();
-            const preview = fetcher.previewFromBundle({ matched_url: "https://example.org/page" }, BASIC_BODY);
+            const preview = await fetcher.previewFromBundle(
+                { "matched_url": "https://example.org/page", "og:url": "https://example.org/page" },
+                BASIC_BODY,
+            );
             expect(preview!.title).toEqual("https://example.org/page");
             expect(preview!.showTooltipOnLink).toBe(false);
         });
 
-        it("should set showTooltipOnLink when tooltips are enabled and title differs from the URL", () => {
+        it("should set showTooltipOnLink when tooltips are enabled and title differs from the URL", async () => {
             const { client } = getFetcher();
             const fetcher = new UrlPreviewFetcher(client as unknown as MatrixClient, 0, true);
-            const preview = fetcher.previewFromBundle(BASIC_BUNDLE, BASIC_BODY);
+            const preview = await fetcher.previewFromBundle(BASIC_BUNDLE, BASIC_BODY);
             expect(preview!.showTooltipOnLink).toBe(true);
         });
 
         // Unlike fetchPreview, the tooltip flag is computed against the raw og:title rather than
         // the resolved title, so a missing og:title still shows a tooltip even though the displayed
         // title falls back to the matched_url.
-        it("should set showTooltipOnLink when tooltips are enabled and og:title is absent", () => {
+        it("should set showTooltipOnLink when tooltips are enabled and og:title is absent", async () => {
             const { client } = getFetcher();
             const fetcher = new UrlPreviewFetcher(client as unknown as MatrixClient, 0, true);
-            const preview = fetcher.previewFromBundle({ matched_url: "https://example.org/page" }, BASIC_BODY);
+            const preview = await fetcher.previewFromBundle(
+                { "matched_url": "https://example.org/page", "og:url": "https://example.org/page" },
+                BASIC_BODY,
+            );
             expect(preview!.showTooltipOnLink).toBe(true);
         });
 
-        it("should not set showTooltipOnLink when tooltips are enabled but og:title equals the URL", () => {
+        it("should not set showTooltipOnLink when tooltips are enabled but og:title equals the URL", async () => {
             const { client } = getFetcher();
             const fetcher = new UrlPreviewFetcher(client as unknown as MatrixClient, 0, true);
-            const preview = fetcher.previewFromBundle(
+            const preview = await fetcher.previewFromBundle(
                 {
                     "matched_url": "https://example.org/page",
                     "og:title": "https://example.org/page",
@@ -302,10 +308,10 @@ describe("UrlPreviewFetcher", () => {
             expect(preview!.showTooltipOnLink).toBe(false);
         });
 
-        it("should include the image when all image fields are present", () => {
+        it("should include the image when all image fields are present", async () => {
             const { fetcher, client } = getFetcher();
             mockMedia(client);
-            const preview = fetcher.previewFromBundle(IMAGE_BUNDLE, BASIC_BODY);
+            const preview = await fetcher.previewFromBundle(IMAGE_BUNDLE, BASIC_BODY);
             expect(preview!.image).toEqual({
                 imageThumb: "https://example.org/image/thumb",
                 imageFull: "https://example.org/image/src",
@@ -324,27 +330,27 @@ describe("UrlPreviewFetcher", () => {
             { "og:image:height": undefined },
             // Non-numeric dimensions are ignored (bundle values are trusted as-is).
             { "og:image:width": "500" as unknown as number },
-        ])("should omit the image when image metadata is incomplete %s", (override) => {
+        ])("should omit the image when image metadata is incomplete %s", async (override) => {
             const { fetcher, client } = getFetcher();
             mockMedia(client);
-            const preview = fetcher.previewFromBundle({ ...IMAGE_BUNDLE, ...override }, BASIC_BODY);
+            const preview = await fetcher.previewFromBundle({ ...IMAGE_BUNDLE, ...override }, BASIC_BODY);
             expect(preview!.image).toBeUndefined();
         });
 
-        it("should omit the image when the media mxc URL is malformed", () => {
+        it("should omit the image when the media mxc URL is malformed", async () => {
             const { fetcher, client } = getFetcher();
             // A malformed/unresolvable mxc yields no HTTP URL.
             // eslint-disable-next-line no-restricted-properties
             client.mxcUrlToHttp.mockReturnValue(null);
-            const preview = fetcher.previewFromBundle(IMAGE_BUNDLE, BASIC_BODY);
+            const preview = await fetcher.previewFromBundle(IMAGE_BUNDLE, BASIC_BODY);
             expect(preview!.image).toBeUndefined();
             // The rest of the preview is still returned.
             expect(preview?.title).toEqual("Bundled title");
         });
 
-        it("should compute the siteName from the matched_url hostname", () => {
+        it("should compute the siteName from the matched_url hostname", async () => {
             const { fetcher } = getFetcher();
-            const preview = fetcher.previewFromBundle(
+            const preview = await fetcher.previewFromBundle(
                 {
                     ...BASIC_BUNDLE,
                     matched_url: "https://sub.example.com:8443/some/path?q=1",
@@ -364,9 +370,9 @@ describe("UrlPreviewFetcher", () => {
             "mailto:foo@bar",
             "x-http://not-real",
             "htttps://still-not-real",
-        ])("should reject '%s'", (url) => {
+        ])("should reject '%s'", async (url) => {
             const { fetcher } = getFetcher();
-            const preview = fetcher.previewFromBundle(
+            const preview = await fetcher.previewFromBundle(
                 {
                     ...BASIC_BUNDLE,
                     "og:url": url as string,
@@ -377,10 +383,18 @@ describe("UrlPreviewFetcher", () => {
             expect(preview).toBeNull();
         });
 
-        it("should reject urls not present in the event body", () => {
+        it("should reject urls not present in the event body", async () => {
             const { fetcher } = getFetcher();
-            const preview = fetcher.previewFromBundle(BASIC_BUNDLE, "No urls in here");
+            const preview = await fetcher.previewFromBundle(BASIC_BUNDLE, "No urls in here");
             expect(preview).toBeNull();
+        });
+
+        it("should fetch bundle from server if only matched_url is present", async () => {
+            const { fetcher, client } = getFetcher();
+            client.getUrlPreview.mockResolvedValue(BASIC_PREVIEW_OGDATA);
+            const preview = await fetcher.previewFromBundle({ matched_url: BASIC_BUNDLE.matched_url }, BASIC_BODY);
+            expect(client.getUrlPreview).toHaveBeenCalledTimes(1);
+            expect(preview).not.toBeNull();
         });
     });
 });

--- a/apps/web/src/utils/UrlPreviewFetcher.ts
+++ b/apps/web/src/utils/UrlPreviewFetcher.ts
@@ -209,11 +209,19 @@ export class UrlPreviewFetcher {
     }
 
     /**
-     * Convert an MSC4095 URL preview bundle item to a UrlPreview
+     * Convert an MSC4095 URL preview bundle item to a UrlPreview.
+     * This will load previews via the server if `single` only contains `matched_url`.
+     *
      * @param single A single preview.
      * @param body The message text body. `matched_url` must appear within it.
+     * @param loadMedia Whether to include the preview image WHEN falling back to loading
+     *                  from the server. Pass false when media is hidden.
      */
-    public previewFromBundle(single: UnstableBundledUrlPreviewSingle, body: string): UrlPreview | null {
+    public async previewFromBundle(
+        single: UnstableBundledUrlPreviewSingle,
+        body: string,
+        loadMedia = false,
+    ): Promise<UrlPreview | null> {
         if (!URL.canParse(single.matched_url)) {
             return null;
         }
@@ -225,6 +233,11 @@ export class UrlPreviewFetcher {
 
         if (!body.includes(single.matched_url)) {
             return null;
+        }
+
+        if (Object.keys(single).length === 1) {
+            // We ONLY have the matched_url, so request a preview.
+            return await this.fetchPreview(single.matched_url, loadMedia);
         }
 
         const preview: UrlPreview = {

--- a/apps/web/src/utils/UrlPreviewFetcher.ts
+++ b/apps/web/src/utils/UrlPreviewFetcher.ts
@@ -208,14 +208,29 @@ export class UrlPreviewFetcher {
         return result;
     }
 
-    /*
+    /**
      * Convert an MSC4095 URL preview bundle item to a UrlPreview
+     * @param single A single preview.
+     * @param body The message text body. `matched_url` must appear within it.
      */
-    public previewFromBundle(single: UnstableBundledUrlPreviewSingle): UrlPreview {
+    public previewFromBundle(single: UnstableBundledUrlPreviewSingle, body: string): UrlPreview | null {
+        if (!URL.canParse(single.matched_url)) {
+            return null;
+        }
+        const url = new URL(single.matched_url);
+        if (url.protocol !== "http:" && url.protocol !== "https:") {
+            // Invalid protocol, skip.
+            return null;
+        }
+
+        if (!body.includes(single.matched_url)) {
+            return null;
+        }
+
         const preview: UrlPreview = {
             link: single.matched_url,
             title: single["og:title"] ?? single.matched_url,
-            siteName: new URL(single.matched_url).hostname,
+            siteName: url.hostname,
             showTooltipOnLink: !!(single.matched_url !== single["og:title"] && this.showTooltips),
             description: single["og:description"],
             ogUrl: single["og:url"],

--- a/apps/web/src/viewmodels/message-body/UrlPreviewGroupViewModel.test.ts
+++ b/apps/web/src/viewmodels/message-body/UrlPreviewGroupViewModel.test.ts
@@ -266,6 +266,7 @@ describe("UrlPreviewGroupViewModel", () => {
                 urlPreviewBundleEnabled: true,
                 content: {
                     msgtype: MsgType.Text,
+                    body: `${BUNDLE_PREVIEW_ONE.matched_url} ${BUNDLE_PREVIEW_TWO.matched_url}`,
                     [BUNDLED_LINK_PREVIEWS]: [BUNDLE_PREVIEW_ONE, BUNDLE_PREVIEW_TWO],
                 },
             });
@@ -298,6 +299,7 @@ describe("UrlPreviewGroupViewModel", () => {
                 urlPreviewBundleEnabled: true,
                 content: {
                     msgtype: MsgType.Text,
+                    body: BUNDLE_PREVIEW_WITH_IMAGE.matched_url,
                     [BUNDLED_LINK_PREVIEWS]: [BUNDLE_PREVIEW_WITH_IMAGE],
                 },
             });
@@ -322,6 +324,7 @@ describe("UrlPreviewGroupViewModel", () => {
                 urlPreviewBundleEnabled: true,
                 content: {
                     msgtype: MsgType.Text,
+                    body: `${BUNDLE_PREVIEW_ONE.matched_url} ${BUNDLE_PREVIEW_TWO.matched_url} ${BUNDLE_PREVIEW_THREE.matched_url}`,
                     [BUNDLED_LINK_PREVIEWS]: [BUNDLE_PREVIEW_ONE, BUNDLE_PREVIEW_TWO, BUNDLE_PREVIEW_THREE],
                 },
             });

--- a/apps/web/src/viewmodels/message-body/UrlPreviewGroupViewModel.ts
+++ b/apps/web/src/viewmodels/message-body/UrlPreviewGroupViewModel.ts
@@ -182,7 +182,8 @@ export class UrlPreviewGroupViewModel
             if (messageContent[BUNDLED_LINK_PREVIEWS] !== undefined) {
                 previews = messageContent[BUNDLED_LINK_PREVIEWS]
                     .slice(0, this.limitPreviews ? MAX_PREVIEWS_WHEN_LIMITED : undefined)
-                    .map((preview) => this.fetcher.previewFromBundle(preview));
+                    .map((preview) => this.fetcher.previewFromBundle(preview, content.body))
+                    .filter((p) => !!p);
             }
         }
 

--- a/apps/web/src/viewmodels/message-body/UrlPreviewGroupViewModel.ts
+++ b/apps/web/src/viewmodels/message-body/UrlPreviewGroupViewModel.ts
@@ -178,12 +178,16 @@ export class UrlPreviewGroupViewModel
         const content = this.props.mxEvent.getContent();
         if (content.msgtype === MsgType.Text && this.props.urlPreviewBundleEnabled) {
             const messageContent = content as RoomMessageEventContent;
+            const bundledPreviews = messageContent[BUNDLED_LINK_PREVIEWS];
 
-            if (messageContent[BUNDLED_LINK_PREVIEWS] !== undefined) {
-                previews = messageContent[BUNDLED_LINK_PREVIEWS]
-                    .slice(0, this.limitPreviews ? MAX_PREVIEWS_WHEN_LIMITED : undefined)
-                    .map((preview) => this.fetcher.previewFromBundle(preview, content.body))
-                    .filter((p) => !!p);
+            if (bundledPreviews && Array.isArray(bundledPreviews)) {
+                previews = (
+                    await Promise.all(
+                        bundledPreviews
+                            .slice(0, this.limitPreviews ? MAX_PREVIEWS_WHEN_LIMITED : undefined)
+                            .map((preview) => this.fetcher.previewFromBundle(preview, content.body, loadMedia)),
+                    )
+                ).filter((p) => !!p);
             }
         }
 


### PR DESCRIPTION
This ensures we check if the link appears in the message body (as per https://github.com/beeper/matrix-spec-proposals/blob/bundled-url-previews/proposals/4095-bundled-url-previews.md#receiving-messages-with-murl_previews) and the URL is properly formatted.

We also fallback to serverside fetches if the bundle only contains a URL, as per the MSC.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
