### PR TITLE
Room list: fix unreliable room name and message preview tooltips

### DIFF
--- a/apps/web/playwright/pages/ElementAppPage.ts
+++ b/apps/web/playwright/pages/ElementAppPage.ts
@@ -132,6 +132,11 @@ export class ElementAppPage {
         for (let attemptsLeft = 10; attemptsLeft > 0; attemptsLeft--) {
             try {
                 await roomTile.click({ timeout: 500 });
+                // Move the pointer off the tile. It would otherwise stay parked there and, ~300ms
+                // later, open the tile's name/preview tooltip over the rows below it - and a
+                // visible Compound tooltip has no `pointer-events: none`, so it can swallow a
+                // later click aimed at the room list.
+                await this.page.mouse.move(0, 0);
                 return;
             } catch (e) {
                 if (attemptsLeft === 1) throw e;

--- a/apps/web/playwright/pages/ElementAppPage.ts
+++ b/apps/web/playwright/pages/ElementAppPage.ts
@@ -120,9 +120,15 @@ export class ElementAppPage {
 
         await dismissToasts();
 
-        // We get the room list by test-id which is a listbox and matching title=name.
+        // Each room tile exposes its name via data-testid="room-name". Match the tile containing
+        // that exact name and click the tile itself.
         // Retry, closing toasts each time, as otherwise it can race and the toast can appear after we try to close them
-        const roomTile = this.page.getByTestId("room-list").locator(`[title="${name}"]`).first();
+        const roomName = this.page.getByTestId("room-name").and(this.page.getByText(name, { exact: true }));
+        const roomTile = this.page
+            .getByTestId("room-list")
+            .locator(".mx_RoomListItemView")
+            .filter({ has: roomName })
+            .first();
         for (let attemptsLeft = 10; attemptsLeft > 0; attemptsLeft--) {
             try {
                 await roomTile.click({ timeout: 500 });

--- a/packages/shared-components/src/room-list/RoomListView/__snapshots__/RoomListView.test.tsx.snap
+++ b/packages/shared-components/src/room-list/RoomListView/__snapshots__/RoomListView.test.tsx.snap
@@ -112,14 +112,15 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="General"
                         >
-                          General
+                          <span
+                            data-testid="room-name"
+                          >
+                            General
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in General"
                         >
                           Last message in General
                         </div>
@@ -261,10 +262,12 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Random"
                         >
-                          Random
+                          <span
+                            data-testid="room-name"
+                          >
+                            Random
+                          </span>
                         </div>
                       </div>
                       <div
@@ -383,14 +386,15 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Engineering"
                         >
-                          Engineering
+                          <span
+                            data-testid="room-name"
+                          >
+                            Engineering
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Engineering"
                         >
                           Last message in Engineering
                         </div>
@@ -511,10 +515,12 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Design"
                         >
-                          Design
+                          <span
+                            data-testid="room-name"
+                          >
+                            Design
+                          </span>
                         </div>
                       </div>
                       <div
@@ -633,14 +639,15 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Product"
                         >
-                          Product
+                          <span
+                            data-testid="room-name"
+                          >
+                            Product
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Product"
                         >
                           Last message in Product
                         </div>
@@ -761,10 +768,12 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Marketing"
                         >
-                          Marketing
+                          <span
+                            data-testid="room-name"
+                          >
+                            Marketing
+                          </span>
                         </div>
                       </div>
                       <div
@@ -906,14 +915,15 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Sales"
                         >
-                          Sales
+                          <span
+                            data-testid="room-name"
+                          >
+                            Sales
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Sales"
                         >
                           Last message in Sales
                         </div>
@@ -1034,10 +1044,12 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Support"
                         >
-                          Support
+                          <span
+                            data-testid="room-name"
+                          >
+                            Support
+                          </span>
                         </div>
                       </div>
                       <div
@@ -1156,14 +1168,15 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Announcements"
                         >
-                          Announcements
+                          <span
+                            data-testid="room-name"
+                          >
+                            Announcements
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Announcements"
                         >
                           Last message in Announcements
                         </div>
@@ -1284,10 +1297,12 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Off-topic"
                         >
-                          Off-topic
+                          <span
+                            data-testid="room-name"
+                          >
+                            Off-topic
+                          </span>
                         </div>
                       </div>
                       <div
@@ -1406,14 +1421,15 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Team Alpha"
                         >
-                          Team Alpha
+                          <span
+                            data-testid="room-name"
+                          >
+                            Team Alpha
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Team Alpha"
                         >
                           Last message in Team Alpha
                         </div>
@@ -1557,10 +1573,12 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Team Beta"
                         >
-                          Team Beta
+                          <span
+                            data-testid="room-name"
+                          >
+                            Team Beta
+                          </span>
                         </div>
                       </div>
                       <div
@@ -1679,14 +1697,15 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Project X"
                         >
-                          Project X
+                          <span
+                            data-testid="room-name"
+                          >
+                            Project X
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Project X"
                         >
                           Last message in Project X
                         </div>
@@ -1807,10 +1826,12 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Project Y"
                         >
-                          Project Y
+                          <span
+                            data-testid="room-name"
+                          >
+                            Project Y
+                          </span>
                         </div>
                       </div>
                       <div
@@ -1929,14 +1950,15 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Water Cooler"
                         >
-                          Water Cooler
+                          <span
+                            data-testid="room-name"
+                          >
+                            Water Cooler
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Water Cooler"
                         >
                           Last message in Water Cooler
                         </div>
@@ -2057,10 +2079,12 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Feedback"
                         >
-                          Feedback
+                          <span
+                            data-testid="room-name"
+                          >
+                            Feedback
+                          </span>
                         </div>
                       </div>
                       <div
@@ -2202,14 +2226,15 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Ideas"
                         >
-                          Ideas
+                          <span
+                            data-testid="room-name"
+                          >
+                            Ideas
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Ideas"
                         >
                           Last message in Ideas
                         </div>
@@ -2330,10 +2355,12 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Bugs"
                         >
-                          Bugs
+                          <span
+                            data-testid="room-name"
+                          >
+                            Bugs
+                          </span>
                         </div>
                       </div>
                       <div
@@ -2452,14 +2479,15 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Features"
                         >
-                          Features
+                          <span
+                            data-testid="room-name"
+                          >
+                            Features
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Features"
                         >
                           Last message in Features
                         </div>
@@ -2580,10 +2608,12 @@ exports[`<RoomListView /> > renders Default story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Releases"
                         >
-                          Releases
+                          <span
+                            data-testid="room-name"
+                          >
+                            Releases
+                          </span>
                         </div>
                       </div>
                       <div
@@ -3370,14 +3400,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="General"
                         >
-                          General
+                          <span
+                            data-testid="room-name"
+                          >
+                            General
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in General"
                         >
                           Last message in General
                         </div>
@@ -3519,10 +3550,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Random"
                         >
-                          Random
+                          <span
+                            data-testid="room-name"
+                          >
+                            Random
+                          </span>
                         </div>
                       </div>
                       <div
@@ -3641,14 +3674,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Engineering"
                         >
-                          Engineering
+                          <span
+                            data-testid="room-name"
+                          >
+                            Engineering
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Engineering"
                         >
                           Last message in Engineering
                         </div>
@@ -3769,10 +3803,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Design"
                         >
-                          Design
+                          <span
+                            data-testid="room-name"
+                          >
+                            Design
+                          </span>
                         </div>
                       </div>
                       <div
@@ -3891,14 +3927,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Product"
                         >
-                          Product
+                          <span
+                            data-testid="room-name"
+                          >
+                            Product
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Product"
                         >
                           Last message in Product
                         </div>
@@ -4019,10 +4056,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Marketing"
                         >
-                          Marketing
+                          <span
+                            data-testid="room-name"
+                          >
+                            Marketing
+                          </span>
                         </div>
                       </div>
                       <div
@@ -4164,14 +4203,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Sales"
                         >
-                          Sales
+                          <span
+                            data-testid="room-name"
+                          >
+                            Sales
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Sales"
                         >
                           Last message in Sales
                         </div>
@@ -4292,10 +4332,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Support"
                         >
-                          Support
+                          <span
+                            data-testid="room-name"
+                          >
+                            Support
+                          </span>
                         </div>
                       </div>
                       <div
@@ -4414,14 +4456,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Announcements"
                         >
-                          Announcements
+                          <span
+                            data-testid="room-name"
+                          >
+                            Announcements
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Announcements"
                         >
                           Last message in Announcements
                         </div>
@@ -4542,10 +4585,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Off-topic"
                         >
-                          Off-topic
+                          <span
+                            data-testid="room-name"
+                          >
+                            Off-topic
+                          </span>
                         </div>
                       </div>
                       <div
@@ -4664,14 +4709,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Team Alpha"
                         >
-                          Team Alpha
+                          <span
+                            data-testid="room-name"
+                          >
+                            Team Alpha
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Team Alpha"
                         >
                           Last message in Team Alpha
                         </div>
@@ -4815,10 +4861,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Team Beta"
                         >
-                          Team Beta
+                          <span
+                            data-testid="room-name"
+                          >
+                            Team Beta
+                          </span>
                         </div>
                       </div>
                       <div
@@ -4937,14 +4985,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Project X"
                         >
-                          Project X
+                          <span
+                            data-testid="room-name"
+                          >
+                            Project X
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Project X"
                         >
                           Last message in Project X
                         </div>
@@ -5065,10 +5114,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Project Y"
                         >
-                          Project Y
+                          <span
+                            data-testid="room-name"
+                          >
+                            Project Y
+                          </span>
                         </div>
                       </div>
                       <div
@@ -5187,14 +5238,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Water Cooler"
                         >
-                          Water Cooler
+                          <span
+                            data-testid="room-name"
+                          >
+                            Water Cooler
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Water Cooler"
                         >
                           Last message in Water Cooler
                         </div>
@@ -5315,10 +5367,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Feedback"
                         >
-                          Feedback
+                          <span
+                            data-testid="room-name"
+                          >
+                            Feedback
+                          </span>
                         </div>
                       </div>
                       <div
@@ -5460,14 +5514,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Ideas"
                         >
-                          Ideas
+                          <span
+                            data-testid="room-name"
+                          >
+                            Ideas
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Ideas"
                         >
                           Last message in Ideas
                         </div>
@@ -5588,10 +5643,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Bugs"
                         >
-                          Bugs
+                          <span
+                            data-testid="room-name"
+                          >
+                            Bugs
+                          </span>
                         </div>
                       </div>
                       <div
@@ -5710,14 +5767,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Features"
                         >
-                          Features
+                          <span
+                            data-testid="room-name"
+                          >
+                            Features
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Features"
                         >
                           Last message in Features
                         </div>
@@ -5838,10 +5896,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Releases"
                         >
-                          Releases
+                          <span
+                            data-testid="room-name"
+                          >
+                            Releases
+                          </span>
                         </div>
                       </div>
                       <div
@@ -5960,14 +6020,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="General"
                         >
-                          General
+                          <span
+                            data-testid="room-name"
+                          >
+                            General
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in General"
                         >
                           Last message in General
                         </div>
@@ -6111,10 +6172,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Random"
                         >
-                          Random
+                          <span
+                            data-testid="room-name"
+                          >
+                            Random
+                          </span>
                         </div>
                       </div>
                       <div
@@ -6233,14 +6296,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Engineering"
                         >
-                          Engineering
+                          <span
+                            data-testid="room-name"
+                          >
+                            Engineering
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Engineering"
                         >
                           Last message in Engineering
                         </div>
@@ -6361,10 +6425,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Design"
                         >
-                          Design
+                          <span
+                            data-testid="room-name"
+                          >
+                            Design
+                          </span>
                         </div>
                       </div>
                       <div
@@ -6483,14 +6549,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Product"
                         >
-                          Product
+                          <span
+                            data-testid="room-name"
+                          >
+                            Product
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Product"
                         >
                           Last message in Product
                         </div>
@@ -6611,10 +6678,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Marketing"
                         >
-                          Marketing
+                          <span
+                            data-testid="room-name"
+                          >
+                            Marketing
+                          </span>
                         </div>
                       </div>
                       <div
@@ -6756,14 +6825,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Sales"
                         >
-                          Sales
+                          <span
+                            data-testid="room-name"
+                          >
+                            Sales
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Sales"
                         >
                           Last message in Sales
                         </div>
@@ -6884,10 +6954,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Support"
                         >
-                          Support
+                          <span
+                            data-testid="room-name"
+                          >
+                            Support
+                          </span>
                         </div>
                       </div>
                       <div
@@ -7006,14 +7078,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Announcements"
                         >
-                          Announcements
+                          <span
+                            data-testid="room-name"
+                          >
+                            Announcements
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Announcements"
                         >
                           Last message in Announcements
                         </div>
@@ -7134,10 +7207,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Off-topic"
                         >
-                          Off-topic
+                          <span
+                            data-testid="room-name"
+                          >
+                            Off-topic
+                          </span>
                         </div>
                       </div>
                       <div
@@ -7256,14 +7331,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Team Alpha"
                         >
-                          Team Alpha
+                          <span
+                            data-testid="room-name"
+                          >
+                            Team Alpha
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Team Alpha"
                         >
                           Last message in Team Alpha
                         </div>
@@ -7407,10 +7483,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Team Beta"
                         >
-                          Team Beta
+                          <span
+                            data-testid="room-name"
+                          >
+                            Team Beta
+                          </span>
                         </div>
                       </div>
                       <div
@@ -7529,14 +7607,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Project X"
                         >
-                          Project X
+                          <span
+                            data-testid="room-name"
+                          >
+                            Project X
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Project X"
                         >
                           Last message in Project X
                         </div>
@@ -7657,10 +7736,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Project Y"
                         >
-                          Project Y
+                          <span
+                            data-testid="room-name"
+                          >
+                            Project Y
+                          </span>
                         </div>
                       </div>
                       <div
@@ -7779,14 +7860,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Water Cooler"
                         >
-                          Water Cooler
+                          <span
+                            data-testid="room-name"
+                          >
+                            Water Cooler
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Water Cooler"
                         >
                           Last message in Water Cooler
                         </div>
@@ -7907,10 +7989,12 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Feedback"
                         >
-                          Feedback
+                          <span
+                            data-testid="room-name"
+                          >
+                            Feedback
+                          </span>
                         </div>
                       </div>
                       <div
@@ -8052,14 +8136,15 @@ exports[`<RoomListView /> > renders LargeFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Ideas"
                         >
-                          Ideas
+                          <span
+                            data-testid="room-name"
+                          >
+                            Ideas
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Ideas"
                         >
                           Last message in Ideas
                         </div>
@@ -8377,14 +8462,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="General"
                               >
-                                General
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  General
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in General"
                               >
                                 Last message in General
                               </div>
@@ -8535,10 +8621,12 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Random"
                               >
-                                Random
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Random
+                                </span>
                               </div>
                             </div>
                             <div
@@ -8666,14 +8754,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Engineering"
                               >
-                                Engineering
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Engineering
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in Engineering"
                               >
                                 Last message in Engineering
                               </div>
@@ -8803,10 +8892,12 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Design"
                               >
-                                Design
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Design
+                                </span>
                               </div>
                             </div>
                             <div
@@ -8934,14 +9025,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Product"
                               >
-                                Product
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Product
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in Product"
                               >
                                 Last message in Product
                               </div>
@@ -9071,10 +9163,12 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Marketing"
                               >
-                                Marketing
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Marketing
+                                </span>
                               </div>
                             </div>
                             <div
@@ -9225,14 +9319,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Sales"
                               >
-                                Sales
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Sales
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in Sales"
                               >
                                 Last message in Sales
                               </div>
@@ -9362,10 +9457,12 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Support"
                               >
-                                Support
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Support
+                                </span>
                               </div>
                             </div>
                             <div
@@ -9493,14 +9590,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Announcements"
                               >
-                                Announcements
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Announcements
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in Announcements"
                               >
                                 Last message in Announcements
                               </div>
@@ -9630,10 +9728,12 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Off-topic"
                               >
-                                Off-topic
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Off-topic
+                                </span>
                               </div>
                             </div>
                             <div
@@ -9761,14 +9861,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Team Alpha"
                               >
-                                Team Alpha
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Team Alpha
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in Team Alpha"
                               >
                                 Last message in Team Alpha
                               </div>
@@ -9921,10 +10022,12 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Team Beta"
                               >
-                                Team Beta
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Team Beta
+                                </span>
                               </div>
                             </div>
                             <div
@@ -10052,14 +10155,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Project X"
                               >
-                                Project X
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Project X
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in Project X"
                               >
                                 Last message in Project X
                               </div>
@@ -10189,10 +10293,12 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Project Y"
                               >
-                                Project Y
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Project Y
+                                </span>
                               </div>
                             </div>
                             <div
@@ -10320,14 +10426,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Water Cooler"
                               >
-                                Water Cooler
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Water Cooler
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in Water Cooler"
                               >
                                 Last message in Water Cooler
                               </div>
@@ -10457,10 +10564,12 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Feedback"
                               >
-                                Feedback
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Feedback
+                                </span>
                               </div>
                             </div>
                             <div
@@ -10611,14 +10720,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Ideas"
                               >
-                                Ideas
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Ideas
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in Ideas"
                               >
                                 Last message in Ideas
                               </div>
@@ -10748,10 +10858,12 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Bugs"
                               >
-                                Bugs
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Bugs
+                                </span>
                               </div>
                             </div>
                             <div
@@ -10879,14 +10991,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Features"
                               >
-                                Features
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Features
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in Features"
                               >
                                 Last message in Features
                               </div>
@@ -11016,10 +11129,12 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Releases"
                               >
-                                Releases
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Releases
+                                </span>
                               </div>
                             </div>
                             <div
@@ -11147,14 +11262,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="General"
                               >
-                                General
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  General
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in General"
                               >
                                 Last message in General
                               </div>
@@ -11307,10 +11423,12 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Random"
                               >
-                                Random
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Random
+                                </span>
                               </div>
                             </div>
                             <div
@@ -11438,14 +11556,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Engineering"
                               >
-                                Engineering
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Engineering
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in Engineering"
                               >
                                 Last message in Engineering
                               </div>
@@ -11633,10 +11752,12 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Design"
                               >
-                                Design
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Design
+                                </span>
                               </div>
                             </div>
                             <div
@@ -11764,14 +11885,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Product"
                               >
-                                Product
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Product
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in Product"
                               >
                                 Last message in Product
                               </div>
@@ -11901,10 +12023,12 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Marketing"
                               >
-                                Marketing
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Marketing
+                                </span>
                               </div>
                             </div>
                             <div
@@ -12055,14 +12179,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Sales"
                               >
-                                Sales
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Sales
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in Sales"
                               >
                                 Last message in Sales
                               </div>
@@ -12192,10 +12317,12 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Support"
                               >
-                                Support
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Support
+                                </span>
                               </div>
                             </div>
                             <div
@@ -12323,14 +12450,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Announcements"
                               >
-                                Announcements
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Announcements
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in Announcements"
                               >
                                 Last message in Announcements
                               </div>
@@ -12460,10 +12588,12 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Off-topic"
                               >
-                                Off-topic
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Off-topic
+                                </span>
                               </div>
                             </div>
                             <div
@@ -12591,14 +12721,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Team Alpha"
                               >
-                                Team Alpha
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Team Alpha
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in Team Alpha"
                               >
                                 Last message in Team Alpha
                               </div>
@@ -12751,10 +12882,12 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Team Beta"
                               >
-                                Team Beta
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Team Beta
+                                </span>
                               </div>
                             </div>
                             <div
@@ -12882,14 +13015,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Project X"
                               >
-                                Project X
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Project X
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in Project X"
                               >
                                 Last message in Project X
                               </div>
@@ -13019,10 +13153,12 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Project Y"
                               >
-                                Project Y
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Project Y
+                                </span>
                               </div>
                             </div>
                             <div
@@ -13150,14 +13286,15 @@ exports[`<RoomListView /> > renders LargeSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Water Cooler"
                               >
-                                Water Cooler
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Water Cooler
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in Water Cooler"
                               >
                                 Last message in Water Cooler
                               </div>
@@ -13428,14 +13565,15 @@ exports[`<RoomListView /> > renders SmallFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="General"
                         >
-                          General
+                          <span
+                            data-testid="room-name"
+                          >
+                            General
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in General"
                         >
                           Last message in General
                         </div>
@@ -13577,10 +13715,12 @@ exports[`<RoomListView /> > renders SmallFlatList story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Random"
                         >
-                          Random
+                          <span
+                            data-testid="room-name"
+                          >
+                            Random
+                          </span>
                         </div>
                       </div>
                       <div
@@ -13896,14 +14036,15 @@ exports[`<RoomListView /> > renders SmallSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="General"
                               >
-                                General
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  General
+                                </span>
                               </div>
                               <div
                                 class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                                title="Last message in General"
                               >
                                 Last message in General
                               </div>
@@ -14054,10 +14195,12 @@ exports[`<RoomListView /> > renders SmallSectionList story 1`] = `
                             >
                               <div
                                 class="RoomListItemView-module_roomName"
-                                data-testid="room-name"
-                                title="Random"
                               >
-                                Random
+                                <span
+                                  data-testid="room-name"
+                                >
+                                  Random
+                                </span>
                               </div>
                             </div>
                             <div
@@ -14319,14 +14462,15 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="General"
                         >
-                          General
+                          <span
+                            data-testid="room-name"
+                          >
+                            General
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in General"
                         >
                           Last message in General
                         </div>
@@ -14468,10 +14612,12 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Random"
                         >
-                          Random
+                          <span
+                            data-testid="room-name"
+                          >
+                            Random
+                          </span>
                         </div>
                       </div>
                       <div
@@ -14590,14 +14736,15 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Engineering"
                         >
-                          Engineering
+                          <span
+                            data-testid="room-name"
+                          >
+                            Engineering
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Engineering"
                         >
                           Last message in Engineering
                         </div>
@@ -14718,10 +14865,12 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Design"
                         >
-                          Design
+                          <span
+                            data-testid="room-name"
+                          >
+                            Design
+                          </span>
                         </div>
                       </div>
                       <div
@@ -14840,14 +14989,15 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Product"
                         >
-                          Product
+                          <span
+                            data-testid="room-name"
+                          >
+                            Product
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Product"
                         >
                           Last message in Product
                         </div>
@@ -14968,10 +15118,12 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Marketing"
                         >
-                          Marketing
+                          <span
+                            data-testid="room-name"
+                          >
+                            Marketing
+                          </span>
                         </div>
                       </div>
                       <div
@@ -15113,14 +15265,15 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Sales"
                         >
-                          Sales
+                          <span
+                            data-testid="room-name"
+                          >
+                            Sales
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Sales"
                         >
                           Last message in Sales
                         </div>
@@ -15241,10 +15394,12 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Support"
                         >
-                          Support
+                          <span
+                            data-testid="room-name"
+                          >
+                            Support
+                          </span>
                         </div>
                       </div>
                       <div
@@ -15363,14 +15518,15 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Announcements"
                         >
-                          Announcements
+                          <span
+                            data-testid="room-name"
+                          >
+                            Announcements
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Announcements"
                         >
                           Last message in Announcements
                         </div>
@@ -15491,10 +15647,12 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Off-topic"
                         >
-                          Off-topic
+                          <span
+                            data-testid="room-name"
+                          >
+                            Off-topic
+                          </span>
                         </div>
                       </div>
                       <div
@@ -15613,14 +15771,15 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Team Alpha"
                         >
-                          Team Alpha
+                          <span
+                            data-testid="room-name"
+                          >
+                            Team Alpha
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Team Alpha"
                         >
                           Last message in Team Alpha
                         </div>
@@ -15764,10 +15923,12 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Team Beta"
                         >
-                          Team Beta
+                          <span
+                            data-testid="room-name"
+                          >
+                            Team Beta
+                          </span>
                         </div>
                       </div>
                       <div
@@ -15886,14 +16047,15 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Project X"
                         >
-                          Project X
+                          <span
+                            data-testid="room-name"
+                          >
+                            Project X
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Project X"
                         >
                           Last message in Project X
                         </div>
@@ -16014,10 +16176,12 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Project Y"
                         >
-                          Project Y
+                          <span
+                            data-testid="room-name"
+                          >
+                            Project Y
+                          </span>
                         </div>
                       </div>
                       <div
@@ -16136,14 +16300,15 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Water Cooler"
                         >
-                          Water Cooler
+                          <span
+                            data-testid="room-name"
+                          >
+                            Water Cooler
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Water Cooler"
                         >
                           Last message in Water Cooler
                         </div>
@@ -16264,10 +16429,12 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Feedback"
                         >
-                          Feedback
+                          <span
+                            data-testid="room-name"
+                          >
+                            Feedback
+                          </span>
                         </div>
                       </div>
                       <div
@@ -16409,14 +16576,15 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Ideas"
                         >
-                          Ideas
+                          <span
+                            data-testid="room-name"
+                          >
+                            Ideas
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Ideas"
                         >
                           Last message in Ideas
                         </div>
@@ -16537,10 +16705,12 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Bugs"
                         >
-                          Bugs
+                          <span
+                            data-testid="room-name"
+                          >
+                            Bugs
+                          </span>
                         </div>
                       </div>
                       <div
@@ -16659,14 +16829,15 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Features"
                         >
-                          Features
+                          <span
+                            data-testid="room-name"
+                          >
+                            Features
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Features"
                         >
                           Last message in Features
                         </div>
@@ -16787,10 +16958,12 @@ exports[`<RoomListView /> > renders Toast story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Releases"
                         >
-                          Releases
+                          <span
+                            data-testid="room-name"
+                          >
+                            Releases
+                          </span>
                         </div>
                       </div>
                       <div
@@ -17025,14 +17198,15 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="General"
                         >
-                          General
+                          <span
+                            data-testid="room-name"
+                          >
+                            General
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in General"
                         >
                           Last message in General
                         </div>
@@ -17174,10 +17348,12 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Random"
                         >
-                          Random
+                          <span
+                            data-testid="room-name"
+                          >
+                            Random
+                          </span>
                         </div>
                       </div>
                       <div
@@ -17296,14 +17472,15 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Engineering"
                         >
-                          Engineering
+                          <span
+                            data-testid="room-name"
+                          >
+                            Engineering
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Engineering"
                         >
                           Last message in Engineering
                         </div>
@@ -17424,10 +17601,12 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Design"
                         >
-                          Design
+                          <span
+                            data-testid="room-name"
+                          >
+                            Design
+                          </span>
                         </div>
                       </div>
                       <div
@@ -17546,14 +17725,15 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Product"
                         >
-                          Product
+                          <span
+                            data-testid="room-name"
+                          >
+                            Product
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Product"
                         >
                           Last message in Product
                         </div>
@@ -17674,10 +17854,12 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Marketing"
                         >
-                          Marketing
+                          <span
+                            data-testid="room-name"
+                          >
+                            Marketing
+                          </span>
                         </div>
                       </div>
                       <div
@@ -17819,14 +18001,15 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Sales"
                         >
-                          Sales
+                          <span
+                            data-testid="room-name"
+                          >
+                            Sales
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Sales"
                         >
                           Last message in Sales
                         </div>
@@ -17947,10 +18130,12 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Support"
                         >
-                          Support
+                          <span
+                            data-testid="room-name"
+                          >
+                            Support
+                          </span>
                         </div>
                       </div>
                       <div
@@ -18069,14 +18254,15 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Announcements"
                         >
-                          Announcements
+                          <span
+                            data-testid="room-name"
+                          >
+                            Announcements
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Announcements"
                         >
                           Last message in Announcements
                         </div>
@@ -18197,10 +18383,12 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Off-topic"
                         >
-                          Off-topic
+                          <span
+                            data-testid="room-name"
+                          >
+                            Off-topic
+                          </span>
                         </div>
                       </div>
                       <div
@@ -18319,14 +18507,15 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Team Alpha"
                         >
-                          Team Alpha
+                          <span
+                            data-testid="room-name"
+                          >
+                            Team Alpha
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Team Alpha"
                         >
                           Last message in Team Alpha
                         </div>
@@ -18470,10 +18659,12 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Team Beta"
                         >
-                          Team Beta
+                          <span
+                            data-testid="room-name"
+                          >
+                            Team Beta
+                          </span>
                         </div>
                       </div>
                       <div
@@ -18592,14 +18783,15 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Project X"
                         >
-                          Project X
+                          <span
+                            data-testid="room-name"
+                          >
+                            Project X
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Project X"
                         >
                           Last message in Project X
                         </div>
@@ -18720,10 +18912,12 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Project Y"
                         >
-                          Project Y
+                          <span
+                            data-testid="room-name"
+                          >
+                            Project Y
+                          </span>
                         </div>
                       </div>
                       <div
@@ -18842,14 +19036,15 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Water Cooler"
                         >
-                          Water Cooler
+                          <span
+                            data-testid="room-name"
+                          >
+                            Water Cooler
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Water Cooler"
                         >
                           Last message in Water Cooler
                         </div>
@@ -18970,10 +19165,12 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Feedback"
                         >
-                          Feedback
+                          <span
+                            data-testid="room-name"
+                          >
+                            Feedback
+                          </span>
                         </div>
                       </div>
                       <div
@@ -19115,14 +19312,15 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Ideas"
                         >
-                          Ideas
+                          <span
+                            data-testid="room-name"
+                          >
+                            Ideas
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Ideas"
                         >
                           Last message in Ideas
                         </div>
@@ -19243,10 +19441,12 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Bugs"
                         >
-                          Bugs
+                          <span
+                            data-testid="room-name"
+                          >
+                            Bugs
+                          </span>
                         </div>
                       </div>
                       <div
@@ -19365,14 +19565,15 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Features"
                         >
-                          Features
+                          <span
+                            data-testid="room-name"
+                          >
+                            Features
+                          </span>
                         </div>
                         <div
                           class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                          title="Last message in Features"
                         >
                           Last message in Features
                         </div>
@@ -19493,10 +19694,12 @@ exports[`<RoomListView /> > renders WithActiveFilter story 1`] = `
                       >
                         <div
                           class="RoomListItemView-module_roomName"
-                          data-testid="room-name"
-                          title="Releases"
                         >
-                          Releases
+                          <span
+                            data-testid="room-name"
+                          >
+                            Releases
+                          </span>
                         </div>
                       </div>
                       <div

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListItemWrapper/RoomListItemView/RoomListItemContent.tsx
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListItemWrapper/RoomListItemView/RoomListItemContent.tsx
@@ -50,10 +50,22 @@ export const RoomListItemContent = memo(function RoomListItemContent({
         >
             {renderAvatar(item.room)}
             <Flex className={styles.content} gap="var(--cpd-space-2x)" align="center" justify="space-between">
-                {/* We truncate the room name when too long. Title here is to show the full name on hover */}
+                {/*
+                    The room name and message preview are truncated when too long, so the full text
+                    is offered on hover. These must be rendered tooltips rather than native `title`
+                    attributes: on Element Desktop for macOS, `title` tooltips fire on the first
+                    hover and then only intermittently, so the text is effectively unreachable.
+                        https://github.com/element-hq/element-web/issues/34049
+                        https://github.com/electron/electron/issues/49843
+                    This follows EventPreviewView, which moved off `title` for the same reason.
+                    The name tooltip wraps only the name text, not the whole cell, so that hovering
+                    the user status emoji shows its own tooltip rather than both at once.
+                */}
                 <div className={styles.ellipsis}>
-                    <div className={styles.roomName} title={item.name} data-testid="room-name">
-                        {item.name}
+                    <div className={styles.roomName}>
+                        <Tooltip description={item.name}>
+                            <span data-testid="room-name">{item.name}</span>
+                        </Tooltip>
                         {item.userStatus && (
                             <Tooltip description={item.userStatus.text}>
                                 <Text as="span" className={styles.userStatusEmoji}>
@@ -64,9 +76,11 @@ export const RoomListItemContent = memo(function RoomListItemContent({
                     </div>
 
                     {item.messagePreview && (
-                        <Text as="div" size="sm" className={styles.ellipsis} title={item.messagePreview}>
-                            {item.messagePreview}
-                        </Text>
+                        <Tooltip description={item.messagePreview}>
+                            <Text as="div" size="sm" className={styles.ellipsis}>
+                                {item.messagePreview}
+                            </Text>
+                        </Tooltip>
                     )}
                 </div>
                 {!isDragging && (item.showMoreOptionsMenu || item.showNotificationMenu) && (

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListItemWrapper/RoomListItemView/RoomListItemView.test.tsx
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListItemWrapper/RoomListItemView/RoomListItemView.test.tsx
@@ -26,6 +26,8 @@ const {
     NoMessagePreview,
     WithHoverMenu,
     WithoutHoverMenu,
+    LongContent,
+    WithUserStatus,
 } = composeStories(stories);
 
 describe("<RoomListItemView />", () => {
@@ -146,5 +148,54 @@ describe("<RoomListItemView />", () => {
         option.blur();
         await waitFor(() => expect(option.className).not.toMatch(/keyboardActive/));
         expect(moreButton).not.toBeVisible();
+    });
+
+    /*
+     * The room name and message preview are truncated with an ellipsis, and the full text is meant
+     * to be available on hover. It is currently exposed through a native `title` attribute, which
+     * on Element Desktop for macOS is at the mercy of an open Electron regression: since Electron
+     * 38 (Element Desktop has shipped >= 38 since 2025-09-16) a `title` tooltip fires on the first
+     * hover and then only intermittently.
+     *   https://github.com/element-hq/element-web/issues/34049
+     *   https://github.com/electron/electron/issues/49843
+     * The fix is to render the tooltip ourselves with the Compound `Tooltip` component, as this
+     * component already does for the user status emoji, rather than asking the browser for one.
+     */
+    describe("truncated text tooltips", () => {
+        // Control: the user status emoji already uses the Compound `Tooltip` component. This proves
+        // the suite can observe a rendered tooltip, so the two failures below are the missing
+        // tooltip itself. (These tests run in real Chromium via Playwright browser mode, where a
+        // native `title` still contributes no element to the DOM for the suite to find.)
+        it("shows the user status text in a tooltip on hover", async () => {
+            const user = userEvent.setup();
+            render(<WithUserStatus />);
+
+            await user.hover(screen.getByText("🌭"));
+            await waitFor(() => {
+                expect(screen.getByRole("tooltip")).toHaveTextContent("Hot");
+            });
+        });
+
+        it("shows the full message preview in a tooltip on hover", async () => {
+            const user = userEvent.setup();
+            const preview = "Loooooooooooooooooooooooooooooooooooooong preview";
+            render(<LongContent />);
+
+            await user.hover(screen.getByText(preview));
+            await waitFor(() => {
+                expect(screen.getByRole("tooltip")).toHaveTextContent(preview);
+            });
+        });
+
+        it("shows the full room name in a tooltip on hover", async () => {
+            const user = userEvent.setup();
+            const name = "Loooooooooooooooooooooooooooooooooooooong name";
+            render(<LongContent />);
+
+            await user.hover(screen.getByTestId("room-name"));
+            await waitFor(() => {
+                expect(screen.getByRole("tooltip")).toHaveTextContent(name);
+            });
+        });
     });
 });

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListItemWrapper/RoomListItemView/__snapshots__/RoomListItemView.test.tsx.snap
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/RoomListItemWrapper/RoomListItemView/__snapshots__/RoomListItemView.test.tsx.snap
@@ -38,14 +38,15 @@ exports[`<RoomListItemView /> > renders Bold story 1`] = `
           >
             <div
               class="RoomListItemView-module_roomName"
-              data-testid="room-name"
-              title="Team Updates"
             >
-              Team Updates
+              <span
+                data-testid="room-name"
+              >
+                Team Updates
+              </span>
             </div>
             <div
               class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-              title="Alice: Hey everyone!"
             >
               Alice: Hey everyone!
             </div>
@@ -168,14 +169,15 @@ exports[`<RoomListItemView /> > renders Default story 1`] = `
           >
             <div
               class="RoomListItemView-module_roomName"
-              data-testid="room-name"
-              title="General"
             >
-              General
+              <span
+                data-testid="room-name"
+              >
+                General
+              </span>
             </div>
             <div
               class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-              title="Alice: Hey everyone!"
             >
               Alice: Hey everyone!
             </div>
@@ -298,14 +300,15 @@ exports[`<RoomListItemView /> > renders Invitation story 1`] = `
           >
             <div
               class="RoomListItemView-module_roomName"
-              data-testid="room-name"
-              title="Secret Project"
             >
-              Secret Project
+              <span
+                data-testid="room-name"
+              >
+                Secret Project
+              </span>
             </div>
             <div
               class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-              title="Bob invited you"
             >
               Bob invited you
             </div>
@@ -446,10 +449,12 @@ exports[`<RoomListItemView /> > renders NoMessagePreview story 1`] = `
           >
             <div
               class="RoomListItemView-module_roomName"
-              data-testid="room-name"
-              title="General"
             >
-              General
+              <span
+                data-testid="room-name"
+              >
+                General
+              </span>
             </div>
           </div>
           <div
@@ -570,14 +575,15 @@ exports[`<RoomListItemView /> > renders Selected story 1`] = `
           >
             <div
               class="RoomListItemView-module_roomName"
-              data-testid="room-name"
-              title="General"
             >
-              General
+              <span
+                data-testid="room-name"
+              >
+                General
+              </span>
             </div>
             <div
               class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-              title="Alice: Hey everyone!"
             >
               Alice: Hey everyone!
             </div>
@@ -700,14 +706,15 @@ exports[`<RoomListItemView /> > renders UnsentMessage story 1`] = `
           >
             <div
               class="RoomListItemView-module_roomName"
-              data-testid="room-name"
-              title="General"
             >
-              General
+              <span
+                data-testid="room-name"
+              >
+                General
+              </span>
             </div>
             <div
               class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-              title="Failed to send message"
             >
               Failed to send message
             </div>
@@ -848,14 +855,15 @@ exports[`<RoomListItemView /> > renders WithHoverMenu story 1`] = `
           >
             <div
               class="RoomListItemView-module_roomName"
-              data-testid="room-name"
-              title="General"
             >
-              General
+              <span
+                data-testid="room-name"
+              >
+                General
+              </span>
             </div>
             <div
               class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-              title="Alice: Hey everyone!"
             >
               Alice: Hey everyone!
             </div>
@@ -978,14 +986,15 @@ exports[`<RoomListItemView /> > renders WithMention story 1`] = `
           >
             <div
               class="RoomListItemView-module_roomName"
-              data-testid="room-name"
-              title="General"
             >
-              General
+              <span
+                data-testid="room-name"
+              >
+                General
+              </span>
             </div>
             <div
               class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-              title="Alice: Hey everyone!"
             >
               Alice: Hey everyone!
             </div>
@@ -1131,14 +1140,15 @@ exports[`<RoomListItemView /> > renders WithNotification story 1`] = `
           >
             <div
               class="RoomListItemView-module_roomName"
-              data-testid="room-name"
-              title="General"
             >
-              General
+              <span
+                data-testid="room-name"
+              >
+                General
+              </span>
             </div>
             <div
               class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-              title="Alice: Hey everyone!"
             >
               Alice: Hey everyone!
             </div>
@@ -1273,14 +1283,15 @@ exports[`<RoomListItemView /> > renders WithVideoCall story 1`] = `
           >
             <div
               class="RoomListItemView-module_roomName"
-              data-testid="room-name"
-              title="General"
             >
-              General
+              <span
+                data-testid="room-name"
+              >
+                General
+              </span>
             </div>
             <div
               class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-              title="Alice: Hey everyone!"
             >
               Alice: Hey everyone!
             </div>
@@ -1421,14 +1432,15 @@ exports[`<RoomListItemView /> > renders WithVoiceCall story 1`] = `
           >
             <div
               class="RoomListItemView-module_roomName"
-              data-testid="room-name"
-              title="General"
             >
-              General
+              <span
+                data-testid="room-name"
+              >
+                General
+              </span>
             </div>
             <div
               class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-              title="Alice: Hey everyone!"
             >
               Alice: Hey everyone!
             </div>

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/__snapshots__/VirtualizedRoomListView.test.tsx.snap
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/__snapshots__/VirtualizedRoomListView.test.tsx.snap
@@ -64,14 +64,15 @@ exports[`<VirtualizedRoomListView /> > renders Default story 1`] = `
                     >
                       <div
                         class="RoomListItemView-module_roomName"
-                        data-testid="room-name"
-                        title="General"
                       >
-                        General
+                        <span
+                          data-testid="room-name"
+                        >
+                          General
+                        </span>
                       </div>
                       <div
                         class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                        title="Last message in General"
                       >
                         Last message in General
                       </div>
@@ -213,10 +214,12 @@ exports[`<VirtualizedRoomListView /> > renders Default story 1`] = `
                     >
                       <div
                         class="RoomListItemView-module_roomName"
-                        data-testid="room-name"
-                        title="Random"
                       >
-                        Random
+                        <span
+                          data-testid="room-name"
+                        >
+                          Random
+                        </span>
                       </div>
                     </div>
                     <div
@@ -335,14 +338,15 @@ exports[`<VirtualizedRoomListView /> > renders Default story 1`] = `
                     >
                       <div
                         class="RoomListItemView-module_roomName"
-                        data-testid="room-name"
-                        title="Engineering"
                       >
-                        Engineering
+                        <span
+                          data-testid="room-name"
+                        >
+                          Engineering
+                        </span>
                       </div>
                       <div
                         class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                        title="Last message in Engineering"
                       >
                         Last message in Engineering
                       </div>
@@ -463,10 +467,12 @@ exports[`<VirtualizedRoomListView /> > renders Default story 1`] = `
                     >
                       <div
                         class="RoomListItemView-module_roomName"
-                        data-testid="room-name"
-                        title="Design"
                       >
-                        Design
+                        <span
+                          data-testid="room-name"
+                        >
+                          Design
+                        </span>
                       </div>
                     </div>
                     <div
@@ -585,14 +591,15 @@ exports[`<VirtualizedRoomListView /> > renders Default story 1`] = `
                     >
                       <div
                         class="RoomListItemView-module_roomName"
-                        data-testid="room-name"
-                        title="Product"
                       >
-                        Product
+                        <span
+                          data-testid="room-name"
+                        >
+                          Product
+                        </span>
                       </div>
                       <div
                         class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                        title="Last message in Product"
                       >
                         Last message in Product
                       </div>
@@ -713,10 +720,12 @@ exports[`<VirtualizedRoomListView /> > renders Default story 1`] = `
                     >
                       <div
                         class="RoomListItemView-module_roomName"
-                        data-testid="room-name"
-                        title="Marketing"
                       >
-                        Marketing
+                        <span
+                          data-testid="room-name"
+                        >
+                          Marketing
+                        </span>
                       </div>
                     </div>
                     <div
@@ -858,14 +867,15 @@ exports[`<VirtualizedRoomListView /> > renders Default story 1`] = `
                     >
                       <div
                         class="RoomListItemView-module_roomName"
-                        data-testid="room-name"
-                        title="Sales"
                       >
-                        Sales
+                        <span
+                          data-testid="room-name"
+                        >
+                          Sales
+                        </span>
                       </div>
                       <div
                         class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                        title="Last message in Sales"
                       >
                         Last message in Sales
                       </div>
@@ -986,10 +996,12 @@ exports[`<VirtualizedRoomListView /> > renders Default story 1`] = `
                     >
                       <div
                         class="RoomListItemView-module_roomName"
-                        data-testid="room-name"
-                        title="Support"
                       >
-                        Support
+                        <span
+                          data-testid="room-name"
+                        >
+                          Support
+                        </span>
                       </div>
                     </div>
                     <div
@@ -1108,14 +1120,15 @@ exports[`<VirtualizedRoomListView /> > renders Default story 1`] = `
                     >
                       <div
                         class="RoomListItemView-module_roomName"
-                        data-testid="room-name"
-                        title="Announcements"
                       >
-                        Announcements
+                        <span
+                          data-testid="room-name"
+                        >
+                          Announcements
+                        </span>
                       </div>
                       <div
                         class="_typography_6v6n8_153 _font-body-sm-regular_6v6n8_31 RoomListItemView-module_ellipsis"
-                        title="Last message in Announcements"
                       >
                         Last message in Announcements
                       </div>
@@ -1236,10 +1249,12 @@ exports[`<VirtualizedRoomListView /> > renders Default story 1`] = `
                     >
                       <div
                         class="RoomListItemView-module_roomName"
-                        data-testid="room-name"
-                        title="Off-topic"
                       >
-                        Off-topic
+                        <span
+                          data-testid="room-name"
+                        >
+                          Off-topic
+                        </span>
                       </div>
                     </div>
                     <div


### PR DESCRIPTION
Fixes  https://github.com/element-hq/element-web/issues/34049

The room name and message preview are truncated with an ellipsis, and the full text is meant to be available on hover. It is currently exposed through a native `title` attribute, which on Element Desktop for macOS is at the mercy of an open Electron regression: since Electron 38 (Element Desktop has shipped >= 38 since 2025-09-16) a `title` tooltip fires on the first hover and then only intermittently.

 *   https://github.com/electron/electron/issues/49843

The fix is to render the tooltip ourselves with the Compound `Tooltip` component, as this component already does for the user status emoji, rather than asking the browser for one.

Note the diff looks large, but that is because the snapshot tests include many rooms and each one is modified. The change to the production code is small and (hopefully) easy to follow. 

I used Claude to help me with the PR. 

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
