### PR TITLE
fix: Element prompts for  device verification BUT it doesn't work and it neve...

### DIFF
--- a/apps/web/src/components/views/settings/encryption/ResetIdentityBody.tsx
+++ b/apps/web/src/components/views/settings/encryption/ResetIdentityBody.tsx
@@ -5,11 +5,12 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-import { Button, InlineSpinner, VisualList, VisualListItem } from "@vector-im/compound-web";
+import { Button, ErrorMessage, InlineSpinner, VisualList, VisualListItem } from "@vector-im/compound-web";
 import CheckIcon from "@vector-im/compound-design-tokens/assets/web/icons/check";
 import InfoIcon from "@vector-im/compound-design-tokens/assets/web/icons/info";
 import ErrorIcon from "@vector-im/compound-design-tokens/assets/web/icons/error-solid";
-import React, { type JSX, useState } from "react";
+import React, { type JSX, useCallback, useState } from "react";
+import { logger } from "matrix-js-sdk/src/logger";
 
 import { _t } from "../../../../languageHandler";
 import { EncryptionCard } from "./EncryptionCard";
@@ -66,6 +67,24 @@ export function ResetIdentityBody({ onCancelClick, onReset, variant }: ResetIden
     // After the user clicks "Continue", we disable the button so it can't be
     // clicked again, and warn the user not to close the window.
     const [inProgress, setInProgress] = useState(false);
+    const [failed, setFailed] = useState(false);
+
+    const onContinueClick = useCallback(async (): Promise<void> => {
+        setFailed(false);
+        setInProgress(true);
+        try {
+            await matrixClient
+                .getCrypto()
+                ?.resetEncryption((makeRequest) => uiAuthCallback(matrixClient, makeRequest));
+        } catch (error) {
+            logger.error("ResetIdentityBody: failed to reset the cryptographic identity", error);
+            setFailed(true);
+            return;
+        } finally {
+            setInProgress(false);
+        }
+        onReset();
+    }, [matrixClient, onReset]);
 
     return (
         <EncryptionCard Icon={ErrorIcon} destructive={true} title={titleForVariant(variant)}>
@@ -82,19 +101,10 @@ export function ResetIdentityBody({ onCancelClick, onReset, variant }: ResetIden
                     </VisualListItem>
                 </VisualList>
                 {variant === "compromised" && <span>{_t("settings|encryption|advanced|breadcrumb_warning")}</span>}
+                {failed && <ErrorMessage>{_t("settings|encryption|advanced|reset_failed")}</ErrorMessage>}
             </EncryptionCardEmphasisedContent>
             <EncryptionCardButtons>
-                <Button
-                    destructive={true}
-                    disabled={inProgress}
-                    onClick={async () => {
-                        setInProgress(true);
-                        await matrixClient
-                            .getCrypto()
-                            ?.resetEncryption((makeRequest) => uiAuthCallback(matrixClient, makeRequest));
-                        onReset();
-                    }}
-                >
+                <Button destructive={true} disabled={inProgress} onClick={onContinueClick}>
                     {inProgress ? (
                         <>
                             <InlineSpinner /> {_t("settings|encryption|advanced|reset_in_progress")}

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -2502,6 +2502,7 @@
                 "other_people_device_description": "Warning: users who have not explicitly verified with you (e.g. using emoji) will not receive your encrypted messages. Also, unverified devices of verified users will not receive your encrypted messages. Changes require an application restart to take effect.",
                 "other_people_device_label": "In encrypted rooms, only send messages to verified users",
                 "other_people_device_title": "Other people’s devices",
+                "reset_failed": "Something went wrong and your cryptographic identity could not be reset. Please try again.",
                 "reset_identity": "Reset cryptographic identity",
                 "reset_in_progress": "Reset in progress...",
                 "session_id": "Session ID:",

--- a/apps/web/test/unit-tests/components/views/settings/encryption/ResetIdentityPanel-test.tsx
+++ b/apps/web/test/unit-tests/components/views/settings/encryption/ResetIdentityPanel-test.tsx
@@ -46,6 +46,31 @@ describe("<ResetIdentityPanel />", () => {
         expect(onReset).toHaveBeenCalled();
     });
 
+    it("should re-enable the continue button and show an error if the reset fails", async () => {
+        const user = userEvent.setup();
+
+        const onReset = jest.fn();
+        render(
+            <ResetIdentityPanel variant="compromised" onReset={onReset} onCancelClick={jest.fn()} />,
+            withClientContextRenderOptions(matrixClient),
+        );
+
+        const { promise: resetEncryptionPromise, reject: rejectResetEncryption } = Promise.withResolvers<void>();
+        jest.spyOn(matrixClient.getCrypto()!, "resetEncryption").mockReturnValue(resetEncryptionPromise);
+
+        await user.click(screen.getByRole("button", { name: "Continue" }));
+        rejectResetEncryption!(new Error("Cross-signing key upload auth canceled"));
+
+        expect(
+            await screen.findByText(
+                "Something went wrong and your cryptographic identity could not be reset. Please try again.",
+            ),
+        ).toBeInTheDocument();
+        expect(onReset).not.toHaveBeenCalled();
+        expect(screen.getByRole("button", { name: "Continue" })).not.toBeDisabled();
+        expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    });
+
     it("should display the 'forgot recovery key' variant correctly", async () => {
         const onReset = jest.fn();
         const { asFragment } = render(


### PR DESCRIPTION
Fixes #34696

## Root cause

Unhandled rejection in ResetIdentityBody leaves reset stuck forever

## Changes

- Wrap the resetEncryption call in ResetIdentityBody in try/catch/finally: log the failure, clear the in-progress state so Continue and Cancel become usable again, and surface an error message instead of only calling onReset on success. Added a Jest regression test asserting the failure path re-enables the buttons and shows the error. The separate complaint that "Use recovery key" is not offered is correct behaviour when m.cross_signing.master is not present in server-side secret storage (SetupEncryptionStore.fetchKeyInfo), so no change was made there.