### PR TITLE
Remove global button styling on mx_Dialog

### DIFF
--- a/apps/web/res/css/_common.pcss
+++ b/apps/web/res/css/_common.pcss
@@ -559,14 +559,15 @@ summary {
     }
 }
 
-/* XXX: Our button styles are a mess; this is opt-in styling for legacy raw <button>s in dialogs.
- * Search `mx_LegacyDialogButton` in the JSX for the buttons still relying on it.
- * Keep the `.mx_Dialog`/`.mx_Dialog_buttons` ancestor + `button` type selector alongside the marker
- * class: they preserve the specificity of the old selectors, which some per-dialog CSS overrides
- * (e.g. width tweaks) rely on losing to.
+/* XXX: Our button styles are a mess; this is opt-in styling for legacy raw <button>s and
+ * <input type="submit">s in dialogs. Search `mx_LegacyDialogButton` in the JSX for the elements
+ * still relying on it.
+ * Keep the `.mx_Dialog`/`.mx_Dialog_buttons` ancestor + `button`/`input[type="submit"]` type
+ * selector alongside the marker class: they preserve the specificity of the old selectors, which
+ * some per-dialog CSS overrides (e.g. width tweaks) rely on losing to.
  */
 .mx_Dialog button.mx_LegacyDialogButton,
