### PR TITLE
Remove global styles for fieldset, legend

### DIFF
--- a/apps/web/res/css/_common.pcss
+++ b/apps/web/res/css/_common.pcss
@@ -232,23 +232,8 @@ textarea:focus {
     outline: none;
 }
 
-/* override defaults */
-fieldset {
-    display: inline-block;
-    margin-inline: unset;
-    padding-block: unset;
-    padding-inline: unset;
-    min-inline-size: unset;
-    border: none;
-}
-
 summary {
     cursor: pointer;
-}
-
-legend {
-    padding-inline: unset;
-    border: none;
 }
 
 /* .mx_textinput is a container for a text input */

--- a/apps/web/res/css/components/views/elements/_FilterTabGroup.pcss
+++ b/apps/web/res/css/components/views/elements/_FilterTabGroup.pcss
@@ -7,6 +7,14 @@ Please see LICENSE files in the repository root for full details.
 */
 
 .mx_FilterTabGroup {
+    /* Reset the browser default <fieldset> styling */
+    display: inline-block;
+    margin-inline: unset;
+    padding-block: unset;
+    padding-inline: unset;
+    min-inline-size: unset;
+    border: none;
+
     color: $primary-content;
     label {
         margin-right: var(--cpd-space-3x);

--- a/apps/web/res/css/views/auth/_AuthBody.pcss
+++ b/apps/web/res/css/views/auth/_AuthBody.pcss
@@ -49,7 +49,13 @@ Please see LICENSE files in the repository root for full details.
     }
 
     fieldset {
+        /* Reset the browser default <fieldset> styling */
         display: block;
+        margin-inline: unset;
+        padding-block: unset;
+        padding-inline: unset;
+        min-inline-size: unset;
+        border: none;
     }
 
     .mx_AuthBody_icon {

--- a/apps/web/res/css/views/messages/_MPollBody.pcss
+++ b/apps/web/res/css/views/messages/_MPollBody.pcss
@@ -14,8 +14,11 @@ $poll-max-width: 550px;
     width: 100%; /* Ensure fieldset takes full available width */
     border: none; /* Remove default fieldset border */
     padding: 0; /* Remove default fieldset padding */
+    margin-inline: unset; /* Remove default fieldset margin */
+    display: inline-block; /* Preserve the fieldset display value we used to set globally */
 
     legend {
+        padding-inline: unset; /* Remove default legend padding */
         font-weight: var(--cpd-font-weight-semibold);
         font-size: $font-15px;
         line-height: $font-24px;

--- a/apps/web/res/css/views/settings/_Notifications.pcss
+++ b/apps/web/res/css/views/settings/_Notifications.pcss
@@ -41,6 +41,7 @@ Please see LICENSE files in the repository root for full details.
 }
 
 .mx_UserNotifSettings_gridRowLabel {
+    padding-inline: unset; /* Remove default legend padding */
     justify-self: start;
     /* <legend> does not accept */
     /* display: inline | inline-block */

--- a/apps/web/res/css/views/settings/_SettingsFieldset.pcss
+++ b/apps/web/res/css/views/settings/_SettingsFieldset.pcss
@@ -7,10 +7,20 @@ Please see LICENSE files in the repository root for full details.
 */
 
 .mx_SettingsFieldset {
+    /* Reset the browser default <fieldset> styling */
+    display: inline-block;
+    margin-inline: unset;
+    padding-block: unset;
+    padding-inline: unset;
+    min-inline-size: unset;
+    border: none;
     box-sizing: content-box;
 }
 
 .mx_SettingsFieldset_legend {
+    /* Reset the browser default <legend> styling */
+    padding-inline: unset;
+    border: none;
     font: var(--cpd-font-heading-md-semibold);
     font-weight: var(--cpd-font-weight-semibold);
     display: block;


### PR DESCRIPTION
This causes conflicts with compound components, and generally is awful. Where the rules were still relied upon, they have been applied directly to those classes.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
