### PR TITLE
Prepare module-api 1.17.0 release

### DIFF
--- a/packages/module-api/package.json
+++ b/packages/module-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@element-hq/element-web-module-api",
     "type": "module",
-    "version": "1.16.0",
+    "version": "1.17.0",
     "description": "Module API surface for element-web",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Mostly, this is to pick up https://github.com/element-hq/element-web/pull/34620.