### PR TITLE
Add module Dispatcher API

### DIFF
--- a/apps/web/src/modules/Api.ts
+++ b/apps/web/src/modules/Api.ts
@@ -37,6 +37,7 @@ import { ComposerApi } from "./ComposerApi.ts";
 import { StorageHelperApi } from "./StorageHelperApi.ts";
 import { SettingsApi } from "./SettingsApi.ts";
 import defaultDispatcher from "../dispatcher/dispatcher.ts";
+import { DispatcherApi } from "./DispatcherApi.ts";
 
 const legacyCustomisationsFactory = <T extends object>(baseCustomisations: T) => {
     let used = false;
@@ -98,6 +99,7 @@ export class ModuleApi implements Api {
     public readonly client = new ClientApi();
     public readonly stores = new StoresApi();
     public readonly composer = new ComposerApi(defaultDispatcher);
+    public readonly dispatcher = new DispatcherApi(defaultDispatcher);
     public readonly storageHelper = new StorageHelperApi();
     public readonly settings = new SettingsApi();
 

--- a/apps/web/src/modules/DispatcherApi.test.ts
+++ b/apps/web/src/modules/DispatcherApi.test.ts
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { describe, it, expect, vi } from "vitest";
+
+import { DispatcherApi } from "./DispatcherApi";
+import type { MatrixDispatcher } from "../dispatcher/dispatcher";
+
+describe("DispatcherApi", () => {
+    it("should register the callback with the dispatcher and return its token", () => {
+        const mockDispatcher = {
+            register: vi.fn().mockReturnValue("token-123"),
+            unregister: vi.fn(),
+        } as unknown as MatrixDispatcher;
+        const api = new DispatcherApi(mockDispatcher);
+
+        const callback = vi.fn();
+        const token = api.register(callback);
+
+        expect(mockDispatcher.register).toHaveBeenCalledWith(callback);
+        expect(token).toBe("token-123");
+    });
+
+    it("should unregister the given token from the dispatcher", () => {
+        const mockDispatcher = {
+            register: vi.fn(),
+            unregister: vi.fn(),
+        } as unknown as MatrixDispatcher;
+        const api = new DispatcherApi(mockDispatcher);
+
+        api.unregister("token-123");
+
+        expect(mockDispatcher.unregister).toHaveBeenCalledWith("token-123");
+    });
+});

--- a/apps/web/src/modules/DispatcherApi.ts
+++ b/apps/web/src/modules/DispatcherApi.ts
@@ -1,0 +1,26 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import type { DispatcherApi as IDispatcherApi, DispatchToken, ActionPayload } from "@element-hq/element-web-module-api";
+import type { MatrixDispatcher } from "../dispatcher/dispatcher";
+
+/**
+ * Implements a minimally exposed form of the MatrixDispatcher.
+ */
+export class DispatcherApi implements IDispatcherApi {
+    public constructor(private readonly dispatcher: MatrixDispatcher) {
+
+    }
+
+    public register(callback: (payload: ActionPayload) => void): DispatchToken {
+        return this.dispatcher.register(callback);
+    };
+
+    public unregister(id: DispatchToken): void {
+        this.dispatcher.unregister(id);
+    };
+}

--- a/packages/module-api/element-web-module-api.api.md
+++ b/packages/module-api/element-web-module-api.api.md
@@ -34,6 +34,14 @@ export interface AccountDataApi {
     set(eventType: string, content: unknown): Promise<void>;
 }
 
+// @alpha
+export interface ActionPayload {
+    // (undocumented)
+    [property: string]: any;
+    // (undocumented)
+    action: string;
+}
+
 // @alpha @deprecated (undocumented)
 export interface AliasCustomisations {
     // (undocumented)
@@ -259,6 +267,15 @@ export interface DirectoryCustomisations {
     // (undocumented)
     requireCanonicalAliasAccessToPublish?(): boolean;
 }
+
+// @alpha
+export interface DispatcherApi {
+    register(callback: (payload: ActionPayload) => void): DispatchToken;
+    unregister(id: DispatchToken): void;
+}
+
+// @alpha
+export type DispatchToken = string;
 
 // @alpha
 export type ExtendablePropsRenderFunction<BaseProps> = <P extends BaseProps>(

--- a/packages/module-api/src/api/dispatcher.ts
+++ b/packages/module-api/src/api/dispatcher.ts
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+/**
+ * Opaque token to track a registered callback.
+ * @alpha Unlikely to change.
+ */
+export type DispatchToken = string;
+
+/**
+ * The base dispatch type, containing an `action` and
+ * a freeform set of properties.
+ * @alpha This payload format may change at any point.
+ */
+export interface ActionPayload {
+    action: string;
+    [property: string]: any; // effectively makes this 'extends Object'
+}
+
+/**
+ * A dispatcher for ActionPayloads, which allows modules to listen
+ * for application events.
+ * @alpha Likely to change.
+ */
+export interface DispatcherApi {
+    /**
+     * Registers a callback to be invoked with every dispatched payload.
+     *
+     * @param callback A callback to call each time an an action is fired.
+     * @returns A token that may be used with `unregister`.
+     * @alpha Unlikely to change.
+     */
+    register(callback: (payload: ActionPayload) => void): DispatchToken;
+
+    /**
+     * Unregister a callback.
+     *
+     * @param id Dispatch token from calling `register`.
+     * @alpha Unlikely to change.
+     */
+    unregister(id: DispatchToken): void;
+}

--- a/packages/module-api/src/index.ts
+++ b/packages/module-api/src/index.ts
@@ -21,6 +21,7 @@ export type * from "./models/event";
 export type * from "./models/Room";
 export type * from "./api/composer";
 export type * from "./api/custom-components";
+export type * from "./api/dispatcher";
 export type * from "./api/extras";
 export type * from "./api/legacy-modules";
 export type * from "./api/legacy-customisations";


### PR DESCRIPTION
This is mostly used for listening for application lifecycle events so that modules can perform actions when the client is ready, or the user performs an action. 
