### PR TITLE
Fix circular-import TDZ in ReadyWatchingStore.start

### DIFF
--- a/apps/web/src/stores/ReadyWatchingStore.ts
+++ b/apps/web/src/stores/ReadyWatchingStore.ts
@@ -27,8 +27,17 @@ export abstract class ReadyWatchingStore extends EventEmitter implements IDestro
     public async start(): Promise<void> {
         this.dispatcherRef = this.dispatcher.register(this.onAction);
 
-        // MatrixClientPeg can be undefined in tests because of circular dependencies with other stores
-        const matrixClient = MatrixClientPeg?.get();
+        // MatrixClientPeg can be unavailable here because of circular dependencies with other stores: if a
+        // store is constructed during module evaluation, the MatrixClientPeg binding may still be in its
+        // temporal dead zone. Optional chaining does not help — reading a binding in its TDZ throws a
+        // ReferenceError before `?.` can apply — so catch that and treat it as "no client yet". The client
+        // is then delivered later via the dispatcher (registered just above) when the lifecycle actions fire.
+        let matrixClient: MatrixClient | null | undefined;
+        try {
+            matrixClient = MatrixClientPeg?.get();
+        } catch (e) {
+            if (!(e instanceof ReferenceError)) throw e;
+        }
         if (matrixClient) {
             this.matrixClient = matrixClient;
             await this.onReady();


### PR DESCRIPTION
A store constructed during module evaluation calls `start()`, which reads `MatrixClientPeg`. When that store is pulled into MatrixClientPeg's own import cycle, the binding is still in its temporal dead zone and `MatrixClientPeg?.get()` throws a ReferenceError — optional chaining does not guard TDZ access. On the app boot path this aborts store startup and leaves the client uninitialised (manifesting as "Homeserver URL does not appear to be a valid Matrix homeserver", and as test flakes). Catch the ReferenceError and treat it as "no client yet"; the client is delivered later via the dispatcher.

Originally found while working on https://github.com/element-hq/element-meta/issues/922 because it was making tests flake.

This code was largely written with Claude, and rebased against current develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)