### PR TITLE
Fix documentation references to Settings.tsx

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -118,7 +118,7 @@ instance. As of writing those settings are not fully documented, however a few a
     }
     ```
     These values will take priority over the hardcoded defaults for the settings. For a list of available settings, see
-    [Settings.tsx](https://github.com/element-hq/element-web/blob/develop/src/settings/Settings.tsx).
+    [Settings.tsx](https://github.com/element-hq/element-web/blob/develop/apps/web/src/settings/Settings.tsx).
 
 ## Customisation & branding
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -35,7 +35,7 @@ clients commit to doing the associated clean up work once a feature stabilises.
 When starting work on a feature, we should create a matching feature flag:
 
 1. Add a new
-   [setting](https://github.com/element-hq/element-web/blob/develop/src/settings/Settings.tsx)
+   [setting](https://github.com/element-hq/element-web/blob/develop/apps/web/src/settings/Settings.tsx)
    of the form:
 
 ```js


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

I noticed a [broken link to Settings.tsx](https://github.com/element-hq/element-web/blob/develop/src/settings/Settings.tsx) in the [documentation for settings_default](https://github.com/element-hq/element-web/blob/develop/docs/config.md#default-settings).

Fixed in two places to https://github.com/element-hq/element-web/blob/develop/apps/web/src/settings/Settings.tsx

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] ~Tests written for new code (and old code if feasible).~
- [ ] ~New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.~
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
