### PR TITLE
Fix - Adding a soft close of release announcements in Playwright tests

### DIFF
--- a/apps/web/playwright/e2e/crypto/history-sharing.spec.ts
+++ b/apps/web/playwright/e2e/crypto/history-sharing.spec.ts
@@ -5,7 +5,11 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { closeReleaseAnnouncement, createNewInstance, rejectToast } from "@element-hq/element-web-playwright-common";
+import {
+    closeReleaseAnnouncementIfExists,
+    createNewInstance,
+    rejectToast,
+} from "@element-hq/element-web-playwright-common";
 
 import { expect, test } from "../../element-web-test";
 import { ElementAppPage } from "../../pages/ElementAppPage";
@@ -33,7 +37,7 @@ test.describe("History sharing", function () {
             await rejectToast(alicePage, "Notifications");
 
             // Close the release announcement about the new room list sections
-            await closeReleaseAnnouncement(alicePage, "Introducing Sections");
+            await closeReleaseAnnouncementIfExists(alicePage, "Introducing Sections");
 
             // Register a second user, and open it in a second instance of the app
             const bobCredentials = await homeserver.registerUser(`user_${testInfo.testId}_bob`, "password", "Bob");

--- a/apps/web/playwright/e2e/integration-manager/kick.spec.ts
+++ b/apps/web/playwright/e2e/integration-manager/kick.spec.ts
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { closeReleaseAnnouncement } from "@element-hq/element-web-playwright-common";
+import { closeReleaseAnnouncementIfExists } from "@element-hq/element-web-playwright-common";
 
 import type { Page } from "@playwright/test";
 import { test, expect } from "../../element-web-test";
@@ -143,7 +143,7 @@ test.describe("Integration Manager: Kick", () => {
 
     test.beforeEach(async ({ page, user, app, room }) => {
         // Close the release announcement about the new room list sections
-        await closeReleaseAnnouncement(page, "Introducing Sections");
+        await closeReleaseAnnouncementIfExists(page, "Introducing Sections");
     });
 
     test("should kick the target", async ({ page, app, bot: targetUser, room }) => {

--- a/apps/web/playwright/e2e/integration-manager/send_event.spec.ts
+++ b/apps/web/playwright/e2e/integration-manager/send_event.spec.ts
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { closeReleaseAnnouncement, rejectToast } from "@element-hq/element-web-playwright-common";
+import { closeReleaseAnnouncementIfExists, rejectToast } from "@element-hq/element-web-playwright-common";
 
 import type { Page } from "@playwright/test";
 import { test, expect } from "../../element-web-test";
@@ -108,7 +108,7 @@ test.describe("Integration Manager: Send Event", () => {
         await rejectToast(page, "Verify this device");
         await rejectToast(page, "Notifications");
         // Close the release announcement about the new room list sections
-        await closeReleaseAnnouncement(page, "Introducing Sections");
+        await closeReleaseAnnouncementIfExists(page, "Introducing Sections");
 
         await app.client.setAccountData("m.widgets", {
             "m.integration_manager": {

--- a/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-custom-sections.spec.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-custom-sections.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { type Locator, type Page } from "@playwright/test";
-import { closeReleaseAnnouncement, rejectToast } from "@element-hq/element-web-playwright-common";
+import { closeReleaseAnnouncementIfExists, rejectToast } from "@element-hq/element-web-playwright-common";
 
 import { expect, test } from "../../../element-web-test";
 import { type ElementAppPage } from "../../../pages/ElementAppPage";
@@ -112,7 +112,7 @@ test.describe("Room list custom sections", () => {
         await rejectToast(page, "Notifications");
 
         // Close the release announcement about the new room list sections
-        await closeReleaseAnnouncement(page, "Introducing Sections");
+        await closeReleaseAnnouncementIfExists(page, "Introducing Sections");
 
         // Focus the user menu to avoid hover decoration
         await page.getByRole("button", { name: "User menu" }).focus();

--- a/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-filter-sort.spec.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-filter-sort.spec.ts
@@ -7,7 +7,7 @@
 
 import { type Visibility } from "matrix-js-sdk/src/matrix";
 import { type Page } from "@playwright/test";
-import { closeReleaseAnnouncement, rejectToast } from "@element-hq/element-web-playwright-common";
+import { closeReleaseAnnouncementIfExists, rejectToast } from "@element-hq/element-web-playwright-common";
 
 import { expect, test } from "../../../element-web-test";
 import { SettingLevel } from "../../../../src/settings/SettingLevel";
@@ -36,7 +36,7 @@ test.describe("Room list filters and sort", () => {
         await rejectToast(page, "Notifications");
 
         // Close the release announcement about the new room list sections
-        await closeReleaseAnnouncement(page, "Introducing Sections");
+        await closeReleaseAnnouncementIfExists(page, "Introducing Sections");
     });
 
     test("Tombstoned rooms are not shown even when they receive updates", async ({ page, app, bot }) => {

--- a/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-header.spec.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-header.spec.ts
@@ -5,7 +5,7 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-import { closeReleaseAnnouncement, rejectToast } from "@element-hq/element-web-playwright-common";
+import { closeReleaseAnnouncementIfExists, rejectToast } from "@element-hq/element-web-playwright-common";
 
 import { test, expect } from "../../../element-web-test";
 import { getHeaderSection } from "./utils";
@@ -17,7 +17,7 @@ test.describe("Header section of the room list", () => {
         await rejectToast(page, "Notifications");
 
         // Close the release announcement about the new room list sections
-        await closeReleaseAnnouncement(page, "Introducing Sections");
+        await closeReleaseAnnouncementIfExists(page, "Introducing Sections");
     });
 
     test("should render the header section", { tag: "@screenshot" }, async ({ page, app, user }) => {

--- a/apps/web/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/room-list.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { type Page } from "@playwright/test";
-import { closeReleaseAnnouncement, rejectToast } from "@element-hq/element-web-playwright-common";
+import { closeReleaseAnnouncementIfExists, rejectToast } from "@element-hq/element-web-playwright-common";
 
 import type { AccountDataEvents } from "matrix-js-sdk/src/matrix";
 import { expect, test } from "../../../element-web-test";
@@ -28,7 +28,7 @@ test.describe("Room list", () => {
         await rejectToast(page, "Notifications");
 
         // Close the release announcement about the new room list sections
-        await closeReleaseAnnouncement(page, "Introducing Sections");
+        await closeReleaseAnnouncementIfExists(page, "Introducing Sections");
 
         // focus the user menu to avoid to have hover decoration
         await page.getByRole("button", { name: "User menu" }).focus();

--- a/apps/web/playwright/e2e/room/room-header.spec.ts
+++ b/apps/web/playwright/e2e/room/room-header.spec.ts
@@ -8,7 +8,7 @@ Please see LICENSE files in the repository root for full details.
 
 import { type Page } from "@playwright/test";
 import { type Visibility } from "matrix-js-sdk/src/matrix";
-import { closeReleaseAnnouncement, rejectToast } from "@element-hq/element-web-playwright-common";
+import { closeReleaseAnnouncementIfExists, rejectToast } from "@element-hq/element-web-playwright-common";
 
 import { test, expect } from "../../element-web-test";
 import { type ElementAppPage } from "../../pages/ElementAppPage";
@@ -24,7 +24,7 @@ test.describe("Room Header", () => {
         await rejectToast(page, "Notifications");
 
         // Close the release announcement about the new room list sections
-        await closeReleaseAnnouncement(page, "Introducing Sections");
+        await closeReleaseAnnouncementIfExists(page, "Introducing Sections");
     });
 
     test.describe("with feature_notifications enabled", () => {

--- a/apps/web/playwright/e2e/settings/room-settings/room-security-tab.spec.ts
+++ b/apps/web/playwright/e2e/settings/room-settings/room-security-tab.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { type Locator } from "@playwright/test";
-import { closeReleaseAnnouncement, rejectToast } from "@element-hq/element-web-playwright-common";
+import { closeReleaseAnnouncementIfExists, rejectToast } from "@element-hq/element-web-playwright-common";
 
 import { test, expect } from "../../../element-web-test";
 
@@ -23,7 +23,7 @@ test.describe("Roles & Permissions room settings tab", () => {
         await rejectToast(page, "Verify this device");
         await rejectToast(page, "Notifications");
         // Close the release announcement about the new room list sections
-        await closeReleaseAnnouncement(page, "Introducing Sections");
+        await closeReleaseAnnouncementIfExists(page, "Introducing Sections");
 
         await app.client.createRoom({
             name: roomName,

--- a/apps/web/playwright/e2e/voip/element-call.spec.ts
+++ b/apps/web/playwright/e2e/voip/element-call.spec.ts
@@ -8,7 +8,7 @@ Please see LICENSE files in the repository root for full details.
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { type Page } from "@playwright/test";
-import { closeReleaseAnnouncement, rejectToast } from "@element-hq/element-web-playwright-common";
+import { closeReleaseAnnouncementIfExists, rejectToast } from "@element-hq/element-web-playwright-common";
 
 import type { EventType, Preset } from "matrix-js-sdk/src/matrix";
 import { SettingLevel } from "../../../src/settings/SettingLevel";
@@ -129,7 +129,7 @@ test.describe("Element Call", () => {
         await rejectToast(page, "Verify this device");
         await rejectToast(page, "Notifications");
         // Close the release announcement about the new room list sections
-        await closeReleaseAnnouncement(page, "Introducing Sections");
+        await closeReleaseAnnouncementIfExists(page, "Introducing Sections");
     });
 
     test.describe("Group Chat", () => {

--- a/packages/playwright-common/src/utils/release_accouncement.ts
+++ b/packages/playwright-common/src/utils/release_accouncement.ts
@@ -5,7 +5,7 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
-import { type Page } from "playwright-core";
+import { type Locator, type Page } from "playwright-core";
 
 /**
  * Close the release announcement with the given name.
@@ -14,4 +14,22 @@ import { type Page } from "playwright-core";
  */
 export async function closeReleaseAnnouncement(page: Page, name: string): Promise<void> {
     await page.getByRole("dialog", { name }).getByRole("button", { name: "OK" }).click();
+}
+
+/**
+ * Close the release announcement with the given name, if it exists.
+ * @param page The Playwright page instance.
+ * @param name The name of the release announcement dialog.
+ * @returns true if the release announcement was found and closed, otherwise false.
+ */
+export async function closeReleaseAnnouncementIfExists(page: Page, name: string): Promise<boolean> {
+    const announcement: Locator = page.getByRole("dialog", { name });
+    try {
+        await announcement.waitFor({ state: "visible", timeout: 2000 });
+    } catch {
+        return false;
+    }
+
+    await announcement.getByRole("button", { name: "OK" }).click();
+    return true;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)

<img width="774" height="446" alt="image" src="https://github.com/user-attachments/assets/a473834f-b8ce-47cf-80e4-523364040a1a" />
