### PR TITLE
feat: modernize Ashram composer picker

### DIFF
--- a/apps/web/playwright/e2e/composer/CIDER.spec.ts
+++ b/apps/web/playwright/e2e/composer/CIDER.spec.ts
@@ -95,9 +95,12 @@ test.describe("Composer", () => {
             test.use({ viewport: { width: 1280, height: 720 } });
             test("render emoji picker", { tag: "@screenshot" }, async ({ page, app }) => {
                 await app.getComposer(false).getByRole("button", { name: "Emoji" }).click();
+                const emojiPicker = page.getByLabel("Emoji picker");
+                await expect(emojiPicker).toHaveCSS("width", "700px");
+                await expect(emojiPicker).toHaveCSS("height", "520px");
                 // Mask the background of the screenshot to avoid failing the test just because some
                 // other component have changed its rendering.
-                await expect(page.getByLabel("Emoji picker")).toMatchScreenshot("emoji-picker.png", {
+                await expect(emojiPicker).toMatchScreenshot("emoji-picker.png", {
                     css: `
                         .mx_ContextualMenu_background {
                             background-color: magenta !important;
@@ -111,9 +114,16 @@ test.describe("Composer", () => {
             test.use({ viewport: { width: 1280, height: 360 } });
             test("render emoji picker", { tag: "@screenshot" }, async ({ page, app }) => {
                 await app.getComposer(false).getByRole("button", { name: "Emoji" }).click();
+                const emojiPicker = page.getByLabel("Emoji picker");
+                const bounds = await emojiPicker.boundingBox();
+                expect(bounds).not.toBeNull();
+                if (!bounds) throw new Error("Emoji picker has no layout bounds");
+                expect(bounds.height).toBeLessThanOrEqual(360 * 0.8);
+                expect(bounds.y).toBeGreaterThanOrEqual(0);
+                expect(bounds.y + bounds.height).toBeLessThanOrEqual(360);
                 // Mask the background of the screenshot to avoid failing the test just because some
                 // other component have changed its rendering.
-                await expect(page.getByLabel("Emoji picker")).toMatchScreenshot("emoji-picker-small.png", {
+                await expect(emojiPicker).toMatchScreenshot("emoji-picker-small.png", {
                     css: `
                         .mx_ContextualMenu_background {
                             background-color: magenta !important;

--- a/apps/web/res/css/_components.pcss
+++ b/apps/web/res/css/_components.pcss
@@ -2,6 +2,7 @@
 @import "./_animations.pcss";
 @import "./_common.pcss";
 @import "./_font-sizes.pcss";
+@import "./components/_EmojiPickerWithRecents.pcss";
 @import "./components/views/beacon/_BeaconListItem.pcss";
 @import "./components/views/beacon/_BeaconStatus.pcss";
 @import "./components/views/beacon/_BeaconStatusTooltip.pcss";

--- a/apps/web/res/css/components/_EmojiPickerWithRecents.pcss
+++ b/apps/web/res/css/components/_EmojiPickerWithRecents.pcss
@@ -1,0 +1,22 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+.mx_EmojiPickerWithRecents {
+    --emoji-picker-width: 700px;
+    --emoji-picker-height: 520px;
+    --emoji-picker-category-rail-width: 44px;
+    --emoji-picker-content-width: 624px;
+    --emoji-picker-row-width: 616px;
+    --emoji-picker-cell-width: 56px;
+    --emoji-picker-cell-height: 52px;
+    --emoji-picker-glyph-size: 44px;
+    --emoji-picker-cell-padding: 1px;
+    --emoji-picker-footer-height: 60px;
+    --emoji-picker-preview-glyph-size: 34px;
+    --emoji-picker-preview-emoji-padding: 6px 12px;
+    --emoji-picker-preview-text-padding-block: 0.35rem;
+}

--- a/apps/web/res/css/views/rooms/_Stickers.pcss
+++ b/apps/web/res/css/views/rooms/_Stickers.pcss
@@ -1,19 +1,64 @@
+.mx_AshramPickerFrame {
+    width: 700px;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.mx_AshramPickerTabs {
+    flex: 0 0 40px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px;
+    box-sizing: border-box;
+    border-bottom: 1px solid $message-action-bar-border-color;
+    background-color: $background;
+}
+
+.mx_AshramPickerTab {
+    border: none;
+    border-radius: 4px;
+    background-color: transparent;
+    color: $primary-content;
+    cursor: pointer;
+    padding: 7px 14px;
+    font: var(--cpd-font-body-md-semibold);
+}
+
+.mx_AshramPickerTab:hover,
+.mx_AshramPickerTab_active {
+    background-color: $focus-bg-color;
+    color: $accent;
+}
+
 .mx_Stickers_content {
     overflow: hidden;
 }
 
-.mx_Stickers_content_container {
-    overflow: hidden;
-    height: 300px;
+.mx_Stickers_content > div {
+    width: 100%;
+    height: 100%;
 }
 
-#mx_persistedElement_stickerPicker {
+.mx_Stickers_content_container {
+    overflow: hidden;
+    height: 520px;
+}
+
+[id^="mx_persistedElement_stickerPicker"] {
     .mx_AppTileFullWidth {
-        height: unset;
+        width: 700px;
+        height: 520px;
         box-sizing: border-box;
         border-left: none;
         border-right: none;
         border-bottom: none;
+    }
+
+    .mx_AppTileBody--large {
+        width: 700px;
+        height: 503px;
     }
 
     .mx_AppTileMenuBar {
@@ -21,8 +66,9 @@
     }
 
     iframe {
-        /* Sticker picker depends on the fixed height previously used for all tiles */
-        height: 283px; /* height of the popout minus the AppTile menu bar */
+        /* Ashram: match the larger sticker picker popover height minus AppTile menu bar */
+        width: 700px;
+        height: 503px;
     }
 }
 

--- a/apps/web/src/components/structures/MessagePanel.tsx
+++ b/apps/web/src/components/structures/MessagePanel.tsx
@@ -25,7 +25,7 @@ import {
     useCreateAutoDisposedViewModel,
 } from "@element-hq/web-shared-components";
 
-import shouldHideEvent from "../../shouldHideEvent";
+import shouldHideEvent, { isHreArchivedCommandRedaction } from "../../shouldHideEvent";
 import { formatDate, wantsDateSeparator } from "../../DateUtils";
 import { MatrixClientPeg } from "../../MatrixClientPeg";
 import SettingsStore from "../../settings/SettingsStore";
@@ -631,9 +631,11 @@ export default class MessagePanel extends React.Component<IProps, IState> {
         // we also need to figure out which is the last event we show which isn't
         // a local echo, to manage the read-marker.
         let lastShownEvent: MatrixEvent | undefined;
-        const events: WrappedEvent[] = this.props.events.map((event) => {
-            return { event, shouldShow: this.shouldShowEvent(event) };
-        });
+        const events: WrappedEvent[] = this.props.events
+            .filter((event) => !isHreArchivedCommandRedaction(event))
+            .map((event) => {
+                return { event, shouldShow: this.shouldShowEvent(event) };
+            });
 
         const userId = MatrixClientPeg.safeGet().getSafeUserId();
 

--- a/apps/web/src/components/views/rooms/EmojiButton.tsx
+++ b/apps/web/src/components/views/rooms/EmojiButton.tsx
@@ -14,14 +14,21 @@ import { _t } from "../../../languageHandler";
 import ContextMenu, { aboveLeftOf, type MenuProps, useContextMenu } from "../../structures/ContextMenu";
 import { CollapsibleButton, OverflowMenuContext } from "./CollapsibleButton";
 import { EmojiPickerWithRecents } from "../../../emojipicker/EmojiPickerWithRecents";
+import { type StickerPickerMode } from "./Stickerpicker";
 
 interface IEmojiButtonProps {
     addEmoji: (unicode: string) => boolean;
     menuPosition?: MenuProps;
     className?: string;
+    openStickerPickerMode: (mode: StickerPickerMode) => void;
 }
 
-export function EmojiButton({ addEmoji, menuPosition, className }: IEmojiButtonProps): JSX.Element {
+export function EmojiButton({
+    addEmoji,
+    menuPosition,
+    className,
+    openStickerPickerMode,
+}: IEmojiButtonProps): JSX.Element {
     const overflowMenuCloser = useContext(OverflowMenuContext);
     const [menuDisplayed, button, openMenu, closeMenu] = useContextMenu();
 
@@ -33,9 +40,44 @@ export function EmojiButton({ addEmoji, menuPosition, className }: IEmojiButtonP
             overflowMenuCloser?.();
         };
 
+        const switchToStickerPicker = (mode: StickerPickerMode): void => {
+            onFinished();
+            window.setTimeout(() => openStickerPickerMode(mode), 0);
+        };
+
         contextMenu = (
             <ContextMenu {...position} onFinished={onFinished} managed={false} focusLock>
-                <EmojiPickerWithRecents onChoose={addEmoji} onFinished={onFinished} />
+                <div className="mx_AshramPickerFrame">
+                    <div className="mx_AshramPickerTabs" role="tablist" aria-label="Composer picker">
+                        <button
+                            type="button"
+                            className="mx_AshramPickerTab mx_AshramPickerTab_active"
+                            role="tab"
+                            aria-selected="true"
+                        >
+                            Emoji
+                        </button>
+                        <button
+                            type="button"
+                            className="mx_AshramPickerTab"
+                            role="tab"
+                            aria-selected="false"
+                            onClick={() => switchToStickerPicker("stickers")}
+                        >
+                            Stickers
+                        </button>
+                        <button
+                            type="button"
+                            className="mx_AshramPickerTab"
+                            role="tab"
+                            aria-selected="false"
+                            onClick={() => switchToStickerPicker("gifs")}
+                        >
+                            GIFs
+                        </button>
+                    </div>
+                    <EmojiPickerWithRecents onChoose={addEmoji} onFinished={onFinished} />
+                </div>
             </ContextMenu>
         );
     }
@@ -49,6 +91,7 @@ export function EmojiButton({ addEmoji, menuPosition, className }: IEmojiButtonP
     return (
         <>
             <CollapsibleButton
+                id="emojiButton"
                 className={computedClassName}
                 onClick={openMenu}
                 title={_t("common|emoji")}

--- a/apps/web/src/components/views/rooms/MessageComposer.tsx
+++ b/apps/web/src/components/views/rooms/MessageComposer.tsx
@@ -25,7 +25,7 @@ import { _t } from "../../../languageHandler";
 import { MatrixClientPeg } from "../../../MatrixClientPeg";
 import dis from "../../../dispatcher/dispatcher";
 import { type ActionPayload } from "../../../dispatcher/payloads";
-import Stickerpicker from "./Stickerpicker";
+import Stickerpicker, { type StickerPickerMode } from "./Stickerpicker";
 import { makeRoomPermalink, type RoomPermalinkCreator } from "../../../utils/permalinks/Permalinks";
 import E2EIcon from "./E2EIcon";
 import SettingsStore from "../../../settings/SettingsStore";
@@ -107,6 +107,7 @@ interface IState {
     me?: RoomMember;
     isMenuOpen: boolean;
     isStickerPickerOpen: boolean;
+    stickerPickerMode: StickerPickerMode;
     showStickersButton: boolean;
     showPollsButton: boolean;
     isWysiwygLabEnabled: boolean;
@@ -157,6 +158,7 @@ export class MessageComposer extends React.Component<IProps, IState> {
             recordingTimeLeftSeconds: undefined, // when set to a number, shows a toast
             isMenuOpen: false,
             isStickerPickerOpen: false,
+            stickerPickerMode: "stickers",
             showStickersButton: SettingsStore.getValue("MessageComposerInput.showStickersButton"),
             showPollsButton: SettingsStore.getValue("MessageComposerInput.showPollsButton"),
             isWysiwygLabEnabled: isWysiwygLabEnabled,
@@ -510,6 +512,26 @@ export class MessageComposer extends React.Component<IProps, IState> {
         this.setStickerPickerOpen(!this.state.isStickerPickerOpen);
     };
 
+    private openStickerPickerMode = (stickerPickerMode: StickerPickerMode): void => {
+        this.setState({
+            stickerPickerMode,
+            isStickerPickerOpen: true,
+            isMenuOpen: false,
+        });
+    };
+
+    private openEmojiPickerFromStickerPicker = (): void => {
+        this.setState(
+            {
+                isStickerPickerOpen: false,
+                isMenuOpen: false,
+            },
+            () => {
+                window.setTimeout(() => document.getElementById("emojiButton")?.click(), 0);
+            },
+        );
+    };
+
     private toggleButtonMenu = (): void => {
         this.setState({
             isMenuOpen: !this.state.isMenuOpen,
@@ -680,6 +702,9 @@ export class MessageComposer extends React.Component<IProps, IState> {
                 threadId={threadId}
                 isStickerPickerOpen={this.state.isStickerPickerOpen}
                 setStickerPickerOpen={this.setStickerPickerOpen}
+                stickerPickerMode={this.state.stickerPickerMode}
+                setStickerPickerMode={this.openStickerPickerMode}
+                openEmojiPicker={this.openEmojiPickerFromStickerPicker}
                 menuPosition={menuPosition}
                 key="stickers"
             />,
@@ -718,6 +743,7 @@ export class MessageComposer extends React.Component<IProps, IState> {
                                     relation={this.props.relation}
                                     onRecordStartEndClick={this.onRecordStartEndClick}
                                     setStickerPickerOpen={this.setStickerPickerOpen}
+                                    openStickerPickerMode={this.openStickerPickerMode}
                                     showLocationButton={
                                         !window.electron && SettingsStore.getValue(UIFeature.LocationSharing)
                                     }

--- a/apps/web/src/components/views/rooms/MessageComposerButtons.tsx
+++ b/apps/web/src/components/views/rooms/MessageComposerButtons.tsx
@@ -39,6 +39,7 @@ import IconizedContextMenu, {
     IconizedContextMenuOptionList,
 } from "../context_menus/IconizedContextMenu";
 import { EmojiButton } from "./EmojiButton";
+import { type StickerPickerMode } from "./Stickerpicker";
 import { filterBoolean } from "../../../utils/arrays";
 import { useSettingValue } from "../../../hooks/useSettings";
 import AccessibleButton, { type ButtonEvent } from "../elements/AccessibleButton";
@@ -54,6 +55,7 @@ interface IProps {
     onRecordStartEndClick: () => void;
     relation?: IEventRelation;
     setStickerPickerOpen: (isStickerPickerOpen: boolean) => void;
+    openStickerPickerMode: (mode: StickerPickerMode) => void;
     showLocationButton: boolean;
     showPollsButton: boolean;
     showStickersButton: boolean;
@@ -87,6 +89,7 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
             ) : (
                 emojiButton(props)
             ),
+            showStickersButton(props),
         ];
         moreButtons = [
             // This a textual list of buttons, so we can't use the UploadButton here.
@@ -98,7 +101,6 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
                     key={type}
                 />
             )),
-            showStickersButton(props),
             voiceRecordingButton(props, narrow),
             props.showPollsButton ? pollButton(room, props.relation) : null,
             showLocationButton(props, room, matrixClient),
@@ -114,10 +116,10 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
             ) : (
                 emojiButton(props)
             ),
+            showStickersButton(props),
             <UploadButton key="upload" vm={roomUploadVM} />,
         ];
         moreButtons = [
-            showStickersButton(props),
             voiceRecordingButton(props, narrow),
             props.showPollsButton ? pollButton(room, props.relation) : null,
             showLocationButton(props, room, matrixClient),
@@ -168,6 +170,7 @@ function emojiButton(props: IProps): ReactElement {
             addEmoji={props.addEmoji}
             menuPosition={props.menuPosition}
             className="mx_MessageComposer_button"
+            openStickerPickerMode={props.openStickerPickerMode}
         />
     );
 }

--- a/apps/web/src/components/views/rooms/Stickerpicker.tsx
+++ b/apps/web/src/components/views/rooms/Stickerpicker.tsx
@@ -11,6 +11,7 @@ import { logger } from "matrix-js-sdk/src/logger";
 import { type IWidget } from "matrix-widget-api";
 
 import { _t, _td } from "../../../languageHandler";
+import ThemeWatcher from "../../../settings/watchers/ThemeWatcher";
 import AppTile from "../elements/AppTile";
 import dis from "../../../dispatcher/dispatcher";
 import AccessibleButton from "../elements/AccessibleButton";
@@ -34,12 +35,17 @@ const STICKERPICKER_Z_INDEX = 3500;
 // Key to store the widget's AppTile under in PersistedElement
 const PERSISTED_ELEMENT_KEY = "stickerPicker";
 
+export type StickerPickerMode = "stickers" | "gifs";
+
 interface IProps {
     room: Room;
     threadId?: string | null;
     isStickerPickerOpen: boolean;
+    stickerPickerMode: StickerPickerMode;
     menuPosition?: any;
     setStickerPickerOpen: (isStickerPickerOpen: boolean) => void;
+    setStickerPickerMode: (mode: StickerPickerMode) => void;
+    openEmojiPicker: () => void;
 }
 
 interface IState {
@@ -62,8 +68,9 @@ export default class Stickerpicker extends React.PureComponent<IProps, IState> {
 
     private prevSentVisibility?: boolean;
 
-    private popoverWidth = 300;
-    private popoverHeight = 300;
+    private popoverWidth = 700;
+    private popoverHeight = 560;
+    private pickerContentHeight = 520;
     // This is loaded by _acquireScalarClient on an as-needed basis.
     private scalarClient: ScalarAuthClient | null = null;
 
@@ -146,7 +153,13 @@ export default class Stickerpicker extends React.PureComponent<IProps, IState> {
         dis.unregister(this.dispatcherRef);
     }
 
-    public componentDidUpdate(): void {
+    public componentDidUpdate(prevProps: IProps): void {
+        if (prevProps.stickerPickerMode !== this.props.stickerPickerMode) {
+            PersistedElement.destroyElement(PERSISTED_ELEMENT_KEY);
+            this.forceUpdate();
+            return;
+        }
+
         this.sendVisibilityToWidget(this.props.isStickerPickerOpen);
     }
 
@@ -232,6 +245,54 @@ export default class Stickerpicker extends React.PureComponent<IProps, IState> {
         }
     }
 
+    private stickerPickerUrl(baseUrl: string): string {
+        const url = new URL(baseUrl, window.location.href);
+        const theme = new ThemeWatcher().getEffectiveTheme();
+        url.searchParams.set("theme", theme.includes("dark") ? "dark" : "light");
+
+        if (this.props.stickerPickerMode === "gifs") {
+            url.searchParams.set("mode", "gifs");
+        } else {
+            url.searchParams.delete("mode");
+        }
+
+        return url.toString();
+    }
+
+    private renderPickerTabs(): JSX.Element {
+        const stickerActive = this.props.stickerPickerMode === "stickers";
+        const gifActive = this.props.stickerPickerMode === "gifs";
+
+        return (
+            <div className="mx_AshramPickerTabs" role="tablist" aria-label="Composer picker">
+                <AccessibleButton
+                    className="mx_AshramPickerTab"
+                    onClick={this.props.openEmojiPicker}
+                    role="tab"
+                    aria-selected={false}
+                >
+                    Emoji
+                </AccessibleButton>
+                <AccessibleButton
+                    className={`mx_AshramPickerTab ${stickerActive ? "mx_AshramPickerTab_active" : ""}`}
+                    onClick={() => this.props.setStickerPickerMode("stickers")}
+                    role="tab"
+                    aria-selected={stickerActive}
+                >
+                    Stickers
+                </AccessibleButton>
+                <AccessibleButton
+                    className={`mx_AshramPickerTab ${gifActive ? "mx_AshramPickerTab_active" : ""}`}
+                    onClick={() => this.props.setStickerPickerMode("gifs")}
+                    role="tab"
+                    aria-selected={gifActive}
+                >
+                    GIFs
+                </AccessibleButton>
+            </div>
+        );
+    }
+
     public getStickerpickerContent(): JSX.Element {
         // Handle integration manager errors
         if (this.state.imError) {
@@ -257,7 +318,7 @@ export default class Stickerpicker extends React.PureComponent<IProps, IState> {
             // FIXME: could this use the same code as other apps?
             const stickerApp: IWidget = {
                 id: stickerpickerWidget.id,
-                url: stickerpickerWidget.content.url,
+                url: this.stickerPickerUrl(stickerpickerWidget.content.url),
                 name: stickerpickerWidget.content.name,
                 type: stickerpickerWidget.content.type,
                 data: stickerpickerWidget.content.data,
@@ -265,37 +326,42 @@ export default class Stickerpicker extends React.PureComponent<IProps, IState> {
             };
 
             stickersContent = (
-                <div className="mx_Stickers_content_container">
-                    <div
-                        id="stickersContent"
-                        className="mx_Stickers_content"
-                        style={{
-                            border: "none",
-                            height: this.popoverHeight,
-                            width: this.popoverWidth,
-                        }}
-                    >
-                        <PersistedElement persistKey={PERSISTED_ELEMENT_KEY} zIndex={STICKERPICKER_Z_INDEX}>
-                            <AppTile
-                                app={stickerApp}
-                                room={this.props.room}
-                                threadId={this.props.threadId}
-                                fullWidth={true}
-                                userId={this.context.client?.credentials.userId ?? undefined}
-                                creatorUserId={
-                                    stickerpickerWidget.sender || this.context.client?.credentials.userId || undefined
-                                }
-                                waitForIframeLoad={true}
-                                showMenubar={true}
-                                onEditClick={this.launchManageIntegrations}
-                                onDeleteClick={this.removeStickerpickerWidgets}
-                                showTitle={false}
-                                showPopout={false}
-                                handleMinimisePointerEvents={true}
-                                userWidget={true}
-                                showLayoutButtons={false}
-                            />
-                        </PersistedElement>
+                <div className="mx_AshramPickerFrame">
+                    {this.renderPickerTabs()}
+                    <div className="mx_Stickers_content_container">
+                        <div
+                            id="stickersContent"
+                            className="mx_Stickers_content"
+                            style={{
+                                border: "none",
+                                height: this.pickerContentHeight,
+                                width: this.popoverWidth,
+                            }}
+                        >
+                            <PersistedElement persistKey={PERSISTED_ELEMENT_KEY} zIndex={STICKERPICKER_Z_INDEX}>
+                                <AppTile
+                                    app={stickerApp}
+                                    room={this.props.room}
+                                    threadId={this.props.threadId}
+                                    fullWidth={true}
+                                    userId={this.context.client?.credentials.userId ?? undefined}
+                                    creatorUserId={
+                                        stickerpickerWidget.sender ||
+                                        this.context.client?.credentials.userId ||
+                                        undefined
+                                    }
+                                    waitForIframeLoad={true}
+                                    showMenubar={true}
+                                    onEditClick={this.launchManageIntegrations}
+                                    onDeleteClick={this.removeStickerpickerWidgets}
+                                    showTitle={false}
+                                    showPopout={false}
+                                    handleMinimisePointerEvents={true}
+                                    userWidget={true}
+                                    showLayoutButtons={false}
+                                />
+                            </PersistedElement>
+                        </div>
                     </div>
                 </div>
             );

--- a/apps/web/src/emojipicker/EmojiPickerWithRecents.props.test.tsx
+++ b/apps/web/src/emojipicker/EmojiPickerWithRecents.props.test.tsx
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+// @vitest-environment happy-dom
+
+import React from "react";
+import { type EmojiPickerProps } from "@element-hq/web-shared-components";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "test-utils-rtl";
+
+import { KeyBindingAction } from "../accessibility/KeyboardShortcuts";
+import { getKeyBindingsManager } from "../KeyBindingsManager";
+import { EmojiPickerWithRecents } from "./EmojiPickerWithRecents";
+import * as recent from "./recent";
+
+const emojiPickerSpy = vi.hoisted(() => vi.fn<(props: EmojiPickerProps) => void>());
+
+vi.mock("@element-hq/web-shared-components", async (importOriginal) => {
+    const actual = (await importOriginal()) as Record<string, unknown>;
+    const React = await import("react");
+
+    return {
+        ...actual,
+        EmojiPicker: (props: EmojiPickerProps): React.ReactNode => {
+            emojiPickerSpy(props);
+            return React.createElement(
+                "div",
+                { role: "row" },
+                Array.from({ length: props.emojisPerRow ?? 0 }, (_, index) =>
+                    React.createElement("div", { key: index, role: "gridcell" }),
+                ),
+            );
+        },
+    };
+});
+
+describe("EmojiPickerWithRecents host props", () => {
+    beforeEach(() => {
+        emojiPickerSpy.mockClear();
+        vi.spyOn(recent, "get").mockReturnValue([]);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("passes consumer props through while locking the Ashram host policy", () => {
+        const selectedEmojis = new Set(["🎉"]);
+        const isEmojiDisabled = vi.fn(() => false);
+        const onChoose = vi.fn(() => true);
+        const onFinished = vi.fn();
+
+        render(
+            <EmojiPickerWithRecents
+                selectedEmojis={selectedEmojis}
+                isEmojiDisabled={isEmojiDisabled}
+                onChoose={onChoose}
+                onFinished={onFinished}
+            />,
+        );
+
+        const props = emojiPickerSpy.mock.lastCall![0];
+        expect(props).toMatchObject({
+            selectedEmojis,
+            isEmojiDisabled,
+            onChoose,
+            onFinished,
+            className: "mx_EmojiPickerWithRecents",
+            emojisPerRow: 11,
+            emojiRowHeight: 52,
+            categoryOrientation: "vertical",
+            previewFallbackEmoji: "😀",
+            showQuickReactions: true,
+            onRecordRecent: recent.add,
+        });
+        expect(screen.getAllByRole("gridcell")).toHaveLength(11);
+    });
+
+    it("passes the first resolvable ordered recent emoji as the Preview fallback", () => {
+        vi.mocked(recent.get).mockReturnValue(["<unsupported>", "🎉", "😀"]);
+
+        render(<EmojiPickerWithRecents onChoose={() => true} onFinished={vi.fn()} />);
+
+        expect(emojiPickerSpy.mock.lastCall![0].previewFallbackEmoji).toBe("🎉");
+    });
+
+    it("passes the grinning face Preview fallback when every recent emoji is unsupported", () => {
+        vi.mocked(recent.get).mockReturnValue(["<unsupported>"]);
+
+        render(<EmojiPickerWithRecents onChoose={() => true} onFinished={vi.fn()} />);
+
+        expect(emojiPickerSpy.mock.lastCall![0].previewFallbackEmoji).toBe("😀");
+    });
+
+    it("resolves roving actions through the app keybinding manager", () => {
+        const getAccessibilityAction = vi
+            .spyOn(getKeyBindingsManager(), "getAccessibilityAction")
+            .mockReturnValue(KeyBindingAction.ArrowRight);
+
+        render(<EmojiPickerWithRecents onChoose={() => true} onFinished={vi.fn()} />);
+        const getAction = emojiPickerSpy.mock.lastCall![0].getAction;
+        const action = getAction!({ key: "ArrowRight" } as React.KeyboardEvent);
+
+        expect(getAccessibilityAction).toHaveBeenCalled();
+        expect(action).toBeDefined();
+    });
+});

--- a/apps/web/src/emojipicker/EmojiPickerWithRecents.test.tsx
+++ b/apps/web/src/emojipicker/EmojiPickerWithRecents.test.tsx
@@ -8,29 +8,52 @@ Please see LICENSE files in the repository root for full details.
 // @vitest-environment happy-dom
 
 import React from "react";
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "test-utils-rtl";
-import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "test-utils-rtl";
 
 import { EmojiPickerWithRecents } from "./EmojiPickerWithRecents";
-import { getKeyBindingsManager } from "../KeyBindingsManager";
+import * as recent from "./recent";
 
 describe("EmojiPickerWithRecents", () => {
-    it("passes the selected emoji through to the picker", () => {
-        render(<EmojiPickerWithRecents onChoose={() => true} onFinished={vi.fn()} selectedEmojis={new Set(["🎉"])} />);
-
-        expect(screen.getByRole("checkbox", { name: "🎉" })).toHaveAttribute("aria-checked", "true");
-        expect(screen.getByRole("checkbox", { name: "🚀" })).toHaveAttribute("aria-checked", "false");
+    beforeEach(() => {
+        vi.spyOn(recent, "get").mockReturnValue([]);
     });
 
-    it("resolves keyboard actions using the app's keybindings", async () => {
-        const getAccessibilityAction = vi.spyOn(getKeyBindingsManager(), "getAccessibilityAction");
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("uses the first resolvable ordered recent emoji as the persistent Preview fallback", async () => {
+        vi.mocked(recent.get).mockReturnValue(["<unsupported>", "🎉", "😀"]);
         render(<EmojiPickerWithRecents onChoose={() => true} onFinished={vi.fn()} />);
 
-        screen.getByRole("button", { name: "🎉" }).focus();
-        await userEvent.keyboard("[ArrowRight]");
+        const picker = screen.getByLabelText("Emoji picker");
+        await waitFor(() => expect(picker.lastElementChild).toHaveTextContent("🎉"));
+        expect(screen.queryByRole("toolbar", { name: "Quick Reactions" })).not.toBeInTheDocument();
+    });
 
-        expect(getAccessibilityAction).toHaveBeenCalled();
-        expect(screen.getByRole("button", { name: "😕" })).toHaveFocus();
+    it("uses the grinning face Preview fallback when every recent emoji is unsupported", async () => {
+        vi.mocked(recent.get).mockReturnValue(["<unsupported>"]);
+        render(<EmojiPickerWithRecents onChoose={() => true} onFinished={vi.fn()} />);
+
+        const picker = screen.getByLabelText("Emoji picker");
+        await waitFor(() => expect(picker.lastElementChild).toHaveTextContent("😀"));
+        expect(screen.queryByRole("toolbar", { name: "Quick Reactions" })).not.toBeInTheDocument();
+    });
+
+    it("uses the grinning face Preview fallback when recents are empty", async () => {
+        render(<EmojiPickerWithRecents onChoose={() => true} onFinished={vi.fn()} />);
+
+        const picker = screen.getByLabelText("Emoji picker");
+        await waitFor(() => expect(picker.lastElementChild).toHaveTextContent("😀"));
+        expect(screen.queryByRole("toolbar", { name: "Quick Reactions" })).not.toBeInTheDocument();
+    });
+
+    it("applies the stable Ashram host class and vertical orientation", () => {
+        render(<EmojiPickerWithRecents onChoose={() => true} onFinished={vi.fn()} />);
+
+        const picker = screen.getByLabelText("Emoji picker");
+        expect(picker).toHaveClass("mx_EmojiPickerWithRecents");
+        expect(screen.getByRole("tablist", { name: "Categories" })).toHaveAttribute("aria-orientation", "vertical");
     });
 });

--- a/apps/web/src/emojipicker/EmojiPickerWithRecents.tsx
+++ b/apps/web/src/emojipicker/EmojiPickerWithRecents.tsx
@@ -6,34 +6,52 @@
  */
 
 import React, { useMemo } from "react";
+import { getEmojiFromUnicode } from "@matrix-org/emojibase-bindings";
 import { EmojiPicker, type EmojiPickerProps } from "@element-hq/web-shared-components";
 import * as recent from "./recent";
 import { getWebRovingAction } from "../accessibility/RovingTabIndex";
+
+type HostOwnedEmojiPickerProp =
+    | "recentEmojis"
+    | "onRecordRecent"
+    | "getAction"
+    | "showQuickReactions"
+    | "emojisPerRow"
+    | "emojiRowHeight"
+    | "categoryOrientation"
+    | "previewFallbackEmoji"
+    | "className";
+
+type EmojiPickerWithRecentsProps = Omit<EmojiPickerProps, HostOwnedEmojiPickerProp>;
 
 /**
  * Wrapped version of the shared-components emoji picker that passes in
  * the recent emojis from the web app's local storage (also passes in the
  * web roving actions).
  */
-export function EmojiPickerWithRecents({
-    selectedEmojis,
-    onChoose,
-    onFinished,
-    isEmojiDisabled,
-}: Omit<EmojiPickerProps, "recentEmojis" | "onRecordRecent" | "getAction">): React.ReactNode {
+export function EmojiPickerWithRecents(props: EmojiPickerWithRecentsProps): React.ReactNode {
     // There isn't anything for us to key the memoisation off here. This will just
     // update when the component mounts which is probably good enough.
-    const recentEmojis = useMemo(() => recent.get(), []);
+    const { recentEmojis, previewFallbackEmoji } = useMemo(() => {
+        const recentEmojis = recent.get();
+        return {
+            recentEmojis,
+            previewFallbackEmoji: recentEmojis.find((emoji) => getEmojiFromUnicode(emoji)) ?? "😀",
+        };
+    }, []);
 
     return (
         <EmojiPicker
-            selectedEmojis={selectedEmojis}
-            onChoose={onChoose}
-            onFinished={onFinished}
-            isEmojiDisabled={isEmojiDisabled}
+            {...props}
+            className="mx_EmojiPickerWithRecents"
             getAction={getWebRovingAction}
             recentEmojis={recentEmojis}
             onRecordRecent={recent.add}
+            showQuickReactions
+            emojisPerRow={11}
+            emojiRowHeight={52}
+            categoryOrientation="vertical"
+            previewFallbackEmoji={previewFallbackEmoji}
         />
     );
 }

--- a/apps/web/src/shouldHideEvent.test.ts
+++ b/apps/web/src/shouldHideEvent.test.ts
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 Ashram Element contributors.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { describe, expect, it } from "vitest";
+import { EventType, type MatrixEvent } from "matrix-js-sdk/src/matrix";
+
+import { isHreArchivedCommandRedaction } from "./shouldHideEvent";
+
+const CURRENT_STATE_ROOM_ID = "!OWGgBUxkmnSBvCqIBO:ashram.home";
+const ALERTS_ROOM_ID = "!RRmMmMOSQqNEMHrCEd:ashram.home";
+const COMMANDS_ROOM_ID = "!JlrFUxRzQgmptKfCjy:ashram.home";
+
+interface EventOptions {
+    roomId?: string;
+    redacted?: boolean;
+    eventType?: string;
+    redactionType?: string;
+    redactor?: string;
+    reason?: string;
+}
+
+function makeEvent({
+    roomId = CURRENT_STATE_ROOM_ID,
+    redacted = true,
+    eventType = EventType.RoomMessage,
+    redactionType = EventType.RoomRedaction,
+    redactor = "@hre-bot:ashram.home",
+    reason = "Archived to HRE Commands",
+}: EventOptions = {}): MatrixEvent {
+    return {
+        isRedacted: () => redacted,
+        getType: () => eventType,
+        getRoomId: () => roomId,
+        getUnsigned: () => ({
+            redacted_because: {
+                type: redactionType,
+                sender: redactor,
+                content: { reason },
+            },
+        }),
+    } as unknown as MatrixEvent;
+}
+
+describe("isHreArchivedCommandRedaction", () => {
+    it.each([CURRENT_STATE_ROOM_ID, ALERTS_ROOM_ID])("matches the exact HRE housekeeping redaction in %s", (roomId) => {
+        expect(isHreArchivedCommandRedaction(makeEvent({ roomId }))).toBe(true);
+    });
+
+    it.each([
+        ["HRE Commands room", { roomId: COMMANDS_ROOM_ID }],
+        ["unrelated room", { roomId: "!elsewhere:ashram.home" }],
+        ["different redactor", { redactor: "@moderator:ashram.home" }],
+        ["different reason", { reason: "Ordinary moderation redaction" }],
+        ["different redaction event type", { redactionType: EventType.RoomMessage }],
+        ["event which is not redacted", { redacted: false }],
+        ["original event which is not a room message", { eventType: EventType.Sticker }],
+    ] satisfies Array<[string, EventOptions]>)("does not match %s", (_name, options) => {
+        expect(isHreArchivedCommandRedaction(makeEvent(options))).toBe(false);
+    });
+});

--- a/apps/web/src/shouldHideEvent.ts
+++ b/apps/web/src/shouldHideEvent.ts
@@ -13,6 +13,36 @@ import SettingsStore from "./settings/SettingsStore";
 import { type IRoomState } from "./components/structures/RoomView";
 import { type SettingKey } from "./settings/Settings.tsx";
 
+const HRE_BOT_USER_ID = "@hre-bot:ashram.home";
+const HRE_ARCHIVE_REDACTION_REASON = "Archived to HRE Commands";
+const HRE_COMMAND_SOURCE_ROOM_IDS = new Set([
+    "!OWGgBUxkmnSBvCqIBO:ashram.home", // HRE Current State
+    "!RRmMmMOSQqNEMHrCEd:ashram.home", // HRE Alerts
+]);
+
+/**
+ * Ashram Element housekeeping rule.
+ *
+ * HRE archives commands before redacting their original source events. Only
+ * those exact bot redactions in the two HRE command source rooms should vanish
+ * completely from the client. All other redactions retain normal Element
+ * behaviour.
+ */
+export function isHreArchivedCommandRedaction(ev: MatrixEvent): boolean {
+    if (!ev.isRedacted() || ev.getType() !== EventType.RoomMessage) return false;
+
+    const roomId = ev.getRoomId();
+    if (!roomId || !HRE_COMMAND_SOURCE_ROOM_IDS.has(roomId)) return false;
+
+    const redaction = ev.getUnsigned().redacted_because;
+
+    return (
+        redaction?.type === EventType.RoomRedaction &&
+        redaction.sender === HRE_BOT_USER_ID &&
+        redaction.content?.reason === HRE_ARCHIVE_REDACTION_REASON
+    );
+}
+
 interface IDiff {
     isMemberEvent: boolean;
     isJoin?: boolean;
@@ -50,6 +80,8 @@ function memberEventDiff(ev: MatrixEvent): IDiff {
  *     hitting the settings store
  */
 export default function shouldHideEvent(ev: MatrixEvent, ctx?: IRoomState): boolean {
+    if (isHreArchivedCommandRedaction(ev)) return true;
+
     // Hide all poll end events
     if (M_POLL_END.matches(ev.getType())) return true;
 

--- a/apps/web/test/unit-tests/components/structures/MessagePanel-test.tsx
+++ b/apps/web/test/unit-tests/components/structures/MessagePanel-test.tsx
@@ -9,7 +9,7 @@ Please see LICENSE files in the repository root for full details.
 
 import React from "react";
 import { EventEmitter } from "node:events";
-import { type MatrixEvent, Room, RoomMember, type Thread, ReceiptType } from "matrix-js-sdk/src/matrix";
+import { EventType, type MatrixEvent, Room, RoomMember, type Thread, ReceiptType } from "matrix-js-sdk/src/matrix";
 import { KnownMembership } from "matrix-js-sdk/src/types";
 import { render, within } from "jest-matrix-react";
 
@@ -313,6 +313,28 @@ describe("MessagePanel", function () {
         ];
     }
 
+    function mkHreArchivedCommandEvent(): MatrixEvent {
+        const event = TestUtilsMatrix.mkMessage({
+            event: true,
+            room: "!OWGgBUxkmnSBvCqIBO:ashram.home",
+            user: "@alice:ashram.home",
+            msg: "!hre status",
+        });
+
+        jest.spyOn(event, "isRedacted").mockReturnValue(true);
+        jest.spyOn(event, "getUnsigned").mockReturnValue({
+            redacted_because: {
+                type: EventType.RoomRedaction,
+                sender: "@hre-bot:ashram.home",
+                content: {
+                    reason: "Archived to HRE Commands",
+                },
+            },
+        } as any);
+
+        return event;
+    }
+
     function isReadMarkerVisible(rmContainer?: Element) {
         return !!rmContainer?.children.length;
     }
@@ -323,6 +345,44 @@ describe("MessagePanel", function () {
         // just check we have the right number of tiles for now
         const tiles = container.getElementsByClassName("mx_EventTile");
         expect(tiles.length).toEqual(10);
+    });
+
+    it("hard-filters HRE archived commands when hidden events are shown", function () {
+        const event = mkHreArchivedCommandEvent();
+
+        const { container } = render(
+            getComponent(
+                {
+                    events: [event],
+                    readMarkerEventId: event.getId(),
+                    readMarkerVisible: true,
+                },
+                {
+                    showHiddenEvents: true,
+                    showRedactions: true,
+                },
+            ),
+            clientAndSDKContextRenderOptions(client, sdkContext),
+        );
+
+        expect(container.getElementsByClassName("mx_EventTile")).toHaveLength(0);
+        expect(container.getElementsByClassName("mx_TimelineSeparator")).toHaveLength(0);
+        expect(container.getElementsByClassName("mx_MessagePanel_myReadMarker")).toHaveLength(0);
+    });
+
+    it("hard-filters HRE archived commands when the event is highlighted", function () {
+        const event = mkHreArchivedCommandEvent();
+
+        const { container } = render(
+            getComponent({
+                events: [event],
+                highlightedEventId: event.getId(),
+            }),
+            clientAndSDKContextRenderOptions(client, sdkContext),
+        );
+
+        expect(container.getElementsByClassName("mx_EventTile")).toHaveLength(0);
+        expect(container.getElementsByClassName("mx_TimelineSeparator")).toHaveLength(0);
     });
 
     it("should collapse adjacent member events", function () {

--- a/packages/shared-components/src/core/EmojiPicker/EmojiPicker.module.css
+++ b/packages/shared-components/src/core/EmojiPicker/EmojiPicker.module.css
@@ -7,8 +7,8 @@
  */
 
 .picker {
-    width: 340px;
-    height: min(450px, 80vh);
+    width: var(--emoji-picker-width, 340px);
+    height: min(var(--emoji-picker-height, 450px), 80vh);
     max-height: 80vh;
 
     border-radius: 4px;
@@ -20,6 +20,8 @@
 .body {
     margin-left: var(--cpd-space-1-5x);
     flex: 1;
+    min-width: 0;
+    min-height: 0;
     overflow-y: scroll;
 }
 
@@ -120,7 +122,7 @@
 }
 
 .categoryLabel {
-    width: 304px;
+    width: var(--emoji-picker-content-width, 304px);
     font: var(--cpd-font-heading-sm-semibold);
 }
 
@@ -132,14 +134,14 @@
 /* A single row of emoji within the grid. Fixed to the width of EMOJIS_PER_ROW
    cells so the row never wraps, offset to align with the category headers. */
 .row {
-    width: 304px;
+    width: var(--emoji-picker-row-width, 304px);
     margin: 0 var(--cpd-space-3x);
 }
 
 .itemWrapper {
     display: inline-block;
     list-style: none;
-    width: 38px;
+    width: var(--emoji-picker-cell-width, 38px);
     cursor: pointer;
 
     &:focus-within {
@@ -153,8 +155,8 @@
 
 .item {
     display: inline-block;
-    font-size: var(--cpd-font-size-heading-sm);
-    padding: 5px;
+    font-size: var(--emoji-picker-glyph-size, var(--cpd-font-size-heading-sm));
+    padding: var(--emoji-picker-cell-padding, 5px);
     width: 100%;
     height: 100%;
     box-sizing: border-box;
@@ -181,24 +183,117 @@
 
 .footer {
     border-top: 1px solid var(--cpd-color-gray-400);
-    min-height: 72px;
-    max-height: 72px;
+    min-height: var(--emoji-picker-footer-height, 72px);
+    max-height: var(--emoji-picker-footer-height, 72px);
 
     display: flex;
     align-items: center;
 }
 
 .previewEmoji {
-    font-size: var(--cpd-font-size-heading-xl);
-    padding: var(--cpd-space-2x) var(--cpd-space-4x);
+    font-size: var(--emoji-picker-preview-glyph-size, var(--cpd-font-size-heading-xl));
+    padding: var(--emoji-picker-preview-emoji-padding, var(--cpd-space-2x) var(--cpd-space-4x));
+}
+
+.pickerVertical {
+    width: min(var(--emoji-picker-width, 340px), calc(100vw - 20px));
+    display: grid;
+    grid-template-columns: var(--emoji-picker-category-rail-width, 44px) minmax(0, 1fr);
+    grid-template-rows: auto minmax(0, 1fr) auto;
+
+    .header {
+        grid-column: 1;
+        grid-row: 1 / -1;
+        min-height: 0;
+        padding: var(--cpd-space-2x) 0;
+        border-right: 1px solid var(--cpd-color-gray-400);
+        border-bottom: none;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--cpd-space-1x);
+        overflow-x: hidden;
+        overflow-y: auto;
+        scrollbar-width: thin;
+
+        &::-webkit-scrollbar {
+            width: 6px;
+        }
+    }
+
+    .anchor {
+        box-sizing: border-box;
+        flex-shrink: 0;
+        padding: 0;
+        border-bottom-color: transparent;
+        border-left: 2px solid transparent;
+        border-radius: 0 4px 4px 0;
+        display: block;
+
+        &:not(:disabled):hover {
+            border-bottom-color: transparent;
+            border-left-color: var(--cpd-color-text-action-accent);
+        }
+    }
+
+    .anchorSelected {
+        border-bottom-color: transparent;
+        border-left-color: var(--cpd-color-text-action-accent);
+    }
+
+    .search,
+    .body,
+    .footer {
+        grid-column: 2;
+    }
+
+    .search {
+        grid-row: 1;
+    }
+
+    .body {
+        grid-row: 2;
+        margin-left: 0;
+        overflow-x: auto;
+    }
+
+    .row {
+        line-height: 0;
+    }
+
+    .itemWrapper {
+        box-sizing: border-box;
+        height: var(--emoji-picker-cell-height, auto);
+        vertical-align: top;
+
+        > [role="button"],
+        > [role="checkbox"] {
+            height: 100%;
+        }
+    }
+
+    .item {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 1;
+    }
+
+    .itemSelected {
+        padding: var(--emoji-picker-cell-padding, 5px);
+    }
+
+    .footer {
+        grid-row: 3;
+        box-sizing: border-box;
+    }
 }
 
 .previewText {
     display: flex;
     flex: 1;
     overflow: hidden;
-    padding-top: 1rem;
-    padding-bottom: 1rem;
+    padding-block: var(--emoji-picker-preview-text-padding-block, 1rem);
     flex-direction: column;
 }
 

--- a/packages/shared-components/src/core/EmojiPicker/EmojiPicker.test.tsx
+++ b/packages/shared-components/src/core/EmojiPicker/EmojiPicker.test.tsx
@@ -22,6 +22,11 @@ describe("EmojiPicker", function () {
     const getActiveEmojiText = (container: HTMLElement): string =>
         container.querySelector('[role="gridcell"] [tabindex="0"]')?.textContent || "";
 
+    const getEmojiRows = (container: HTMLElement): Element[] =>
+        Array.from(container.querySelectorAll('[role="row"]')).filter((row) =>
+            Array.from(row.children).some((cell) => cell.querySelector('[role="button"], [role="checkbox"]')),
+        );
+
     it("should disable the recent category when no recent emojis", () => {
         render(<EmojiPicker onChoose={() => false} onFinished={vi.fn()} />);
 
@@ -42,6 +47,26 @@ describe("EmojiPicker", function () {
         const recentTab = screen.getByRole("tab", { name: "🕒" });
         expect(recentTab).toBeEnabled();
         expect(recentTab).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("groups emoji using the configured column count", async () => {
+        const { container } = render(<EmojiPicker emojisPerRow={11} onChoose={() => false} onFinished={vi.fn()} />);
+
+        await waitFor(() => expect(getEmojiRows(container).length).toBeGreaterThanOrEqual(2));
+
+        const [firstRow, secondRow] = getEmojiRows(container);
+        expect(firstRow.children).toHaveLength(11);
+        expect(Array.from(firstRow.children, (cell) => cell.textContent)).toEqual(
+            DATA_BY_CATEGORY.people.slice(0, 11).map((emoji) => emoji.unicode),
+        );
+        expect(secondRow.children[0]).toHaveTextContent(DATA_BY_CATEGORY.people[11].unicode);
+    });
+
+    it("falls back to the stock column count for invalid configuration", async () => {
+        const { container } = render(<EmojiPicker emojisPerRow={0} onChoose={() => false} onFinished={vi.fn()} />);
+
+        await waitFor(() => expect(getEmojiRows(container)[0]).toBeDefined());
+        expect(getEmojiRows(container)[0].children).toHaveLength(8);
     });
 
     it("should record recent emoji when onChoose does not return false", async () => {
@@ -171,6 +196,53 @@ describe("EmojiPicker", function () {
 
         expect(onChoose).toHaveBeenCalledWith("📫️");
         expect(onFinished).toHaveBeenCalled();
+    });
+
+    it("keeps same-row keyboard targets horizontally visible without moving search focus", async () => {
+        const { container } = render(<EmojiPicker onChoose={() => false} onFinished={vi.fn()} />);
+        const input = container.querySelector("input")!;
+
+        await waitFor(() => expect(getEmojiRows(container)[0]?.children).toHaveLength(8));
+        await waitFor(() => expect(input).toHaveFocus());
+        const secondEmoji = getEmojiRows(container)[0].children[1].querySelector<HTMLElement>('[role="button"]')!;
+        const scrollIntoView = vi.spyOn(secondEmoji, "scrollIntoView");
+
+        await userEvent.keyboard("[ArrowDown]");
+        await userEvent.keyboard("[ArrowRight]");
+
+        expect(input).toHaveFocus();
+        expect(scrollIntoView).toHaveBeenCalledWith({
+            behavior: "auto",
+            block: "nearest",
+            inline: "nearest",
+        });
+    });
+
+    it("moves Up and Down by the configured 11-column row geometry", async () => {
+        const { container } = render(<EmojiPicker emojisPerRow={11} onChoose={() => false} onFinished={vi.fn()} />);
+
+        await waitFor(() => expect(getActiveEmojiText(container)).toEqual(DATA_BY_CATEGORY.people[0].unicode));
+        await userEvent.keyboard("[ArrowDown]");
+        await userEvent.keyboard("[ArrowDown]");
+        expect(getActiveEmojiText(container)).toEqual(DATA_BY_CATEGORY.people[11].unicode);
+
+        await userEvent.keyboard("[ArrowUp]");
+        expect(getActiveEmojiText(container)).toEqual(DATA_BY_CATEGORY.people[0].unicode);
+    });
+
+    it("clamps 11-column navigation to the end of a ragged row", async () => {
+        const recentEmojis = DATA_BY_CATEGORY.people.slice(0, 13).map((emoji) => emoji.unicode);
+        const { container } = render(
+            <EmojiPicker emojisPerRow={11} recentEmojis={recentEmojis} onChoose={() => false} onFinished={vi.fn()} />,
+        );
+
+        await waitFor(() => expect(getActiveEmojiText(container)).toEqual(recentEmojis[0]));
+        await userEvent.keyboard("[ArrowDown]");
+        await userEvent.keyboard("[ArrowRight]".repeat(10));
+        expect(getActiveEmojiText(container)).toEqual(recentEmojis[10]);
+
+        await userEvent.keyboard("[ArrowDown]");
+        expect(getActiveEmojiText(container)).toEqual(recentEmojis[12]);
     });
 
     it("should move actual focus when navigating between emojis after Tab", async () => {
@@ -343,6 +415,62 @@ describe("EmojiPicker", function () {
         expect(getActiveEmoji().id).not.toEqual(activeId);
     });
 
+    describe("Preview fallback", () => {
+        const getFooter = (): HTMLElement => screen.getByLabelText("Emoji picker").lastElementChild as HTMLElement;
+
+        it("shows a supplied grinning-face fallback instead of Quick Reactions", async () => {
+            render(<EmojiPicker previewFallbackEmoji="😀" onChoose={() => false} onFinished={vi.fn()} />);
+
+            await waitFor(() => expect(getFooter()).toHaveTextContent("😀"));
+            expect(screen.queryByRole("toolbar", { name: "Quick Reactions" })).not.toBeInTheDocument();
+        });
+
+        it("shows a supplied ordered-recent fallback", async () => {
+            render(
+                <EmojiPicker
+                    recentEmojis={["🎉", "😀"]}
+                    previewFallbackEmoji="🎉"
+                    onChoose={() => false}
+                    onFinished={vi.fn()}
+                />,
+            );
+
+            await waitFor(() => expect(getFooter()).toHaveTextContent("🎉"));
+        });
+
+        it("gives hover Preview precedence and restores the fallback on mouse leave", async () => {
+            const { container } = render(
+                <EmojiPicker previewFallbackEmoji="😀" onChoose={() => false} onFinished={vi.fn()} />,
+            );
+
+            await waitFor(() => expect(getEmojiRows(container)[0]).toBeDefined());
+            const hoveredEmoji = DATA_BY_CATEGORY.people[1].unicode;
+            const hoveredButton = getEmojiRows(container)[0].children[1].querySelector<HTMLElement>('[role="button"]')!;
+
+            await userEvent.hover(hoveredButton);
+            expect(getFooter()).toHaveTextContent(hoveredEmoji);
+            expect(getFooter()).not.toHaveTextContent("😀");
+
+            await userEvent.unhover(hoveredButton);
+            expect(getFooter()).toHaveTextContent("😀");
+        });
+
+        it("keeps the stock footerless behavior when Quick Reactions are disabled", async () => {
+            render(
+                <EmojiPicker
+                    showQuickReactions={false}
+                    previewFallbackEmoji="😀"
+                    onChoose={() => false}
+                    onFinished={vi.fn()}
+                />,
+            );
+
+            const picker = screen.getByLabelText("Emoji picker");
+            await waitFor(() => expect(picker.querySelector('[role="gridcell"]')).toBeInTheDocument());
+            expect(picker.children).toHaveLength(3);
+        });
+    });
+
     describe("Category keyboard selection", () => {
         it("check tabindex for the first category when no recent emojis", async () => {
             const { container } = render(<EmojiPicker onChoose={vi.fn()} onFinished={vi.fn()} />);
@@ -427,6 +555,60 @@ describe("EmojiPicker", function () {
                 expect(focusedTab?.getAttribute("role")).toBe("tab");
                 expect(focusedTab).not.toBe(peopleTab);
             });
+        });
+
+        it("exposes vertical orientation and navigates categories with Down", async () => {
+            const { container } = render(
+                <EmojiPicker categoryOrientation="vertical" onChoose={vi.fn()} onFinished={vi.fn()} />,
+            );
+
+            const tablist = screen.getByRole("tablist", { name: "Categories" });
+            expect(tablist).toHaveAttribute("aria-orientation", "vertical");
+
+            const peopleTab = container.querySelector<HTMLButtonElement>('[title*="Smileys"]')!;
+            const natureTab = container.querySelector<HTMLButtonElement>('[title*="Animals"]')!;
+            peopleTab.focus();
+
+            await userEvent.keyboard("[ArrowDown]");
+            expect(natureTab).toHaveFocus();
+        });
+
+        it("retains Left and Right aliases in vertical orientation", async () => {
+            const { container, unmount } = render(
+                <EmojiPicker categoryOrientation="vertical" onChoose={vi.fn()} onFinished={vi.fn()} />,
+            );
+
+            const peopleTab = container.querySelector<HTMLButtonElement>('[title*="Smileys"]')!;
+            const natureTab = container.querySelector<HTMLButtonElement>('[title*="Animals"]')!;
+            peopleTab.focus();
+
+            await userEvent.keyboard("[ArrowRight]");
+            expect(natureTab).toHaveFocus();
+
+            unmount();
+            const secondRender = render(
+                <EmojiPicker categoryOrientation="vertical" onChoose={vi.fn()} onFinished={vi.fn()} />,
+            );
+            const secondPeopleTab = secondRender.container.querySelector<HTMLButtonElement>('[title*="Smileys"]')!;
+            const flagsTab = secondRender.container.querySelector<HTMLButtonElement>('[title*="Flags"]')!;
+            secondPeopleTab.focus();
+
+            await userEvent.keyboard("[ArrowLeft]");
+            expect(flagsTab).toHaveFocus();
+        });
+
+        it("skips the disabled Recent category when wrapping vertically", async () => {
+            const { container } = render(
+                <EmojiPicker categoryOrientation="vertical" onChoose={vi.fn()} onFinished={vi.fn()} />,
+            );
+
+            const peopleTab = container.querySelector<HTMLButtonElement>('[title*="Smileys"]')!;
+            const flagsTab = container.querySelector<HTMLButtonElement>('[title*="Flags"]')!;
+            expect(screen.getByRole("tab", { name: "🕒" })).toBeDisabled();
+            peopleTab.focus();
+
+            await userEvent.keyboard("[ArrowUp]");
+            expect(flagsTab).toHaveFocus();
         });
 
         it("should navigate to first/last category using Home/End keys", async () => {

--- a/packages/shared-components/src/core/EmojiPicker/EmojiPicker.tsx
+++ b/packages/shared-components/src/core/EmojiPicker/EmojiPicker.tsx
@@ -127,6 +127,28 @@ export interface EmojiPickerProps {
      * Previews of emoji are displayed in the same bar as will also be hidden when this is false.
      */
     showQuickReactions?: boolean;
+    /**
+     * Number of emoji rendered in each virtualized grid row. Defaults to 8.
+     */
+    emojisPerRow?: number;
+    /**
+     * Estimated height of each virtualized emoji row in pixels. Defaults to 35.
+     */
+    emojiRowHeight?: number;
+    /**
+     * Orientation of the category tabs. Defaults to horizontal.
+     */
+    categoryOrientation?: "horizontal" | "vertical";
+    /**
+     * Additional class name applied to the picker root.
+     */
+    className?: string;
+    /**
+     * Emoji to preview when no grid emoji is hovered.
+     *
+     * When omitted or unknown, the stock Quick Reactions footer is shown.
+     */
+    previewFallbackEmoji?: string;
 }
 
 /** Convert recent emoji characters to emoji data, removing unknowns and duplicates */
@@ -199,6 +221,11 @@ export function EmojiPicker({
     onRecordRecent,
     getAction,
     showQuickReactions = true,
+    emojisPerRow = EMOJIS_PER_ROW,
+    emojiRowHeight = EMOJI_HEIGHT,
+    categoryOrientation = "horizontal",
+    className,
+    previewFallbackEmoji,
 }: EmojiPickerProps): React.ReactNode {
     const [filter, setFilter] = useState("");
     const [previewEmoji, setPreviewEmoji] = useState<IEmoji | undefined>(undefined);
@@ -212,6 +239,14 @@ export function EmojiPicker({
     const virtuosoRef = useRef<VirtuosoHandle>(null);
 
     const recentlyUsed = useMemo(() => resolveRecentEmojis(recentEmojis), [recentEmojis]);
+    const resolvedEmojisPerRow =
+        Number.isFinite(emojisPerRow) && emojisPerRow > 0 ? Math.max(1, Math.floor(emojisPerRow)) : EMOJIS_PER_ROW;
+    const resolvedEmojiRowHeight =
+        Number.isFinite(emojiRowHeight) && emojiRowHeight > 0 ? emojiRowHeight : EMOJI_HEIGHT;
+    const resolvedPreviewFallbackEmoji = useMemo(
+        () => (previewFallbackEmoji ? getEmojiFromUnicode(previewFallbackEmoji) : undefined),
+        [previewFallbackEmoji],
+    );
 
     const lcFilter = filter.toLowerCase().trim(); // filter is case insensitive
 
@@ -247,12 +282,16 @@ export function EmojiPicker({
             const emojis = dataByCategory[cat.id];
             if (emojis.length === 0) continue;
             flat.push({ type: "header", category: cat });
-            for (let i = 0; i < emojis.length; i += EMOJIS_PER_ROW) {
-                flat.push({ type: "row", emojis: emojis.slice(i, i + EMOJIS_PER_ROW), categoryId: cat.id });
+            for (let i = 0; i < emojis.length; i += resolvedEmojisPerRow) {
+                flat.push({
+                    type: "row",
+                    emojis: emojis.slice(i, i + resolvedEmojisPerRow),
+                    categoryId: cat.id,
+                });
             }
         }
         return flat;
-    }, [dataByCategory]);
+    }, [dataByCategory, resolvedEmojisPerRow]);
 
     const onRangeChanged = useCallback(
         (range: ListRange): void => {
@@ -323,13 +362,12 @@ export function EmojiPicker({
 
     const onGridNavigation = useCallback(
         (_ev: React.KeyboardEvent, focusNode: HTMLElement, state: RovingState): void => {
-            if (getRow(state.activeNode) !== getRow(focusNode)) {
-                focusNode.scrollIntoView({
-                    behavior: "auto",
-                    block: "center",
-                    inline: "center",
-                });
-            }
+            const rowChanged = getRow(state.activeNode) !== getRow(focusNode);
+            focusNode.scrollIntoView({
+                behavior: "auto",
+                block: rowChanged ? "center" : "nearest",
+                inline: rowChanged ? "center" : "nearest",
+            });
         },
         [getRow],
     );
@@ -388,6 +426,7 @@ export function EmojiPicker({
     // (generate a single unique ID and then suffix because hooks can't be called in
     // a loop).
     const emojiIdBase = useId();
+    const footerPreviewEmoji = previewEmoji ?? resolvedPreviewFallbackEmoji;
 
     const renderItem = useCallback(
         (_index: number, item: ListItem): React.ReactNode => {
@@ -435,7 +474,9 @@ export function EmojiPicker({
         >
             {({ onKeyDownHandler }) => (
                 <section
-                    className={styles.picker}
+                    className={classNames(styles.picker, className, {
+                        [styles.pickerVertical]: categoryOrientation === "vertical",
+                    })}
                     onKeyDown={onKeyDownHandler}
                     aria-label={_t("emoji_picker|emoji_picker")}
                 >
@@ -446,6 +487,7 @@ export function EmojiPicker({
                         onAnchorClick={scrollToCategory}
                         pickerBodyId={pickerBodyId}
                         getAction={getAction}
+                        orientation={categoryOrientation}
                     />
                     <Search
                         query={filter}
@@ -467,7 +509,7 @@ export function EmojiPicker({
                                 ref={virtuosoRef}
                                 customScrollParent={scrollElement}
                                 data={items}
-                                defaultItemHeight={EMOJI_HEIGHT}
+                                defaultItemHeight={resolvedEmojiRowHeight}
                                 components={gridComponents}
                                 itemContent={renderItem}
                                 rangeChanged={onRangeChanged}
@@ -475,8 +517,8 @@ export function EmojiPicker({
                         )}
                     </AutoHideScrollbar>
                     {showQuickReactions &&
-                        (previewEmoji ? (
-                            <Preview emoji={previewEmoji} />
+                        (footerPreviewEmoji ? (
+                            <Preview emoji={footerPreviewEmoji} />
                         ) : (
                             <QuickReactions
                                 onClick={onClickEmoji}

--- a/packages/shared-components/src/core/EmojiPicker/Tabs.tsx
+++ b/packages/shared-components/src/core/EmojiPicker/Tabs.tsx
@@ -45,14 +45,25 @@ interface Props {
      * When omitted, a default mapping based on `KeyboardEvent.key` is used.
      */
     getAction?: RovingTabIndexProviderProps["getAction"];
+    /**
+     * Orientation of the category tabs.
+     */
+    orientation: "horizontal" | "vertical";
 }
 
-const getDefaultAction = (ev: React.KeyboardEvent): RovingAction | undefined => {
+const getDefaultAction = (
+    ev: React.KeyboardEvent,
+    orientation: "horizontal" | "vertical",
+): RovingAction | undefined => {
     switch (ev.key) {
         case "ArrowLeft":
             return RovingAction.ArrowLeft;
         case "ArrowRight":
             return RovingAction.ArrowRight;
+        case "ArrowUp":
+            return orientation === "vertical" ? RovingAction.ArrowUp : undefined;
+        case "ArrowDown":
+            return orientation === "vertical" ? RovingAction.ArrowDown : undefined;
         case "Home":
             return RovingAction.Home;
         case "End":
@@ -72,6 +83,7 @@ export const Tabs: React.FC<Props> = ({
     onAnchorClick,
     pickerBodyId,
     getAction,
+    orientation,
 }) => {
     const findNearestEnabled = useCallback(
         (index: number, delta: number): number | undefined => {
@@ -112,10 +124,24 @@ export const Tabs: React.FC<Props> = ({
         (ev: React.KeyboardEvent): void => {
             let handled = true;
 
-            const action = getAction?.(ev) ?? getDefaultAction(ev);
+            const action = getAction?.(ev) ?? getDefaultAction(ev, orientation);
             switch (action) {
+                case RovingAction.ArrowUp:
+                    if (orientation !== "vertical") {
+                        handled = false;
+                        break;
+                    }
+                    changeCategoryRelative(-1);
+                    break;
                 case RovingAction.ArrowLeft:
                     changeCategoryRelative(-1);
+                    break;
+                case RovingAction.ArrowDown:
+                    if (orientation !== "vertical") {
+                        handled = false;
+                        break;
+                    }
+                    changeCategoryRelative(1);
                     break;
                 case RovingAction.ArrowRight:
                     changeCategoryRelative(1);
@@ -136,7 +162,7 @@ export const Tabs: React.FC<Props> = ({
                 ev.stopPropagation();
             }
         },
-        [getAction, changeCategoryRelative, changeCategoryAbsolute, categories.length],
+        [getAction, orientation, changeCategoryRelative, changeCategoryAbsolute, categories.length],
     );
 
     const tabRefs = useRef({} as Record<CategoryKey, React.RefObject<HTMLButtonElement | null>>);
@@ -147,7 +173,13 @@ export const Tabs: React.FC<Props> = ({
     }
 
     return (
-        <nav className={styles.header} role="tablist" aria-label={_t("emoji|categories")} onKeyDown={onKeyDown}>
+        <nav
+            className={styles.header}
+            role="tablist"
+            aria-label={_t("emoji|categories")}
+            aria-orientation={orientation === "vertical" ? "vertical" : undefined}
+            onKeyDown={onKeyDown}
+        >
             {categories.map((category) => {
                 const classes = classNames(styles.anchor, {
                     [styles.anchorSelected]: category.id === selectedCategory,


### PR DESCRIPTION
Modernizes the Ashram Element composer picker while preserving the current v1.12.26 architecture.

- Enlarges and modernizes the Emoji picker.
- Preserves vertical categories, recents, and persistent preview.
- Restores Emoji | Stickers | GIFs picker tabs.
- Restores direct Sticker access in the composer.
- Preserves the modern Stickerpicker/AppTile/SDKContext architecture.

Verification completed:

- formatter/lint clean
- git diff --check clean
- production Element Web build passed
- fresh desktop ASAR packaged with Ashram config
- manual Emoji → Stickers → GIFs → Emoji test passed
- visual-test Electron session cleaned up

Commit: 5de0f32857de391509553b3514dd48cb2e785398