### PR TITLE
playwright-common: export all fixture types, and prep 6.2.0

### DIFF
--- a/packages/playwright-common/package.json
+++ b/packages/playwright-common/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@element-hq/element-web-playwright-common",
     "type": "module",
-    "version": "6.1.0",
+    "version": "6.2.0",
     "license": "SEE LICENSE IN README.md",
     "repository": {
         "type": "git",

--- a/packages/playwright-common/src/fixtures/config.ts
+++ b/packages/playwright-common/src/fixtures/config.ts
@@ -1,0 +1,35 @@
+/*
+Copyright 2025-2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+// We want to avoid using `mergeTests` because it drops useful type
+// information about the fixtures. Instead, we just add our fixtures to the linear hierarchy.
+import { test as base } from "./user.js";
+
+import { type Config } from "@element-hq/element-web-module-api";
+
+import { routeConfigJson } from "../utils/config_json.js";
+
+interface TestFixtures {
+    /**
+     * The contents of the config.json to send when the client requests it.
+     */
+    config: Partial<Config>;
+
+    labsFlags: string[];
+    disablePresence: boolean;
+}
+
+export const test = base.extend<TestFixtures>({
+    // We merge this atop the default CONFIG_JSON in the page fixture to make extending it easier
+    config: async ({}, use) => use({}),
+    labsFlags: async ({}, use) => use([]),
+    disablePresence: async ({}, use) => use(false),
+    page: async ({ homeserver, context, page, config, labsFlags, disablePresence }, use) => {
+        await routeConfigJson(context, homeserver.baseUrl, config, labsFlags, disablePresence);
+        await use(page);
+    },
+});

--- a/packages/playwright-common/src/fixtures/index.ts
+++ b/packages/playwright-common/src/fixtures/index.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 New Vector Ltd.
+Copyright 2025-2026 Element Creations Ltd.
 
 SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.
@@ -8,5 +8,5 @@ Please see LICENSE files in the repository root for full details.
 export { type Services, type WorkerOptions } from "./services.js";
 
 // We avoid using `mergeTests` because it drops useful type information about the fixtures.
-// `user` is the top of our stack of extensions (it extends services, axe, etc), so it includes everything.
-export { test } from "./user.js";
+// `config` is the top of our stack of extensions (it extends services, axe, etc), so it includes everything.
+export { test } from "./config.js";

--- a/packages/playwright-common/src/fixtures/index.ts
+++ b/packages/playwright-common/src/fixtures/index.ts
@@ -5,8 +5,35 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.
 */
 
-export { type Services, type WorkerOptions } from "./services.js";
-
 // We avoid using `mergeTests` because it drops useful type information about the fixtures.
 // `config` is the top of our stack of extensions (it extends services, axe, etc), so it includes everything.
-export { test } from "./config.js";
+import { test } from "./config.js";
+import type { TestType } from "@playwright/test";
+
+// `Services` and `WorkerOptions` are exported to avoid breaking existing code.
+// Prefer to use `WorkerArgs` in new code.
+export { type Services, type WorkerOptions } from "./services.js";
+
+export { test };
+
+type FixtureTypes =
+    typeof test extends TestType<infer TestArgs, infer WorkerArgs>
+        ? [testArgs: TestArgs, workerArgs: WorkerArgs]
+        : never;
+
+/**
+ * The test-scoped fixtures and options available to tests declared with {@link test}, including
+ * Playwright's own (`page`, `context`, `request`, `browserName`, ...).
+ */
+export type TestFixtures = FixtureTypes[0];
+
+/**
+ * The worker-scoped fixtures and options available to tests declared with {@link test}, including
+ * Playwright's own as well as our `Services` and `WorkerOptions`.
+ */
+export type WorkerArgs = FixtureTypes[1];
+
+/**
+ * Every fixture available as the first argument of the callback passed to {@link test}.
+ */
+export type CombinedTestFixtures = TestFixtures & WorkerArgs;

--- a/packages/playwright-common/src/index.ts
+++ b/packages/playwright-common/src/index.ts
@@ -8,13 +8,11 @@ Please see LICENSE files in the repository root for full details.
 
 import { type Config } from "@element-hq/element-web-module-api";
 
-import { test as base } from "./fixtures/index.js";
-import { routeConfigJson } from "./utils/config_json.js";
-
 export * from "./utils/config_json.js";
 export * from "./utils/context.js";
 export * from "./utils/release_accouncement.js";
 export * from "./utils/toasts.js";
+export { test } from "./fixtures/index.js";
 
 export { populateLocalStorageWithCredentials } from "./fixtures/user.js";
 
@@ -43,26 +41,5 @@ export const CONFIG_JSON: Partial<Config> = {
         feature_release_announcement: false,
     },
 };
-
-export interface TestFixtures {
-    /**
-     * The contents of the config.json to send when the client requests it.
-     */
-    config: Partial<typeof CONFIG_JSON>;
-
-    labsFlags: string[];
-    disablePresence: boolean;
-}
-
-export const test = base.extend<TestFixtures>({
-    // We merge this atop the default CONFIG_JSON in the page fixture to make extending it easier
-    config: async ({}, use) => use({}),
-    labsFlags: async ({}, use) => use([]),
-    disablePresence: async ({}, use) => use(false),
-    page: async ({ homeserver, context, page, config, labsFlags, disablePresence }, use) => {
-        await routeConfigJson(context, homeserver.baseUrl, config, labsFlags, disablePresence);
-        await use(page);
-    },
-});
 
 export { expect, type ToMatchScreenshotOptions } from "./expect/index.js";

--- a/packages/playwright-common/src/index.ts
+++ b/packages/playwright-common/src/index.ts
@@ -12,7 +12,7 @@ export * from "./utils/config_json.js";
 export * from "./utils/context.js";
 export * from "./utils/release_accouncement.js";
 export * from "./utils/toasts.js";
-export { test } from "./fixtures/index.js";
+export { test, type CombinedTestFixtures, type TestFixtures, type WorkerArgs } from "./fixtures/index.js";
 
 export { populateLocalStorageWithCredentials } from "./fixtures/user.js";
 


### PR DESCRIPTION
The playwight-common project already exposes a `TestFixtures` type, but it only includes a subset of the actually-defined test fixtures.

This PR derives the type from the exported `test` definition, to ensure that it actually includes all the available fixtures.

Also bumps the package version ready for a release, to save a separate PR.

There are three commits; it will probably be easier to review them individually.