### PR TITLE
Remove global styles for input[type="password]

### DIFF
--- a/apps/web/res/css/_common.pcss
+++ b/apps/web/res/css/_common.pcss
@@ -169,8 +169,7 @@ a:where(:not([data-kind]):not(.mx_MessageTimestamp)):visited {
 }
 
 :not(.mx_no_textinput):not(.mx_textinput):not(.mx_Field) > input[type="text"],
-:not(.mx_no_textinput):not(.mx_textinput):not(.mx_Field) > input[type="search"],
-:not(.mx_no_textinput):not(.mx_textinput):not(.mx_Field) > input[type="password"] {
+:not(.mx_no_textinput):not(.mx_textinput):not(.mx_Field) > input[type="search"] {
     padding: 9px;
     font: var(--cpd-font-body-md-semibold);
     font-weight: var(--cpd-font-weight-semibold);
@@ -206,7 +205,6 @@ textarea::placeholder {
 }
 
 input[type="text"],
-input[type="password"],
 textarea {
     background-color: transparent;
     color: $primary-content;
@@ -218,7 +216,6 @@ textarea {
 }
 
 input[type="text"]:focus,
-input[type="password"]:focus,
 textarea:focus {
     outline: none;
     box-shadow: none;

--- a/apps/web/res/css/views/auth/_AuthBody.pcss
+++ b/apps/web/res/css/views/auth/_AuthBody.pcss
@@ -79,6 +79,14 @@ Please see LICENSE files in the repository root for full details.
         color: $authpage-primary-color;
     }
 
+    input[type="password"] {
+        background-color: transparent;
+        &:focus {
+            outline: none;
+            box-shadow: none;
+        }
+    }
+
     .mx_Field label {
         color: $authpage-secondary-color;
     }

--- a/apps/web/res/css/views/dialogs/security/_AccessSecretStorageDialog.pcss
+++ b/apps/web/res/css/views/dialogs/security/_AccessSecretStorageDialog.pcss
@@ -16,18 +16,22 @@ Please see LICENSE files in the repository root for full details.
 
     .mx_AccessSecretStorageDialog_primaryContainer {
         .mx_AccessSecretStorageDialog_recoveryKeyEntry {
-            /*
-             * Be specific here to avoid "margin: 9px" from _common.pcss
-             */
-            :not(.mx_textinput):not(.mx_Field):not(.mx_no_textinput) {
-                input {
-                    /*
-                     * From figma: https://www.figma.com/design/ZodBLtGnKmRTGJo5SGLnH3/ER-137--Excluding-Insecure-Devices?node-id=102-43729&t=QmewENUd7f6Tmw9U-1
-                     */
-                    width: 448px;
-                    height: 70px;
-                    margin: 0px;
-                    border: 1px solid;
+            input {
+                /*
+                * From figma: https://www.figma.com/design/ZodBLtGnKmRTGJo5SGLnH3/ER-137--Excluding-Insecure-Devices?node-id=102-43729&t=QmewENUd7f6Tmw9U-1
+                */
+                width: 448px;
+                height: 70px;
+                margin: 0px;
+                border: 1px solid;
+                background-color: transparent;
+                color: $primary-content;
+                padding: 9px;
+                font: var(--cpd-font-body-md-semibold);
+                font-weight: var(--cpd-font-weight-semibold);
+                &:focus {
+                    outline: none;
+                    box-shadow: none;
                 }
             }
         }

--- a/apps/web/res/css/views/dialogs/security/_RestoreKeyBackupDialog.pcss
+++ b/apps/web/res/css/views/dialogs/security/_RestoreKeyBackupDialog.pcss
@@ -16,6 +16,19 @@ Please see LICENSE files in the repository root for full details.
     padding: 20px;
 }
 
+.mx_RestoreKeyBackupDialog_passPhraseInput {
+    background-color: transparent;
+    color: $primary-content;
+    padding: 9px;
+    font: var(--cpd-font-body-md-semibold);
+    font-weight: var(--cpd-font-weight-semibold);
+    min-width: 0;
+    &:focus {
+        outline: none;
+        box-shadow: none;
+    }
+}
+
 .mx_RestoreKeyBackupDialog_passPhraseInput,
 .mx_RestoreKeyBackupDialog_recoveryKeyInput {
     width: 300px;

--- a/apps/web/res/css/views/elements/_Field.pcss
+++ b/apps/web/res/css/views/elements/_Field.pcss
@@ -41,6 +41,15 @@ Please see LICENSE files in the repository root for full details.
     min-width: 0;
 }
 
+.mx_Field input[type="password"] {
+    background-color: transparent;
+    color: $primary-content;
+    &:focus {
+        outline: none;
+        box-shadow: none;
+    }
+}
+
 .mx_Field select {
     -moz-appearance: none;
     -webkit-appearance: none;

--- a/apps/web/res/css/views/settings/encryption/_ChangeRecoveryKey.pcss
+++ b/apps/web/res/css/views/settings/encryption/_ChangeRecoveryKey.pcss
@@ -79,6 +79,10 @@
                 border: var(--cpd-border-width-1) solid;
                 border-radius: 8px;
                 margin: 0px;
+                &:focus {
+                    outline: none;
+                    box-shadow: none;
+                }
             }
 
             > button {


### PR DESCRIPTION
Checked through and manually applied the global styles to relevant components, keeping the styleset clean of global styles that might impact Compound.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>