### PR TITLE
Add a preference to open threads in the main chat area

### DIFF
--- a/apps/web/playwright/e2e/threads/full-size-thread-view.spec.ts
+++ b/apps/web/playwright/e2e/threads/full-size-thread-view.spec.ts
@@ -142,7 +142,10 @@ test.describe("Full-size thread view", () => {
         await summary.click();
         await expect(page.locator(".mx_ThreadView_fullSize").getByText("Reply from the bot")).toBeVisible();
 
-        await page.locator(".mx_ThreadHeader").getByRole("button", { name: "Back" }).click();
+        await page
+            .locator(".mx_ThreadHeader")
+            .getByRole("button", { name: /^Back to / })
+            .click();
         await expect(summary).toBeVisible();
         await expect(rootTile).toBeInViewport();
 

--- a/apps/web/playwright/e2e/threads/full-size-thread-view.spec.ts
+++ b/apps/web/playwright/e2e/threads/full-size-thread-view.spec.ts
@@ -1,0 +1,226 @@
+/*
+Copyright 2026 hayaksi1
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+import { type Locator, type Page } from "@playwright/test";
+
+import { SettingLevel } from "../../../src/settings/SettingLevel";
+import { Layout } from "../../../src/settings/enums/Layout";
+import { test, expect } from "../../element-web-test";
+import { isDendrite } from "../../plugins/homeserver/dendrite";
+
+async function box(locator: Locator): Promise<{ start: number; end: number }> {
+    const rect = await locator.boundingBox();
+    if (!rect) throw new Error("expected the element to be laid out");
+    return { start: Math.round(rect.x), end: Math.round(rect.x + rect.width) };
+}
+
+async function insets(scope: Locator): Promise<{ avatar: number; avatarWidth: number; line: number; tileEnd: number }> {
+    const panel = await box(scope.locator(".mx_RoomView_messagePanel"));
+    const tile = scope.locator('.mx_EventTile[data-layout="bubble"][data-self="false"]').last();
+    const tileBox = await box(tile);
+    const avatar = await box(tile.locator(".mx_EventTile_avatar"));
+    const line = await box(tile.locator(".mx_EventTile_line"));
+    return {
+        avatar: avatar.start - panel.start,
+        avatarWidth: avatar.end - avatar.start,
+        line: line.start - panel.start,
+        tileEnd: panel.end - tileBox.end,
+    };
+}
+
+async function groupInsets(
+    scope: Locator,
+    text: string,
+): Promise<{ avatarHeight: number; sender: number; body: number; lineEnd: number }> {
+    const panel = await box(scope.locator(".mx_RoomView_messagePanel"));
+    const tile = scope.locator('.mx_EventTile[data-layout="group"]').filter({ hasText: text }).last();
+    const avatar = await tile.locator(".mx_EventTile_avatar").boundingBox();
+    if (!avatar) throw new Error("expected the avatar to be laid out");
+    const sender = await box(tile.locator(".mx_DisambiguatedProfile"));
+    const body = await box(tile.locator(".mx_EventTile_body"));
+    const line = await box(tile.locator(".mx_EventTile_line"));
+    return {
+        avatarHeight: Math.round(avatar.height),
+        sender: sender.start - panel.start,
+        body: body.start - panel.start,
+        lineEnd: panel.end - line.end,
+    };
+}
+
+test.describe("Full-size thread view", () => {
+    test.skip(isDendrite, "due to a Dendrite bug https://github.com/element-hq/dendrite/issues/3489");
+    test.use({
+        displayName: "Tom",
+        botCreateOpts: {
+            displayName: "BotBob",
+            autoAcceptInvites: true,
+        },
+    });
+
+    test.beforeEach(async ({ page }: { page: Page }) => {
+        await page.addInitScript(() => {
+            window.localStorage.setItem("mx_lhs_size", "0");
+        });
+    });
+
+    test("aligns bubble tiles with the room timeline they replace", async ({ page, app, bot }) => {
+        await app.settings.setValue("Threads.fullSizeView", null, SettingLevel.DEVICE, true);
+        await app.settings.setValue("layout", null, SettingLevel.DEVICE, Layout.Bubble);
+
+        const roomId = await app.client.createRoom({});
+        await app.client.inviteUser(roomId, bot.credentials!.userId);
+        await bot.joinRoom(roomId);
+        await page.goto("/#/room/" + roomId);
+
+        const roomView = page.locator(".mx_RoomView_body");
+        const textbox = roomView.getByRole("textbox", { name: "Send an unencrypted message…" });
+        await textbox.fill("Hello Mr. Bot");
+        await textbox.press("Enter");
+
+        const threadId = await roomView
+            .locator(".mx_EventTile[data-scroll-tokens]")
+            .filter({ hasText: "Hello Mr. Bot" })
+            .getAttribute("data-scroll-tokens");
+
+        await bot.sendMessage(roomId, "Reply from the bot", threadId!);
+        await bot.sendMessage(roomId, "A message in the room itself");
+
+        await expect(roomView.getByText("A message in the room itself")).toBeVisible();
+        const room = await insets(roomView);
+
+        await roomView.locator(".mx_ThreadSummary").click();
+
+        const threadView = page.locator(".mx_ThreadView_fullSize");
+        await expect(threadView.getByText("Reply from the bot")).toBeVisible();
+        const thread = await insets(threadView);
+
+        expect(thread).toEqual(room);
+        expect(thread.avatar).toBeGreaterThanOrEqual(0);
+    });
+
+    test("restores the room scroll position when the thread is closed", async ({ page, app, bot }) => {
+        await app.settings.setValue("Threads.fullSizeView", null, SettingLevel.DEVICE, true);
+
+        const roomId = await app.client.createRoom({});
+        await app.client.inviteUser(roomId, bot.credentials!.userId);
+        await bot.joinRoom(roomId);
+        await page.goto("/#/room/" + roomId);
+
+        const roomView = page.locator(".mx_RoomView_body");
+        const textbox = roomView.getByRole("textbox", { name: "Send an unencrypted message…" });
+        await textbox.fill("Thread root");
+        await textbox.press("Enter");
+
+        const threadId = await roomView
+            .locator(".mx_EventTile[data-scroll-tokens]")
+            .filter({ hasText: "Thread root" })
+            .getAttribute("data-scroll-tokens");
+        await bot.sendMessage(roomId, "Reply from the bot", threadId!);
+
+        for (let i = 0; i < 40; i++) await bot.sendMessage(roomId, `Filler ${i}`);
+        await expect(roomView.getByText("Filler 39")).toBeVisible();
+
+        const rootTile = roomView.locator(".mx_EventTile[data-scroll-tokens]").filter({ hasText: "Thread root" });
+        const summary = roomView.locator(".mx_ThreadSummary");
+        await rootTile.scrollIntoViewIfNeeded();
+        await expect(summary).toBeVisible();
+        await expect(roomView.getByText("Filler 39")).not.toBeInViewport();
+
+        const rootOffset = async (): Promise<number> => {
+            const panel = await roomView.locator(".mx_RoomView_messagePanel").boundingBox();
+            const tile = await rootTile.boundingBox();
+            if (!panel || !tile) throw new Error("expected the thread root to be laid out");
+            return Math.round(tile.y - panel.y);
+        };
+
+        await page.waitForTimeout(500);
+        const before = await rootOffset();
+
+        await summary.click();
+        await expect(page.locator(".mx_ThreadView_fullSize").getByText("Reply from the bot")).toBeVisible();
+
+        await page.locator(".mx_ThreadHeader").getByRole("button", { name: "Back" }).click();
+        await expect(summary).toBeVisible();
+        await expect(rootTile).toBeInViewport();
+
+        await expect.poll(rootOffset).toBe(before);
+    });
+
+    test.describe("with read receipts turned off", () => {
+        test.beforeEach(async ({ page }: { page: Page }) => {
+            await page.addInitScript(() => {
+                window.localStorage.setItem("mx_local_settings", JSON.stringify({ hideReadReceipts: true }));
+            });
+        });
+
+        test("gives a group tile the same text column as the room timeline", async ({ page, app, bot }) => {
+            await app.settings.setValue("Threads.fullSizeView", null, SettingLevel.DEVICE, true);
+            await app.settings.setValue("layout", null, SettingLevel.DEVICE, Layout.Group);
+
+            const roomId = await app.client.createRoom({});
+            await app.client.inviteUser(roomId, bot.credentials!.userId);
+            await bot.joinRoom(roomId);
+            await page.goto("/#/room/" + roomId);
+
+            const roomView = page.locator(".mx_RoomView_body");
+            const textbox = roomView.getByRole("textbox", { name: "Send an unencrypted message…" });
+            await textbox.fill("Hello Mr. Bot");
+            await textbox.press("Enter");
+
+            const threadId = await roomView
+                .locator(".mx_EventTile[data-scroll-tokens]")
+                .filter({ hasText: "Hello Mr. Bot" })
+                .getAttribute("data-scroll-tokens");
+
+            await bot.sendMessage(roomId, "Reply from the bot", threadId!);
+            await bot.sendMessage(roomId, "A message in the room itself");
+
+            await expect(roomView.getByText("A message in the room itself")).toBeVisible();
+            const room = await groupInsets(roomView, "A message in the room itself");
+
+            await roomView.locator(".mx_ThreadSummary").click();
+
+            const threadView = page.locator(".mx_ThreadView_fullSize");
+            await expect(threadView.getByText("Reply from the bot")).toBeVisible();
+
+            expect(await groupInsets(threadView, "Reply from the bot")).toEqual(room);
+        });
+    });
+
+    test("keeps the room status bar above the thread composer", async ({ page, app, bot }) => {
+        await app.settings.setValue("Threads.fullSizeView", null, SettingLevel.DEVICE, true);
+
+        const roomId = await app.client.createRoom({});
+        await app.client.inviteUser(roomId, bot.credentials!.userId);
+        await bot.joinRoom(roomId);
+        await page.goto("/#/room/" + roomId);
+
+        const roomView = page.locator(".mx_RoomView_body");
+        const textbox = roomView.getByRole("textbox", { name: "Send an unencrypted message…" });
+        await textbox.fill("Hello Mr. Bot");
+        await textbox.press("Enter");
+
+        const threadId = await roomView
+            .locator(".mx_EventTile[data-scroll-tokens]")
+            .filter({ hasText: "Hello Mr. Bot" })
+            .getAttribute("data-scroll-tokens");
+
+        await bot.sendMessage(roomId, "Reply from the bot", threadId!);
+        await bot.sendMessage(roomId, "A message in the room itself");
+
+        await expect(roomView.getByText("A message in the room itself")).toBeVisible();
+
+        await roomView.locator(".mx_ThreadSummary").click();
+
+        const threadView = page.locator(".mx_ThreadView_fullSize");
+        await expect(threadView.getByText("Reply from the bot")).toBeVisible();
+
+        const statusArea = await roomView.locator(".mx_RoomView_statusArea").boundingBox();
+        const composer = await threadView.locator(".mx_MessageComposer").boundingBox();
+        if (!statusArea || !composer) throw new Error("expected the status area and the composer to be laid out");
+        expect(statusArea.y).toBeLessThanOrEqual(composer.y);
+    });
+});

--- a/apps/web/playwright/e2e/threads/threads.spec.ts
+++ b/apps/web/playwright/e2e/threads/threads.spec.ts
@@ -24,6 +24,8 @@ test.describe("Threads", () => {
     test.beforeEach(async ({ page }) => {
         await page.addInitScript(() => {
             window.localStorage.setItem("mx_lhs_size", "0"); // Collapse left panel for these tests
+            // These tests assert the right-panel thread card, not the full-size thread view
+            window.localStorage.setItem("mx_local_settings", JSON.stringify({ "Threads.fullSizeView": false }));
         });
     });
 

--- a/apps/web/res/css/_components.pcss
+++ b/apps/web/res/css/_components.pcss
@@ -78,6 +78,7 @@
 @import "./structures/_SpaceRoomView.pcss";
 @import "./structures/_SplashPage.pcss";
 @import "./structures/_TabbedView.pcss";
+@import "./structures/_ThreadView.pcss";
 @import "./structures/_ThreadsActivityCentre.pcss";
 @import "./structures/_ToastContainer.pcss";
 @import "./structures/_UploadBar.pcss";
@@ -280,6 +281,7 @@
 @import "./views/rooms/_SendMessageComposer.pcss";
 @import "./views/rooms/_Stickers.pcss";
 @import "./views/rooms/_ThirdPartyMemberInfo.pcss";
+@import "./views/rooms/_ThreadHeader.pcss";
 @import "./views/rooms/_TopUnreadMessagesBar.pcss";
 @import "./views/rooms/_UserIdentityWarning.pcss";
 @import "./views/rooms/_VoiceRecordComposerTile.pcss";

--- a/apps/web/res/css/structures/_ThreadView.pcss
+++ b/apps/web/res/css/structures/_ThreadView.pcss
@@ -1,0 +1,69 @@
+/*
+Copyright 2026 hayaksi1
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+.mx_ThreadView.mx_ThreadView_fullSize {
+    --ThreadView_group_spacing-start: 64px;
+    --ThreadView_group_spacing-end: 0px;
+    --BaseCard_EventTile_line-padding-block: 1px 3px;
+    --event-tile-thread-gutter: 64px;
+    --event-tile-thread-line-margin-inline-end: 0px;
+    --event-tile-thread-line-spacing-block: 1px 3px;
+    --event-tile-thread-sender-gutter: var(--cpd-space-4x);
+
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+
+    .mx_ThreadView_timelinePanelWrapper {
+        min-height: 0;
+    }
+
+    .mx_RoomView_timeline_rr_enabled {
+        --ThreadView_group_spacing-end: 80px;
+        --event-tile-thread-line-margin-inline-end: 80px;
+    }
+
+    .mx_RoomView_messagePanelSpinner {
+        flex: 1;
+        min-height: 0;
+    }
+
+    .mx_EventTile_line {
+        padding-block: var(--EventTile_group_line-spacing-block-start) var(--EventTile_group_line-spacing-block-end);
+        margin-inline-end: var(--ThreadView_group_spacing-end);
+        line-height: var(--EventTile_group_line-line-height);
+    }
+
+    .mx_EventTile[data-layout="group"]:not(.mx_EventTile_continuation) {
+        padding-block-start: 18px;
+    }
+
+    .mx_EventTile[data-layout="group"] .mx_EventTile_msgOption {
+        align-self: flex-end;
+    }
+
+    .mx_EventTile[data-layout="group"] .mx_EventTile_senderDetails {
+        padding-inline-start: var(--cpd-space-2x);
+        gap: 0;
+
+        .mx_EventTile_avatar {
+            flex: 0 0 calc(var(--ThreadView_group_spacing-start) - var(--cpd-space-2x));
+        }
+    }
+
+    .mx_EventTile[data-layout="bubble"] {
+        margin-inline: var(--EventTile_bubble-margin-inline-start) var(--EventTile_bubble-margin-inline-end);
+
+        &::before {
+            inset-inline: calc(-1 * var(--EventTile_bubble-margin-inline-start))
+                calc(-1 * var(--EventTile_bubble-margin-inline-end));
+            z-index: -1;
+        }
+    }
+}

--- a/apps/web/res/css/structures/_UploadBar.pcss
+++ b/apps/web/res/css/structures/_UploadBar.pcss
@@ -48,7 +48,7 @@ Please see LICENSE files in the repository root for full details.
     }
 }
 
-.mx_ThreadView {
+.mx_ThreadPanel {
     .mx_UploadBar {
         padding-left: 0;
     }

--- a/apps/web/res/css/views/rooms/_RoomHeader.pcss
+++ b/apps/web/res/css/views/rooms/_RoomHeader.pcss
@@ -67,7 +67,8 @@ Please see LICENSE files in the repository root for full details.
     flex-shrink: 0;
 }
 
-.mx_RoomHeader .mx_FacePile {
+.mx_RoomHeader .mx_FacePile,
+.mx_ThreadHeader .mx_FacePile {
     color: $secondary-content;
     background: $background;
     display: flex;
@@ -100,7 +101,8 @@ Please see LICENSE files in the repository root for full details.
     }
 }
 
-.mx_RoomHeader .mx_BaseAvatar {
+.mx_RoomHeader .mx_BaseAvatar,
+.mx_ThreadHeader .mx_BaseAvatar {
     flex-shrink: 0;
 }
 
@@ -109,6 +111,7 @@ Please see LICENSE files in the repository root for full details.
     min-width: 240px;
 }
 
-.mx_RoomHeader .mx_RoomHeader_toggled {
+.mx_RoomHeader .mx_RoomHeader_toggled,
+.mx_ThreadHeader .mx_RoomHeader_toggled {
     fill: var(--cpd-color-icon-accent-primary);
 }

--- a/apps/web/res/css/views/rooms/_ThreadHeader.pcss
+++ b/apps/web/res/css/views/rooms/_ThreadHeader.pcss
@@ -13,6 +13,10 @@ Please see LICENSE files in the repository root for full details.
     border-bottom: 1px solid $separator;
     background-color: $background;
 
+    button:has(svg.mx_RoomHeader_toggled) {
+        outline: 1px solid transparent;
+    }
+
     .mx_ThreadHeader_info {
         display: flex;
         flex: 1;
@@ -20,7 +24,7 @@ Please see LICENSE files in the repository root for full details.
         min-width: 0;
     }
 
-    .mx_ThreadHeader_roomName {
+    .mx_ThreadHeader_root {
         color: var(--cpd-color-text-secondary);
     }
 }

--- a/apps/web/res/css/views/rooms/_ThreadHeader.pcss
+++ b/apps/web/res/css/views/rooms/_ThreadHeader.pcss
@@ -1,0 +1,26 @@
+/*
+Copyright 2026 hayaksi1
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+.mx_ThreadHeader {
+    flex-shrink: 0;
+    height: 64px;
+    box-sizing: border-box;
+    padding: 0 var(--cpd-space-3x) 0 calc(var(--cpd-space-3x) + var(--cpd-space-1-5x));
+    border-bottom: 1px solid $separator;
+    background-color: $background;
+
+    .mx_ThreadHeader_info {
+        display: flex;
+        flex: 1;
+        flex-direction: column;
+        min-width: 0;
+    }
+
+    .mx_ThreadHeader_roomName {
+        color: var(--cpd-color-text-secondary);
+    }
+}

--- a/apps/web/src/components/structures/MatrixChat.test.tsx
+++ b/apps/web/src/components/structures/MatrixChat.test.tsx
@@ -80,6 +80,8 @@ import UserSettingsDialog from "../../components/views/dialogs/UserSettingsDialo
 import { SDKContextClass } from "../../contexts/SDKContextClass";
 import { type QrLoginCredentials } from "../../components/views/auth/LoginWithQR.tsx";
 import { storeAuthContext } from "../../utils/oauth/persistOAuthSettings.ts";
+import RightPanelStore from "../../stores/right-panel/RightPanelStore";
+import { RightPanelPhases } from "../../stores/right-panel/RightPanelStorePhases";
 
 // Stub out ThemeWatcher as the necessary bits for themes are done in element-web's index.html and thus are lacking here,
 // plus JSDOM's implementation of CSSStyleDeclaration has a bunch of differences to real browsers which cause issues.
@@ -851,6 +853,101 @@ describe("<MatrixChat />", () => {
         describe("onAction()", () => {
             afterEach(() => {
                 vi.restoreAllMocks();
+            });
+
+            describe("ShowThread", () => {
+                const roomId = "!thread-room:server.org";
+                let room: Room;
+                let rootEvent: MatrixEvent;
+
+                const setFullSizeView = (enabled: boolean): void => {
+                    const getValue = SettingsStore.getValue.bind(SettingsStore);
+                    vi.spyOn(SettingsStore, "getValue").mockImplementation(((
+                        settingName: string,
+                        targetRoomId?: string | null,
+                        excludeDefault?: boolean,
+                    ) => {
+                        if (settingName === "Threads.fullSizeView") return enabled;
+                        return getValue(settingName as any, targetRoomId, excludeDefault as false);
+                    }) as typeof SettingsStore.getValue);
+                };
+
+                const prepareRoom = async (fullSizeView: boolean): Promise<void> => {
+                    await getComponentAndWaitForReady();
+                    room = new Room(roomId, mockClient, userId);
+                    rootEvent = new MatrixEvent({
+                        event_id: "$thread-root",
+                        room_id: roomId,
+                        sender: userId,
+                        type: "m.room.message",
+                        content: { msgtype: "m.text", body: "Thread root" },
+                    });
+                    mockClient.getRoom.mockImplementation((id) => (id === roomId ? room : null));
+                    RightPanelStore.instance.reset();
+                    defaultDispatcher.dispatch(
+                        { action: Action.ActiveRoomChanged, oldRoomId: null, newRoomId: roomId },
+                        true,
+                    );
+                    setFullSizeView(fullSizeView);
+                };
+
+                const showThread = (push?: boolean): void => {
+                    act(() => {
+                        defaultDispatcher.dispatch({ action: Action.ShowThread, rootEvent, push }, true);
+                    });
+                };
+
+                it("opens a full-size thread without disturbing the right panel", async () => {
+                    await prepareRoom(true);
+                    RightPanelStore.instance.setCard({ phase: RightPanelPhases.MemberList }, true, roomId);
+
+                    showThread();
+
+                    expect(RightPanelStore.instance.getFullSizeThreadForRoom(roomId)?.state?.threadHeadEvent).toBe(
+                        rootEvent,
+                    );
+                    expect(RightPanelStore.instance.currentCardForRoom(roomId).phase).toBe(RightPanelPhases.MemberList);
+                });
+
+                it("opens a video-room thread in the right panel", async () => {
+                    await prepareRoom(true);
+                    vi.spyOn(room, "isElementVideoRoom").mockReturnValue(true);
+
+                    showThread();
+
+                    expect(RightPanelStore.instance.getFullSizeThreadForRoom(roomId)).toBeUndefined();
+                    expect(RightPanelStore.instance.currentCardForRoom(roomId).phase).toBe(RightPanelPhases.ThreadView);
+                });
+
+                it("opens a thread in the right panel when a widget is maximised", async () => {
+                    await prepareRoom(true);
+                    vi.spyOn(SDKContextClass.instance.widgetLayoutStore, "hasMaximisedWidget").mockReturnValue(true);
+
+                    showThread();
+
+                    expect(RightPanelStore.instance.getFullSizeThreadForRoom(roomId)).toBeUndefined();
+                    expect(RightPanelStore.instance.currentCardForRoom(roomId).phase).toBe(RightPanelPhases.ThreadView);
+                });
+
+                it.each([
+                    { push: true, previousPhase: RightPanelPhases.MemberList },
+                    { push: false, previousPhase: RightPanelPhases.ThreadPanel },
+                ])(
+                    "uses the existing card behaviour when full-size view is off and push is $push",
+                    async (testCase) => {
+                        await prepareRoom(false);
+                        RightPanelStore.instance.setCard({ phase: RightPanelPhases.MemberList }, true, roomId);
+
+                        showThread(testCase.push);
+
+                        expect(RightPanelStore.instance.getFullSizeThreadForRoom(roomId)).toBeUndefined();
+                        expect(RightPanelStore.instance.currentCardForRoom(roomId).phase).toBe(
+                            RightPanelPhases.ThreadView,
+                        );
+                        RightPanelStore.instance.popCard(roomId);
+                        expect(RightPanelStore.instance.currentCardForRoom(roomId).phase).toBe(testCase.previousPhase);
+                    },
+                );
             });
 
             it("ViewUserDeviceSettings should open user device settings", async () => {

--- a/apps/web/src/components/structures/MatrixChat.tsx
+++ b/apps/web/src/components/structures/MatrixChat.tsx
@@ -47,6 +47,7 @@ import PageType from "../../PageTypes";
 import createRoom, { type IOpts } from "../../createRoom";
 import { _t, _td } from "../../languageHandler";
 import SettingsStore from "../../settings/SettingsStore";
+import { isVideoRoom } from "../../utils/video-rooms";
 import { startAnyRegistrationFlow } from "../../Registration";
 import AutoDiscoveryUtils from "../../utils/AutoDiscoveryUtils";
 import { calculateRoomVia, makeRoomPermalink } from "../../utils/permalinks/Permalinks";
@@ -918,7 +919,17 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
                         initialEventScrollIntoView: scrollIntoView,
                     },
                 };
-                if (push ?? false) {
+                const threadRoomId = rootEvent.getRoomId();
+                const threadRoom = threadRoomId ? MatrixClientPeg.safeGet().getRoom(threadRoomId) : null;
+                const mainSplitIsTimeline =
+                    !!threadRoom &&
+                    !this.stores.roomViewStore.isViewingCall() &&
+                    !isVideoRoom(threadRoom) &&
+                    !this.stores.widgetLayoutStore.hasMaximisedWidget(threadRoom);
+
+                if (SettingsStore.getValue("Threads.fullSizeView") && mainSplitIsTimeline) {
+                    RightPanelStore.instance.setFullSizeThread(threadViewCard, threadRoom.roomId);
+                } else if (push ?? false) {
                     RightPanelStore.instance.pushCard(threadViewCard);
                 } else {
                     RightPanelStore.instance.setCards([{ phase: RightPanelPhases.ThreadPanel }, threadViewCard]);

--- a/apps/web/src/components/structures/RoomView.test.tsx
+++ b/apps/web/src/components/structures/RoomView.test.tsx
@@ -373,7 +373,7 @@ describe("RoomView", () => {
             expect(container.querySelector(".mx_RoomHeader")).not.toBeInTheDocument();
             expect(within(container).getByRole("heading", { name: /^Thread in / })).toBeInTheDocument();
 
-            fireEvent.click(within(container).getByRole("button", { name: "Back" }));
+            fireEvent.click(within(container).getByRole("button", { name: /^Back to / }));
 
             await waitFor(() => expect(screen.getByTestId("timeline")).toBeInTheDocument());
             expect(container.querySelector(".mx_ThreadView")).not.toBeInTheDocument();

--- a/apps/web/src/components/structures/RoomView.test.tsx
+++ b/apps/web/src/components/structures/RoomView.test.tsx
@@ -27,7 +27,17 @@ import {
 } from "matrix-js-sdk/src/matrix";
 import { type CryptoApi, CryptoEvent, UserVerificationStatus } from "matrix-js-sdk/src/crypto-api";
 import { KnownMembership } from "matrix-js-sdk/src/types";
-import { act, cleanup, fireEvent, render, type RenderResult, screen, waitFor, findByRole } from "test-utils-rtl";
+import {
+    act,
+    cleanup,
+    fireEvent,
+    render,
+    type RenderResult,
+    screen,
+    waitFor,
+    findByRole,
+    within,
+} from "test-utils-rtl";
 import userEvent from "@testing-library/user-event";
 import {
     createTestClient,
@@ -77,6 +87,8 @@ import { TimelineRenderingType } from "../../contexts/RoomContext";
 import { ModuleApi } from "../../modules/Api";
 import MatrixClientBackedController from "../../settings/controllers/MatrixClientBackedController.ts";
 import { type ComposerInsertPayload, ComposerType } from "../../dispatcher/payloads/ComposerInsertPayload.ts";
+import { mkThread } from "../../../test/test-utils/threads";
+import { WIDGET_LAYOUT_EVENT_TYPE } from "../../stores/widgets/WidgetLayoutStore";
 
 // Used by group calls
 vi.spyOn(MediaDeviceHandler, "getDevices").mockResolvedValue({
@@ -302,6 +314,122 @@ describe("RoomView", () => {
         // Check that the right panel is not rendered
         await expect(screen.findByTestId("right-panel")).rejects.toThrow();
         expect(asFragment()).toMatchSnapshot();
+    });
+
+    describe("full-size thread view", () => {
+        let rootEvent: MatrixEvent;
+
+        beforeEach(async () => {
+            vi.spyOn(cli, "supportsThreads").mockReturnValue(true);
+            vi.spyOn(room, "getMyMembership").mockReturnValue(KnownMembership.Join);
+            vi.spyOn(room, "maySendMessage").mockReturnValue(true);
+            await SettingsStore.setValue("Threads.fullSizeView", null, SettingLevel.DEVICE, true);
+            rootEvent = mkThread({
+                room,
+                client: cli,
+                authorId: cli.getSafeUserId(),
+                participantUserIds: [cli.getSafeUserId()],
+            }).rootEvent;
+        });
+
+        const setFullSizeThread = (): void => {
+            act(() => {
+                stores.rightPanelStore.setFullSizeThread(
+                    {
+                        phase: RightPanelPhases.ThreadView,
+                        state: { threadHeadEvent: rootEvent },
+                    },
+                    room.roomId,
+                );
+            });
+        };
+
+        it("keeps the member list open alongside the full-size thread", async () => {
+            const { container } = await mountRoomView();
+            expect(screen.getByTestId("timeline")).toBeInTheDocument();
+
+            act(() => {
+                stores.rightPanelStore.setCard({ phase: RightPanelPhases.MemberList }, true, room.roomId);
+            });
+            const rightPanel = await screen.findByTestId("right-panel");
+            expect(within(rightPanel).getByRole("heading", { name: "People" })).toBeInTheDocument();
+
+            setFullSizeThread();
+
+            await waitFor(() => expect(container.querySelector(".mx_ThreadView")).toBeInTheDocument());
+            expect(screen.queryByTestId("timeline")).not.toBeInTheDocument();
+            expect(await screen.findByTestId("basicmessagecomposer")).toBeInTheDocument();
+            expect(within(rightPanel).getByRole("heading", { name: "People" })).toBeInTheDocument();
+            expect(stores.rightPanelStore.currentCardForRoom(room.roomId).phase).toBe(RightPanelPhases.MemberList);
+        });
+
+        it("replaces the room header and restores the timeline when Back is activated", async () => {
+            const { container } = await mountRoomView();
+            expect(container.querySelector(".mx_RoomHeader")).toBeInTheDocument();
+
+            setFullSizeThread();
+
+            await waitFor(() => expect(container.querySelector(".mx_ThreadHeader")).toBeInTheDocument());
+            expect(container.querySelector(".mx_RoomHeader")).not.toBeInTheDocument();
+            expect(within(container).getByRole("heading", { name: /^Thread in / })).toBeInTheDocument();
+
+            fireEvent.click(within(container).getByRole("button", { name: "Back" }));
+
+            await waitFor(() => expect(screen.getByTestId("timeline")).toBeInTheDocument());
+            expect(container.querySelector(".mx_ThreadView")).not.toBeInTheDocument();
+            expect(container.querySelector(".mx_ThreadHeader")).not.toBeInTheDocument();
+            expect(container.querySelector(".mx_RoomHeader")).toBeInTheDocument();
+        });
+
+        it("renders the room timeline when the setting is off despite a stored thread", async () => {
+            setFullSizeThread();
+            const getValue = SettingsStore.getValue.bind(SettingsStore);
+            const settingSpy = vi.spyOn(SettingsStore, "getValue").mockImplementation(((
+                settingName: string,
+                targetRoomId?: string | null,
+                excludeDefault?: boolean,
+            ) => {
+                if (settingName === "Threads.fullSizeView") return false;
+                return getValue(settingName as any, targetRoomId, excludeDefault as false);
+            }) as typeof SettingsStore.getValue);
+
+            const { container } = await mountRoomView();
+            settingSpy.mockRestore();
+
+            expect(screen.getByTestId("timeline")).toBeInTheDocument();
+            expect(container.querySelector(".mx_ThreadView")).not.toBeInTheDocument();
+            expect(stores.rightPanelStore.getFullSizeThreadForRoom(room.roomId)).toBeDefined();
+        });
+
+        it("renders a maximised widget instead of a stored thread", async () => {
+            const widget = WidgetStore.instance.addVirtualWidget(
+                {
+                    id: "full-size-thread-widget",
+                    creatorUserId: cli.getSafeUserId(),
+                    type: WidgetType.CUSTOM.preferred,
+                    url: "https://example.org/widget",
+                    name: "Example widget",
+                },
+                room.roomId,
+            );
+            room.currentState.setStateEvents([
+                new MatrixEvent({
+                    event_id: "$widget-layout",
+                    room_id: room.roomId,
+                    sender: cli.getSafeUserId(),
+                    state_key: "",
+                    type: WIDGET_LAYOUT_EVENT_TYPE,
+                    content: { widgets: { [widget.id]: { container: "center" } } },
+                }),
+            ]);
+            stores.widgetLayoutStore.recalculateRoom(room);
+            setFullSizeThread();
+
+            const { container } = await mountRoomView();
+
+            expect(container.querySelector(".mx_AppsDrawer--maximised")).toBeInTheDocument();
+            expect(container.querySelector(".mx_ThreadView")).not.toBeInTheDocument();
+        });
     });
 
     it("should hide the pinned message banner when hidePinnedMessageBanner=true", async () => {

--- a/apps/web/src/components/structures/RoomView.tsx
+++ b/apps/web/src/components/structures/RoomView.tsx
@@ -82,6 +82,9 @@ import RoomPreviewCard from "../views/rooms/RoomPreviewCard";
 import RoomUpgradeWarningBar from "../views/rooms/RoomUpgradeWarningBar";
 import AuxPanel from "../views/rooms/AuxPanel";
 import RoomHeader from "../views/rooms/RoomHeader/RoomHeader";
+import { ThreadHeader } from "../views/rooms/ThreadHeader";
+import ThreadView from "./ThreadView";
+import { type IRightPanelCard } from "../../stores/right-panel/RightPanelStoreIPanelState";
 import { type IOOBData, type IThreepidInvite } from "../../stores/ThreepidInviteStore";
 import EffectsOverlay from "../views/elements/EffectsOverlay";
 import { containsEmoji } from "../../effects/utils";
@@ -229,6 +232,13 @@ export interface IRoomState {
      * The state of an ongoing search if there is one.
      */
     search?: SearchInfo;
+    /** Whether opening a thread replaces the room timeline instead of opening the right-hand panel. */
+    fullSizeThreadViewEnabled: boolean;
+    /**
+     * The thread replacing the room timeline in the main split. Mirrored from RightPanelStore's
+     * per-room slot because {@link RoomView.shouldComponentUpdate} compares state by reference.
+     */
+    fullSizeThread?: IRightPanelCard;
     callState?: CallState;
     canPeek: boolean;
     canSelfRedact: boolean;
@@ -477,6 +487,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             showApps: false,
             isPeeking: false,
             showRightPanel: false,
+            fullSizeThreadViewEnabled: SettingsStore.getValue("Threads.fullSizeView"),
             joining: false,
             showTopUnreadMessagesBar: false,
             statusBarVisible: false,
@@ -657,6 +668,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             mainSplitContentType: room ? this.getMainSplitContentType(room) : undefined,
             initialEventId: undefined, // default to clearing this, will get set later in the method if needed
             showRightPanel: roomId ? this.context.rightPanelStore.isOpenForRoom(roomId) : false,
+            fullSizeThread: roomId ? this.context.rightPanelStore.getFullSizeThreadForRoom(roomId) : undefined,
             promptAskToJoin: promptAskToJoin,
             viewRoomOpts: viewRoomOpts,
         };
@@ -986,6 +998,9 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
 
         this.settingWatchers = [
             SettingsStore.watchSetting("layout", null, (...[, , , value]) => this.setState({ layout: value! })),
+            SettingsStore.watchSetting("Threads.fullSizeView", null, (...[, , , value]) =>
+                this.setState({ fullSizeThreadViewEnabled: value! }),
+            ),
             SettingsStore.watchSetting("lowBandwidth", null, (...[, , , value]) =>
                 this.setState({ lowBandwidth: value! }),
             ),
@@ -1062,7 +1077,7 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         this.context.legacyCallHandler.removeListener(LegacyCallHandlerEvent.CallState, this.onCallState);
 
         // update the scroll map before we get unmounted
-        if (this.state.roomId) {
+        if (this.state.roomId && this.messagePanel) {
             RoomScrollStateStore.setScrollState(this.state.roomId, this.getScrollState());
         }
 
@@ -1124,9 +1139,32 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
 
     private onRightPanelStoreUpdate = (): void => {
         const { roomId } = this.state;
+        const fullSizeThread = roomId ? this.context.rightPanelStore.getFullSizeThreadForRoom(roomId) : undefined;
+
+        if (roomId && fullSizeThread && !this.state.fullSizeThread) {
+            RoomScrollStateStore.setScrollState(roomId, this.getScrollState());
+            this.messagePanel?.sendReadReceipts().catch((err) => {
+                logger.error("Failed to flush read receipts before showing a full-size thread", err);
+            });
+        }
+
+        const restoring = Boolean(roomId && !fullSizeThread && this.state.fullSizeThread);
+        const restored = restoring ? RoomScrollStateStore.getScrollState(roomId!) : undefined;
+
         this.setState({
             showRightPanel: roomId ? this.context.rightPanelStore.isOpenForRoom(roomId) : false,
+            fullSizeThread,
+            ...(restoring && {
+                initialEventId: restored?.focussedEvent,
+                initialEventPixelOffset: restored?.pixelOffset,
+                isInitialEventHighlighted: false,
+                initialEventScrollIntoView: undefined,
+            }),
         });
+    };
+
+    private onCloseFullSizeThread = (): void => {
+        if (this.state.roomId) this.context.rightPanelStore.clearFullSizeThread(this.state.roomId);
     };
 
     private onPageUnload = (event: BeforeUnloadEvent): string | undefined => {
@@ -2625,6 +2663,14 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
             mainSplitContentType = MainSplitContentType.Timeline;
         }
 
+        const fullSizeThreadState =
+            this.state.fullSizeThreadViewEnabled &&
+            mainSplitContentType === MainSplitContentType.Timeline &&
+            !this.state.search
+                ? this.state.fullSizeThread?.state
+                : undefined;
+        const fullSizeThreadRoot = fullSizeThreadState?.threadHeadEvent;
+
         const mainClasses = classNames("mx_RoomView", {
             mx_RoomView_inCall: Boolean(activeCall),
             mx_RoomView_immersive: mainSplitContentType !== MainSplitContentType.Timeline,
@@ -2638,7 +2684,28 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
         switch (mainSplitContentType) {
             case MainSplitContentType.Timeline:
                 mainSplitContentClassName = "mx_MainSplit_timeline";
-                mainSplitBody = (
+                mainSplitBody = fullSizeThreadRoot ? (
+                    <>
+                        <Measured sensor={this.roomViewBody} onMeasurement={this.onMeasurement} />
+                        <ThreadView
+                            fullSize
+                            room={this.state.room}
+                            mxEvent={fullSizeThreadRoot}
+                            initialEvent={fullSizeThreadState?.initialEvent}
+                            isInitialEventHighlighted={fullSizeThreadState?.isInitialEventHighlighted}
+                            resizeNotifier={this.context.resizeNotifier}
+                            permalinkCreator={this.permalinkCreator}
+                            e2eStatus={this.state.e2eStatus}
+                            onClose={this.onCloseFullSizeThread}
+                            aboveComposer={
+                                <>
+                                    {statusBarArea}
+                                    {previewBar}
+                                </>
+                            }
+                        />
+                    </>
+                ) : (
                     <RoomUploadContextProvider>
                         <Measured sensor={this.roomViewBody} onMeasurement={this.onMeasurement} />
                         {auxPanel}
@@ -2728,13 +2795,16 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                                 ref={this.roomViewBody}
                                 data-layout={this.state.layout}
                             >
-                                {!this.props.hideHeader && (
-                                    <RoomHeader
-                                        room={this.state.room}
-                                        legacyAdditionalButtons={this.state.viewRoomOpts.buttons}
-                                        extraButtons={<>{extraButtons}</>}
-                                    />
-                                )}
+                                {!this.props.hideHeader &&
+                                    (fullSizeThreadRoot ? (
+                                        <ThreadHeader room={this.state.room} onBack={this.onCloseFullSizeThread} />
+                                    ) : (
+                                        <RoomHeader
+                                            room={this.state.room}
+                                            legacyAdditionalButtons={this.state.viewRoomOpts.buttons}
+                                            extraButtons={<>{extraButtons}</>}
+                                        />
+                                    ))}
                                 {mainSplitBody}
                             </div>
                         </MainSplit>

--- a/apps/web/src/components/structures/RoomView.tsx
+++ b/apps/web/src/components/structures/RoomView.tsx
@@ -2797,7 +2797,11 @@ export class RoomView extends React.Component<IRoomProps, IRoomState> {
                             >
                                 {!this.props.hideHeader &&
                                     (fullSizeThreadRoot ? (
-                                        <ThreadHeader room={this.state.room} onBack={this.onCloseFullSizeThread} />
+                                        <ThreadHeader
+                                            room={this.state.room}
+                                            threadRoot={fullSizeThreadRoot}
+                                            onBack={this.onCloseFullSizeThread}
+                                        />
                                     ) : (
                                         <RoomHeader
                                             room={this.state.room}

--- a/apps/web/src/components/structures/ThreadView.test.tsx
+++ b/apps/web/src/components/structures/ThreadView.test.tsx
@@ -37,6 +37,8 @@ import { ScopedRoomContextProvider } from "../../contexts/ScopedRoomContext.tsx"
 import { TimelineRenderingType } from "../../contexts/RoomContext.ts";
 import { type ComposerInsertPayload, ComposerType } from "../../dispatcher/payloads/ComposerInsertPayload.ts";
 import { SDKContext } from "../../contexts/SDKContext.ts";
+import RightPanelStore from "../../stores/right-panel/RightPanelStore.ts";
+import { RightPanelPhases } from "../../stores/right-panel/RightPanelStorePhases.ts";
 
 describe("ThreadView", () => {
     const ROOM_ID = "!roomId:example.org";
@@ -47,24 +49,28 @@ describe("ThreadView", () => {
     let rootEvent: MatrixEvent;
 
     let changeEvent: (event: MatrixEvent) => void;
+    let changeRoom: (room: Room) => void;
 
-    function TestThreadView({ initialEvent }: { initialEvent?: MatrixEvent }) {
+    function TestThreadView({ initialEvent, fullSize = false }: { initialEvent?: MatrixEvent; fullSize?: boolean }) {
         const [event, setEvent] = useState(rootEvent);
+        const [currentRoom, setCurrentRoom] = useState(room);
         changeEvent = setEvent;
+        changeRoom = setCurrentRoom;
 
         return (
             <MatrixClientContext.Provider value={mockClient}>
                 <ScopedRoomContextProvider
-                    {...getRoomContext(room, {
+                    {...getRoomContext(currentRoom, {
                         canSendMessages: true,
                     })}
                 >
                     <ThreadView
-                        room={room}
+                        room={currentRoom}
                         onClose={vi.fn()}
                         mxEvent={event}
                         initialEvent={initialEvent}
                         resizeNotifier={new ResizeNotifier()}
+                        fullSize={fullSize}
                     />
                 </ScopedRoomContextProvider>
                 ,
@@ -72,8 +78,8 @@ describe("ThreadView", () => {
         );
     }
 
-    async function getComponent(initialEvent?: MatrixEvent): Promise<RenderResult> {
-        const renderResult = render(<TestThreadView initialEvent={initialEvent} />, {
+    async function getComponent(initialEvent?: MatrixEvent, fullSize = false): Promise<RenderResult> {
+        const renderResult = render(<TestThreadView initialEvent={initialEvent} fullSize={fullSize} />, {
             wrapper: ({ children }) => (
                 <SDKContext.Provider value={SDKContextClass.instance}>{children}</SDKContext.Provider>
             ),
@@ -117,6 +123,7 @@ describe("ThreadView", () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        RightPanelStore.instance.reset();
 
         stubClient();
         mockPlatformPeg();
@@ -193,15 +200,59 @@ describe("ThreadView", () => {
         );
     });
 
-    it("sets the correct thread in the room view store", async () => {
-        // expect(SDKContextClass.instance.roomViewStore.getThreadId()).toBeNull();
-        const { unmount } = await getComponent();
-        waitFor(() => {
+    it.each([
+        { fullSize: false, presentation: "right-panel" },
+        { fullSize: true, presentation: "full-size" },
+    ])("sets the correct thread in the room view store in the $presentation presentation", async ({ fullSize }) => {
+        const { unmount } = await getComponent(undefined, fullSize);
+        await waitFor(() => {
             expect(SDKContextClass.instance.roomViewStore.getThreadId()).toBe(rootEvent.getId());
         });
 
         unmount();
         await waitFor(() => expect(SDKContextClass.instance.roomViewStore.getThreadId()).toBeNull());
+    });
+
+    it("renders the right-panel card presentation", async () => {
+        RightPanelStore.instance.setCards([
+            { phase: RightPanelPhases.ThreadPanel },
+            { phase: RightPanelPhases.ThreadView, state: { threadHeadEvent: rootEvent } },
+        ]);
+
+        const { container } = await getComponent();
+        const threadView = container.querySelector(".mx_ThreadView");
+        const composer = getByTestId(container, "basicmessagecomposer").closest(".mx_MessageComposer");
+
+        expect(threadView).toBeInTheDocument();
+        expect(getByTestId(container, "base-card-close-button")).toBeInTheDocument();
+        expect(getByTestId(container, "base-card-back-button")).toBeInTheDocument();
+        expect(getByTestId(container, "threadlist-dropdown-button")).toBeInTheDocument();
+        expect(composer).toHaveClass("mx_MessageComposer--compact");
+    });
+
+    it("renders the full-size presentation without right-panel card controls", async () => {
+        const { container } = await getComponent(undefined, true);
+        const threadView = container.querySelector(".mx_ThreadView");
+        const composer = getByTestId(container, "basicmessagecomposer").closest(".mx_MessageComposer");
+
+        expect(threadView).toBeInTheDocument();
+        expect(threadView).toHaveClass("mx_ThreadView_fullSize");
+        expect(container.querySelector('[data-testid="base-card-close-button"]')).not.toBeInTheDocument();
+        expect(container.querySelector('[data-testid="base-card-back-button"]')).not.toBeInTheDocument();
+        expect(container.querySelector('[data-testid="threadlist-dropdown-button"]')).not.toBeInTheDocument();
+        expect(composer).toBeInTheDocument();
+        expect(composer).not.toHaveClass("mx_MessageComposer--compact");
+    });
+
+    it("does not replace the right-panel card when the room changes in full-size presentation", async () => {
+        const setCard = vi.spyOn(RightPanelStore.instance, "setCard");
+        await getComponent(undefined, true);
+        setCard.mockClear();
+        const nextRoom = new Room("!next-room:example.org", mockClient, mockClient.getUserId() ?? "");
+
+        act(() => changeRoom(nextRoom));
+
+        expect(setCard).not.toHaveBeenCalled();
     });
 
     it("clears highlight message in the room view store", async () => {

--- a/apps/web/src/components/structures/ThreadView.tsx
+++ b/apps/web/src/components/structures/ThreadView.tsx
@@ -63,6 +63,16 @@ interface IProps {
     initialEvent?: MatrixEvent;
     isInitialEventHighlighted?: boolean;
     initialEventScrollIntoView?: boolean;
+    /**
+     * Render the thread full-size in the room's main split instead of as a right-panel card: the
+     * surrounding card chrome is dropped and the caller supplies the header.
+     */
+    fullSize?: boolean;
+    /**
+     * Content to render between the timeline and the composer. The room puts its status and preview
+     * bars there, and full-size threads own the composer, so the caller has to hand them over.
+     */
+    aboveComposer?: React.ReactNode;
 }
 
 interface IState {
@@ -149,7 +159,7 @@ export default class ThreadView extends React.Component<IProps, IState> {
             this.setupThread(this.props.mxEvent);
         }
 
-        if (prevProps.room !== this.props.room) {
+        if (prevProps.room !== this.props.room && !this.props.fullSize) {
             RightPanelStore.instance.setCard({ phase: RightPanelPhases.RoomSummary });
         }
     }
@@ -413,47 +423,75 @@ export default class ThreadView extends React.Component<IProps, IState> {
             );
         }
 
+        const body = (
+            <>
+                <Measured breakpoint={400} sensor={this.card} onMeasurement={this.onMeasurement} />
+                <div
+                    className={classNames("mx_ThreadView_timelinePanelWrapper", {
+                        mx_RoomView_timeline: this.props.fullSize,
+                        mx_RoomView_timeline_rr_enabled: this.props.fullSize && this.context.showReadReceipts,
+                    })}
+                >
+                    {timeline}
+                </div>
+
+                {ContentMessages.sharedInstance().getCurrentUploads(threadRelation).length > 0 && (
+                    <UploadBar room={this.props.room} relation={threadRelation} />
+                )}
+
+                {this.props.aboveComposer}
+
+                {this.state.thread?.timelineSet && (
+                    <MessageComposer
+                        room={this.props.room}
+                        resizeNotifier={this.props.resizeNotifier}
+                        relation={threadRelation}
+                        replyToEvent={this.state.replyToEvent}
+                        permalinkCreator={this.props.permalinkCreator}
+                        e2eStatus={this.props.e2eStatus}
+                        compact={!this.props.fullSize}
+                    />
+                )}
+            </>
+        );
+
         return (
             <ScopedRoomContextProvider
                 {...this.context}
                 timelineRenderingType={TimelineRenderingType.Thread}
+                fullSizeThreadViewEnabled={!!this.props.fullSize}
                 threadId={this.state.thread?.id}
                 liveTimeline={this.state?.thread?.timelineSet?.getLiveTimeline()}
                 narrow={this.state.narrow}
             >
                 <RoomUploadContextProvider threadRelation={this.threadRelation}>
-                    <BaseCard
-                        className={classNames("mx_ThreadView mx_ThreadPanel", {
-                            mx_ThreadView_narrow: this.state.narrow,
-                        })}
-                        onClose={this.props.onClose}
-                        withoutScrollContainer={true}
-                        header={this.renderThreadViewHeader()}
-                        ref={this.card}
-                        onKeyDown={this.onKeyDown}
-                        onBack={(ev: ButtonEvent) => {
-                            PosthogTrackers.trackInteraction("WebThreadViewBackButton", ev);
-                        }}
-                    >
-                        <Measured breakpoint={400} sensor={this.card} onMeasurement={this.onMeasurement} />
-                        <div className="mx_ThreadView_timelinePanelWrapper">{timeline}</div>
-
-                        {ContentMessages.sharedInstance().getCurrentUploads(threadRelation).length > 0 && (
-                            <UploadBar room={this.props.room} relation={threadRelation} />
-                        )}
-
-                        {this.state.thread?.timelineSet && (
-                            <MessageComposer
-                                room={this.props.room}
-                                resizeNotifier={this.props.resizeNotifier}
-                                relation={threadRelation}
-                                replyToEvent={this.state.replyToEvent}
-                                permalinkCreator={this.props.permalinkCreator}
-                                e2eStatus={this.props.e2eStatus}
-                                compact={true}
-                            />
-                        )}
-                    </BaseCard>
+                    {this.props.fullSize ? (
+                        <div
+                            className={classNames("mx_ThreadView mx_ThreadView_fullSize", {
+                                mx_ThreadView_narrow: this.state.narrow,
+                            })}
+                            ref={this.card}
+                            onKeyDown={this.onKeyDown}
+                        >
+                            {body}
+                        </div>
+                    ) : (
+                        <BaseCard
+                            className={classNames("mx_ThreadView mx_ThreadPanel", {
+                                mx_ThreadView_narrow: this.state.narrow,
+                            })}
+                            onClose={this.props.onClose}
+                            withoutScrollContainer={true}
+                            header={this.renderThreadViewHeader()}
+                            ref={this.card}
+                            onKeyDown={this.onKeyDown}
+                            onBack={(ev: ButtonEvent) => {
+                                PosthogTrackers.trackInteraction("WebThreadViewBackButton", ev);
+                            }}
+                        >
+                            {body}
+                        </BaseCard>
+                    )}
                 </RoomUploadContextProvider>
             </ScopedRoomContextProvider>
         );

--- a/apps/web/src/components/views/context_menus/MessageContextMenu.tsx
+++ b/apps/web/src/components/views/context_menus/MessageContextMenu.tsx
@@ -399,6 +399,7 @@ export default class MessageContextMenu extends React.Component<IProps, IState> 
             action: Action.ViewRoom,
             event_id: this.props.mxEvent.getId(),
             highlighted: true,
+            view_in_room: true,
             room_id: this.props.mxEvent.getRoomId(),
             metricsTrigger: undefined, // room doesn't change
         });

--- a/apps/web/src/components/views/context_menus/ThreadListContextMenu.tsx
+++ b/apps/web/src/components/views/context_menus/ThreadListContextMenu.tsx
@@ -52,6 +52,7 @@ const ThreadListContextMenu: React.FC<ThreadListContextMenuProps> = ({
                 action: Action.ViewRoom,
                 event_id: mxEvent.getId(),
                 highlighted: true,
+                view_in_room: true,
                 room_id: mxEvent.getRoomId(),
                 metricsTrigger: undefined, // room doesn't change
             });

--- a/apps/web/src/components/views/rooms/EventTile.tsx
+++ b/apps/web/src/components/views/rooms/EventTile.tsx
@@ -476,6 +476,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
             action: Action.ViewRoom,
             event_id: this.props.mxEvent.getId(),
             highlighted: true,
+            view_in_room: true,
             room_id: this.props.mxEvent.getRoomId(),
             metricsTrigger: undefined, // room doesn't change
         });
@@ -869,6 +870,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
             display: {
                 timelineRenderingType: this.context.timelineRenderingType,
                 layout: this.props.layout,
+                fullSizeThreadView: this.context.fullSizeThreadViewEnabled,
                 continuation: this.props.continuation,
                 isProbablyMedia,
                 isTwelveHour: this.props.isTwelveHour,
@@ -1060,6 +1062,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
 
         switch (this.context.timelineRenderingType) {
             case TimelineRenderingType.Thread: {
+                const fullSizeThread = this.context.fullSizeThreadViewEnabled;
                 return React.createElement(
                     this.props.as || "li",
                     {
@@ -1092,7 +1095,7 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                             )}
                             {actionBar}
                             {linkedTimestamp}
-                            {msgOption}
+                            {!fullSizeThread && msgOption}
                         </div>,
                         <EventTileFooter
                             key="mx_EventTile_footer"
@@ -1107,6 +1110,9 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
                             showMainPinnedMessageBadge={showMainPinnedMessageBadge}
                             showBubblePinnedMessageBadge={showBubblePinnedMessageBadge}
                         />,
+                        fullSizeThread ? (
+                            <React.Fragment key="mx_EventTile_msgOption">{msgOption}</React.Fragment>
+                        ) : null,
                     ],
                 );
             }

--- a/apps/web/src/components/views/rooms/RoomHeader/RoomHeader.tsx
+++ b/apps/web/src/components/views/rooms/RoomHeader/RoomHeader.tsx
@@ -58,7 +58,12 @@ import { useIsEncrypted } from "../../../../hooks/useIsEncrypted.ts";
 import { useUserStatus } from "../../../../hooks/useUserStatus.ts";
 import { SDKContext } from "../../../../contexts/SDKContext.ts";
 
-function RoomHeaderButtons({
+/**
+ * The room header's trailing actions: calls, threads, notifications, room info and the member
+ * face pile. Exported so a thread shown in place of the room timeline can carry the same
+ * quick actions as the room it replaced.
+ */
+export function RoomHeaderButtons({
     room,
     legacyAdditionalButtons,
     extraButtons,

--- a/apps/web/src/components/views/rooms/ThreadHeader.test.tsx
+++ b/apps/web/src/components/views/rooms/ThreadHeader.test.tsx
@@ -1,0 +1,69 @@
+/*
+Copyright 2026 hayaksi1
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import React from "react";
+import { render, screen } from "test-utils-rtl";
+import userEvent from "@testing-library/user-event";
+import { test, describe, beforeEach, expect, vi } from "vitest";
+import { type MatrixClient, type Room } from "matrix-js-sdk/src/matrix";
+
+import { ThreadHeader } from "./ThreadHeader";
+import { getMockClientWithEventEmitter, mkStubRoom, mockClientMethodsUser } from "../../../../test/test-utils";
+import MatrixClientContext from "../../../contexts/MatrixClientContext";
+import DMRoomMap from "../../../utils/DMRoomMap";
+
+// @vitest-environment happy-dom
+
+describe("<ThreadHeader />", () => {
+    const userId = "@alice:server.org";
+    let client: MatrixClient;
+    let room: Room;
+
+    beforeEach(() => {
+        client = getMockClientWithEventEmitter({
+            ...mockClientMethodsUser(userId),
+            getRoom: vi.fn(),
+        });
+        room = mkStubRoom("!room:server.org", "Github", client);
+        (client.getRoom as unknown as ReturnType<typeof vi.fn>).mockReturnValue(room);
+        DMRoomMap.setShared({
+            getUserIdForRoomId: vi.fn(),
+        } as unknown as DMRoomMap);
+    });
+
+    const renderHeader = (onBack = vi.fn()) => {
+        render(
+            <MatrixClientContext.Provider value={client}>
+                <ThreadHeader room={room} onBack={onBack} />
+            </MatrixClientContext.Provider>,
+        );
+        return onBack;
+    };
+
+    test("identifies the thread and the room it belongs to", () => {
+        renderHeader();
+
+        expect(screen.getByText("Thread")).toBeInTheDocument();
+        expect(screen.getByText("Github")).toBeInTheDocument();
+    });
+
+    test("exposes the thread and its room as a single heading to assistive technology", () => {
+        renderHeader();
+
+        expect(screen.getByRole("heading", { name: "Thread in Github" })).toBeInTheDocument();
+    });
+
+    test("offers leaving the thread as the only action", async () => {
+        const onBack = renderHeader();
+
+        const buttons = screen.getAllByRole("button");
+        expect(buttons).toHaveLength(1);
+
+        await userEvent.click(buttons[0]);
+        expect(onBack).toHaveBeenCalled();
+    });
+});

--- a/apps/web/src/components/views/rooms/ThreadHeader.test.tsx
+++ b/apps/web/src/components/views/rooms/ThreadHeader.test.tsx
@@ -5,65 +5,140 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import React from "react";
-import { render, screen } from "test-utils-rtl";
-import userEvent from "@testing-library/user-event";
-import { test, describe, beforeEach, expect, vi } from "vitest";
-import { type MatrixClient, type Room } from "matrix-js-sdk/src/matrix";
-
-import { ThreadHeader } from "./ThreadHeader";
-import { getMockClientWithEventEmitter, mkStubRoom, mockClientMethodsUser } from "../../../../test/test-utils";
-import MatrixClientContext from "../../../contexts/MatrixClientContext";
-import DMRoomMap from "../../../utils/DMRoomMap";
-
 // @vitest-environment happy-dom
 
+import React from "react";
+import { act, render, screen, waitFor, type RenderOptions } from "test-utils-rtl";
+import userEvent from "@testing-library/user-event";
+import { test, describe, beforeEach, afterEach, expect, vi, type Mocked } from "vitest";
+import {
+    EventType,
+    type MatrixClient,
+    type MatrixEvent,
+    PendingEventOrdering,
+    Room,
+    RoomEvent,
+} from "matrix-js-sdk/src/matrix";
+
+import { ThreadHeader } from "./ThreadHeader";
+import { mkEvent, mkMessage, stubClient } from "../../../../test/test-utils";
+import MatrixClientContext from "../../../contexts/MatrixClientContext";
+import RoomContext, { type RoomContextType } from "../../../contexts/RoomContext";
+import { ScopedRoomContextProvider } from "../../../contexts/ScopedRoomContext";
+import { SDKContext } from "../../../contexts/SDKContext";
+import { SDKContextClass } from "../../../contexts/SDKContextClass";
+import RightPanelStore from "../../../stores/right-panel/RightPanelStore";
+import { RightPanelPhases } from "../../../stores/right-panel/RightPanelStorePhases";
+import DMRoomMap from "../../../utils/DMRoomMap";
+import { CallStore } from "../../../stores/CallStore";
+
+vi.mock("../../../hooks/right-panel/useCurrentPhase", () => ({
+    useCurrentPhase: () => ({ currentPhase: null, isOpen: false }),
+}));
+
 describe("<ThreadHeader />", () => {
-    const userId = "@alice:server.org";
+    const roomId = "!room:server.org";
     let client: MatrixClient;
     let room: Room;
+    let threadRoot: MatrixEvent;
+    let roomContext: RoomContextType;
+    let setCardSpy: Mocked<RightPanelStore["setCard"]>;
+
+    const roomViewStore = {
+        isViewingCall: vi.fn().mockReturnValue(false),
+        on: vi.fn(),
+        off: vi.fn(),
+        emit: vi.fn(),
+    };
 
     beforeEach(() => {
-        client = getMockClientWithEventEmitter({
-            ...mockClientMethodsUser(userId),
-            getRoom: vi.fn(),
+        client = stubClient();
+        room = new Room(roomId, client, "@alice:server.org", {
+            pendingEventOrdering: PendingEventOrdering.Detached,
         });
-        room = mkStubRoom("!room:server.org", "Github", client);
-        (client.getRoom as unknown as ReturnType<typeof vi.fn>).mockReturnValue(room);
+        room.name = "Github";
+        threadRoot = mkMessage({ event: true, room: roomId, user: "@bob:server.org", msg: "Ship it on Friday?" });
         DMRoomMap.setShared({
             getUserIdForRoomId: vi.fn(),
         } as unknown as DMRoomMap);
+        setCardSpy = vi.spyOn(RightPanelStore.instance, "setCard");
+        vi.spyOn(CallStore.instance, "getCall").mockReturnValue(null);
+        vi.spyOn(CallStore.instance, "getConfiguredRTCTransports").mockReturnValue([]);
+        roomContext = { ...RoomContext, roomId, roomViewStore } as unknown as RoomContextType;
     });
 
-    const renderHeader = (onBack = vi.fn()) => {
-        render(
-            <MatrixClientContext.Provider value={client}>
-                <ThreadHeader room={room} onBack={onBack} />
-            </MatrixClientContext.Provider>,
-        );
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    const wrapper = (): RenderOptions => ({
+        wrapper: ({ children }) => (
+            <SDKContext.Provider value={SDKContextClass.instance}>
+                <MatrixClientContext.Provider value={client}>
+                    <ScopedRoomContextProvider {...roomContext}>{children}</ScopedRoomContextProvider>
+                </MatrixClientContext.Provider>
+            </SDKContext.Provider>
+        ),
+    });
+
+    const renderHeader = (onBack = vi.fn()): (() => void) => {
+        render(<ThreadHeader room={room} threadRoot={threadRoot} onBack={onBack} />, wrapper());
         return onBack;
     };
 
-    test("identifies the thread and the room it belongs to", () => {
+    test("identifies the thread by the message it started from", () => {
         renderHeader();
 
         expect(screen.getByText("Thread")).toBeInTheDocument();
-        expect(screen.getByText("Github")).toBeInTheDocument();
+        expect(screen.getByText("Ship it on Friday?")).toBeInTheDocument();
     });
 
-    test("exposes the thread and its room as a single heading to assistive technology", () => {
+    test("names the thread and its room in a single heading for assistive technology", () => {
         renderHeader();
 
-        expect(screen.getByRole("heading", { name: "Thread in Github" })).toBeInTheDocument();
+        expect(screen.getByRole("heading", { name: "Thread in Github: Ship it on Friday?" })).toBeInTheDocument();
     });
 
-    test("offers leaving the thread as the only action", async () => {
+    test("follows the thread root when it is redacted", async () => {
+        renderHeader();
+        expect(screen.getByText("Ship it on Friday?")).toBeInTheDocument();
+
+        act(() => {
+            threadRoot.makeRedacted(
+                mkEvent({
+                    event: true,
+                    type: EventType.RoomRedaction,
+                    room: roomId,
+                    user: "@bob:server.org",
+                    content: {},
+                    redacts: threadRoot.getId(),
+                }),
+                room,
+            );
+            room.emit(RoomEvent.Redaction, threadRoot, room);
+        });
+
+        await waitFor(() => expect(screen.getByRole("heading", { name: "Thread in Github" })).toBeInTheDocument());
+        expect(screen.queryByText("Ship it on Friday?")).not.toBeInTheDocument();
+    });
+
+    test("names the room the back affordance returns to", async () => {
         const onBack = renderHeader();
 
-        const buttons = screen.getAllByRole("button");
-        expect(buttons).toHaveLength(1);
-
-        await userEvent.click(buttons[0]);
+        await userEvent.click(screen.getByRole("button", { name: "Back to Github" }));
         expect(onBack).toHaveBeenCalled();
+    });
+
+    test("keeps the threads list reachable from inside a thread", async () => {
+        renderHeader();
+
+        await userEvent.click(screen.getByRole("button", { name: "Threads" }));
+        expect(setCardSpy).toHaveBeenCalledWith({ phase: RightPanelPhases.ThreadPanel });
+    });
+
+    test("keeps the room's own quick actions in reach", () => {
+        renderHeader();
+
+        expect(screen.getByRole("button", { name: "Room info" })).toBeInTheDocument();
     });
 });

--- a/apps/web/src/components/views/rooms/ThreadHeader.tsx
+++ b/apps/web/src/components/views/rooms/ThreadHeader.tsx
@@ -5,32 +5,48 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import React, { type JSX } from "react";
-import { type Room } from "matrix-js-sdk/src/matrix";
+import React, { type JSX, useCallback, useEffect, useState } from "react";
+import { MatrixEventEvent, type MatrixEvent, type Room, RoomEvent } from "matrix-js-sdk/src/matrix";
 import { Text, IconButton } from "@vector-im/compound-web";
 import { Flex } from "@element-hq/web-shared-components";
 import ChevronLeftIcon from "@vector-im/compound-design-tokens/assets/web/icons/chevron-left";
 
 import { _t } from "../../../languageHandler";
 import { useRoomName } from "../../../hooks/useRoomName";
+import { useTypedEventEmitter } from "../../../hooks/useEventEmitter";
+import { MessagePreviewStore } from "../../../stores/message-preview";
 import RoomAvatar from "../avatars/RoomAvatar";
 import PosthogTrackers from "../../../PosthogTrackers";
 import { type ButtonEvent } from "../elements/AccessibleButton";
+import { RoomHeaderButtons } from "./RoomHeader/RoomHeader";
+import { CurrentRightPanelPhaseContextProvider } from "../../../contexts/CurrentRightPanelPhaseContext";
 
 interface Props {
-    /** The room the thread belongs to; supplies the avatar and the second header line. */
+    /** The room the thread belongs to; supplies the avatar and the header's actions. */
     room: Room;
+    /** The thread's root event, previewed on the second header line. */
+    threadRoot: MatrixEvent;
     /** Leave the thread and restore the room timeline. */
     onBack: () => void;
 }
 
 /**
- * Header for a thread shown full-size in the room's main split: a back affordance, the room avatar,
- * and the thread's identity over the room name. Deliberately carries no actions, so the header reads
- * as a thread rather than as the room it replaced.
+ * Header for a thread shown full-size in the room's main split: a back affordance naming the room
+ * it returns to, the thread's identity over a preview of the message it started from, and the room
+ * header's own actions, so the threads list and the room's panels stay reachable from inside a thread.
  */
-export const ThreadHeader: React.FC<Props> = ({ room, onBack }): JSX.Element => {
+export const ThreadHeader: React.FC<Props> = ({ room, threadRoot, onBack }): JSX.Element => {
     const roomName = useRoomName(room);
+
+    const [preview, setPreview] = useState(() => MessagePreviewStore.instance.generatePreviewForEvent(threadRoot));
+    const refreshPreview = useCallback(
+        () => setPreview(MessagePreviewStore.instance.generatePreviewForEvent(threadRoot)),
+        [threadRoot],
+    );
+    useEffect(refreshPreview, [refreshPreview]);
+    useTypedEventEmitter(threadRoot, MatrixEventEvent.Decrypted, refreshPreview);
+    useTypedEventEmitter(threadRoot, MatrixEventEvent.Replaced, refreshPreview);
+    useTypedEventEmitter(room, RoomEvent.Redaction, refreshPreview);
 
     const onClick = (ev: ButtonEvent): void => {
         PosthogTrackers.trackInteraction("WebThreadViewBackButton", ev);
@@ -38,24 +54,36 @@ export const ThreadHeader: React.FC<Props> = ({ room, onBack }): JSX.Element => 
     };
 
     return (
-        <Flex as="header" align="center" gap="var(--cpd-space-3x)" className="mx_ThreadHeader light-panel">
-            <IconButton size="32px" kind="secondary" onClick={onClick} tooltip={_t("action|back")}>
-                <ChevronLeftIcon />
-            </IconButton>
-            <RoomAvatar room={room} size="32px" aria-hidden={true} />
-            <div
-                className="mx_ThreadHeader_info"
-                role="heading"
-                aria-level={1}
-                aria-label={_t("room|thread_header_a11y_label", { roomName })}
-            >
-                <Text as="div" size="md" weight="semibold">
-                    {_t("common|thread")}
-                </Text>
-                <Text as="div" size="sm" weight="regular" dir="auto" className="mx_ThreadHeader_roomName mx_lineClamp">
-                    {roomName}
-                </Text>
-            </div>
-        </Flex>
+        <CurrentRightPanelPhaseContextProvider roomId={room.roomId}>
+            <Flex as="header" align="center" gap="var(--cpd-space-3x)" className="mx_ThreadHeader light-panel">
+                <IconButton
+                    size="32px"
+                    kind="secondary"
+                    onClick={onClick}
+                    tooltip={_t("room|thread_header_back_label", { roomName })}
+                >
+                    <ChevronLeftIcon />
+                </IconButton>
+                <RoomAvatar room={room} size="32px" aria-hidden={true} />
+                <div
+                    className="mx_ThreadHeader_info"
+                    role="heading"
+                    aria-level={1}
+                    aria-label={
+                        preview
+                            ? _t("room|thread_header_a11y_label_with_message", { roomName, message: preview })
+                            : _t("room|thread_header_a11y_label", { roomName })
+                    }
+                >
+                    <Text as="div" size="md" weight="semibold">
+                        {_t("common|thread")}
+                    </Text>
+                    <Text as="div" size="sm" weight="regular" dir="auto" className="mx_ThreadHeader_root mx_lineClamp">
+                        {preview || roomName}
+                    </Text>
+                </div>
+                <RoomHeaderButtons room={room} />
+            </Flex>
+        </CurrentRightPanelPhaseContextProvider>
     );
 };

--- a/apps/web/src/components/views/rooms/ThreadHeader.tsx
+++ b/apps/web/src/components/views/rooms/ThreadHeader.tsx
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 hayaksi1
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import React, { type JSX } from "react";
+import { type Room } from "matrix-js-sdk/src/matrix";
+import { Text, IconButton } from "@vector-im/compound-web";
+import { Flex } from "@element-hq/web-shared-components";
+import ChevronLeftIcon from "@vector-im/compound-design-tokens/assets/web/icons/chevron-left";
+
+import { _t } from "../../../languageHandler";
+import { useRoomName } from "../../../hooks/useRoomName";
+import RoomAvatar from "../avatars/RoomAvatar";
+import PosthogTrackers from "../../../PosthogTrackers";
+import { type ButtonEvent } from "../elements/AccessibleButton";
+
+interface Props {
+    /** The room the thread belongs to; supplies the avatar and the second header line. */
+    room: Room;
+    /** Leave the thread and restore the room timeline. */
+    onBack: () => void;
+}
+
+/**
+ * Header for a thread shown full-size in the room's main split: a back affordance, the room avatar,
+ * and the thread's identity over the room name. Deliberately carries no actions, so the header reads
+ * as a thread rather than as the room it replaced.
+ */
+export const ThreadHeader: React.FC<Props> = ({ room, onBack }): JSX.Element => {
+    const roomName = useRoomName(room);
+
+    const onClick = (ev: ButtonEvent): void => {
+        PosthogTrackers.trackInteraction("WebThreadViewBackButton", ev);
+        onBack();
+    };
+
+    return (
+        <Flex as="header" align="center" gap="var(--cpd-space-3x)" className="mx_ThreadHeader light-panel">
+            <IconButton size="32px" kind="secondary" onClick={onClick} tooltip={_t("action|back")}>
+                <ChevronLeftIcon />
+            </IconButton>
+            <RoomAvatar room={room} size="32px" aria-hidden={true} />
+            <div
+                className="mx_ThreadHeader_info"
+                role="heading"
+                aria-level={1}
+                aria-label={_t("room|thread_header_a11y_label", { roomName })}
+            >
+                <Text as="div" size="md" weight="semibold">
+                    {_t("common|thread")}
+                </Text>
+                <Text as="div" size="sm" weight="regular" dir="auto" className="mx_ThreadHeader_roomName mx_lineClamp">
+                    {roomName}
+                </Text>
+            </div>
+        </Flex>
+    );
+};

--- a/apps/web/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -357,6 +357,10 @@ export default class PreferencesUserSettingsTab extends React.Component<EmptyObj
                         {this.renderGroup(PreferencesUserSettingsTab.IMAGES_AND_VIDEOS_SETTINGS)}
                     </SettingsSubsection>
 
+                    <SettingsSubsection heading={_t("common|threads")} formWrap>
+                        <SettingsFlag name="Threads.fullSizeView" level={SettingLevel.ACCOUNT} />
+                    </SettingsSubsection>
+
                     <SettingsSubsection heading={_t("common|timeline")} formWrap>
                         {this.renderGroup(PreferencesUserSettingsTab.TIMELINE_SETTINGS)}
                     </SettingsSubsection>

--- a/apps/web/src/contexts/RoomContext.ts
+++ b/apps/web/src/contexts/RoomContext.ts
@@ -45,6 +45,7 @@ const RoomContext = createContext<RoomContextType>({
     showApps: false,
     isPeeking: false,
     showRightPanel: true,
+    fullSizeThreadViewEnabled: false,
     joining: false,
     showTopUnreadMessagesBar: false,
     statusBarVisible: false,

--- a/apps/web/src/dispatcher/payloads/ViewRoomPayload.ts
+++ b/apps/web/src/dispatcher/payloads/ViewRoomPayload.ts
@@ -36,6 +36,7 @@ interface BaseViewRoomPayload extends Pick<ActionPayload, "action"> {
     forceTimeline?: boolean; // Whether to override default behaviour to end up at a timeline
     show_room_tile?: boolean; // Whether to ensure that the room tile is visible in the room list
     clear_search?: boolean; // Whether to clear the room list search
+    view_in_room?: boolean; // Whether the user explicitly asked to leave a thread and see `event_id` in the room timeline
     view_call?: boolean; // Whether to view the call or call lobby for the room
     skipLobby?: boolean; // Whether to skip the call lobby when showing the call (only supported for element calls)
     voiceOnly?: boolean; // Whether the call is voice only (only supported for element calls)

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -2090,6 +2090,7 @@
             },
             "this_room_button": "Search this room"
         },
+        "thread_header_a11y_label": "Thread in %(roomName)s",
         "unknown_status_code_for_timeline_jump": "unknown status code",
         "unread_notifications_predecessor": {
             "one": "You have %(count)s unread notification in a prior version of this room.",
@@ -2794,6 +2795,8 @@
             "show_polls_button": "Show polls button",
             "startup_window_behaviour_label": "Start-up and window behaviour",
             "surround_text": "Surround selected text when typing special characters",
+            "threads_full_size_view": "Show threads in the main chat area",
+            "threads_full_size_view_description": "Opening a thread replaces the conversation instead of opening the right-hand panel.",
             "time_heading": "Displaying time",
             "user_timezone": "Set timezone"
         },

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -2091,6 +2091,8 @@
             "this_room_button": "Search this room"
         },
         "thread_header_a11y_label": "Thread in %(roomName)s",
+        "thread_header_a11y_label_with_message": "Thread in %(roomName)s: %(message)s",
+        "thread_header_back_label": "Back to %(roomName)s",
         "unknown_status_code_for_timeline_jump": "unknown status code",
         "unread_notifications_predecessor": {
             "one": "You have %(count)s unread notification in a prior version of this room.",

--- a/apps/web/src/settings/Settings.tsx
+++ b/apps/web/src/settings/Settings.tsx
@@ -341,6 +341,7 @@ export interface Settings {
     "layout": IBaseSetting<Layout>;
     "Images.size": IBaseSetting<ImageSize>;
     "showChatEffects": IBaseSetting<boolean>;
+    "Threads.fullSizeView": IBaseSetting<boolean>;
     "Performance.addSendMessageTimingMetadata": IBaseSetting<boolean>;
     "Widgets.pinned": IBaseSetting<{ [widgetId: string]: boolean }>;
     "Widgets.layout": IBaseSetting<ILayoutSettings | null>;
@@ -1269,6 +1270,12 @@ export const SETTINGS: Settings = {
         displayName: _td("settings|show_chat_effects"),
         default: true,
         controller: new ReducedMotionController(),
+    },
+    "Threads.fullSizeView": {
+        supportedLevels: LEVELS_ACCOUNT_SETTINGS,
+        displayName: _td("settings|preferences|threads_full_size_view"),
+        description: _td("settings|preferences|threads_full_size_view_description"),
+        default: false,
     },
     "Performance.addSendMessageTimingMetadata": {
         supportedLevels: [SettingLevel.CONFIG],

--- a/apps/web/src/stores/right-panel/RightPanelStore.test.ts
+++ b/apps/web/src/stores/right-panel/RightPanelStore.test.ts
@@ -178,6 +178,91 @@ describe("RightPanelStore", () => {
         });
     });
 
+    describe("full-size thread", () => {
+        const roomId = "!1:example.org";
+        const threadCard = (id: string) => ({
+            phase: RightPanelPhases.ThreadView,
+            state: { threadHeadEvent: { getId: () => id } as any },
+        });
+
+        it("shows a thread without opening the right panel", () => {
+            store.setFullSizeThread(threadCard("$root"), roomId);
+
+            expect(store.getFullSizeThreadForRoom(roomId)?.state?.threadHeadEvent?.getId()).toEqual("$root");
+            expect(store.isOpenForRoom(roomId)).toEqual(false);
+            expect(store.currentCardForRoom(roomId).phase).toEqual(null);
+        });
+
+        it("leaves the thread showing when the right panel is used afterwards", () => {
+            store.setFullSizeThread(threadCard("$root"), roomId);
+
+            store.setCard({ phase: RightPanelPhases.MemberList }, true, roomId);
+            expect(store.getFullSizeThreadForRoom(roomId)).toBeDefined();
+
+            store.setCards([{ phase: RightPanelPhases.RoomSummary }], true, roomId);
+            expect(store.getFullSizeThreadForRoom(roomId)).toBeDefined();
+            expect(store.currentCardForRoom(roomId).phase).toEqual(RightPanelPhases.RoomSummary);
+        });
+
+        it("never leaves the same thread mounted in both presentations", () => {
+            store.setCards([{ phase: RightPanelPhases.ThreadPanel }, threadCard("$root")], true, roomId);
+            expect(store.isOpenForRoom(roomId)).toEqual(true);
+
+            store.setFullSizeThread(threadCard("$root"), roomId);
+
+            expect(store.roomPhaseHistory.some((card) => card.phase === RightPanelPhases.ThreadView)).toEqual(false);
+        });
+
+        it("restores the room timeline when cleared, without disturbing the panel", () => {
+            store.setCard({ phase: RightPanelPhases.MemberList }, true, roomId);
+            store.setFullSizeThread(threadCard("$root"), roomId);
+
+            store.clearFullSizeThread(roomId);
+
+            expect(store.getFullSizeThreadForRoom(roomId)).toBeUndefined();
+            expect(store.isOpenForRoom(roomId)).toEqual(true);
+            expect(store.currentCardForRoom(roomId).phase).toEqual(RightPanelPhases.MemberList);
+        });
+
+        it("does not persist anything when clearing a room that has no thread showing", () => {
+            const setValue = vi.mocked(SettingsStore.setValue);
+            setValue.mockClear();
+
+            store.clearFullSizeThread(roomId);
+
+            expect(setValue).not.toHaveBeenCalled();
+        });
+
+        it("keeps each room's thread separate", () => {
+            store.setFullSizeThread(threadCard("$one"), "!1:example.org");
+            store.setFullSizeThread(threadCard("$two"), "!2:example.org");
+
+            expect(store.getFullSizeThreadForRoom("!1:example.org")?.state?.threadHeadEvent?.getId()).toEqual("$one");
+            expect(store.getFullSizeThreadForRoom("!2:example.org")?.state?.threadHeadEvent?.getId()).toEqual("$two");
+        });
+
+        it("does not re-enter a thread permalink when the room is revisited", async () => {
+            store.setFullSizeThread(
+                {
+                    phase: RightPanelPhases.ThreadView,
+                    state: {
+                        threadHeadEvent: { getId: () => "$root" } as any,
+                        initialEvent: { getId: () => "$reply" } as any,
+                        isInitialEventHighlighted: true,
+                    },
+                },
+                roomId,
+            );
+
+            await viewRoom(roomId);
+
+            const state = store.getFullSizeThreadForRoom(roomId)?.state;
+            expect(state?.threadHeadEvent).toBeDefined();
+            expect(state?.initialEvent).toBeUndefined();
+            expect(state?.isInitialEventHighlighted).toBeUndefined();
+        });
+    });
+
     describe("togglePanel", () => {
         it("does nothing if the room has no phase to open to", () => {
             expect(store.isOpenForRoom("!1:example.org")).toEqual(false);

--- a/apps/web/src/stores/right-panel/RightPanelStore.ts
+++ b/apps/web/src/stores/right-panel/RightPanelStore.ts
@@ -26,6 +26,7 @@ import {
 import { type ActionPayload } from "../../dispatcher/payloads";
 import { Action } from "../../dispatcher/actions";
 import { type ActiveRoomChangedPayload } from "../../dispatcher/payloads/ActiveRoomChangedPayload";
+import { type ViewRoomPayload } from "../../dispatcher/payloads/ViewRoomPayload";
 import { SDKContextClass } from "../../contexts/SDKContextClass";
 import { MatrixClientPeg } from "../../MatrixClientPeg";
 
@@ -89,6 +90,14 @@ export default class RightPanelStore extends ReadyWatchingStore {
             case Action.ActiveRoomChanged: {
                 const changePayload = <ActiveRoomChangedPayload>payload;
                 this.handleViewedRoomChange(changePayload.oldRoomId, changePayload.newRoomId);
+                break;
+            }
+
+            case Action.ViewRoom: {
+                const viewRoomPayload = <ViewRoomPayload>payload;
+                if (viewRoomPayload.view_in_room && viewRoomPayload.room_id) {
+                    this.clearFullSizeThread(viewRoomPayload.room_id);
+                }
                 break;
             }
 
@@ -176,7 +185,7 @@ export default class RightPanelStore extends ReadyWatchingStore {
         } else if (targetPhase !== this.currentCardForRoom(rId)?.phase || !this.byRoom[rId]) {
             // Set right panel and initialize/erase history
             const history = this.generateHistoryForPhase(targetPhase, cardState ?? {});
-            this.byRoom[rId] = { history, isOpen: true };
+            this.byRoom[rId] = { ...this.byRoom[rId], history, isOpen: true };
             this.emitAndUpdateSettings();
         } else {
             this.show(rId);
@@ -188,7 +197,7 @@ export default class RightPanelStore extends ReadyWatchingStore {
         // This function sets the history of the right panel and shows the right panel if not already visible.
         const rId = roomId ?? this.viewedRoomId ?? "";
         const history = cards.map((c) => ({ phase: c.phase, state: c.state ?? {} }));
-        this.byRoom[rId] = { history, isOpen: true };
+        this.byRoom[rId] = { ...this.byRoom[rId], history, isOpen: true };
         this.show(rId);
         this.emitAndUpdateSettings();
     }
@@ -227,6 +236,36 @@ export default class RightPanelStore extends ReadyWatchingStore {
         const removedCard = this.byRoom[rId].history.pop();
         this.emitAndUpdateSettings();
         return removedCard;
+    }
+
+    /**
+     * The thread being shown full-size in the given room's main split, if any.
+     */
+    public getFullSizeThreadForRoom(roomId: string): IRightPanelCard | undefined {
+        return this.byRoom[roomId]?.fullSizeThread;
+    }
+
+    /**
+     * Show a thread full-size in the given room's main split, leaving the right panel's own card
+     * stack untouched. Any thread card already in that stack is dropped, so a room never has the
+     * same thread mounted in both presentations at once.
+     */
+    public setFullSizeThread(card: IRightPanelCard, roomId: string): void {
+        const room = (this.byRoom[roomId] ??= { history: [], isOpen: false });
+        room.fullSizeThread = card;
+        room.history = room.history.filter((c) => c.phase !== RightPanelPhases.ThreadView);
+        if (!room.history.length) room.isOpen = false;
+        this.emitAndUpdateSettings();
+    }
+
+    /**
+     * Stop showing a thread full-size in the given room, restoring its timeline. A no-op when no
+     * thread is showing, so callers on the right-panel path do not trigger a needless update.
+     */
+    public clearFullSizeThread(roomId: string): void {
+        if (!this.byRoom[roomId]?.fullSizeThread) return;
+        this.byRoom[roomId].fullSizeThread = undefined;
+        this.emitAndUpdateSettings();
     }
 
     public togglePanel(roomId: string | null): void {
@@ -332,7 +371,11 @@ export default class RightPanelStore extends ReadyWatchingStore {
     }
 
     private filterValidCards(rightPanelForRoom?: IRightPanelForRoom): void {
-        if (!rightPanelForRoom?.history) return;
+        if (!rightPanelForRoom) return;
+        if (rightPanelForRoom.fullSizeThread && !this.isCardStateValid(rightPanelForRoom.fullSizeThread)) {
+            rightPanelForRoom.fullSizeThread = undefined;
+        }
+        if (!rightPanelForRoom.history) return;
         rightPanelForRoom.history = rightPanelForRoom.history.filter((card) => this.isCardStateValid(card));
         if (!rightPanelForRoom.history.length) {
             rightPanelForRoom.isOpen = false;
@@ -441,6 +484,13 @@ export default class RightPanelStore extends ReadyWatchingStore {
             this.currentCard.state.initialEvent = undefined;
             this.currentCard.state.isInitialEventHighlighted = undefined;
             this.currentCard.state.initialEventScrollIntoView = undefined;
+        }
+
+        const arrivingFullSizeThreadState = this.byRoom[this.viewedRoomId ?? ""]?.fullSizeThread?.state;
+        if (arrivingFullSizeThreadState) {
+            arrivingFullSizeThreadState.initialEvent = undefined;
+            arrivingFullSizeThreadState.isInitialEventHighlighted = undefined;
+            arrivingFullSizeThreadState.initialEventScrollIntoView = undefined;
         }
 
         this.emitAndUpdateSettings();

--- a/apps/web/src/stores/right-panel/RightPanelStoreIPanelState.ts
+++ b/apps/web/src/stores/right-panel/RightPanelStoreIPanelState.ts
@@ -53,23 +53,38 @@ export interface IRightPanelCardStored {
 export interface IRightPanelForRoom {
     isOpen: boolean;
     history: Array<IRightPanelCard>;
+    /**
+     * The thread shown full-size in the room's main split, orthogonal to the visible card stack.
+     * Its `phase` is always {@link RightPanelPhases.ThreadView}.
+     */
+    fullSizeThread?: IRightPanelCard;
 }
 
 export type IRightPanelForRoomStored = {
     isOpen: boolean;
     history: Array<IRightPanelCardStored>;
+    /** Stored form of {@link IRightPanelForRoom.fullSizeThread}. */
+    fullSizeThread?: IRightPanelCardStored;
 };
 
 export function convertToStorePanel(cacheRoom?: IRightPanelForRoom): IRightPanelForRoomStored | null {
     if (!cacheRoom) return null;
     const storeHistory = [...cacheRoom.history].map((panelState) => convertCardToStore(panelState));
-    return { isOpen: cacheRoom.isOpen, history: storeHistory };
+    return {
+        isOpen: cacheRoom.isOpen,
+        history: storeHistory,
+        fullSizeThread: cacheRoom.fullSizeThread ? convertCardToStore(cacheRoom.fullSizeThread) : undefined,
+    };
 }
 
 export function convertToStatePanel(storeRoom: IRightPanelForRoomStored | null, room: Room): IRightPanelForRoom | null {
     if (!storeRoom) return storeRoom;
     const stateHistory = [...storeRoom.history].map((panelStateStore) => convertStoreToCard(panelStateStore, room));
-    return { history: stateHistory, isOpen: storeRoom.isOpen };
+    return {
+        history: stateHistory,
+        isOpen: storeRoom.isOpen,
+        fullSizeThread: storeRoom.fullSizeThread ? convertStoreToCard(storeRoom.fullSizeThread, room) : undefined,
+    };
 }
 
 export function convertCardToStore(panelState: IRightPanelCard): IRightPanelCardStored {

--- a/apps/web/src/viewmodels/room/timeline/event-tile/EventTileDerivedState.ts
+++ b/apps/web/src/viewmodels/room/timeline/event-tile/EventTileDerivedState.ts
@@ -90,6 +90,8 @@ export interface EventTileSenderProfileStateInput {
     isBubbleMessage: boolean;
     /** The current timeline layout. */
     layout?: Layout;
+    /** Whether the thread is rendering full-size in the room's main split rather than as a card. */
+    fullSizeThreadView?: boolean;
     /** Whether the event is a room create event. */
     isRoomCreate: boolean;
     /** Whether the event is a call invite. */
@@ -115,6 +117,7 @@ export function getEventTileSenderProfileState({
     eventType,
     isBubbleMessage,
     layout,
+    fullSizeThreadView,
     isRoomCreate,
     isCallInvite,
     isRtcNotification,
@@ -129,7 +132,7 @@ export function getEventTileSenderProfileState({
 
     if (
         timelineRenderingType === TimelineRenderingType.ThreadsList ||
-        (timelineRenderingType === TimelineRenderingType.Thread && !continuation)
+        (timelineRenderingType === TimelineRenderingType.Thread && !continuation && !fullSizeThreadView)
     ) {
         return { avatarSize: "32px", needsSenderProfile: true };
     }

--- a/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
+++ b/apps/web/src/viewmodels/room/timeline/event-tile/EventTileViewModel.ts
@@ -103,6 +103,8 @@ export interface EventTileDisplayInput {
     timelineRenderingType: TimelineRenderingType;
     /** The current timeline layout. */
     layout?: Layout;
+    /** Whether the thread is rendering full-size in the room's main split rather than as a card. */
+    fullSizeThreadView?: boolean;
     /** Whether the tile is a continuation of the previous event. */
     continuation?: boolean;
     /** Whether the event body is likely to render media content. */
@@ -652,6 +654,7 @@ export class EventTileViewModel extends BaseViewModel<EventTileRenderState, Even
             eventType: event.eventType,
             isBubbleMessage: display.isBubbleMessage,
             layout: display.layout,
+            fullSizeThreadView: display.fullSizeThreadView,
             isRoomCreate: event.isRoomCreate,
             isCallInvite: event.isCallInvite,
             isRtcNotification: event.isRtcNotification,

--- a/apps/web/test/test-utils/room.ts
+++ b/apps/web/test/test-utils/room.ts
@@ -55,6 +55,7 @@ export function getRoomContext(room: Room, override: Partial<RoomContextType>): 
         showApps: false,
         isPeeking: false,
         showRightPanel: true,
+        fullSizeThreadViewEnabled: false,
         joining: false,
         atEndOfLiveTimeline: true,
         showTopUnreadMessagesBar: false,

--- a/apps/web/test/unit-tests/components/views/rooms/SendMessageComposer-test.tsx
+++ b/apps/web/test/unit-tests/components/views/rooms/SendMessageComposer-test.tsx
@@ -54,6 +54,7 @@ describe("<SendMessageComposer/>", () => {
         showApps: false,
         isPeeking: false,
         showRightPanel: true,
+        fullSizeThreadViewEnabled: false,
         joining: false,
         atEndOfLiveTimeline: true,
         showTopUnreadMessagesBar: false,

--- a/apps/web/test/unit-tests/components/views/settings/tabs/user/__snapshots__/PreferencesUserSettingsTab-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/settings/tabs/user/__snapshots__/PreferencesUserSettingsTab-test.tsx.snap
@@ -1116,7 +1116,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                 <h2
                   class="mx_Heading_h4 mx_SettingsSubsectionHeading_heading"
                 >
-                  Timeline
+                  Threads
                 </h2>
               </div>
               <div
@@ -1132,7 +1132,6 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       class="_container_udcm8_10"
                     >
                       <input
-                        checked=""
                         class="_input_udcm8_24"
                         disabled=""
                         id="mx_SettingsFlag_dXFDGgBsKXay"
@@ -1151,10 +1150,37 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       class="_label_1o4d9_60"
                       for="mx_SettingsFlag_dXFDGgBsKXay"
                     >
-                      Show typing notifications
+                      Show threads in the main chat area
                     </label>
+                    <span
+                      class="_message_1o4d9_86 _help-message_1o4d9_92"
+                      id="radix-react-use-id-5"
+                    >
+                      Opening a thread replaces the conversation instead of opening the right-hand panel.
+                    </span>
                   </div>
                 </div>
+              </div>
+            </div>
+          </form>
+          <form
+            class="_root_1o4d9_17"
+          >
+            <div
+              class="mx_SettingsSubsection"
+            >
+              <div
+                class="mx_SettingsSubsectionHeading"
+              >
+                <h2
+                  class="mx_Heading_h4 mx_SettingsSubsectionHeading_heading"
+                >
+                  Timeline
+                </h2>
+              </div>
+              <div
+                class="mx_SettingsSubsection_content"
+              >
                 <div
                   class="_inline-field_1o4d9_33"
                 >
@@ -1184,7 +1210,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       class="_label_1o4d9_60"
                       for="mx_SettingsFlag_7Az0xw4Bs4Tt"
                     >
-                      Show a placeholder for removed messages
+                      Show typing notifications
                     </label>
                   </div>
                 </div>
@@ -1217,7 +1243,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       class="_label_1o4d9_60"
                       for="mx_SettingsFlag_8jmzPIlPoBCv"
                     >
-                      Show read receipts sent by other users
+                      Show a placeholder for removed messages
                     </label>
                   </div>
                 </div>
@@ -1250,7 +1276,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       class="_label_1o4d9_60"
                       for="mx_SettingsFlag_enFRaTjdsFou"
                     >
-                      Show join/leave messages (invites/removes/bans unaffected)
+                      Show read receipts sent by other users
                     </label>
                   </div>
                 </div>
@@ -1283,7 +1309,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       class="_label_1o4d9_60"
                       for="mx_SettingsFlag_bfwnd5rz4XNX"
                     >
-                      Show display name changes
+                      Show join/leave messages (invites/removes/bans unaffected)
                     </label>
                   </div>
                 </div>
@@ -1316,7 +1342,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       class="_label_1o4d9_60"
                       for="mx_SettingsFlag_gs5uWEzYzZrS"
                     >
-                      Show chat effects (animations when receiving e.g. confetti)
+                      Show display name changes
                     </label>
                   </div>
                 </div>
@@ -1349,7 +1375,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       class="_label_1o4d9_60"
                       for="mx_SettingsFlag_qWg7OgID1yRR"
                     >
-                      Show profile picture changes
+                      Show chat effects (animations when receiving e.g. confetti)
                     </label>
                   </div>
                 </div>
@@ -1382,7 +1408,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       class="_label_1o4d9_60"
                       for="mx_SettingsFlag_pOPewl7rtMbV"
                     >
-                      Show avatars in user, room and event mentions
+                      Show profile picture changes
                     </label>
                   </div>
                 </div>
@@ -1415,7 +1441,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       class="_label_1o4d9_60"
                       for="mx_SettingsFlag_cmt3PZSyNp3v"
                     >
-                      Enable big emoji in chat
+                      Show avatars in user, room and event mentions
                     </label>
                   </div>
                 </div>
@@ -1448,7 +1474,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       class="_label_1o4d9_60"
                       for="mx_SettingsFlag_dJJz3lHUv9XX"
                     >
-                      Jump to the bottom of the timeline when you send a message
+                      Enable big emoji in chat
                     </label>
                   </div>
                 </div>
@@ -1480,6 +1506,39 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                     <label
                       class="_label_1o4d9_60"
                       for="mx_SettingsFlag_SBSSOZDRlzlA"
+                    >
+                      Jump to the bottom of the timeline when you send a message
+                    </label>
+                  </div>
+                </div>
+                <div
+                  class="_inline-field_1o4d9_33"
+                >
+                  <div
+                    class="_inline-field-control_1o4d9_45"
+                  >
+                    <div
+                      class="_container_udcm8_10"
+                    >
+                      <input
+                        checked=""
+                        class="_input_udcm8_24"
+                        disabled=""
+                        id="mx_SettingsFlag_FLEpLCb0jpp6"
+                        role="switch"
+                        type="checkbox"
+                      />
+                      <div
+                        class="_ui_udcm8_34"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="_inline-field-body_1o4d9_39"
+                  >
+                    <label
+                      class="_label_1o4d9_60"
+                      for="mx_SettingsFlag_FLEpLCb0jpp6"
                     >
                       Show current profile picture and name for users in message history
                     </label>
@@ -1517,7 +1576,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                     >
                       <input
                         class="_input_udcm8_24"
-                        id="react-use-id-5"
+                        id="react-use-id-6"
                         role="switch"
                         type="checkbox"
                       />
@@ -1531,7 +1590,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   >
                     <label
                       class="_label_1o4d9_60"
-                      for="react-use-id-5"
+                      for="react-use-id-6"
                     >
                       Hide avatars of room and inviter
                     </label>
@@ -1545,13 +1604,13 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                 >
                   <label
                     class="_label_1o4d9_60"
-                    for="radix-react-use-id-6"
+                    for="radix-react-use-id-7"
                   >
                     Show media in timeline
                   </label>
                   <span
                     class="_message_1o4d9_86 _help-message_1o4d9_92 mx_MediaPreviewAccountSetting_RadioHelp"
-                    id="radix-react-use-id-7"
+                    id="radix-react-use-id-8"
                   >
                     A hidden media can always be shown by tapping on it
                   </span>
@@ -1664,7 +1723,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                         checked=""
                         class="_input_udcm8_24"
                         disabled=""
-                        id="react-use-id-8"
+                        id="react-use-id-9"
                         role="switch"
                         type="checkbox"
                       />
@@ -1678,13 +1737,13 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   >
                     <label
                       class="_label_1o4d9_60"
-                      for="react-use-id-8"
+                      for="react-use-id-9"
                     >
                       Allow users to invite you to rooms
                     </label>
                     <span
                       class="_message_1o4d9_86 _help-message_1o4d9_92"
-                      id="radix-react-use-id-9"
+                      id="radix-react-use-id-10"
                     >
                       Your server does not implement this feature.
                     </span>
@@ -1729,7 +1788,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                       <input
                         class="_input_udcm8_24"
                         disabled=""
-                        id="mx_SettingsFlag_FLEpLCb0jpp6"
+                        id="mx_SettingsFlag_NQFWldEwbV3q"
                         role="switch"
                         type="checkbox"
                       />
@@ -1743,7 +1802,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   >
                     <label
                       class="_label_1o4d9_60"
-                      for="mx_SettingsFlag_FLEpLCb0jpp6"
+                      for="mx_SettingsFlag_NQFWldEwbV3q"
                     >
                       Show NSFW content
                     </label>
@@ -1783,7 +1842,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                         checked=""
                         class="_input_udcm8_24"
                         disabled=""
-                        id="mx_SettingsFlag_NQFWldEwbV3q"
+                        id="mx_SettingsFlag_5ZjibYJT2HFm"
                         role="switch"
                         type="checkbox"
                       />
@@ -1797,7 +1856,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   >
                     <label
                       class="_label_1o4d9_60"
-                      for="mx_SettingsFlag_NQFWldEwbV3q"
+                      for="mx_SettingsFlag_5ZjibYJT2HFm"
                     >
                       Prompt before sending invites to potentially invalid matrix IDs
                     </label>

--- a/packages/shared-components/src/room/timeline/event-tile/EventTileView/EventTileView.module.css
+++ b/packages/shared-components/src/room/timeline/event-tile/EventTileView/EventTileView.module.css
@@ -953,7 +953,7 @@
         .senderDetails {
             align-items: center;
             gap: var(--cpd-space-4x, 16px);
-            padding-inline-start: var(--cpd-space-2x, 8px);
+            padding-inline-start: var(--event-tile-thread-sender-gutter, var(--cpd-space-2x, 8px));
         }
 
         .senderDetails .slotAvatar {
@@ -970,9 +970,9 @@
         }
 
         .line {
-            padding-block: 2px;
-            padding-inline-start: 56px;
-            margin-inline-end: 8px;
+            padding-block: var(--event-tile-thread-line-spacing-block, 2px);
+            padding-inline-start: var(--event-tile-thread-gutter, 56px);
+            margin-inline-end: var(--event-tile-thread-line-margin-inline-end, 8px);
         }
 
         .slotTimestamp {
@@ -982,8 +982,8 @@
         }
 
         .slotFooter {
-            margin-inline-start: 56px;
-            margin-inline-end: 8px;
+            margin-inline-start: var(--event-tile-thread-gutter, 56px);
+            margin-inline-end: var(--event-tile-thread-line-margin-inline-end, 8px);
         }
     }
 


### PR DESCRIPTION
Opening a thread puts it in the right-hand panel, next to the room timeline. The panel can be
dragged out to half the viewport, so this is not a hard width limit, but widening it is a poor
trade: the space comes straight out of the conversation beside it, and the width is shared with
every other right-panel view rather than remembered per panel type. Reading a long thread means
either a cramped column or a squeezed room.

Behind a new preference, off by default, opening a thread now replaces the room timeline in the
main split: full width, its own header with a back affordance, and a full-size composer. The
thread lives in a slot on the per-room right-panel state that is orthogonal to the visible card
stack, so the right panel keeps working independently and the member list, room info or threads
list can stay open beside a full-size thread — and per-room persistence, thread permalinks and the
unsynced-root degradation behave exactly as they already did for the panel.

That header is the room header with three parts swapped, rather than a new surface. The back
affordance names the room it returns to, because a full-size thread has only ever returned to the
room and nothing said so. Under the "Thread" label sits a preview of the message the thread grew
out of, generated by the same store the room list and the thread summaries use and followed
through decryption, edits and redaction, so a thread can be told apart without scrolling it to the
top; the heading's accessible name carries that preview alongside the room name, so two threads in
one room do not read identically to a screen reader. Everything to the right is the room header's
own action row, rendered as it stands rather than rebuilt, so calls, notifications, room info and
the members face pile keep their icons, ordering and toggled states — and the threads list stays
one click away from inside a thread rather than only after leaving it.

Event tiles adopt the room timeline's own spacing at full width, so a thread and the conversation
it replaced align identically: measured off the live DOM relative to the message panel, the avatar,
message line, sender name and read-receipt offsets are all zero delta in both group and bubble
layout, with read receipts on and off. Two behaviours had to follow the timeline rather than the
card. Replacing the timeline unmounts it, and TimelinePanel only sends a read receipt once a 500ms
activity timer elapses, so a receipt owed inside that window was dropped and the room stayed unread;
it is now flushed while the timeline is still mounted and its measurement of what was on screen is
still accurate. Closing a thread also used to drop the reader at the live end of the room, because
both halves of `RoomScrollStateStore` are keyed to `RoomView`'s own lifecycle and opening a
full-size thread neither unmounts `RoomView` nor changes the room; the position is now saved as the
thread is shown and restored when it closes.

The threads list is untouched and still opens as a right-panel card. Copying a thread link and
viewing a message in the room stay on threads-list rows rather than gaining an in-header menu, and
the module API's extra header buttons are deliberately not carried over: they are declared against
the room view, and no module can currently tell the two headers apart. IRC layout renders as group
inside a full-size thread, as it already does in the panel.

| | Light | Dark |
|---|---|---|
| Thread opened in the right panel — every sentence wraps after four or five words | <img src="https://raw.githubusercontent.com/hayaksi1/element-web/04e38075304b51114ad28dbebbb489b53ac07abd/1-thread-in-right-panel-light.png" width="420"> | <img src="https://raw.githubusercontent.com/hayaksi1/element-web/04e38075304b51114ad28dbebbb489b53ac07abd/1-thread-in-right-panel-dark.png" width="420"> |
| The same thread in the main chat area, with the preference on | <img src="https://raw.githubusercontent.com/hayaksi1/element-web/04e38075304b51114ad28dbebbb489b53ac07abd/2-thread-full-size-light.png" width="420"> | <img src="https://raw.githubusercontent.com/hayaksi1/element-web/04e38075304b51114ad28dbebbb489b53ac07abd/2-thread-full-size-dark.png" width="420"> |
| Full size with the room info card opened from the thread header | <img src="https://raw.githubusercontent.com/hayaksi1/element-web/04e38075304b51114ad28dbebbb489b53ac07abd/3-full-size-with-right-panel-light.png" width="420"> | <img src="https://raw.githubusercontent.com/hayaksi1/element-web/04e38075304b51114ad28dbebbb489b53ac07abd/3-full-size-with-right-panel-dark.png" width="420"> |

Testing strategy: turn on Settings → Preferences → "Open threads in the main chat area", open a
thread from a room, and check that it fills the chat area with a header that names the message the
thread started from and the room its back button returns to; from there open the threads list and
the room info card and check they open beside the thread rather than replacing it; scroll a room's
timeline well up, open a thread from there, come back, and check the timeline is where you left it
rather than at the newest message; then compare a thread and its room side by side in group and
bubble layout, with read receipts on and off, and with the right panel open.

Tests: `full-size-thread-view.spec.ts` measures panel-relative insets for a room and the thread that
replaces it and asserts they are equal, in bubble layout and in group layout with receipts off,
asserts the room's status bar stays above the thread composer, and asserts the room's scroll offset
is unchanged across opening and closing a thread; `RightPanelStore`, `RoomView`, `ThreadView`,
`ThreadHeader` and `MatrixChat` have unit cases for the new state slot, the preference, the routing,
and the header's root preview, redaction handling, accessible name, back label and threads-list
button. The existing thread suite opts the preference off so it keeps asserting the right-hand card,
and its screenshot baselines are unchanged.

Fixes #25310

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
