### PR TITLE
Prompt to recover a dehydrated device whose key is missing

### DIFF
--- a/apps/web/src/DeviceListener.test.ts
+++ b/apps/web/src/DeviceListener.test.ts
@@ -124,6 +124,7 @@ describe("DeviceListener", () => {
             getSessionBackupPrivateKey: vi.fn(),
             isEncryptionEnabledInRoom: vi.fn(),
             getKeyBackupInfo: vi.fn().mockResolvedValue(null),
+            isDehydratedDeviceKeyMissing: vi.fn().mockResolvedValue(false),
         } as unknown as Mocked<CryptoApi>;
         mockClient = getMockClientWithEventEmitter({
             isGuest: vi.fn(),
@@ -477,6 +478,18 @@ describe("DeviceListener", () => {
 
                     await createAndStart();
                     expect(SetupEncryptionToast.hideToast).toHaveBeenCalled();
+                });
+
+                it("shows a dehydration-key-out-of-sync toast when a dehydrated device exists but its key is missing locally", async () => {
+                    // Everything else is healthy, but a dehydrated device exists on the server whose key
+                    // we don't have (e.g. dehydration was set up on another device): prompt to recover it.
+                    mockCrypto!.getSecretStorageStatus.mockResolvedValue(readySecretStorageStatus);
+                    mockCrypto!.getActiveSessionBackupVersion.mockResolvedValue("1");
+                    mockCrypto!.isDehydratedDeviceKeyMissing.mockResolvedValue(true);
+
+                    await createAndStart();
+
+                    expect(SetupEncryptionToast.showToast).toHaveBeenCalledWith("dehydration_key_out_of_sync");
                 });
 
                 it("shows an out-of-sync toast when one of the cross-signing secrets is missing locally", async () => {

--- a/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
+++ b/apps/web/src/device-listener/DeviceListenerCurrentDevice.ts
@@ -197,6 +197,11 @@ export class DeviceListenerCurrentDevice {
             return;
         }
 
+        failed = await this.failIfDehydrationKeyMissing(crypto, logSpan);
+        if (failed) {
+            return;
+        }
+
         // Everything is OK - no need to show a toast
         logSpan.info("No toast needed");
         this.setDeviceState("ok", logSpan);
@@ -337,6 +342,27 @@ export class DeviceListenerCurrentDevice {
             await this.failedCheck("key_storage_out_of_sync", logSpan, "warn", "Backup key is not cached locally");
             return true;
         }
+    }
+
+    /**
+     * If a dehydrated device exists on the server (set up on another of the user's devices) but we don't
+     * hold its dehydration key, show a toast prompting the user to recover the key and return true.
+     * Otherwise, return false.
+     *
+     * Checked last, so it only fires once the device is otherwise healthy. See
+     * https://github.com/element-hq/element-web/issues/29579.
+     */
+    private async failIfDehydrationKeyMissing(crypto: CryptoApi, logSpan: LogSpan): Promise<boolean> {
+        if (await crypto.isDehydratedDeviceKeyMissing()) {
+            await this.failedCheck(
+                "dehydration_key_out_of_sync",
+                logSpan,
+                "info",
+                "A dehydrated device exists but its key is missing locally",
+            );
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/apps/web/src/device-listener/DeviceState.ts
+++ b/apps/web/src/device-listener/DeviceState.ts
@@ -32,6 +32,11 @@ export type DeviceState =
      */
     | "turn_on_key_storage"
     /**
+     * There is a dehydrated device on the server (set up on another device) for which we don't have the
+     * dehydration key, so we can't access it. The user can enter their recovery key to recover the key.
+     */
+    | "dehydration_key_out_of_sync"
+    /**
      * The user's identity needs resetting, due to missing keys.
      */
     | "identity_needs_reset";

--- a/apps/web/src/i18n/strings/en_EN.json
+++ b/apps/web/src/i18n/strings/en_EN.json
@@ -952,6 +952,8 @@
         "cross_signing_user_normal": "You have not verified this user.",
         "cross_signing_user_verified": "You have verified this user. This user has verified all of their sessions.",
         "cross_signing_user_warning": "This user has not verified all of their sessions.",
+        "dehydration_key_out_of_sync": "Recover your offline device.",
+        "dehydration_key_out_of_sync_description": "One of your other devices set up an offline device that catches messages while you're away, but this device can't access it. Confirm your recovery key to restore access.",
         "enter_recovery_key": "Enter recovery key",
         "event_shield_reason_authenticity_not_guaranteed": "The authenticity of this encrypted message can't be guaranteed on this device.",
         "event_shield_reason_mismatched_sender": "The sender of the event does not match the owner of the device that sent it.",

--- a/apps/web/src/toasts/SetupEncryptionToast.tsx
+++ b/apps/web/src/toasts/SetupEncryptionToast.tsx
@@ -30,6 +30,7 @@ import { UserTab } from "../components/views/dialogs/UserTab";
 import defaultDispatcher from "../dispatcher/dispatcher";
 import ConfirmKeyStorageOffDialog from "../components/views/dialogs/ConfirmKeyStorageOffDialog";
 import { MatrixClientPeg } from "../MatrixClientPeg";
+import { initialiseDehydrationIfEnabled } from "../utils/device/dehydration";
 import { resetKeyBackupAndWait } from "../utils/crypto/resetKeyBackup";
 import { PosthogAnalytics } from "../PosthogAnalytics";
 
@@ -51,6 +52,8 @@ const getTitle = (state: DeviceStateForToast): string => {
             return _t("encryption|key_storage_out_of_sync");
         case "turn_on_key_storage":
             return _t("encryption|turn_on_key_storage");
+        case "dehydration_key_out_of_sync":
+            return _t("encryption|dehydration_key_out_of_sync");
     }
 };
 
@@ -61,6 +64,7 @@ const getIcon = (state: DeviceStateForToast): IToast<any>["icon"] => {
         case "verify_this_session":
         case "key_storage_out_of_sync":
         case "identity_needs_reset":
+        case "dehydration_key_out_of_sync":
             return <ErrorSolidIcon color="var(--cpd-color-icon-critical-primary)" />;
         case "turn_on_key_storage":
             return <SettingsSolidIcon color="var(--cpd-color-text-primary)" />;
@@ -71,6 +75,7 @@ const shouldShowCloseButton = (state: DeviceStateForToast): boolean => {
     switch (state) {
         case "key_storage_out_of_sync":
         case "identity_needs_reset":
+        case "dehydration_key_out_of_sync":
             return true;
         case "set_up_recovery":
         case "verify_this_session":
@@ -86,6 +91,7 @@ const getSetupCaption = (state: DeviceStateForToast): string => {
         case "verify_this_session":
             return _t("action|continue");
         case "key_storage_out_of_sync":
+        case "dehydration_key_out_of_sync":
             return _t("encryption|enter_recovery_key");
         case "turn_on_key_storage":
             return _t("action|continue");
@@ -103,6 +109,7 @@ const getPrimaryButtonIcon = (
 ): ComponentType<React.SVGAttributes<SVGElement>> | undefined => {
     switch (state) {
         case "key_storage_out_of_sync":
+        case "dehydration_key_out_of_sync":
             return KeyIcon;
         default:
             return;
@@ -118,6 +125,7 @@ const getSecondaryButtonLabel = (state: DeviceStateForToast): string => {
         case "key_storage_out_of_sync":
             return _t("encryption|forgot_recovery_key");
         case "turn_on_key_storage":
+        case "dehydration_key_out_of_sync":
             return _t("action|dismiss");
         case "identity_needs_reset":
             return "";
@@ -146,6 +154,8 @@ const getDescription = (state: DeviceStateForToast): string | React.ReactNode =>
             return _t("encryption|turn_on_key_storage_description");
         case "identity_needs_reset":
             return _t("encryption|identity_needs_reset_description");
+        case "dehydration_key_out_of_sync":
+            return _t("encryption|dehydration_key_out_of_sync_description");
     }
 };
 
@@ -251,6 +261,40 @@ export const showToast = (state: DeviceStateForToast): void => {
                     },
                 };
                 defaultDispatcher.dispatch(payload);
+                break;
+            }
+            case "dehydration_key_out_of_sync": {
+                myLogger.debug("Primary button clicked: recovering the dehydration key");
+                const modal = Modal.createDialog(
+                    Spinner,
+                    undefined,
+                    "mx_Dialog_spinner",
+                    /* priority */ false,
+                    /* static */ true,
+                );
+
+                const matrixClient = MatrixClientPeg.safeGet();
+
+                try {
+                    const deviceListener = DeviceListener.sharedInstance();
+                    // Pause the device listener while we unlock secret storage and recover the key, so the
+                    // toast doesn't flicker while the state changes.
+                    await deviceListener.whilePaused(async () => {
+                        await accessSecretStorage(async () => {
+                            // Secret storage is now unlocked: read the dehydration key from it and
+                            // rehydrate the device (and create a fresh dehydrated device).
+                            await initialiseDehydrationIfEnabled(matrixClient, { rehydrate: true });
+                        });
+                    });
+                } catch (error) {
+                    if (error instanceof AccessCancelledError) {
+                        myLogger.debug("Dehydration recovery cancelled by the user");
+                    } else {
+                        myLogger.error("Failed to recover the dehydration key", error);
+                    }
+                } finally {
+                    modal.close();
+                }
                 break;
             }
         }


### PR DESCRIPTION
When a dehydrated device exists on the server (set up on another of the user's devices) but this device does not hold the dehydration key, surface it: DeviceListener checks `CryptoApi.isDehydratedDeviceKeyMissing()` (last, so it only fires once the device is otherwise healthy) and shows a new `dehydration_key_out_of_sync` toast whose primary action unlocks Secret Storage and rehydrates via `initialiseDehydrationIfEnabled`.

Fixes https://github.com/element-hq/element-web/issues/29579.

⚠️ Blocked on matrix-org/matrix-js-sdk#5492, which adds `isDehydratedDeviceKeyMissing()`; CI will fail typecheck until that lands and is picked up.

This code was largely written with Claude, and rebased/revalidated against current develop (DeviceListener unit tests pass locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)