### PR TITLE
Add multiple controller supports for settings

### DIFF
--- a/apps/web/src/accessibility/KeyboardShortcutUtils.ts
+++ b/apps/web/src/accessibility/KeyboardShortcutUtils.ts
@@ -11,6 +11,7 @@ import { IS_MAC, Key } from "../Keyboard";
 import { _t, _td } from "../languageHandler";
 import PlatformPeg from "../PlatformPeg";
 import SettingsStore from "../settings/SettingsStore";
+import { getSettingDisabled } from "../settings/controllers/SettingController.ts";
 import {
     DESKTOP_SHORTCUTS,
     DIGITS,
@@ -89,7 +90,7 @@ export const getKeyboardShortcuts = (): IKeyboardShortcuts => {
 
     return (Object.keys(KEYBOARD_SHORTCUTS) as KeyBindingAction[])
         .filter((k) => {
-            if (KEYBOARD_SHORTCUTS[k]?.controller?.settingDisabled) return false;
+            if (getSettingDisabled(KEYBOARD_SHORTCUTS[k]?.controller)) return false;
             if (MAC_ONLY_SHORTCUTS.includes(k) && !IS_MAC) return false;
             if (DESKTOP_SHORTCUTS.includes(k) && !overrideBrowserShortcuts) return false;
 

--- a/apps/web/src/settings/Settings.tsx
+++ b/apps/web/src/settings/Settings.tsx
@@ -148,8 +148,10 @@ export interface IBaseSetting<T extends SettingValueType = SettingValueType> {
     // represent a boolean).
     default: T;
 
-    // Optional settings controller. See SettingsController for more information.
-    controller?: SettingController;
+    // Optional setting controller(s). See SettingController for more information.
+    // When several are given they are consulted in the order they are declared in: the first one
+    // to return an override wins, and the first one to refuse a change stops the change.
+    controller?: SettingController | SettingController[];
 
     // Optional flag to make supportedLevels be respected as the order to handle
     // settings. The first element is treated as "most preferred". The "default"

--- a/apps/web/src/settings/SettingsStore.test.ts
+++ b/apps/web/src/settings/SettingsStore.test.ts
@@ -19,6 +19,7 @@ import SettingsStore from "./SettingsStore";
 import { mkStubRoom, mockPlatformPeg, stubClient } from "../../test/test-utils";
 import { SETTINGS, type SettingKey } from "./Settings.tsx";
 import MatrixClientBackedController from "./controllers/MatrixClientBackedController.ts";
+import SettingController from "./controllers/SettingController.ts";
 
 const TEST_DATA = [
     {
@@ -83,6 +84,89 @@ describe("SettingsStore", () => {
         it(`supportedLevelsAreOrdered doesn't incorrectly override setting`, async () => {
             await SettingsStore.setValue(SETTING_NAME_WITH_CONFIG_OVERRIDE, null, SettingLevel.DEVICE, true);
             expect(SettingsStore.getValueAt(SettingLevel.DEVICE, SETTING_NAME_WITH_CONFIG_OVERRIDE)).toBe(true);
+        });
+    });
+
+    describe("multiple controllers", () => {
+        /**
+         * An existing device-level boolean setting which has no controller of its own, so the
+         * tests below can attach their own without disturbing real behaviour.
+         */
+        const SETTING_NAME = "showHiddenEventsInTimeline";
+
+        /** A controller which records the calls it receives and can be told how to answer. */
+        class TestController extends SettingController {
+            public readonly calls: string[] = [];
+
+            public constructor(
+                private readonly answers: { override?: any; allowChange?: boolean; disabled?: boolean | string } = {},
+            ) {
+                super();
+            }
+
+            public getValueOverride(): any {
+                this.calls.push("getValueOverride");
+                return this.answers.override ?? null;
+            }
+
+            public async beforeChange(): Promise<boolean> {
+                this.calls.push("beforeChange");
+                return this.answers.allowChange ?? true;
+            }
+
+            public onChange(): void {
+                this.calls.push("onChange");
+            }
+
+            public get settingDisabled(): boolean | string {
+                return this.answers.disabled ?? false;
+            }
+        }
+
+        const setControllers = (...controllers: SettingController[]): void => {
+            SETTINGS[SETTING_NAME].controller = controllers;
+        };
+
+        afterEach(() => {
+            SETTINGS[SETTING_NAME].controller = undefined;
+        });
+
+        it("uses the first override given, and does not consult the controllers after it", () => {
+            const [noOverride, override, ignored] = [
+                new TestController(),
+                new TestController({ override: true }),
+                new TestController({ override: false }),
+            ];
+            setControllers(noOverride, override, ignored);
+
+            expect(SettingsStore.getValue(SETTING_NAME)).toBe(true);
+            expect(noOverride.calls).toEqual(["getValueOverride"]);
+            expect(ignored.calls).toEqual([]);
+        });
+
+        it("tells every controller about a change which goes through", async () => {
+            const [first, second] = [new TestController(), new TestController()];
+            setControllers(first, second);
+
+            await SettingsStore.setValue(SETTING_NAME, null, SettingLevel.DEVICE, true);
+            expect(first.calls).toEqual(["beforeChange", "onChange"]);
+            expect(second.calls).toEqual(["beforeChange", "onChange"]);
+        });
+
+        it("stops at the first controller which refuses a change", async () => {
+            const [refuses, ignored] = [new TestController({ allowChange: false }), new TestController()];
+            setControllers(refuses, ignored);
+
+            await SettingsStore.setValue(SETTING_NAME, null, SettingLevel.DEVICE, true);
+            expect(refuses.calls).toEqual(["beforeChange"]);
+            expect(ignored.calls).toEqual([]);
+        });
+
+        it("is disabled if any controller disables it, preferring one which gives a reason", () => {
+            setControllers(new TestController({ disabled: true }), new TestController({ disabled: "Not today" }));
+
+            expect(SettingsStore.canSetValue(SETTING_NAME, null, SettingLevel.DEVICE)).toBe(false);
+            expect(SettingsStore.disabledMessage(SETTING_NAME)).toBe("Not today");
         });
     });
 

--- a/apps/web/src/settings/SettingsStore.ts
+++ b/apps/web/src/settings/SettingsStore.ts
@@ -40,7 +40,7 @@ import PlatformSettingsHandler from "./handlers/PlatformSettingsHandler";
 import ReloadOnChangeController from "./controllers/ReloadOnChangeController";
 import { MatrixClientPeg } from "../MatrixClientPeg";
 import { MediaPreviewValue } from "../@types/media_preview";
-import SettingController from "./controllers/SettingController.ts";
+import SettingController, { getSettingDisabled, toControllers } from "./controllers/SettingController.ts";
 
 // Convert the settings to easier to manage objects for the handlers
 const defaultSettings: Record<string, any> = {};
@@ -338,7 +338,10 @@ export default class SettingsStore {
             const betaInfo = SETTINGS[settingName].betaInfo;
             if (betaInfo) {
                 betaInfo.requiresRefresh =
-                    betaInfo.requiresRefresh ?? SETTINGS[settingName].controller instanceof ReloadOnChangeController;
+                    betaInfo.requiresRefresh ??
+                    toControllers(SETTINGS[settingName].controller).some(
+                        (controller) => controller instanceof ReloadOnChangeController,
+                    );
             }
             return betaInfo;
         }
@@ -358,7 +361,7 @@ export default class SettingsStore {
      * @returns {string} The reason the setting is disabled.
      */
     public static disabledMessage(settingName: SettingKey): string | undefined {
-        const disabled = SETTINGS[settingName].controller?.settingDisabled;
+        const disabled = getSettingDisabled(SETTINGS[settingName].controller);
         return typeof disabled === "string" ? disabled : undefined;
     }
 
@@ -481,9 +484,12 @@ export default class SettingsStore {
     ): Settings[S]["default"] {
         let resultingValue = calculatedValue;
 
-        if (setting.controller) {
-            const actualValue = setting.controller.getValueOverride(level, roomId, calculatedValue, calculatedAtLevel);
-            if (actualValue !== undefined && actualValue !== null) resultingValue = actualValue;
+        for (const controller of toControllers(setting.controller)) {
+            const actualValue = controller.getValueOverride(level, roomId, calculatedValue, calculatedAtLevel);
+            if (actualValue !== undefined && actualValue !== null) {
+                resultingValue = actualValue;
+                break;
+            }
         }
 
         if (setting.invertedSettingName) resultingValue = !resultingValue;
@@ -532,13 +538,18 @@ export default class SettingsStore {
             throw new Error("User cannot set " + finalSettingName + " at " + level + " in " + roomId);
         }
 
-        if (setting.controller && !(await setting.controller.beforeChange(level, roomId, value))) {
-            return; // controller says no
+        const controllers = toControllers(setting.controller);
+        for (const controller of controllers) {
+            if (!(await controller.beforeChange(level, roomId, value))) {
+                return; // controller says no
+            }
         }
 
         await handler.setValue(finalSettingName, roomId, value);
 
-        setting.controller?.onChange(level, roomId, value);
+        for (const controller of controllers) {
+            controller.onChange(level, roomId, value);
+        }
     }
 
     /**
@@ -566,7 +577,7 @@ export default class SettingsStore {
             throw new Error("Setting '" + settingName + "' does not appear to be a setting.");
         }
 
-        if (setting.controller?.settingDisabled) {
+        if (getSettingDisabled(setting.controller)) {
             return false;
         }
 

--- a/apps/web/src/settings/controllers/BlockInvitesConfigController.test.ts
+++ b/apps/web/src/settings/controllers/BlockInvitesConfigController.test.ts
@@ -14,6 +14,7 @@ import { stubClient } from "test-utils";
 
 import { SETTINGS } from "../Settings";
 import MatrixClientBackedController from "./MatrixClientBackedController";
+import type SettingController from "./SettingController.ts";
 import { SettingLevel } from "../SettingLevel.ts";
 
 describe("BlockInvitesConfigController", () => {
@@ -26,7 +27,7 @@ describe("BlockInvitesConfigController", () => {
         });
 
         it("settingDisabled() should give a message", () => {
-            const controller = SETTINGS.blockInvites.controller!;
+            const controller = SETTINGS.blockInvites.controller as SettingController;
             expect(controller.settingDisabled).toEqual("Your server does not implement this feature.");
         });
     });
@@ -42,20 +43,20 @@ describe("BlockInvitesConfigController", () => {
         });
 
         it("settingDisabled() should be false", () => {
-            const controller = SETTINGS.blockInvites.controller!;
+            const controller = SETTINGS.blockInvites.controller as SettingController;
             expect(controller.settingDisabled).toEqual(false);
         });
 
         describe("getValueOverride()", () => {
             it("should return true when invites are blocked", async () => {
-                const controller = SETTINGS.blockInvites.controller!;
+                const controller = SETTINGS.blockInvites.controller as SettingController;
 
                 mockAccountData(cli, { default_action: "block" });
                 expect(controller.getValueOverride(SettingLevel.DEVICE, null, null, null)).toEqual(true);
             });
 
             it("should return false when invites are not blocked", async () => {
-                const controller = SETTINGS.blockInvites.controller!;
+                const controller = SETTINGS.blockInvites.controller as SettingController;
 
                 mockAccountData(cli, { default_action: {} });
                 expect(controller.getValueOverride(SettingLevel.DEVICE, null, null, null)).toEqual(false);
@@ -64,7 +65,7 @@ describe("BlockInvitesConfigController", () => {
 
         describe("beforeChange()", () => {
             it("should set the account data when the value is enabled", async () => {
-                const controller = SETTINGS.blockInvites.controller!;
+                const controller = SETTINGS.blockInvites.controller as SettingController;
                 await controller.beforeChange(SettingLevel.DEVICE, null, true);
                 expect(cli.setAccountData).toHaveBeenCalledTimes(1);
                 expect(cli.setAccountData).toHaveBeenCalledWith("m.invite_permission_config", {
@@ -73,7 +74,7 @@ describe("BlockInvitesConfigController", () => {
             });
 
             it("should set the account data when the value is disabled", async () => {
-                const controller = SETTINGS.blockInvites.controller!;
+                const controller = SETTINGS.blockInvites.controller as SettingController;
                 await controller.beforeChange(SettingLevel.DEVICE, null, false);
                 expect(cli.setAccountData).toHaveBeenCalledTimes(1);
                 expect(cli.setAccountData).toHaveBeenCalledWith("m.invite_permission_config", {});

--- a/apps/web/src/settings/controllers/SettingController.ts
+++ b/apps/web/src/settings/controllers/SettingController.ts
@@ -88,3 +88,31 @@ export default abstract class SettingController {
         return SettingController.sdkContext;
     }
 }
+
+/**
+ * Normalises a setting's `controller` field into a list, keeping the order it was declared in.
+ * @param controller The controller, list of controllers, or nothing.
+ * @returns The controllers to consult, in declaration order.
+ */
+export function toControllers(controller?: SettingController | SettingController[]): SettingController[] {
+    if (!controller) return [];
+    return Array.isArray(controller) ? controller : [controller];
+}
+
+/**
+ * Gets whether any of the given controllers disables the setting.
+ * A reason given by one controller is preferred over a plain `true` from another, so that the
+ * UI can tell the user why the setting is disabled.
+ * @param controller The controller, list of controllers, or nothing.
+ * @returns The reason the setting is disabled, `true` if it is disabled without a reason,
+ * or `false` if it is not disabled.
+ */
+export function getSettingDisabled(controller?: SettingController | SettingController[]): boolean | string {
+    let disabled: boolean | string = false;
+    for (const c of toControllers(controller)) {
+        const settingDisabled = c.settingDisabled;
+        if (typeof settingDisabled === "string") return settingDisabled;
+        if (settingDisabled) disabled = true;
+    }
+    return disabled;
+}


### PR DESCRIPTION
Add a way to setup multiple controllers in the settings.
The motivation is to be able to add analytics controller + another controller on settings (needed for people section https://github.com/element-hq/element-web/pull/34713 and `Notifications.activityIsUnread`)