### PR TITLE
RoomList: wire up "Show People" Space settings Space

### DIFF
--- a/apps/web/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
@@ -8,6 +8,7 @@
 import { type Page } from "@playwright/test";
 import { closeReleaseAnnouncement, rejectToast } from "@element-hq/element-web-playwright-common";
 
+import type { AccountDataEvents } from "matrix-js-sdk/src/matrix";
 import { expect, test } from "../../../element-web-test";
 import { type Bot } from "../../../pages/bot";
 import { type ElementAppPage } from "../../../pages/ElementAppPage";
@@ -538,6 +539,68 @@ test.describe("Room list", () => {
             const room = roomListView.getByRole("option", { name: "silent" });
             await expect(room.getByTestId("notification-decoration")).toBeVisible();
             await expect(room).toMatchScreenshot("room-list-item-silent.png");
+        });
+    });
+
+    test.describe("Show people in space", () => {
+        const SPACE_NAME = "My space";
+
+        /**
+         * Toggle the "People" checkbox in the preferences of the given space.
+         */
+        async function togglePeopleInSpace(page: Page, app: ElementAppPage, spaceName: string): Promise<void> {
+            const spaceButton = await app.getSpacePanelButton(spaceName);
+            await spaceButton.click({ button: "right" });
+            await page.getByRole("menuitem", { name: "Preferences" }).click();
+
+            const dialog = page.getByRole("dialog");
+            await dialog.getByRole("checkbox", { name: "People" }).click();
+            await app.settings.closeDialog();
+        }
+
+        test("should hide and show the DMs of a space when the People preference is toggled", async ({
+            page,
+            app,
+            user,
+            bot,
+        }) => {
+            const botUserId = bot.credentials!.userId;
+
+            const roomId = await app.client.createRoom({ name: "Space room" });
+            const spaceId = await app.client.createSpace({
+                name: SPACE_NAME,
+                initial_state: [
+                    {
+                        type: "m.space.child",
+                        state_key: roomId,
+                        content: { via: [user.homeServer] },
+                    },
+                ],
+            });
+            // A DM only shows up in a space when the other user is a member of the space itself.
+            await app.client.inviteUser(spaceId, botUserId);
+
+            await app.client.evaluate(async (cli, botUserId) => {
+                const { room_id: dmRoomId } = await cli.createRoom({ is_direct: true, invite: [botUserId] });
+                await cli.setAccountData("m.direct" as keyof AccountDataEvents, { [botUserId]: [dmRoomId] });
+            }, botUserId);
+
+            await app.viewSpaceByName(SPACE_NAME);
+
+            const roomListView = getRoomList(page);
+            const dm = roomListView.getByRole("option", { name: "Open room BotBob" });
+            const room = roomListView.getByRole("option", { name: "Open room Space room" });
+            await expect(dm).toBeVisible();
+            await expect(room).toBeVisible();
+
+            // Turning the preference off hides the DM straight away, without switching space
+            await togglePeopleInSpace(page, app, SPACE_NAME);
+            await expect(dm).not.toBeVisible();
+            await expect(room).toBeVisible();
+
+            // Turning it back on brings the DM back
+            await togglePeopleInSpace(page, app, SPACE_NAME);
+            await expect(dm).toBeVisible();
         });
     });
 });

--- a/apps/web/src/stores/room-list-v3/RoomListStoreV3.test.ts
+++ b/apps/web/src/stores/room-list-v3/RoomListStoreV3.test.ts
@@ -554,6 +554,57 @@ describe("RoomListStoreV3", () => {
                     expect(result2).toContain(id);
                 }
             });
+
+            it("recomputes the rooms in the active space when Spaces.showPeopleInSpace changes", async () => {
+                const { client, rooms } = getClientAndRooms();
+                const { spaceRoom, roomIds } = createSpace(rooms, [6, 8, 13, 27, 75], client);
+                // Room 8 is a DM with a member of the space, the others are regular children.
+                const dmRoomId = rooms[8].roomId;
+
+                let showPeopleInSpace = true;
+                // Mirrors SpaceStore.isRoomInSpace: the DM only belongs to the space while the setting is on.
+                vi.spyOn(SDKContextClass.instance.spaceStore, "isRoomInSpace").mockImplementation((space, id) => {
+                    if (space !== spaceRoom.roomId || !roomIds.includes(id)) return false;
+                    return id !== dmRoomId || showPeopleInSpace;
+                });
+                vi.spyOn(SDKContextClass.instance.spaceStore, "activeSpace", "get").mockImplementation(
+                    () => spaceRoom.roomId,
+                );
+
+                let settingsWatcher: (settingName: string, roomId: string | null) => void = () => {};
+                vi.spyOn(SettingsStore, "watchSetting").mockImplementation((settingName, _roomId, callback) => {
+                    if (settingName === "Spaces.showPeopleInSpace") {
+                        settingsWatcher = callback as typeof settingsWatcher;
+                    }
+                    return "watcher-id";
+                });
+
+                const store = new RoomListStoreV3Class(dispatcher);
+                await store.start();
+                const fn = vi.fn();
+                store.on(LISTS_UPDATE_EVENT, fn);
+
+                const roomIdsInActiveSpace = (): string[] =>
+                    store
+                        .getSortedRoomsInActiveSpace()
+                        .sections.flatMap((s) => s.rooms)
+                        .map((r) => r.roomId);
+
+                expect(roomIdsInActiveSpace()).toContain(dmRoomId);
+
+                // Turning the setting off for the active space removes the DM without a space change
+                showPeopleInSpace = false;
+                settingsWatcher("Spaces.showPeopleInSpace", spaceRoom.roomId);
+                expect(fn).toHaveBeenCalled();
+                expect(roomIdsInActiveSpace()).not.toContain(dmRoomId);
+
+                // A change in another space is ignored
+                fn.mockClear();
+                showPeopleInSpace = true;
+                settingsWatcher("Spaces.showPeopleInSpace", "!space2:matrix.org");
+                expect(fn).not.toHaveBeenCalled();
+                expect(roomIdsInActiveSpace()).not.toContain(dmRoomId);
+            });
         });
 
         describe("Filters", () => {

--- a/apps/web/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/apps/web/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -136,6 +136,9 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
             this.onActivityIsUnreadChange(Boolean(newValue)),
         );
         SettingsStore.watchSetting("RoomList.showSections", null, () => this.scheduleEmit());
+        SettingsStore.watchSetting("Spaces.showPeopleInSpace", null, (_settingName, roomId) => {
+            if (roomId === SDKContextClass.instance.spaceStore.activeSpace) this.onActiveSpaceChanged();
+        });
     }
 
     /**


### PR DESCRIPTION
closes https://github.com/element-hq/element-web/issues/30792

The setting `Spaces.showPeopleInSpace` wasn't listen in the room list store and the user has to switch to another space and come back to make it work.

The PR doesn't hide the People or Room filters because, an user can still add manually a DM into a space. In this case, these filters are useful/