-.mx_Dialog input[type="submit"] {
+.mx_Dialog input.mx_LegacyDialogButton[type="submit"] {
     @mixin mx_DialogButton;
     margin-left: 0px;
     margin-right: var(--buttons-dialog-gap-column);
@@ -585,7 +586,7 @@ summary {
 }
 
 .mx_Dialog button.mx_LegacyDialogButton:focus,
-.mx_Dialog input[type="submit"]:focus {
+.mx_Dialog input.mx_LegacyDialogButton[type="submit"]:focus {
     filter: brightness($focus-brightness);
 }
 
@@ -594,7 +595,7 @@ summary {
  * same-specificity, later-in-source rule; disabled overrides everyone the same way.
  */
 .mx_Dialog button.mx_LegacyDialogButton.mx_Dialog_primary,
-.mx_Dialog input[type="submit"].mx_Dialog_primary,
+.mx_Dialog input.mx_LegacyDialogButton[type="submit"].mx_Dialog_primary,
 .mx_Dialog_buttons button.mx_LegacyDialogButton:not(.cancel) {
     color: var(--cpd-color-text-on-solid-primary);
     background-color: var(--cpd-color-bg-action-primary-rest);
@@ -603,16 +604,14 @@ summary {
 }
 
 .mx_Dialog button.mx_LegacyDialogButton.danger,
-.mx_Dialog_buttons button.mx_LegacyDialogButton.danger,
-.mx_Dialog input[type="submit"].danger {
+.mx_Dialog input.mx_LegacyDialogButton[type="submit"].danger {
     background-color: var(--cpd-color-bg-critical-primary);
     border: solid 1px var(--cpd-color-bg-critical-primary);
     color: var(--cpd-color-text-on-solid-primary);
 }
 
 .mx_Dialog button.mx_LegacyDialogButton.warning,
-.mx_Dialog_buttons button.mx_LegacyDialogButton.warning,
-.mx_Dialog input[type="submit"].warning {
+.mx_Dialog input.mx_LegacyDialogButton[type="submit"].warning {
     border: solid 1px var(--cpd-color-border-critical-subtle);
     color: var(--cpd-color-text-critical-primary);
 }
@@ -625,8 +624,7 @@ summary {
 }
 
 .mx_Dialog button.mx_LegacyDialogButton:disabled,
-.mx_Dialog_buttons button.mx_LegacyDialogButton:disabled,
-.mx_Dialog input[type="submit"]:disabled {
+.mx_Dialog input.mx_LegacyDialogButton[type="submit"]:disabled {
     background-color: $light-fg-color;
     border: solid 1px $light-fg-color;
     opacity: 0.7;

--- a/apps/web/res/css/_common.pcss
+++ b/apps/web/res/css/_common.pcss
@@ -559,16 +559,13 @@ summary {
     }
 }
 
-/* XXX: Our button style are a mess: buttons that happen to appear in dialogs get special styles applied
- * to them that no button anywhere else in the app gets by default. In practice, buttons in other places
- * in the app look the same by being AccessibleButtons, or possibly by having explict button classes.
- * We should go through and have one consistent set of styles for buttons throughout the app.
- * These rules are opt-in: only elements explicitly carrying the `mx_LegacyDialogButton` marker class
- * are styled here, so this can never accidentally catch AccessibleButton/Compound Button `<button>`
- * internals. Search for `mx_LegacyDialogButton` in the JSX to find the current set of legacy raw
- * <button> elements still relying on this rule.
+/* XXX: Our button styles are a mess; this is opt-in styling for legacy raw <button>s in dialogs.
+ * Search `mx_LegacyDialogButton` in the JSX for the buttons still relying on it.
+ * Keep the `.mx_Dialog`/`.mx_Dialog_buttons` ancestor + `button` type selector alongside the marker
+ * class: they preserve the specificity of the old selectors, which some per-dialog CSS overrides
+ * (e.g. width tweaks) rely on losing to.
  */
-.mx_LegacyDialogButton,
+.mx_Dialog button.mx_LegacyDialogButton,
 .mx_Dialog input[type="submit"] {
     @mixin mx_DialogButton;
     margin-left: 0px;
@@ -583,11 +580,11 @@ summary {
     font-family: inherit;
 }
 
-.mx_LegacyDialogButton:last-child {
+.mx_Dialog button.mx_LegacyDialogButton:last-child {
     margin-right: 0px;
 }
 
-.mx_LegacyDialogButton:focus,
+.mx_Dialog button.mx_LegacyDialogButton:focus,
 .mx_Dialog input[type="submit"]:focus {
     filter: brightness($focus-brightness);
 }
@@ -596,39 +593,39 @@ summary {
  * even without the mx_Dialog_primary class - .danger/.warning override the colours below via a
  * same-specificity, later-in-source rule; disabled overrides everyone the same way.
  */
-.mx_LegacyDialogButton.mx_Dialog_primary,
+.mx_Dialog button.mx_LegacyDialogButton.mx_Dialog_primary,
 .mx_Dialog input[type="submit"].mx_Dialog_primary,
-.mx_Dialog_buttons .mx_LegacyDialogButton:not(.cancel) {
+.mx_Dialog_buttons button.mx_LegacyDialogButton:not(.cancel) {
     color: var(--cpd-color-text-on-solid-primary);
     background-color: var(--cpd-color-bg-action-primary-rest);
     border-color: var(--cpd-color-bg-action-primary-rest);
     min-width: 156px;
 }
 
-.mx_LegacyDialogButton.danger,
-.mx_Dialog_buttons .mx_LegacyDialogButton.danger,
+.mx_Dialog button.mx_LegacyDialogButton.danger,
+.mx_Dialog_buttons button.mx_LegacyDialogButton.danger,
 .mx_Dialog input[type="submit"].danger {
     background-color: var(--cpd-color-bg-critical-primary);
     border: solid 1px var(--cpd-color-bg-critical-primary);
     color: var(--cpd-color-text-on-solid-primary);
 }
 
-.mx_LegacyDialogButton.warning,
-.mx_Dialog_buttons .mx_LegacyDialogButton.warning,
+.mx_Dialog button.mx_LegacyDialogButton.warning,
+.mx_Dialog_buttons button.mx_LegacyDialogButton.warning,
 .mx_Dialog input[type="submit"].warning {
     border: solid 1px var(--cpd-color-border-critical-subtle);
     color: var(--cpd-color-text-critical-primary);
 }
 
-.mx_Dialog_buttons .mx_LegacyDialogButton.cancel {
+.mx_Dialog_buttons button.mx_LegacyDialogButton.cancel {
     color: var(--cpd-color-text-primary);
     background-color: var(--cpd-color-bg-action-secondary-rest);
     border-color: var(--cpd-color-border-interactive-secondary);
     min-width: 156px;
 }
 
-.mx_LegacyDialogButton:disabled,
-.mx_Dialog_buttons .mx_LegacyDialogButton:disabled,
+.mx_Dialog button.mx_LegacyDialogButton:disabled,
+.mx_Dialog_buttons button.mx_LegacyDialogButton:disabled,
 .mx_Dialog input[type="submit"]:disabled {
     background-color: $light-fg-color;
     border: solid 1px $light-fg-color;

--- a/apps/web/res/css/_common.pcss
+++ b/apps/web/res/css/_common.pcss
@@ -563,31 +563,13 @@ summary {
  * to them that no button anywhere else in the app gets by default. In practice, buttons in other places
  * in the app look the same by being AccessibleButtons, or possibly by having explict button classes.
  * We should go through and have one consistent set of styles for buttons throughout the app.
- * For now, I am duplicating the selectors here for mx_Dialog and mx_DialogButtons.
+ * These rules are opt-in: only elements explicitly carrying the `mx_LegacyDialogButton` marker class
+ * are styled here, so this can never accidentally catch AccessibleButton/Compound Button `<button>`
+ * internals. Search for `mx_LegacyDialogButton` in the JSX to find the current set of legacy raw
+ * <button> elements still relying on this rule.
  */
-.mx_Dialog
-    button:not(
-        .mx_EncryptionUserSettingsTab button,
-        .mx_EncryptionCard button,
-        .mx_UserProfileSettings button,
-        .mx_ShareDialog button,
-        .mx_UnpinAllDialog button,
-        .mx_ThemeChoicePanel_CustomTheme button,
-        .mx_Dialog_nonDialogButton,
-        .mx_AccessibleButton,
-        .mx_IdentityServerPicker button,
-        .mx_AccessSecretStorageDialog button,
-        .mx_InviteDialog_section button,
-        .mx_InviteDialog_editor button,
-        .mx_UnknownIdentityUsersWarningDialog button,
-        .mx_ThreadActionBar button,
-        .mx_HistoryActionBar button,
-        [data-kind],
-        [class|="maplibregl"]
-    ),
-.mx_Dialog_buttons button:not(.mx_Dialog_nonDialogButton, .mx_AccessibleButton, [data-kind]),
-.mx_Dialog input[type="submit"],
-.mx_Dialog_buttons input[type="submit"] {
+.mx_LegacyDialogButton,
+.mx_Dialog input[type="submit"] {
     @mixin mx_DialogButton;
     margin-left: 0px;
     margin-right: var(--buttons-dialog-gap-column);
@@ -601,116 +583,56 @@ summary {
     font-family: inherit;
 }
 
-.mx_Dialog
-    button:not(
-        .mx_Dialog_nonDialogButton,
-        [class|="maplibregl"],
-        .mx_AccessibleButton,
-        .mx_UserProfileSettings button,
-        .mx_ThemeChoicePanel_CustomTheme button,
-        .mx_UnpinAllDialog button,
-        .mx_ShareDialog button,
-        .mx_EncryptionUserSettingsTab button,
-        .mx_UnknownIdentityUsersWarningDialog button,
-        [data-kind]
-    ):last-child {
+.mx_LegacyDialogButton:last-child {
     margin-right: 0px;
 }
 
-.mx_Dialog
-    button:not(
-        .mx_Dialog_nonDialogButton,
-        [class|="maplibregl"],
-        .mx_AccessibleButton,
-        .mx_UserProfileSettings button,
-        .mx_ThemeChoicePanel_CustomTheme button,
-        .mx_UnpinAllDialog button,
-        .mx_ShareDialog button,
-        .mx_EncryptionUserSettingsTab button,
-        .mx_InviteDialog_section button,
-        .mx_InviteDialog_editor button,
-        .mx_UnknownIdentityUsersWarningDialog button,
-        [data-kind]
-    ):focus,
-.mx_Dialog input[type="submit"]:focus,
-.mx_Dialog_buttons button:not(.mx_Dialog_nonDialogButton, .mx_AccessibleButton, [data-kind]):focus,
-.mx_Dialog_buttons input[type="submit"]:focus {
+.mx_LegacyDialogButton:focus,
+.mx_Dialog input[type="submit"]:focus {
     filter: brightness($focus-brightness);
 }
 
-.mx_Dialog button.mx_Dialog_primary:not(.mx_Dialog_nonDialogButton, [class|="maplibregl"], [data-kind]),
+/* Default (non-cancel) buttons inside a DialogButtons footer get filled in as the primary action,
+ * even without the mx_Dialog_primary class - .danger/.warning override the colours below via a
+ * same-specificity, later-in-source rule; disabled overrides everyone the same way.
+ */
+.mx_LegacyDialogButton.mx_Dialog_primary,
 .mx_Dialog input[type="submit"].mx_Dialog_primary,
-.mx_Dialog_buttons
-    button:not(
-        .mx_Dialog_nonDialogButton,
-        .mx_AccessibleButton,
-        .cancel,
-        .mx_UserProfileSettings button,
-        .mx_ThemeChoicePanel_CustomTheme button,
-        .mx_UnpinAllDialog button,
-        .mx_ShareDialog button,
-        .mx_EncryptionUserSettingsTab button,
-        .mx_UnknownIdentityUsersWarningDialog button,
-        [data-kind]
-    ),
-.mx_Dialog_buttons input[type="submit"].mx_Dialog_primary {
+.mx_Dialog_buttons .mx_LegacyDialogButton:not(.cancel) {
     color: var(--cpd-color-text-on-solid-primary);
     background-color: var(--cpd-color-bg-action-primary-rest);
     border-color: var(--cpd-color-bg-action-primary-rest);
     min-width: 156px;
 }
 
-.mx_Dialog button.danger:not(.mx_Dialog_nonDialogButton, [class|="maplibregl"]),
-.mx_Dialog input[type="submit"].danger,
-.mx_Dialog_buttons
-    button.danger:not(
-        .mx_Dialog_nonDialogButton,
-        .mx_AccessibleButton,
-        .mx_UserProfileSettings button,
-        .mx_ThemeChoicePanel_CustomTheme button,
-        .mx_UnpinAllDialog button,
-        .mx_ShareDialog button,
-        .mx_EncryptionUserSettingsTab button,
-        .mx_UnknownIdentityUsersWarningDialog button
-    ),
-.mx_Dialog_buttons input[type="submit"].danger {
+.mx_LegacyDialogButton.danger,
+.mx_Dialog_buttons .mx_LegacyDialogButton.danger,
+.mx_Dialog input[type="submit"].danger {
     background-color: var(--cpd-color-bg-critical-primary);
     border: solid 1px var(--cpd-color-bg-critical-primary);
     color: var(--cpd-color-text-on-solid-primary);
 }
 
-.mx_Dialog button.warning:not(.mx_Dialog_nonDialogButton, [class|="maplibregl"]),
+.mx_LegacyDialogButton.warning,
+.mx_Dialog_buttons .mx_LegacyDialogButton.warning,
 .mx_Dialog input[type="submit"].warning {
     border: solid 1px var(--cpd-color-border-critical-subtle);
     color: var(--cpd-color-text-critical-primary);
 }
 
-.mx_Dialog
-    button:not(
-        .mx_Dialog_nonDialogButton,
-        [class|="maplibregl"],
-        .mx_AccessibleButton,
-        .mx_UserProfileSettings button,
-        .mx_ThemeChoicePanel_CustomTheme button,
-        .mx_UnpinAllDialog button,
-        .mx_ShareDialog button,
-        .mx_EncryptionUserSettingsTab button,
-        .mx_UnknownIdentityUsersWarningDialog button,
-        [data-kind]
-    ):disabled,
-.mx_Dialog input[type="submit"]:disabled,
-.mx_Dialog_buttons button:not(.mx_Dialog_nonDialogButton, .mx_AccessibleButton):disabled,
-.mx_Dialog_buttons input[type="submit"]:disabled {
-    background-color: $light-fg-color;
-    border: solid 1px $light-fg-color;
-    opacity: 0.7;
-}
-
-.mx_Dialog_buttons button.cancel {
+.mx_Dialog_buttons .mx_LegacyDialogButton.cancel {
     color: var(--cpd-color-text-primary);
     background-color: var(--cpd-color-bg-action-secondary-rest);
     border-color: var(--cpd-color-border-interactive-secondary);
     min-width: 156px;
+}
+
+.mx_LegacyDialogButton:disabled,
+.mx_Dialog_buttons .mx_LegacyDialogButton:disabled,
+.mx_Dialog input[type="submit"]:disabled {
+    background-color: $light-fg-color;
+    border: solid 1px $light-fg-color;
+    opacity: 0.7;
 }
 
 /* Spinner Dialog overide */

--- a/apps/web/src/Registration.tsx
+++ b/apps/web/src/Registration.tsx
@@ -56,6 +56,7 @@ export async function startAnyRegistrationFlow(
                           modal.close();
                           dis.dispatch({ action: "start_registration", screenAfterLogin: options.screen_after });
                       }}
+                      className="mx_LegacyDialogButton"
                       type="button"
                   >
                       {_t("auth|register_action")}

--- a/apps/web/src/__snapshots__/Terms.test.ts.snap
+++ b/apps/web/src/__snapshots__/Terms.test.ts.snap
@@ -107,14 +107,14 @@ exports[`dialogTermsInteractionCallback > should render a dialog with the expect
       class="mx_Dialog_buttons_row"
     >
       <button
-        class="cancel"
+        class="mx_LegacyDialogButton cancel"
         data-testid="dialog-cancel-button"
         type="button"
       >
         Cancel
       </button>
       <button
-        class="mx_Dialog_primary"
+        class="mx_LegacyDialogButton mx_Dialog_primary"
         data-testid="dialog-primary-button"
         disabled=""
         type="button"

--- a/apps/web/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
+++ b/apps/web/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
@@ -426,7 +426,7 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
                     hasCancel={false}
                     disabled={!this.state.passPhraseValid}
                 >
-                    <button type="button" onClick={this.onCancelClick} className="danger">
+                    <button type="button" onClick={this.onCancelClick} className="mx_LegacyDialogButton danger">
                         {_t("action|cancel")}
                     </button>
                 </DialogButtons>
@@ -486,7 +486,7 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
                     hasCancel={false}
                     disabled={this.state.passPhrase !== this.state.passPhraseConfirm}
                 >
-                    <button type="button" onClick={this.onCancelClick} className="danger">
+                    <button type="button" onClick={this.onCancelClick} className="mx_LegacyDialogButton danger">
                         {_t("action|skip")}
                     </button>
                 </DialogButtons>
@@ -600,7 +600,7 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
                     onPrimaryButtonClick={this.onGoBackClick}
                     hasCancel={false}
                 >
-                    <button type="button" className="danger" onClick={this.onCancel}>
+                    <button type="button" className="mx_LegacyDialogButton danger" onClick={this.onCancel}>
                         {_t("action|cancel")}
                     </button>
                 </DialogButtons>

--- a/apps/web/src/async-components/views/dialogs/security/ExportE2eKeysDialog.tsx
+++ b/apps/web/src/async-components/views/dialogs/security/ExportE2eKeysDialog.tsx
@@ -206,7 +206,7 @@ export default class ExportE2eKeysDialog extends React.Component<IProps, IState>
                     </div>
                     <div className="mx_Dialog_buttons">
                         <input
-                            className="mx_Dialog_primary"
+                            className="mx_LegacyDialogButton mx_Dialog_primary"
                             type="submit"
                             value={_t("action|export")}
                             disabled={disableForm}

--- a/apps/web/src/async-components/views/dialogs/security/ExportE2eKeysDialog.tsx
+++ b/apps/web/src/async-components/views/dialogs/security/ExportE2eKeysDialog.tsx
@@ -211,7 +211,12 @@ export default class ExportE2eKeysDialog extends React.Component<IProps, IState>
                             value={_t("action|export")}
                             disabled={disableForm}
                         />
-                        <button onClick={this.onCancelClick} disabled={disableForm} type="button">
+                        <button
+                            onClick={this.onCancelClick}
+                            disabled={disableForm}
+                            className="mx_LegacyDialogButton"
+                            type="button"
+                        >
                             {_t("action|cancel")}
                         </button>
                     </div>

--- a/apps/web/src/async-components/views/dialogs/security/ImportE2eKeysDialog.tsx
+++ b/apps/web/src/async-components/views/dialogs/security/ImportE2eKeysDialog.tsx
@@ -174,7 +174,7 @@ export default class ImportE2eKeysDialog extends React.Component<IProps, IState>
                     </div>
                     <div className="mx_Dialog_buttons">
                         <input
-                            className="mx_Dialog_primary"
+                            className="mx_LegacyDialogButton mx_Dialog_primary"
                             type="submit"
                             value={_t("action|import")}
                             disabled={!this.state.enableSubmit || disableForm}

--- a/apps/web/src/async-components/views/dialogs/security/ImportE2eKeysDialog.tsx
+++ b/apps/web/src/async-components/views/dialogs/security/ImportE2eKeysDialog.tsx
@@ -179,7 +179,12 @@ export default class ImportE2eKeysDialog extends React.Component<IProps, IState>
                             value={_t("action|import")}
                             disabled={!this.state.enableSubmit || disableForm}
                         />
-                        <button onClick={this.onCancelClick} disabled={disableForm} type="button">
+                        <button
+                            onClick={this.onCancelClick}
+                            disabled={disableForm}
+                            className="mx_LegacyDialogButton"
+                            type="button"
+                        >
                             {_t("action|cancel")}
                         </button>
                     </div>

--- a/apps/web/src/async-components/views/dialogs/security/__snapshots__/NewRecoveryMethodDialog.test.tsx.snap
+++ b/apps/web/src/async-components/views/dialogs/security/__snapshots__/NewRecoveryMethodDialog.test.tsx.snap
@@ -54,14 +54,14 @@ exports[`<NewRecoveryMethodDialog /> > when key backup is disabled 1`] = `
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="cancel"
+          class="mx_LegacyDialogButton cancel"
           data-testid="dialog-cancel-button"
           type="button"
         >
           Go to Settings
         </button>
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           type="button"
         >
@@ -154,14 +154,14 @@ exports[`<NewRecoveryMethodDialog /> > when key backup is enabled 1`] = `
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="cancel"
+          class="mx_LegacyDialogButton cancel"
           data-testid="dialog-cancel-button"
           type="button"
         >
           Go to Settings
         </button>
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           type="button"
         >

--- a/apps/web/src/components/structures/ViewSource.test.tsx
+++ b/apps/web/src/components/structures/ViewSource.test.tsx
@@ -63,4 +63,16 @@ describe("ViewSource", () => {
         const { getByRole } = render(<ViewSource mxEvent={event} onFinished={() => {}} />);
         expect(getByRole("button", { name: "Edit" })).toBeInTheDocument();
     });
+
+    it("should render", () => {
+        const event = mkMessage({
+            msg: "hello",
+            user: SENDER,
+            room: ROOM_ID,
+            event: true,
+            id: "$event1:example.org",
+        });
+        const { asFragment } = render(<ViewSource mxEvent={event} onFinished={() => {}} />);
+        expect(asFragment()).toMatchSnapshot();
+    });
 });

--- a/apps/web/src/components/structures/ViewSource.test.tsx
+++ b/apps/web/src/components/structures/ViewSource.test.tsx
@@ -72,6 +72,7 @@ describe("ViewSource", () => {
             user: MatrixClientPeg.get()!.getSafeUserId(),
             room: ROOM_ID,
             event: true,
+            id: "$event2:example.org",
         });
         const { getByRole, asFragment } = render(<ViewSource mxEvent={event} onFinished={() => {}} />);
         const editButton = getByRole("button", { name: "Edit" });

--- a/apps/web/src/components/structures/ViewSource.test.tsx
+++ b/apps/web/src/components/structures/ViewSource.test.tsx
@@ -16,6 +16,7 @@ import React from "react";
 import { mkEvent, stubClient, mkMessage } from "test-utils";
 import ViewSource from "./ViewSource";
 import { MatrixClientPeg } from "../../MatrixClientPeg";
+import userEvent from "@testing-library/user-event";
 
 describe("ViewSource", () => {
     const ROOM_ID = "!roomId:example.org";
@@ -43,6 +44,18 @@ describe("ViewSource", () => {
 
     beforeEach(stubClient);
 
+    it("should render", () => {
+        const event = mkMessage({
+            msg: "hello",
+            user: SENDER,
+            room: ROOM_ID,
+            event: true,
+            id: "$event1:example.org",
+        });
+        const { asFragment } = render(<ViewSource mxEvent={event} onFinished={() => {}} />);
+        expect(asFragment()).toMatchSnapshot();
+    });
+
     // See https://github.com/vector-im/element-web/issues/24165
     it("doesn't error when viewing redacted encrypted messages", () => {
         // Sanity checks
@@ -53,26 +66,17 @@ describe("ViewSource", () => {
         expect(() => render(<ViewSource mxEvent={redactedMessageEvent} onFinished={() => {}} />)).not.toThrow();
     });
 
-    it("should show edit button if we are the sender and can post an edit", () => {
+    it("should be able to edit a message", async () => {
         const event = mkMessage({
             msg: "Test",
             user: MatrixClientPeg.get()!.getSafeUserId(),
             room: ROOM_ID,
             event: true,
         });
-        const { getByRole } = render(<ViewSource mxEvent={event} onFinished={() => {}} />);
-        expect(getByRole("button", { name: "Edit" })).toBeInTheDocument();
-    });
-
-    it("should render", () => {
-        const event = mkMessage({
-            msg: "hello",
-            user: SENDER,
-            room: ROOM_ID,
-            event: true,
-            id: "$event1:example.org",
-        });
-        const { asFragment } = render(<ViewSource mxEvent={event} onFinished={() => {}} />);
+        const { getByRole, asFragment } = render(<ViewSource mxEvent={event} onFinished={() => {}} />);
+        const editButton = getByRole("button", { name: "Edit" });
+        expect(editButton).toBeInTheDocument();
+        await userEvent.click(editButton);
         expect(asFragment()).toMatchSnapshot();
     });
 });

--- a/apps/web/src/components/structures/ViewSource.tsx
+++ b/apps/web/src/components/structures/ViewSource.tsx
@@ -172,7 +172,7 @@ export default class ViewSource extends React.Component<IProps, IState> {
                 {isEditing ? this.editSourceContent() : this.viewSourceContent()}
                 {!isEditing && canEdit && (
                     <div className="mx_Dialog_buttons">
-                        <button onClick={() => this.onEdit()} type="button">
+                        <button onClick={() => this.onEdit()} className="mx_LegacyDialogButton" type="button">
                             {_t("action|edit")}
                         </button>
                     </div>

--- a/apps/web/src/components/structures/__snapshots__/MatrixChat.test.tsx.snap
+++ b/apps/web/src/components/structures/__snapshots__/MatrixChat.test.tsx.snap
@@ -611,14 +611,14 @@ exports[`<MatrixChat /> > with an existing session > onAction() > room actions >
       class="mx_Dialog_buttons_row"
     >
       <button
-        class="cancel"
+        class="mx_LegacyDialogButton cancel"
         data-testid="dialog-cancel-button"
         type="button"
       >
         Cancel
       </button>
       <button
-        class="mx_Dialog_primary"
+        class="mx_LegacyDialogButton mx_Dialog_primary"
         data-testid="dialog-primary-button"
         type="button"
       >
@@ -682,14 +682,14 @@ exports[`<MatrixChat /> > with an existing session > onAction() > room actions >
       class="mx_Dialog_buttons_row"
     >
       <button
-        class="cancel"
+        class="mx_LegacyDialogButton cancel"
         data-testid="dialog-cancel-button"
         type="button"
       >
         Cancel
       </button>
       <button
-        class="mx_Dialog_primary"
+        class="mx_LegacyDialogButton mx_Dialog_primary"
         data-testid="dialog-primary-button"
         type="button"
       >

--- a/apps/web/src/components/structures/__snapshots__/ViewSource.test.tsx.snap
+++ b/apps/web/src/components/structures/__snapshots__/ViewSource.test.tsx.snap
@@ -1,0 +1,175 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ViewSource > should render 1`] = `
+<DocumentFragment>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+  <div
+    aria-labelledby="mx_BaseDialog_title"
+    class="mx_ViewSource mx_Dialog_fixedWidth"
+    data-focus-lock-disabled="false"
+    role="dialog"
+    tabindex="-1"
+  >
+    <div
+      class="mx_Dialog_header"
+    >
+      <h1
+        class="mx_Heading_h3 mx_Dialog_title"
+        id="mx_BaseDialog_title"
+      >
+        View Source
+      </h1>
+    </div>
+    <div
+      class="mx_ViewSource_header"
+    >
+      <span
+        class="mx_CopyableText"
+      >
+        Room ID: !roomId:example.org
+        <button
+          aria-labelledby="react-use-id-1"
+          class="_icon-button_1215g_8 mx_CopyableText_copyButton"
+          data-kind="primary"
+          role="button"
+          style="--cpd-icon-button-size: 28px; padding: 4px;"
+          tabindex="0"
+        >
+          <div
+            class="_indicator-icon_147l5_17"
+            style="--cpd-icon-button-size: 100%;"
+          >
+            <svg
+              fill="currentColor"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M14 5H5v9h1a1 1 0 1 1 0 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1a1 1 0 1 1-2 0z"
+              />
+              <path
+                d="M8 10a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-9a2 2 0 0 1-2-2zm2 0v9h9v-9z"
+              />
+            </svg>
+          </div>
+        </button>
+      </span>
+      <span
+        class="mx_CopyableText"
+      >
+        Event ID: $event1:example.org
+        <button
+          aria-labelledby="react-use-id-2"
+          class="_icon-button_1215g_8 mx_CopyableText_copyButton"
+          data-kind="primary"
+          role="button"
+          style="--cpd-icon-button-size: 28px; padding: 4px;"
+          tabindex="0"
+        >
+          <div
+            class="_indicator-icon_147l5_17"
+            style="--cpd-icon-button-size: 100%;"
+          >
+            <svg
+              fill="currentColor"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M14 5H5v9h1a1 1 0 1 1 0 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1a1 1 0 1 1-2 0z"
+              />
+              <path
+                d="M8 10a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-9a2 2 0 0 1-2-2zm2 0v9h9v-9z"
+              />
+            </svg>
+          </div>
+        </button>
+      </span>
+    </div>
+    <div
+      class="mx_ViewSource_heading"
+    >
+      Original event source
+    </div>
+    <span
+      class="mx_CopyableText mx_CopyableText_border"
+    >
+      <pre
+        class="mx_SyntaxHighlight hljs language-undefined"
+      >
+        {
+  "type": "m.room.message",
+  "room_id": "!roomId:example.org",
+  "sender": "@alice:example.org",
+  "content": {
+    "msgtype": "m.text",
+    "body": "hello"
+  },
+  "event_id": "$event1:example.org",
+  "origin_server_ts": 0,
+  "unsigned": {}
+}
+      </pre>
+      <button
+        aria-labelledby="react-use-id-3"
+        class="_icon-button_1215g_8 mx_CopyableText_copyButton"
+        data-kind="primary"
+        role="button"
+        style="--cpd-icon-button-size: 28px; padding: 4px;"
+        tabindex="0"
+      >
+        <div
+          class="_indicator-icon_147l5_17"
+          style="--cpd-icon-button-size: 100%;"
+        >
+          <svg
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M14 5H5v9h1a1 1 0 1 1 0 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1a1 1 0 1 1-2 0z"
+            />
+            <path
+              d="M8 10a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-9a2 2 0 0 1-2-2zm2 0v9h9v-9z"
+            />
+          </svg>
+        </div>
+      </button>
+    </span>
+    <div
+      aria-label="Close dialog"
+      class="mx_AccessibleButton mx_Dialog_cancelButton"
+      role="button"
+      tabindex="0"
+    >
+      <svg
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.293 6.293a1 1 0 0 1 1.414 0L12 10.586l4.293-4.293a1 1 0 1 1 1.414 1.414L13.414 12l4.293 4.293a1 1 0 0 1-1.414 1.414L12 13.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L10.586 12 6.293 7.707a1 1 0 0 1 0-1.414"
+        />
+      </svg>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+</DocumentFragment>
+`;

--- a/apps/web/src/components/structures/__snapshots__/ViewSource.test.tsx.snap
+++ b/apps/web/src/components/structures/__snapshots__/ViewSource.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`ViewSource > should be able to edit a message 1`] = `
       <span
         class="mx_CopyableText"
       >
-        Event ID: $0.3489593811169033-0.9457090711759738
+        Event ID: $event2:example.org
         <button
           aria-labelledby="react-use-id-2"
           class="_icon-button_1215g_8 mx_CopyableText_copyButton"
@@ -138,7 +138,7 @@ exports[`ViewSource > should be able to edit a message 1`] = `
   },
   "m.relates_to": {
     "rel_type": "m.replace",
-    "event_id": "$0.3489593811169033-0.9457090711759738"
+    "event_id": "$event2:example.org"
   }
 }
         </textarea>

--- a/apps/web/src/components/structures/__snapshots__/ViewSource.test.tsx.snap
+++ b/apps/web/src/components/structures/__snapshots__/ViewSource.test.tsx.snap
@@ -1,5 +1,197 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`ViewSource > should be able to edit a message 1`] = `
+<DocumentFragment>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+  <div
+    aria-labelledby="mx_BaseDialog_title"
+    class="mx_ViewSource mx_Dialog_fixedWidth"
+    data-focus-lock-disabled="false"
+    role="dialog"
+    tabindex="-1"
+  >
+    <div
+      class="mx_Dialog_header"
+    >
+      <h1
+        class="mx_Heading_h3 mx_Dialog_title"
+        id="mx_BaseDialog_title"
+      >
+        View Source
+      </h1>
+    </div>
+    <div
+      class="mx_ViewSource_header"
+    >
+      <span
+        class="mx_CopyableText"
+      >
+        Room ID: !roomId:example.org
+        <button
+          aria-labelledby="react-use-id-1"
+          class="_icon-button_1215g_8 mx_CopyableText_copyButton"
+          data-kind="primary"
+          role="button"
+          style="--cpd-icon-button-size: 28px; padding: 4px;"
+          tabindex="0"
+        >
+          <div
+            class="_indicator-icon_147l5_17"
+            style="--cpd-icon-button-size: 100%;"
+          >
+            <svg
+              fill="currentColor"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M14 5H5v9h1a1 1 0 1 1 0 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1a1 1 0 1 1-2 0z"
+              />
+              <path
+                d="M8 10a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-9a2 2 0 0 1-2-2zm2 0v9h9v-9z"
+              />
+            </svg>
+          </div>
+        </button>
+      </span>
+      <span
+        class="mx_CopyableText"
+      >
+        Event ID: $0.3489593811169033-0.9457090711759738
+        <button
+          aria-labelledby="react-use-id-2"
+          class="_icon-button_1215g_8 mx_CopyableText_copyButton"
+          data-kind="primary"
+          role="button"
+          style="--cpd-icon-button-size: 28px; padding: 4px;"
+          tabindex="0"
+        >
+          <div
+            class="_indicator-icon_147l5_17"
+            style="--cpd-icon-button-size: 100%;"
+          >
+            <svg
+              fill="currentColor"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M14 5H5v9h1a1 1 0 1 1 0 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1a1 1 0 1 1-2 0z"
+              />
+              <path
+                d="M8 10a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-9a2 2 0 0 1-2-2zm2 0v9h9v-9z"
+              />
+            </svg>
+          </div>
+        </button>
+      </span>
+    </div>
+    <div
+      class="mx_DevTools_content"
+    >
+      <div
+        class="mx_DevTools_eventTypeStateKeyGroup"
+      >
+        <div
+          class="mx_Field mx_Field_input"
+        >
+          <input
+            autocomplete="on"
+            id="eventType"
+            label="Event Type"
+            placeholder="Event Type"
+            size="42"
+            type="text"
+            value="m.room.message"
+          />
+          <label
+            for="eventType"
+          >
+            Event Type
+          </label>
+        </div>
+      </div>
+      <div
+        class="mx_Field mx_Field_textarea mx_DevTools_textarea"
+      >
+        <textarea
+          autocomplete="off"
+          id="evContent"
+          label="Event Content"
+          placeholder="Event Content"
+          type="text"
+        >
+          {
+  "body": " * Test",
+  "msgtype": "m.text",
+  "m.new_content": {
+    "body": "Test",
+    "msgtype": "m.text"
+  },
+  "m.relates_to": {
+    "rel_type": "m.replace",
+    "event_id": "$0.3489593811169033-0.9457090711759738"
+  }
+}
+        </textarea>
+        <label
+          for="evContent"
+        >
+          Event Content
+        </label>
+      </div>
+    </div>
+    <div
+      class="mx_Dialog_buttons"
+    >
+      <button
+        class="mx_LegacyDialogButton"
+        type="button"
+      >
+        Back
+      </button>
+      <button
+        class="mx_LegacyDialogButton"
+        type="button"
+      >
+        Send
+      </button>
+    </div>
+    <div
+      aria-label="Close dialog"
+      class="mx_AccessibleButton mx_Dialog_cancelButton"
+      role="button"
+      tabindex="0"
+    >
+      <svg
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6.293 6.293a1 1 0 0 1 1.414 0L12 10.586l4.293-4.293a1 1 0 1 1 1.414 1.414L13.414 12l4.293 4.293a1 1 0 0 1-1.414 1.414L12 13.414l-4.293 4.293a1 1 0 0 1-1.414-1.414L10.586 12 6.293 7.707a1 1 0 0 1 0-1.414"
+        />
+      </svg>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+</DocumentFragment>
+`;
+
 exports[`ViewSource > should render 1`] = `
 <DocumentFragment>
   <div

--- a/apps/web/src/components/views/auth/InteractiveAuthEntryComponents.tsx
+++ b/apps/web/src/components/views/auth/InteractiveAuthEntryComponents.tsx
@@ -141,7 +141,7 @@ export class PasswordAuthEntry extends React.Component<IAuthEntryProps, IPasswor
             submitButtonOrSpinner = (
                 <input
                     type="submit"
-                    className="mx_Dialog_primary"
+                    className="mx_LegacyDialogButton mx_Dialog_primary"
                     disabled={!this.state.password}
                     value={_t("action|continue")}
                 />
@@ -625,6 +625,7 @@ export class MsisdnAuthEntry extends React.Component<IMsisdnAuthEntryProps, IMsi
             const submitClasses = classNames({
                 mx_InteractiveAuthEntryComponents_msisdnSubmit: true,
                 mx_GeneralButton: true,
+                mx_LegacyDialogButton: true,
             });
             let errorSection;
             if (this.state.errorText) {

--- a/apps/web/src/components/views/dialogs/AskInviteAnywayDialog.tsx
+++ b/apps/web/src/components/views/dialogs/AskInviteAnywayDialog.tsx
@@ -77,13 +77,13 @@ export default function AskInviteAnywayDialog({
             </div>
 
             <div className="mx_Dialog_buttons">
-                <button onClick={onGiveUpClicked} type="button">
+                <button onClick={onGiveUpClicked} className="mx_LegacyDialogButton" type="button">
                     {_t("action|close")}
                 </button>
-                <button onClick={onInviteNeverWarnClicked} type="button">
+                <button onClick={onInviteNeverWarnClicked} className="mx_LegacyDialogButton" type="button">
                     {inviteNeverWarnLabel ?? _t("invite|unable_find_profiles_invite_never_warn_label_default")}
                 </button>
-                <button onClick={onInviteClicked} autoFocus={true} type="button">
+                <button onClick={onInviteClicked} autoFocus={true} className="mx_LegacyDialogButton" type="button">
                     {inviteLabel ?? _t("invite|unable_find_profiles_invite_label_default")}
                 </button>
             </div>

--- a/apps/web/src/components/views/dialogs/DevtoolsDialog.tsx
+++ b/apps/web/src/components/views/dialogs/DevtoolsDialog.tsx
@@ -99,7 +99,12 @@ const DevtoolsDialog: React.FC<IProps> = ({ roomId, threadRootId, onFinished }) 
                                 setTool([label, tool]);
                             };
                             return (
-                                <button className="mx_DevTools_button" key={label} onClick={onClick} type="button">
+                                <button
+                                    className="mx_LegacyDialogButton mx_DevTools_button"
+                                    key={label}
+                                    onClick={onClick}
+                                    type="button"
+                                >
                                     {_t(label)}
                                 </button>
                             );

--- a/apps/web/src/components/views/dialogs/ErrorDialog.tsx
+++ b/apps/web/src/components/views/dialogs/ErrorDialog.tsx
@@ -75,7 +75,7 @@ export default class ErrorDialog extends React.Component<IProps, IState> {
                 </div>
                 <div className="mx_Dialog_buttons">
                     <button
-                        className="mx_Dialog_primary"
+                        className="mx_LegacyDialogButton mx_Dialog_primary"
                         onClick={this.onClick}
                         autoFocus={this.props.focus}
                         type="button"

--- a/apps/web/src/components/views/dialogs/SessionRestoreErrorDialog.test.tsx
+++ b/apps/web/src/components/views/dialogs/SessionRestoreErrorDialog.test.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 New Vector Ltd.
+Copyright 2026 Element Creations Ltd.
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.

--- a/apps/web/src/components/views/dialogs/SessionRestoreErrorDialog.test.tsx
+++ b/apps/web/src/components/views/dialogs/SessionRestoreErrorDialog.test.tsx
@@ -1,0 +1,23 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+// @vitest-environment happy-dom
+
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render } from "test-utils-rtl";
+
+import SessionRestoreErrorDialog from "./SessionRestoreErrorDialog";
+
+describe("<SessionRestoreErrorDialog />", () => {
+    it("should render", () => {
+        const { asFragment } = render(
+            <SessionRestoreErrorDialog error={new Error("it broke")} onFinished={() => {}} />,
+        );
+        expect(asFragment()).toMatchSnapshot();
+    });
+});

--- a/apps/web/src/components/views/dialogs/SessionRestoreErrorDialog.tsx
+++ b/apps/web/src/components/views/dialogs/SessionRestoreErrorDialog.tsx
@@ -50,7 +50,7 @@ export default class SessionRestoreErrorDialog extends React.Component<IProps> {
         const brand = SdkConfig.get().brand;
 
         const clearStorageButton = (
-            <button onClick={this.onClearStorageClick} className="danger" type="button">
+            <button onClick={this.onClearStorageClick} className="mx_LegacyDialogButton danger" type="button">
                 {_t("error|session_restore|clear_storage_button")}
             </button>
         );

--- a/apps/web/src/components/views/dialogs/SetEmailDialog.tsx
+++ b/apps/web/src/components/views/dialogs/SetEmailDialog.tsx
@@ -159,12 +159,17 @@ export default class SetEmailDialog extends React.Component<IProps, IState> {
                 </div>
                 <div className="mx_Dialog_buttons">
                     <input
-                        className="mx_Dialog_primary"
+                        className="mx_LegacyDialogButton mx_Dialog_primary"
                         type="submit"
                         value={_t("action|continue")}
                         onClick={this.onSubmit}
                     />
-                    <input type="submit" value={_t("action|skip")} onClick={this.onCancelled} />
+                    <input
+                        className="mx_LegacyDialogButton"
+                        type="submit"
+                        value={_t("action|skip")}
+                        onClick={this.onCancelled}
+                    />
                 </div>
             </BaseDialog>
         );

--- a/apps/web/src/components/views/dialogs/UploadConfirmDialog.tsx
+++ b/apps/web/src/components/views/dialogs/UploadConfirmDialog.tsx
@@ -105,7 +105,7 @@ export default class UploadConfirmDialog extends React.Component<IProps, IState>
         let uploadAllButton: JSX.Element | undefined;
         if (this.props.currentIndex + 1 < this.props.totalFiles) {
             uploadAllButton = (
-                <button onClick={this.onUploadAllClick} type="button">
+                <button onClick={this.onUploadAllClick} className="mx_LegacyDialogButton" type="button">
                     {_t("upload_file|upload_all_button")}
                 </button>
             );

--- a/apps/web/src/components/views/dialogs/__snapshots__/AnalyticsLearnMoreDialog.test.tsx.snap
+++ b/apps/web/src/components/views/dialogs/__snapshots__/AnalyticsLearnMoreDialog.test.tsx.snap
@@ -102,14 +102,14 @@ exports[`AnalyticsLearnMoreDialog > should match snapshot 1`] = `
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="cancel"
+          class="mx_LegacyDialogButton cancel"
           data-testid="dialog-cancel-button"
           type="button"
         >
           Cancel
         </button>
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           type="button"
         />

--- a/apps/web/src/components/views/dialogs/__snapshots__/BugReportDialog.test.tsx.snap
+++ b/apps/web/src/components/views/dialogs/__snapshots__/BugReportDialog.test.tsx.snap
@@ -47,14 +47,14 @@ exports[`BugReportDialog > renders when the config only allows local downloads >
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="cancel"
+          class="mx_LegacyDialogButton cancel"
           data-testid="dialog-cancel-button"
           type="button"
         >
           Cancel
         </button>
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           type="button"
         >

--- a/apps/web/src/components/views/dialogs/__snapshots__/ChangelogDialog.test.tsx.snap
+++ b/apps/web/src/components/views/dialogs/__snapshots__/ChangelogDialog.test.tsx.snap
@@ -92,14 +92,14 @@ exports[`<ChangelogDialog /> > should fetch github proxy url for each repo with 
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="cancel"
+          class="mx_LegacyDialogButton cancel"
           data-testid="dialog-cancel-button"
           type="button"
         >
           Cancel
         </button>
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           type="button"
         >

--- a/apps/web/src/components/views/dialogs/__snapshots__/ConfirmUserActionDialog.test.tsx.snap
+++ b/apps/web/src/components/views/dialogs/__snapshots__/ConfirmUserActionDialog.test.tsx.snap
@@ -66,14 +66,14 @@ exports[`ConfirmUserActionDialog > renders 1`] = `
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="cancel"
+          class="mx_LegacyDialogButton cancel"
           data-testid="dialog-cancel-button"
           type="button"
         >
           Cancel
         </button>
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           type="button"
         >

--- a/apps/web/src/components/views/dialogs/__snapshots__/CreateRoomDialog.test.tsx.snap
+++ b/apps/web/src/components/views/dialogs/__snapshots__/CreateRoomDialog.test.tsx.snap
@@ -208,14 +208,14 @@ exports[`<CreateRoomDialog /> > for a private room > should create a private roo
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="cancel"
+          class="mx_LegacyDialogButton cancel"
           data-testid="dialog-cancel-button"
           type="button"
         >
           Cancel
         </button>
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           type="button"
         >
@@ -449,14 +449,14 @@ exports[`<CreateRoomDialog /> > for a private room > should render not the advan
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="cancel"
+          class="mx_LegacyDialogButton cancel"
           data-testid="dialog-cancel-button"
           type="button"
         >
           Cancel
         </button>
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           type="button"
         >
@@ -692,14 +692,14 @@ exports[`<CreateRoomDialog /> > for a private room > when the state encryption l
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="cancel"
+          class="mx_LegacyDialogButton cancel"
           data-testid="dialog-cancel-button"
           type="button"
         >
           Cancel
         </button>
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           type="button"
         >

--- a/apps/web/src/components/views/dialogs/__snapshots__/CreateSectionDialog.test.tsx.snap
+++ b/apps/web/src/components/views/dialogs/__snapshots__/CreateSectionDialog.test.tsx.snap
@@ -64,14 +64,14 @@ exports[`CreateSectionDialog > renders the dialog 1`] = `
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="cancel"
+          class="mx_LegacyDialogButton cancel"
           data-testid="dialog-cancel-button"
           type="button"
         >
           Cancel
         </button>
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           disabled=""
           type="button"

--- a/apps/web/src/components/views/dialogs/__snapshots__/DeclineAndBlockInviteDialog.test.tsx.snap
+++ b/apps/web/src/components/views/dialogs/__snapshots__/DeclineAndBlockInviteDialog.test.tsx.snap
@@ -131,14 +131,14 @@ exports[`ConfirmRejectInviteDialog > can reject with options selected 1`] = `
           class="mx_Dialog_buttons_row"
         >
           <button
-            class="cancel"
+            class="mx_LegacyDialogButton cancel"
             data-testid="dialog-cancel-button"
             type="button"
           >
             Cancel
           </button>
           <button
-            class="mx_Dialog_primary danger"
+            class="mx_LegacyDialogButton mx_Dialog_primary danger"
             data-testid="dialog-primary-button"
             type="button"
           >

--- a/apps/web/src/components/views/dialogs/__snapshots__/DevtoolsDialog.test.tsx.snap
+++ b/apps/web/src/components/views/dialogs/__snapshots__/DevtoolsDialog.test.tsx.snap
@@ -75,49 +75,49 @@ exports[`DevtoolsDialog > renders the devtools dialog 1`] = `
           Room
         </h2>
         <button
-          class="mx_DevTools_button"
+          class="mx_LegacyDialogButton mx_DevTools_button"
           type="button"
         >
           Send custom timeline event
         </button>
         <button
-          class="mx_DevTools_button"
+          class="mx_LegacyDialogButton mx_DevTools_button"
           type="button"
         >
           Explore room state
         </button>
         <button
-          class="mx_DevTools_button"
+          class="mx_LegacyDialogButton mx_DevTools_button"
           type="button"
         >
           Explore room account data
         </button>
         <button
-          class="mx_DevTools_button"
+          class="mx_LegacyDialogButton mx_DevTools_button"
           type="button"
         >
           View servers in room
         </button>
         <button
-          class="mx_DevTools_button"
+          class="mx_LegacyDialogButton mx_DevTools_button"
           type="button"
         >
           Notifications debug
         </button>
         <button
-          class="mx_DevTools_button"
+          class="mx_LegacyDialogButton mx_DevTools_button"
           type="button"
         >
           Active Widgets
         </button>
         <button
-          class="mx_DevTools_button"
+          class="mx_LegacyDialogButton mx_DevTools_button"
           type="button"
         >
           Users
         </button>
         <button
-          class="mx_DevTools_button"
+          class="mx_LegacyDialogButton mx_DevTools_button"
           type="button"
         >
           Explore sticky state
@@ -130,31 +130,31 @@ exports[`DevtoolsDialog > renders the devtools dialog 1`] = `
           Other
         </h2>
         <button
-          class="mx_DevTools_button"
+          class="mx_LegacyDialogButton mx_DevTools_button"
           type="button"
         >
           Explore account data
         </button>
         <button
-          class="mx_DevTools_button"
+          class="mx_LegacyDialogButton mx_DevTools_button"
           type="button"
         >
           Settings explorer
         </button>
         <button
-          class="mx_DevTools_button"
+          class="mx_LegacyDialogButton mx_DevTools_button"
           type="button"
         >
           Server info
         </button>
         <button
-          class="mx_DevTools_button"
+          class="mx_LegacyDialogButton mx_DevTools_button"
           type="button"
         >
           End-to-end encryption
         </button>
         <button
-          class="mx_DevTools_button"
+          class="mx_LegacyDialogButton mx_DevTools_button"
           type="button"
         >
           Custom themes
@@ -336,6 +336,7 @@ exports[`DevtoolsDialog > renders the devtools dialog 1`] = `
       class="mx_Dialog_buttons"
     >
       <button
+        class="mx_LegacyDialogButton"
         type="button"
       >
         Back

--- a/apps/web/src/components/views/dialogs/__snapshots__/ExportDialog.test.tsx.snap
+++ b/apps/web/src/components/views/dialogs/__snapshots__/ExportDialog.test.tsx.snap
@@ -218,14 +218,14 @@ exports[`<ExportDialog /> > renders export dialog 1`] = `
       class="mx_Dialog_buttons_row"
     >
       <button
-        class="cancel"
+        class="mx_LegacyDialogButton cancel"
         data-testid="dialog-cancel-button"
         type="button"
       >
         Cancel
       </button>
       <button
-        class="mx_Dialog_primary"
+        class="mx_LegacyDialogButton mx_Dialog_primary"
         data-testid="dialog-primary-button"
         type="button"
       >

--- a/apps/web/src/components/views/dialogs/__snapshots__/FeedbackDialog.test.tsx.snap
+++ b/apps/web/src/components/views/dialogs/__snapshots__/FeedbackDialog.test.tsx.snap
@@ -108,7 +108,7 @@ exports[`FeedbackDialog > should respect feedback config 1`] = `
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           type="button"
         >

--- a/apps/web/src/components/views/dialogs/__snapshots__/LogoutDialog.test.tsx.snap
+++ b/apps/web/src/components/views/dialogs/__snapshots__/LogoutDialog.test.tsx.snap
@@ -497,14 +497,14 @@ exports[`LogoutDialog > shows a regular dialog when crypto is disabled 1`] = `
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="cancel"
+          class="mx_LegacyDialogButton cancel"
           data-testid="dialog-cancel-button"
           type="button"
         >
           Cancel
         </button>
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           type="button"
         >

--- a/apps/web/src/components/views/dialogs/__snapshots__/ManualDeviceKeyVerificationDialog.test.tsx.snap
+++ b/apps/web/src/components/views/dialogs/__snapshots__/ManualDeviceKeyVerificationDialog.test.tsx.snap
@@ -78,14 +78,14 @@ exports[`ManualDeviceKeyVerificationDialog > should render correctly 1`] = `
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="cancel"
+          class="mx_LegacyDialogButton cancel"
           data-testid="dialog-cancel-button"
           type="button"
         >
           Cancel
         </button>
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           type="button"
         >

--- a/apps/web/src/components/views/dialogs/__snapshots__/SessionRestoreErrorDialog.test.tsx.snap
+++ b/apps/web/src/components/views/dialogs/__snapshots__/SessionRestoreErrorDialog.test.tsx.snap
@@ -1,0 +1,70 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`<SessionRestoreErrorDialog /> > should render 1`] = `
+<DocumentFragment>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+  <div
+    aria-describedby="mx_Dialog_content"
+    aria-labelledby="mx_BaseDialog_title"
+    class="mx_ErrorDialog mx_Dialog_fixedWidth"
+    data-focus-lock-disabled="false"
+    role="dialog"
+    tabindex="-1"
+  >
+    <div
+      class="mx_Dialog_header"
+    >
+      <h1
+        class="mx_Heading_h3 mx_Dialog_title"
+        id="mx_BaseDialog_title"
+      >
+        Unable to restore session
+      </h1>
+    </div>
+    <div
+      class="mx_Dialog_content"
+      id="mx_Dialog_content"
+    >
+      <p>
+        We encountered an error trying to restore your session.
+      </p>
+      <p>
+        If you have previously used a more recent version of Element, your session may be incompatible with this version. Close this window and return to the more recent version.
+      </p>
+      <p>
+        Clearing your browser's storage may fix the problem, but will remove this device and cause any encrypted chat history to become unreadable.
+      </p>
+    </div>
+    <div
+      class="mx_Dialog_buttons"
+    >
+      <span
+        class="mx_Dialog_buttons_row"
+      >
+        <button
+          class="mx_LegacyDialogButton danger"
+          type="button"
+        >
+          Remove this device
+        </button>
+        <button
+          class="mx_LegacyDialogButton mx_Dialog_primary"
+          data-testid="dialog-primary-button"
+          type="button"
+        >
+          Refresh
+        </button>
+      </span>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+</DocumentFragment>
+`;

--- a/apps/web/src/components/views/dialogs/__snapshots__/UploadConfirmDialog.test.tsx.snap
+++ b/apps/web/src/components/views/dialogs/__snapshots__/UploadConfirmDialog.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`<UploadConfirmDialog /> > should display image preview 1`] = `
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           type="button"
         >

--- a/apps/web/src/components/views/dialogs/devtools/AccountData.tsx
+++ b/apps/web/src/components/views/dialogs/devtools/AccountData.tsx
@@ -78,7 +78,12 @@ const BaseAccountDataExplorer: React.FC<IProps> = ({ events, Editor, actionLabel
                     };
 
                     return (
-                        <button className="mx_DevTools_button" key={eventType} onClick={onClick} type="button">
+                        <button
+                            className="mx_LegacyDialogButton mx_DevTools_button"
+                            key={eventType}
+                            onClick={onClick}
+                            type="button"
+                        >
                             {eventType}
                         </button>
                     );

--- a/apps/web/src/components/views/dialogs/devtools/BaseTool.tsx
+++ b/apps/web/src/components/views/dialogs/devtools/BaseTool.tsx
@@ -62,7 +62,7 @@ const BaseTool: React.FC<XOR<IMinProps, IProps>> = ({
         };
 
         actionButton = (
-            <button onClick={onActionClick} type="button">
+            <button onClick={onActionClick} className="mx_LegacyDialogButton" type="button">
                 {_t(actionLabel)}
             </button>
         );
@@ -73,7 +73,7 @@ const BaseTool: React.FC<XOR<IMinProps, IProps>> = ({
             <div className={classNames("mx_DevTools_content", className)}>{children}</div>
             <div className="mx_Dialog_buttons">
                 {extraButton}
-                <button onClick={onBackClick} type="button">
+                <button onClick={onBackClick} className="mx_LegacyDialogButton" type="button">
                     {_t("action|back")}
                 </button>
                 {actionButton}

--- a/apps/web/src/components/views/dialogs/devtools/Crypto.tsx
+++ b/apps/web/src/components/views/dialogs/devtools/Crypto.tsx
@@ -38,6 +38,7 @@ export function Crypto({ onBack }: KeyBackupProps): JSX.Element {
 
                     <button
                         type="button"
+                        className="mx_LegacyDialogButton"
                         onClick={() => {
                             Modal.createDialog(ManualDeviceKeyVerificationDialog);
                         }}
@@ -46,6 +47,7 @@ export function Crypto({ onBack }: KeyBackupProps): JSX.Element {
                     </button>
                     <button
                         type="button"
+                        className="mx_LegacyDialogButton"
                         onClick={() => {
                             Modal.createDialog(
                                 RestoreKeyBackupDialog,

--- a/apps/web/src/components/views/dialogs/devtools/FilteredList.tsx
+++ b/apps/web/src/components/views/dialogs/devtools/FilteredList.tsx
@@ -50,7 +50,7 @@ const FilteredList: React.FC<IProps> = ({ children, query, onChange }) => {
         };
 
         return (
-            <button className="mx_DevTools_button" onClick={showMore} type="button">
+            <button className="mx_LegacyDialogButton mx_DevTools_button" onClick={showMore} type="button">
                 {_t("common|and_n_others", { count: overflowCount })}
             </button>
         );

--- a/apps/web/src/components/views/dialogs/devtools/RoomState.test.tsx
+++ b/apps/web/src/components/views/dialogs/devtools/RoomState.test.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 New Vector Ltd.
+Copyright 2026 Element Creations Ltd.
 
 SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.

--- a/apps/web/src/components/views/dialogs/devtools/RoomState.test.tsx
+++ b/apps/web/src/components/views/dialogs/devtools/RoomState.test.tsx
@@ -8,34 +8,91 @@ Please see LICENSE files in the repository root for full details.
 // @vitest-environment happy-dom
 
 import React from "react";
-import { describe, it, expect, beforeEach } from "vitest";
-import { Room, PendingEventOrdering } from "matrix-js-sdk/src/matrix";
-import { render } from "test-utils-rtl";
-import { stubClient } from "test-utils";
+import { describe, it, expect, beforeEach, vi, type MockedObject } from "vitest";
+import { type IEvent, Room, PendingEventOrdering, type MatrixClient } from "matrix-js-sdk/src/matrix";
+import { render, screen, waitFor } from "test-utils-rtl";
+import userEvent from "@testing-library/user-event";
+import { stubClient, mkEvent, makeRoomWithStateEvents } from "test-utils";
 
 import { RoomStateExplorer } from "./RoomState";
 import MatrixClientContext from "../../../../contexts/MatrixClientContext";
-import { MatrixClientPeg } from "../../../../MatrixClientPeg";
 import { DevtoolsContext } from "./BaseTool";
 
 describe("<RoomStateExplorer />", () => {
+    const roomId = "!roomId:example.com";
+    const userId = "@alice:example.com";
+    let cli: MockedObject<MatrixClient>;
+
     beforeEach(() => {
-        stubClient();
+        cli = stubClient() as MockedObject<MatrixClient>;
     });
 
-    it("should render", () => {
-        const cli = MatrixClientPeg.safeGet();
-        const room = new Room("!roomId:example.com", cli, "@alice:example.com", {
-            pendingEventOrdering: PendingEventOrdering.Detached,
-        });
-
-        const { asFragment } = render(
+    function renderComponent(room: Room): ReturnType<typeof render> {
+        return render(
             <MatrixClientContext.Provider value={cli}>
                 <DevtoolsContext.Provider value={{ room }}>
                     <RoomStateExplorer onBack={() => {}} setTool={() => {}} />
                 </DevtoolsContext.Provider>
             </MatrixClientContext.Provider>,
         );
+    }
+
+    it("should render", () => {
+        const room = new Room(roomId, cli, userId, {
+            pendingEventOrdering: PendingEventOrdering.Detached,
+        });
+
+        const { asFragment } = renderComponent(room);
         expect(asFragment()).toMatchSnapshot();
+    });
+
+    it("shows real room state and can check a single event", async () => {
+        const nameEvent = mkEvent({
+            event: true,
+            type: "m.room.name",
+            content: { name: "Test room" },
+            room: roomId,
+            user: userId,
+        });
+        const room = makeRoomWithStateEvents([nameEvent], { roomId, mockClient: cli });
+
+        renderComponent(room);
+
+        await userEvent.click(screen.getByRole("button", { name: "m.room.name" }));
+
+        expect(screen.getByText(/Test room/)).toBeInTheDocument();
+    });
+
+    it("shows the history of a state event", async () => {
+        const previousEvent = mkEvent({
+            event: false,
+            type: "m.room.topic",
+            content: { topic: "Old topic" },
+            room: roomId,
+            user: userId,
+            id: "$prevEventId",
+        });
+        const currentEvent = mkEvent({
+            event: true,
+            type: "m.room.topic",
+            content: { topic: "New topic" },
+            room: roomId,
+            user: userId,
+            id: "$currentEventId",
+            unsigned: { replaces_state: "$prevEventId" },
+        });
+        vi.mocked(cli.fetchRoomEvent).mockResolvedValueOnce(previousEvent as unknown as IEvent);
+
+        const room = makeRoomWithStateEvents([currentEvent], { roomId, mockClient: cli });
+
+        renderComponent(room);
+
+        await userEvent.click(screen.getByRole("button", { name: "m.room.topic" }));
+        expect(screen.getByText(/New topic/)).toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole("button", { name: "See history" }));
+
+        await waitFor(() => expect(screen.getByText(/Old topic/)).toBeInTheDocument());
+        expect(screen.getByText(/New topic/)).toBeInTheDocument();
     });
 });

--- a/apps/web/src/components/views/dialogs/devtools/RoomState.test.tsx
+++ b/apps/web/src/components/views/dialogs/devtools/RoomState.test.tsx
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+// @vitest-environment happy-dom
+
+import React from "react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { Room, PendingEventOrdering } from "matrix-js-sdk/src/matrix";
+import { render } from "test-utils-rtl";
+import { stubClient } from "test-utils";
+
+import { RoomStateExplorer } from "./RoomState";
+import MatrixClientContext from "../../../../contexts/MatrixClientContext";
+import { MatrixClientPeg } from "../../../../MatrixClientPeg";
+import { DevtoolsContext } from "./BaseTool";
+
+describe("<RoomStateExplorer />", () => {
+    beforeEach(() => {
+        stubClient();
+    });
+
+    it("should render", () => {
+        const cli = MatrixClientPeg.safeGet();
+        const room = new Room("!roomId:example.com", cli, "@alice:example.com", {
+            pendingEventOrdering: PendingEventOrdering.Detached,
+        });
+
+        const { asFragment } = render(
+            <MatrixClientContext.Provider value={cli}>
+                <DevtoolsContext.Provider value={{ room }}>
+                    <RoomStateExplorer onBack={() => {}} setTool={() => {}} />
+                </DevtoolsContext.Provider>
+            </MatrixClientContext.Provider>,
+        );
+        expect(asFragment()).toMatchSnapshot();
+    });
+});

--- a/apps/web/src/components/views/dialogs/devtools/RoomState.tsx
+++ b/apps/web/src/components/views/dialogs/devtools/RoomState.tsx
@@ -95,7 +95,7 @@ const StateEventButton: React.FC<StateEventButtonProps> = ({ label, onClick }) =
 
     return (
         <button
-            className={classNames("mx_DevTools_button", {
+            className={classNames("mx_LegacyDialogButton mx_DevTools_button", {
                 mx_DevTools_RoomStateExplorer_button_hasSpaces: trimmed.length !== label.length,
                 mx_DevTools_RoomStateExplorer_button_emptyString: !trimmed,
             })}
@@ -150,7 +150,7 @@ const RoomStateExplorerEventType: React.FC<IEventTypeProps> = ({ eventType, onBa
             setHistory(true);
         };
         const extraButton = (
-            <button onClick={onHistoryClick} type="button">
+            <button onClick={onHistoryClick} className="mx_LegacyDialogButton" type="button">
                 {_t("devtools|see_history")}
             </button>
         );

--- a/apps/web/src/components/views/dialogs/devtools/StickyEventState.tsx
+++ b/apps/web/src/components/views/dialogs/devtools/StickyEventState.tsx
@@ -57,7 +57,7 @@ export const StickyStateExplorer: React.FC<IDevtoolsProps> = ({ onBack, setTool 
                     type="critical"
                     title={_t("common|error")}
                     actions={
-                        <button onClick={onBack} type="button">
+                        <button onClick={onBack} className="mx_LegacyDialogButton" type="button">
                             {_t("action|back")}
                         </button>
                     }
@@ -113,7 +113,7 @@ export const StickyStateExplorer: React.FC<IDevtoolsProps> = ({ onBack, setTool 
                 {uniqueEventTypes.map((eventType) => (
                     <button
                         key={eventType}
-                        className="mx_DevTools_button"
+                        className="mx_LegacyDialogButton mx_DevTools_button"
                         onClick={() => setEventType(eventType)}
                         type="button"
                     >

--- a/apps/web/src/components/views/dialogs/devtools/Users.tsx
+++ b/apps/web/src/components/views/dialogs/devtools/Users.tsx
@@ -88,7 +88,7 @@ interface UserButtonProps {
  */
 const UserButton: React.FC<UserButtonProps> = ({ member, onClick }) => {
     return (
-        <button className="mx_DevTools_button" onClick={onClick} type="button">
+        <button className="mx_LegacyDialogButton mx_DevTools_button" onClick={onClick} type="button">
             {member.userId}
         </button>
     );
@@ -273,7 +273,7 @@ const DeviceButton: React.FC<DeviceButtonProps> = ({ crypto, device, onClick }) 
         null,
     );
     return (
-        <button className="mx_DevTools_button" onClick={onClick} type="button">
+        <button className="mx_LegacyDialogButton mx_DevTools_button" onClick={onClick} type="button">
             {verificationIcon}
             {device.deviceId}
         </button>

--- a/apps/web/src/components/views/dialogs/devtools/WidgetExplorer.tsx
+++ b/apps/web/src/components/views/dialogs/devtools/WidgetExplorer.tsx
@@ -54,7 +54,7 @@ const WidgetExplorer: React.FC<IDevtoolsProps> = ({ onBack }) => {
             <FilteredList query={query} onChange={setQuery}>
                 {widgets.map((w) => (
                     <button
-                        className="mx_DevTools_button"
+                        className="mx_LegacyDialogButton mx_DevTools_button"
                         key={w.url + w.eventId}
                         onClick={() => setWidget(w)}
                         type="button"

--- a/apps/web/src/components/views/dialogs/devtools/__snapshots__/RoomState.test.tsx.snap
+++ b/apps/web/src/components/views/dialogs/devtools/__snapshots__/RoomState.test.tsx.snap
@@ -1,0 +1,45 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`<RoomStateExplorer /> > should render 1`] = `
+<DocumentFragment>
+  <div
+    class="mx_DevTools_content"
+  >
+    <div
+      class="mx_Field mx_Field_input mx_TextInputDialog_input mx_DevTools_RoomStateExplorer_query"
+    >
+      <input
+        autocomplete="off"
+        id="mx_Field_1"
+        label="Filter results"
+        placeholder="Filter results"
+        size="64"
+        type="text"
+        value=""
+      />
+      <label
+        for="mx_Field_1"
+      >
+        Filter results
+      </label>
+    </div>
+    No results found
+  </div>
+  <div
+    class="mx_Dialog_buttons"
+  >
+    <button
+      class="mx_LegacyDialogButton"
+      type="button"
+    >
+      Back
+    </button>
+    <button
+      class="mx_LegacyDialogButton"
+      type="button"
+    >
+      Send custom state event
+    </button>
+  </div>
+</DocumentFragment>
+`;

--- a/apps/web/src/components/views/elements/DialogButtons.tsx
+++ b/apps/web/src/components/views/elements/DialogButtons.tsx
@@ -9,6 +9,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import React, { type JSX, type ReactNode } from "react";
+import classNames from "classnames";
 
 import { _t } from "../../../languageHandler";
 
@@ -68,7 +69,7 @@ export default class DialogButtons extends React.Component<IProps> {
     };
 
     public render(): React.ReactNode {
-        let primaryButtonClassName = "mx_Dialog_primary";
+        let primaryButtonClassName = "mx_LegacyDialogButton mx_Dialog_primary";
         if (this.props.primaryButtonClass) {
             primaryButtonClassName += " " + this.props.primaryButtonClass;
         }
@@ -82,7 +83,7 @@ export default class DialogButtons extends React.Component<IProps> {
                     data-testid="dialog-cancel-button"
                     type="button"
                     onClick={this.onCancelClick}
-                    className={this.props.cancelButtonClass}
+                    className={classNames("mx_LegacyDialogButton", this.props.cancelButtonClass)}
                     disabled={this.props.disabled}
                 >
                     {this.props.cancelButton || _t("action|cancel")}

--- a/apps/web/src/components/views/rooms/wysiwyg_composer/components/LinkModal.tsx
+++ b/apps/web/src/components/views/rooms/wysiwyg_composer/components/LinkModal.tsx
@@ -114,7 +114,7 @@ export const LinkModal: React.FC<LinkModalProps> = ({
                     {isEditing && (
                         <button
                             type="button"
-                            className="danger"
+                            className="mx_LegacyDialogButton danger"
                             onClick={() => {
                                 composer.removeLinks();
                                 onFinished();

--- a/apps/web/test/unit-tests/components/views/dialogs/__snapshots__/IntegrationsDisabledDialog-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/dialogs/__snapshots__/IntegrationsDisabledDialog-test.tsx.snap
@@ -38,14 +38,14 @@ exports[`<IntegrationsDisabledDialog /> should render as expected 1`] = `
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="cancel"
+          class="mx_LegacyDialogButton cancel"
           data-testid="dialog-cancel-button"
           type="button"
         >
           OK
         </button>
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           type="button"
         >

--- a/apps/web/test/unit-tests/components/views/dialogs/__snapshots__/RemoveSectionDialog-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/dialogs/__snapshots__/RemoveSectionDialog-test.tsx.snap
@@ -36,14 +36,14 @@ exports[`RemoveSectionDialog renders the dialog when section is empty 1`] = `
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="cancel"
+          class="mx_LegacyDialogButton cancel"
           data-testid="dialog-cancel-button"
           type="button"
         >
           Cancel
         </button>
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           type="button"
         >
@@ -120,14 +120,14 @@ exports[`RemoveSectionDialog renders the dialog when section is not empty 1`] = 
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="cancel"
+          class="mx_LegacyDialogButton cancel"
           data-testid="dialog-cancel-button"
           type="button"
         >
           Cancel
         </button>
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           type="button"
         >

--- a/apps/web/test/unit-tests/components/views/dialogs/__snapshots__/ReportRoomDialog-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/dialogs/__snapshots__/ReportRoomDialog-test.tsx.snap
@@ -103,14 +103,14 @@ exports[`ReportRoomDialog displays admin message 1`] = `
           class="mx_Dialog_buttons_row"
         >
           <button
-            class="cancel"
+            class="mx_LegacyDialogButton cancel"
             data-testid="dialog-cancel-button"
             type="button"
           >
             Cancel
           </button>
           <button
-            class="mx_Dialog_primary danger"
+            class="mx_LegacyDialogButton mx_Dialog_primary danger"
             data-testid="dialog-primary-button"
             disabled=""
             type="button"

--- a/apps/web/test/unit-tests/components/views/dialogs/__snapshots__/WidgetOpenIDPermissionsDialog-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/dialogs/__snapshots__/WidgetOpenIDPermissionsDialog-test.tsx.snap
@@ -82,14 +82,14 @@ exports[`WidgetOpenIDPermissionsDialog should render 1`] = `
         class="mx_Dialog_buttons_row"
       >
         <button
-          class="cancel"
+          class="mx_LegacyDialogButton cancel"
           data-testid="dialog-cancel-button"
           type="button"
         >
           Cancel
         </button>
         <button
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           data-testid="dialog-primary-button"
           type="button"
         >

--- a/apps/web/test/unit-tests/components/views/dialogs/devtools/__snapshots__/Event-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/dialogs/devtools/__snapshots__/Event-test.tsx.snap
@@ -52,11 +52,13 @@ exports[`<EventEditor /> should render 1`] = `
     class="mx_Dialog_buttons"
   >
     <button
+      class="mx_LegacyDialogButton"
       type="button"
     >
       Back
     </button>
     <button
+      class="mx_LegacyDialogButton"
       type="button"
     >
       Send
@@ -120,11 +122,13 @@ exports[`<EventEditor /> thread context should pre-populate a thread relationshi
     class="mx_Dialog_buttons"
   >
     <button
+      class="mx_LegacyDialogButton"
       type="button"
     >
       Back
     </button>
     <button
+      class="mx_LegacyDialogButton"
       type="button"
     >
       Send

--- a/apps/web/test/unit-tests/components/views/dialogs/devtools/__snapshots__/RoomNotifications-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/dialogs/devtools/__snapshots__/RoomNotifications-test.tsx.snap
@@ -65,6 +65,7 @@ exports[`<RoomNotifications /> should render 1`] = `
     class="mx_Dialog_buttons"
   >
     <button
+      class="mx_LegacyDialogButton"
       type="button"
     >
       Back

--- a/apps/web/test/unit-tests/components/views/dialogs/devtools/__snapshots__/Users-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/dialogs/devtools/__snapshots__/Users-test.tsx.snap
@@ -186,6 +186,7 @@ exports[`<Users /> should render a single device - signed by owner 1`] = `
     class="mx_Dialog_buttons"
   >
     <button
+      class="mx_LegacyDialogButton"
       type="button"
     >
       Back
@@ -380,6 +381,7 @@ exports[`<Users /> should render a single device - unsigned 1`] = `
     class="mx_Dialog_buttons"
   >
     <button
+      class="mx_LegacyDialogButton"
       type="button"
     >
       Back
@@ -576,6 +578,7 @@ exports[`<Users /> should render a single device - verified by cross-signing 1`]
     class="mx_Dialog_buttons"
   >
     <button
+      class="mx_LegacyDialogButton"
       type="button"
     >
       Back
@@ -677,7 +680,7 @@ exports[`<Users /> should render a single user 1`] = `
       <ul>
         <li>
           <button
-            class="mx_DevTools_button"
+            class="mx_LegacyDialogButton mx_DevTools_button"
             type="button"
           >
             <div
@@ -704,7 +707,7 @@ exports[`<Users /> should render a single user 1`] = `
         </li>
         <li>
           <button
-            class="mx_DevTools_button"
+            class="mx_LegacyDialogButton mx_DevTools_button"
             type="button"
           >
             <div
@@ -729,7 +732,7 @@ exports[`<Users /> should render a single user 1`] = `
         </li>
         <li>
           <button
-            class="mx_DevTools_button"
+            class="mx_LegacyDialogButton mx_DevTools_button"
             type="button"
           >
             <div
@@ -767,6 +770,7 @@ exports[`<Users /> should render a single user 1`] = `
     class="mx_Dialog_buttons"
   >
     <button
+      class="mx_LegacyDialogButton"
       type="button"
     >
       Back
@@ -840,6 +844,7 @@ exports[`<Users /> should render a user list 1`] = `
     class="mx_Dialog_buttons"
   >
     <button
+      class="mx_LegacyDialogButton"
       type="button"
     >
       Back

--- a/apps/web/test/unit-tests/components/views/dialogs/security/__snapshots__/CreateSecretStorageDialog-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/dialogs/security/__snapshots__/CreateSecretStorageDialog-test.tsx.snap
@@ -98,14 +98,14 @@ exports[`CreateSecretStorageDialog handles the happy path 1`] = `
             class="mx_Dialog_buttons_row"
           >
             <button
-              class="cancel"
+              class="mx_LegacyDialogButton cancel"
               data-testid="dialog-cancel-button"
               type="button"
             >
               Cancel
             </button>
             <button
-              class="mx_Dialog_primary"
+              class="mx_LegacyDialogButton mx_Dialog_primary"
               data-testid="dialog-primary-button"
               type="button"
             >
@@ -196,7 +196,7 @@ exports[`CreateSecretStorageDialog handles the happy path 2`] = `
             class="mx_Dialog_buttons_row"
           >
             <button
-              class="mx_Dialog_primary"
+              class="mx_LegacyDialogButton mx_Dialog_primary"
               data-testid="dialog-primary-button"
               disabled=""
               type="button"
@@ -248,14 +248,14 @@ exports[`CreateSecretStorageDialog when there is an error fetching the backup ve
               class="mx_Dialog_buttons_row"
             >
               <button
-                class="cancel"
+                class="mx_LegacyDialogButton cancel"
                 data-testid="dialog-cancel-button"
                 type="button"
               >
                 Cancel
               </button>
               <button
-                class="mx_Dialog_primary"
+                class="mx_LegacyDialogButton mx_Dialog_primary"
                 data-testid="dialog-primary-button"
                 type="button"
               >

--- a/apps/web/test/unit-tests/components/views/dialogs/security/__snapshots__/ExportE2eKeysDialog-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/dialogs/security/__snapshots__/ExportE2eKeysDialog-test.tsx.snap
@@ -93,6 +93,7 @@ exports[`ExportE2eKeysDialog renders 1`] = `
           value="Export"
         />
         <button
+          class="mx_LegacyDialogButton"
           type="button"
         >
           Cancel

--- a/apps/web/test/unit-tests/components/views/dialogs/security/__snapshots__/ExportE2eKeysDialog-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/dialogs/security/__snapshots__/ExportE2eKeysDialog-test.tsx.snap
@@ -88,7 +88,7 @@ exports[`ExportE2eKeysDialog renders 1`] = `
         class="mx_Dialog_buttons"
       >
         <input
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           type="submit"
           value="Export"
         />

--- a/apps/web/test/unit-tests/components/views/dialogs/security/__snapshots__/ImportE2eKeysDialog-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/dialogs/security/__snapshots__/ImportE2eKeysDialog-test.tsx.snap
@@ -94,6 +94,7 @@ exports[`ImportE2eKeysDialog renders 1`] = `
           value="Import"
         />
         <button
+          class="mx_LegacyDialogButton"
           type="button"
         >
           Cancel

--- a/apps/web/test/unit-tests/components/views/dialogs/security/__snapshots__/ImportE2eKeysDialog-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/dialogs/security/__snapshots__/ImportE2eKeysDialog-test.tsx.snap
@@ -88,7 +88,7 @@ exports[`ImportE2eKeysDialog renders 1`] = `
         class="mx_Dialog_buttons"
       >
         <input
-          class="mx_Dialog_primary"
+          class="mx_LegacyDialogButton mx_Dialog_primary"
           disabled=""
           type="submit"
           value="Import"

--- a/apps/web/test/unit-tests/components/views/dialogs/security/__snapshots__/RestoreKeyBackupDialog-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/dialogs/security/__snapshots__/RestoreKeyBackupDialog-test.tsx.snap
@@ -58,14 +58,14 @@ exports[`<RestoreKeyBackupDialog /> should display an error when recovery key is
               class="mx_Dialog_buttons_row"
             >
               <button
-                class="cancel"
+                class="mx_LegacyDialogButton cancel"
                 data-testid="dialog-cancel-button"
                 type="button"
               >
                 Cancel
               </button>
               <button
-                class="mx_Dialog_primary"
+                class="mx_LegacyDialogButton mx_Dialog_primary"
                 data-testid="dialog-primary-button"
                 disabled=""
                 type="button"
@@ -172,14 +172,14 @@ exports[`<RestoreKeyBackupDialog /> should not raise an error when recovery is v
               class="mx_Dialog_buttons_row"
             >
               <button
-                class="cancel"
+                class="mx_LegacyDialogButton cancel"
                 data-testid="dialog-cancel-button"
                 type="button"
               >
                 Cancel
               </button>
               <button
-                class="mx_Dialog_primary"
+                class="mx_LegacyDialogButton mx_Dialog_primary"
                 data-testid="dialog-primary-button"
                 type="button"
               >
@@ -283,14 +283,14 @@ exports[`<RestoreKeyBackupDialog /> should render 1`] = `
               class="mx_Dialog_buttons_row"
             >
               <button
-                class="cancel"
+                class="mx_LegacyDialogButton cancel"
                 data-testid="dialog-cancel-button"
                 type="button"
               >
                 Cancel
               </button>
               <button
-                class="mx_Dialog_primary"
+                class="mx_LegacyDialogButton mx_Dialog_primary"
                 data-testid="dialog-primary-button"
                 disabled=""
                 type="button"
@@ -381,7 +381,7 @@ exports[`<RestoreKeyBackupDialog /> should restore key backup when Recovery key 
             class="mx_Dialog_buttons_row"
           >
             <button
-              class="mx_Dialog_primary"
+              class="mx_LegacyDialogButton mx_Dialog_primary"
               data-testid="dialog-primary-button"
               type="button"
             >
@@ -459,7 +459,7 @@ exports[`<RestoreKeyBackupDialog /> should restore key backup when passphrase is
             class="mx_Dialog_buttons_row"
           >
             <button
-              class="mx_Dialog_primary"
+              class="mx_LegacyDialogButton mx_Dialog_primary"
               data-testid="dialog-primary-button"
               type="button"
             >
@@ -537,7 +537,7 @@ exports[`<RestoreKeyBackupDialog /> should restore key backup when the key is ca
             class="mx_Dialog_buttons_row"
           >
             <button
-              class="mx_Dialog_primary"
+              class="mx_LegacyDialogButton mx_Dialog_primary"
               data-testid="dialog-primary-button"
               type="button"
             >
@@ -616,7 +616,7 @@ exports[`<RestoreKeyBackupDialog /> should restore key backup when the key is in
             class="mx_Dialog_buttons_row"
           >
             <button
-              class="mx_Dialog_primary"
+              class="mx_LegacyDialogButton mx_Dialog_primary"
               data-testid="dialog-primary-button"
               type="button"
             >

--- a/apps/web/test/unit-tests/components/views/settings/tabs/room/__snapshots__/SecurityRoomSettingsTab-test.tsx.snap
+++ b/apps/web/test/unit-tests/components/views/settings/tabs/room/__snapshots__/SecurityRoomSettingsTab-test.tsx.snap
@@ -122,7 +122,7 @@ exports[`<SecurityRoomSettingsTab /> join rule handles error when updating join 
     class="mx_Dialog_buttons"
   >
     <button
-      class="mx_Dialog_primary"
+      class="mx_LegacyDialogButton mx_Dialog_primary"
       type="button"
     >
       OK
@@ -209,14 +209,14 @@ exports[`<SecurityRoomSettingsTab /> join rule warns when trying to make an encr
       class="mx_Dialog_buttons_row"
     >
       <button
-        class="cancel"
+        class="mx_LegacyDialogButton cancel"
         data-testid="dialog-cancel-button"
         type="button"
       >
         Cancel
       </button>
       <button
-        class="mx_Dialog_primary"
+        class="mx_LegacyDialogButton mx_Dialog_primary"
         data-testid="dialog-primary-button"
         type="button"
       >


### PR DESCRIPTION
And replace with an explicit class for those components that still depend on it. This ensures we can use compound buttons in dialogs, without having rules conflict. I had a look through all the usages of buttons inside dialogs, and reduced the ruleset down massively.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
