### PR TITLE
Add user status in timeline pills

### DIFF
--- a/apps/web/res/css/views/elements/_Pill.pcss
+++ b/apps/web/res/css/views/elements/_Pill.pcss
@@ -69,6 +69,18 @@ Please see LICENSE files in the repository root for full details.
         white-space: nowrap;
     }
 
+    .mx_Pill_userStatus {
+        margin-inline-start: var(--cpd-space-1x);
+        flex: 0 0 auto;
+    }
+
+    /* Pills with user status are flex so the status emoji stays visible if the
+       display name gets truncated. */
+    &.mx_Pill_withStatus {
+        display: inline-flex;
+        align-items: center;
+    }
+
     a& {
         text-overflow: ellipsis;
         white-space: nowrap;

--- a/apps/web/src/components/views/elements/Pill.tsx
+++ b/apps/web/src/components/views/elements/Pill.tsx
@@ -14,6 +14,7 @@ import { LinkIcon, UserSolidIcon } from "@vector-im/compound-design-tokens/asset
 
 import MatrixClientContext from "../../../contexts/MatrixClientContext";
 import { usePermalink } from "../../../hooks/usePermalink";
+import { useUserStatus } from "../../../hooks/useUserStatus";
 import RoomAvatar from "../avatars/RoomAvatar";
 import MemberAvatar from "../avatars/MemberAvatar";
 import { _t } from "../../../languageHandler";
@@ -87,6 +88,8 @@ export const Pill: React.FC<PillProps> = ({
         url,
     });
     const text = customPillText ?? linkText;
+    // Only user pills show a status
+    const userStatus = useUserStatus(type === PillType.UserMention && resourceId !== null ? resourceId : undefined);
 
     if (!type || !text) {
         return null;
@@ -100,6 +103,7 @@ export const Pill: React.FC<PillProps> = ({
         mx_UserPill_me: resourceId === cli.getUserId(),
         mx_EventPill: type === PillType.EventInOtherRoom || type === PillType.EventInSameRoom,
         mx_KeywordPill: type === PillType.Keyword,
+        mx_Pill_withStatus: !!userStatus,
     });
 
     let avatar: ReactElement | null = null;
@@ -141,6 +145,14 @@ export const Pill: React.FC<PillProps> = ({
             return null;
     }
 
+    const pillContent = (
+        <>
+            {avatar}
+            <span className="mx_Pill_text">{pillText}</span>
+            {userStatus && <span className="mx_Pill_userStatus">{userStatus.emoji}</span>}
+        </>
+    );
+
     const isAnchor = !!inMessage && !!url;
     return (
         <bdi>
@@ -152,14 +164,10 @@ export const Pill: React.FC<PillProps> = ({
             >
                 {isAnchor ? (
                     <a className={classes} href={url} onClick={onClick}>
-                        {avatar}
-                        <span className="mx_Pill_text">{pillText}</span>
+                        {pillContent}
                     </a>
                 ) : (
-                    <span className={classes}>
-                        {avatar}
-                        <span className="mx_Pill_text">{pillText}</span>
-                    </span>
+                    <span className={classes}>{pillContent}</span>
                 )}
             </Tooltip>
         </bdi>

--- a/apps/web/test/unit-tests/components/views/elements/Pill-test.tsx
+++ b/apps/web/test/unit-tests/components/views/elements/Pill-test.tsx
@@ -31,6 +31,11 @@ import { SDKContext } from "../../../../../src/contexts/SDKContext";
 import { SDKContextClass } from "../../../../../src/contexts/SDKContextClass";
 import { MatrixClientPeg } from "../../../../../src/MatrixClientPeg.ts";
 import { TestSDKContext } from "../../../TestSDKContext.ts";
+import { useUserStatus } from "../../../../../src/hooks/useUserStatus.ts";
+
+jest.mock("../../../../../src/hooks/useUserStatus.ts", () => ({
+    useUserStatus: jest.fn(),
+}));
 
 describe("<Pill>", () => {
     let client: Mocked<MatrixClient>;
@@ -122,6 +127,8 @@ describe("<Pill>", () => {
             if (userId === user2Id) return { displayname: "User 2" };
             throw new Error(`Unknown user ${userId}`);
         });
+
+        mocked(useUserStatus).mockReturnValue(undefined);
 
         jest.spyOn(dis, "dispatch");
         pillParentClickHandler = jest.fn();
@@ -220,6 +227,36 @@ describe("<Pill>", () => {
                 expect(pillParentClickHandler).not.toHaveBeenCalled();
             });
         });
+    });
+
+    it("should render the status emoji for a user with a status", () => {
+        // The real hook only returns a status when given a user ID
+        mocked(useUserStatus).mockImplementation((userId) =>
+            userId ? { emoji: "💡", text: "Bright idea" } : undefined,
+        );
+        renderPill({
+            room: room1,
+            url: permalinkPrefix + user1Id,
+        });
+
+        expect(useUserStatus).toHaveBeenCalledWith(user1Id);
+        expect(screen.getByText("💡")).toBeInTheDocument();
+        expect(renderResult.container.querySelector(".mx_Pill_withStatus")).toBeInTheDocument();
+        expect(renderResult.asFragment()).toMatchSnapshot();
+    });
+
+    it("should not render a status for a pill which is not a user mention", () => {
+        // The real hook only returns a status when given a user ID
+        mocked(useUserStatus).mockImplementation((userId) =>
+            userId ? { emoji: "💡", text: "Bright idea" } : undefined,
+        );
+        renderPill({
+            url: permalinkPrefix + room1Id,
+        });
+
+        expect(useUserStatus).toHaveBeenCalledWith(undefined);
+        expect(screen.queryByText("💡")).not.toBeInTheDocument();
+        expect(renderResult.container.querySelector(".mx_Pill_withStatus")).not.toBeInTheDocument();
     });
 
     it("should render the expected pill for a known user not in the room", async () => {

--- a/apps/web/test/unit-tests/components/views/elements/__snapshots__/Pill-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/elements/__snapshots__/Pill-test.tsx.snap
@@ -242,6 +242,41 @@ exports[`<Pill> should render the expected pill for an uknown user not in the ro
 </DocumentFragment>
 `;
 
+exports[`<Pill> should render the status emoji for a user with a status 1`] = `
+<DocumentFragment>
+  <div>
+    <bdi>
+      <a
+        class="mx_Pill mx_UserPill mx_Pill_withStatus"
+        href="https://matrix.to/#/@user1:example.com"
+      >
+        <span
+          aria-hidden="true"
+          class="_avatar_va14e_8 mx_BaseAvatar _avatar-imageless_va14e_55"
+          data-color="4"
+          data-testid="avatar-img"
+          data-type="round"
+          role="presentation"
+          style="--cpd-avatar-size: 16px;"
+        >
+          U
+        </span>
+        <span
+          class="mx_Pill_text"
+        >
+          User 1
+        </span>
+        <span
+          class="mx_Pill_userStatus"
+        >
+          💡
+        </span>
+      </a>
+    </bdi>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`<Pill> when rendering a pill for a room should render the expected pill 1`] = `
 <DocumentFragment>
   <div>


### PR DESCRIPTION
Which, naturally, are entirely separate to composer pills.

<img width="414" height="151" alt="Screenshot 2026-08-26 at 12 06 11" src="https://github.com/user-attachments/assets/81e1518c-179b-47dc-9c2b-135b362db22b" />
<img width="491" height="153" alt="Screenshot 2026-08-26 at 12 06 17" src="https://github.com/user-attachments/assets/c04dca5b-830c-4d83-81ba-ccb0422aa04f" />


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
