### PR TITLE
Add UI copy and German translation style guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ To add a new translation, head to the [translating doc](docs/translating.md).
 
 For a developer guide, see the [translating dev doc](docs/translating-dev.md).
 
+For guidance on writing UI copy and how translations should relate to the English source, see the
+[UI copy and localisation guidelines](docs/ui-copy.md). Language-specific style guides live in
+`docs/translations/` (currently [German](docs/translations/de.md)).
+
 # Triaging issues
 
 Issues are triaged by community members and the Web App Team, following the [triage process](https://github.com/element-hq/element-meta/wiki/Triage-process).

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -5,7 +5,12 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE in the repository root for full details.
 */
 
+import { existsSync } from "node:fs";
+import { join, posix } from "node:path";
+import { fileURLToPath } from "node:url";
 import { withMermaid } from "vitepress-plugin-mermaid";
+
+const docsDir = fileURLToPath(new URL("..", import.meta.url));
 
 function customPathResolver(href: string, currentPath: string): string {
     const [link, fragment] = href.split("#", 2);
@@ -25,8 +30,14 @@ function customPathResolver(href: string, currentPath: string): string {
         case "../README.md":
             return `../docs/index.md#${fragment}`;
 
-        default:
+        default: {
+            // Relative links between pages within docs/ are resolved by VitePress natively
+            const resolved = posix.normalize(posix.join(posix.dirname(currentPath), link));
+            if (!resolved.startsWith("..") && existsSync(join(docsDir, resolved))) {
+                return href;
+            }
             return `https://github.com/element-hq/element-web/blob/develop/${href.split("/").pop()}`;
+        }
     }
 }
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -129,7 +129,14 @@ export default withMermaid({
                 text: "Contribution",
                 items: [
                     { text: "Choosing an issue", link: "/choosing-an-issue" },
-                    { text: "Translation", link: "/translating" },
+                    {
+                        text: "Translation",
+                        items: [
+                            { text: "How to translate", link: "/translating" },
+                            { text: "UI copy & localisation", link: "/ui-copy" },
+                            { text: "German style guide", link: "/translations/de" },
+                        ],
+                    },
                     { text: "Netlify builds", link: "/pr-previews" },
                     { text: "Code review", link: "/review" },
                 ],

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -6,7 +6,7 @@ Please see LICENSE in the repository root for full details.
 */
 
 import { existsSync } from "node:fs";
-import { join, posix } from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { withMermaid } from "vitepress-plugin-mermaid";
 
@@ -32,8 +32,8 @@ function customPathResolver(href: string, currentPath: string): string {
 
         default: {
             // Relative links between pages within docs/ are resolved by VitePress natively
-            const resolved = posix.normalize(posix.join(posix.dirname(currentPath), link));
-            if (!resolved.startsWith("..") && existsSync(join(docsDir, resolved))) {
+            const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(currentPath), link));
+            if (!resolved.startsWith("..") && existsSync(path.join(docsDir, resolved))) {
                 return href;
             }
             return `https://github.com/element-hq/element-web/blob/develop/${href.split("/").pop()}`;

--- a/docs/translating-dev.md
+++ b/docs/translating-dev.md
@@ -6,6 +6,9 @@
 - Latest LTS version of Node.js installed
 - Be able to understand English
 
+This document covers the **mechanics** of translation. For guidance on **what to write** — voice, grammatical form,
+punctuation, terminology — see the [UI copy and localisation guidelines](./ui-copy.md).
+
 ## Translating strings vs. marking strings for translation
 
 Translating strings are done with the `_t()` function found in `languageHandler`.

--- a/docs/translating.md
+++ b/docs/translating.md
@@ -18,6 +18,17 @@ Go to https://localazy.com/p/element-web. If your language is listed then you ca
 of https://localazy.com/docs/general/translating-strings if you need help getting started. If your language is not yet
 listed please express your wishes to start translating it in the general discussion room linked above.
 
+## Style guides
+
+Before translating, read the [UI copy and localisation guidelines](./ui-copy.md) — the language-independent rules for
+how any translation should relate to the English source (placeholders, plurals, punctuation, terminology).
+
+Some languages additionally have their own style guide in `docs/translations/`:
+
+- [German](./translations/de.md)
+
+If you would like to contribute a guide for your language, PRs are welcome — use the German one as a template.
+
 ### What are `%(something)s`?
 
 These things are placeholders that are expanded when displayed by Element. They can be room names, usernames or similar.

--- a/docs/translations/de.md
+++ b/docs/translations/de.md
@@ -1,0 +1,413 @@
+# English → German Translation Guidelines
+
+These guidelines keep Element's German UI consistent and familiar—aligned with muscle memory from WhatsApp, Signal, Teams, and Slack.
+
+Applies to Element Web, Element Desktop, shared-components, Element X, Element Call, Element Admin and MAS. Where a rule differs by product, it is called out explicitly.
+
+Language-independent rules — grammatical form by position, punctuation, placeholders, plurals — live in the [UI copy and localisation guidelines](../ui-copy.md). For how to join the translation effort, see [How to translate Element](../translating.md).
+
+## Tone & Voice
+
+- **Addressing users:** use **du** (lowercase), never _Sie_. This applies to **every** product, including Element Admin — an administrator is still a person using a product.
+
+    - informal language even though used in professional contexts
+
+    - Watch for third-person „Sie"/„sie" that is not address at all: „Sie umfasst alle Funktionen" (the distribution), „Sie stimmen überein" (the emoji). Those are correct.
+
+- **Direct & action-first:** prefer short sentences. The grammatical form depends on position:
+
+    | Position                                            | Form         | Example                              |
+    | --------------------------------------------------- | ------------ | ------------------------------------ |
+    | Body text, instructions, empty states               | Imperative   | „Sende die erste Nachricht."         |
+    | Dialog titles, buttons, menu items, checkbox labels | Infinitive   | „Konto deaktivieren"                 |
+    | Descriptions of what a feature does                 | Third person | „Entfernt Nachrichten automatisch …" |
+    - ❌ Never use the imperative for a dialog title („Deaktiviere das Konto?").
+
+    - „Bitte" is kept where the English source says _Please_. It is not filler; dropping it changes register.
+
+- **Plain language:** avoid jargon unless it's a **fixed term** in the glossary (e.g. **Homeserver**).
+
+- **Friendly, not chatty:** no filler, no excessive emojis. Keep microcopy crisp.
+
+- **Match the source's register — do not default to formal.** German should be exactly as informal as the English it translates, no more and no less.
+
+    - ❌ „Falsches Passwort, versuch's nochmal" for _Incorrect password, please try again_ — the German is chattier than the source.
+
+    - ✓ „Los geht's" for _Get started_ — the English is equally informal, so the German is right.
+
+    - Colloquial elisions (_versuch's_, _gibt's_, _probier's_) are the usual symptom. Prefer the full form unless the English is casual too.
+
+## Style Conventions
+
+- **Sentence case** in buttons/labels: „Nachricht senden", „Fertig".
+
+- **Quotation marks:** always German typographic quotes **„…“**, single **‚…‘**.
+
+    - ⚠ **The closing double quote is the same character English uses as an _opening_ quote** (U+201C). They look nothing alike in a font but are easy to confuse when copying. This is the single commonest error in the German files.
+
+    | Character | Purpose                            | Unicode | Windows Alt code |
+    | --------- | ---------------------------------- | ------- | ---------------- |
+    | „         | opening double                     | U+201E  | Alt + 0132       |
+    | “         | closing double                     | U+201C  | Alt + 0147       |
+    | ‚         | opening single                     | U+201A  | Alt + 0130       |
+    | ‘         | closing single                     | U+2018  | Alt + 0145       |
+    | ’         | apostrophe (elision, „Los geht’s") | U+2019  | Alt + 0146       |
+    - Alt codes need the **separate numeric keypad** with Num Lock on — the number row above the letters does not work, and most laptops have no keypad. Copying the character is usually faster.
+
+    - ‘ and ’ are mirror images: ‘ curls like a 6, ’ curls like a 9. The closing single quote and the apostrophe are **different characters** despite looking alike.
+
+    - Never straight quotes (`"…"`) — those are inch marks, not quotation marks.
+
+    - This applies even where the English source uses straight quotes or curly English ones.
+
+    - A quote **inside** a quote takes the single form ‚…'.
+
+    - Do **not** add quotes the English does not have. Several German strings had invented them around placeholders and adjectives.
+
+    - Practical bonus: „ and " need no escaping in JSON, unlike `\"`.
+
+- **Apostrophes:** the elision apostrophe is **’** (U+2019), never the straight `'`.
+
+    - Never carry an **English possessive `'s`** into German — „%(displayName)s's Identität" is not German. Restructure with _von_: „die digitale Identität von %(displayName)s". This also avoids the problem of a name that already ends in _s_, since a placeholder cannot be inflected.
+
+- **Punctuation — the test is _position_, not grammatical completeness.** A string can be a full sentence and still take no period.
+
+    | Takes a period                      | Takes none                                                                    |
+    | ----------------------------------- | ----------------------------------------------------------------------------- |
+    | Body text and descriptions          | Titles and headings                                                           |
+    | Any string of two or more sentences | Buttons, labels, menu items                                                   |
+    |                                     | Inline form-validation errors („Dieser Wert passt nicht zu deiner Matrix-ID") |
+    |                                     | List and bullet items                                                         |
+    |                                     | Tooltips and short status text                                                |
+    - **Within any list, every item follows the same convention** — check the siblings before deciding one item.
+
+    - **A string containing a sentence break must end with a period.** „Diese Sitzung wurde beendet. Melde dich ab…" without a final stop is wrong in either language; if the English lacks it, that is an English defect to raise, not a German one to copy.
+
+    - German follows the source per string — do not add or drop a period the English does not have, unless the rule above is being applied to both languages.
+
+    - ⚠ **A period mismatch is sometimes a symptom, not the problem.** Before mechanically adding or removing one, check the German still translates the current English. `screen.leave_space.subtitle` differed only by a full stop in the scan, but the German was translating a source that no longer existed.
+
+- **Dashes:** spaced en dash **„ – "**, never a hyphen („ - ") in dash constructions. Where the English uses an em dash („ — "), German still takes the spaced en dash — a deliberate divergence, not a mismatch.
+
+- **Ellipsis:** single character **…**, never three dots. German puts a space before it: „Wird vorbereitet …". This is a deliberate divergence from the English source, which has no space.
+
+- **Numbers & dates:** follow German format (1.234,56; 31.12.2025). Non-breaking space between number and unit: „1 h", „25 MB".
+
+- **Acronyms** stay uppercase: MIME, URL, URI, SSO, PIN.
+
+- **Compounds with loanwords** take a hyphen: „Legacy-Gerät", „LiveKit-Server", „State-Events", „Grant-Typen", „Redirect-URIs". Native compounds are written closed: „Kontoanbieter", „Schlüsselspeicher", „Gruppenbild".
+
+- **Gender:** Prefer phrasing that avoids gendered nouns
+
+    - use **du**, plurals, or role nouns
+
+    - there is no policy (yet) on gender language, so for now avoid it (z. B. „Besitzer:in", „Nutzer:innen")
+
+    - Where the English uses singular _they_ about one unknown person, use **„Person"** or restructure: „Diese Person kann …", not „Er/Sie kann …"
+
+    - Where the object is really an account rather than a human, name the object: „Konto deaktivieren", not „Nutzer deaktivieren"
+
+## Microcopy Patterns
+
+- **Primary actions:** „Senden", „Teilen", „Speichern", „Bestätigen", „Fertig" (final step), „Abschließen" (wirklich final/transaktional).
+
+- **Secondary/escape actions:** „Abbrechen", „Zurück".
+
+- **Destructive:** „Löschen", „Entfernen", „Verlassen".
+
+    - Note: in Matrix, often content cannot be truly deleted, so use „Löschen" only where appropriate
+
+- **Progress states** — always the **passive** form, so the control visibly changes state:
+
+    - Preparing: **„Wird vorbereitet …"** (spezifisch: „Upload wird vorbereitet …")
+
+    - Loading: **„Wird geladen …"**
+
+    - Syncing: **„Wird synchronisiert …"**
+
+    - Downloading: **„Wird heruntergeladen …"**
+
+    - Saving: **„Wird gespeichert …"**
+
+    - ❌ Never reuse the idle infinitive for the progress state — „Herunterladen" / „Herunterladen" leaves the button looking unchanged.
+
+- **Completion:** „Erfolgreich gespeichert", „Gesendet", „Erledigt".
+
+- **Errors:** klar + lösungsorientiert.
+
+    - „Verbindung unterbrochen. **Erneut versuchen**"
+
+    - „Senden fehlgeschlagen. **Nochmal senden**"
+
+    - State the consequence where one exists, and make it conditional if the app knows: „Wenn du die Wiederherstellung eingerichtet hast, …"
+
+## Touch & Interaction Terms
+
+- **Select (device-neutral, default):** **wählen** / **auswählen** („Wähle „Fortfahren"")
+
+    - This is the default rendering of the English _select_, which is replacing _click_ and _tap_ in the source.
+
+- **Click:** **klicken** — only where the interaction is genuinely pointer-specific, e.g. a drag handle („Zum Aufklappen klicken oder ziehen").
+
+- **Tap:** **tippen** („Tippe auf …") — only where the instruction refers to a phone the user is holding, e.g. QR sign-in steps performed on the mobile device.
+
+- **Drag / drop:** **ziehen** / **ablegen** (Teams convention). _Verschieben_ is reserved for the menu command „Verschieben nach".
+
+- **Long-press:** **„Tippen und halten"** / **„Berühren und halten"**
+
+- **Before dropping an interaction verb, check what else signals the affordance.** English strings like _Click to view edits_ often read better in German without the verb — but only where the user is already interacting with the element.
+
+    | Surface                                  | Verb needed?                         | Example                                                                                                                                                            |
+    | ---------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+    | Tooltip on a hovered element             | No — hovering already implies action | `room.read_topic` → „Vollständiges Thema anzeigen"                                                                                                                 |
+    | Link text                                | No                                   | `see_older_messages` → „Ältere Nachrichten anzeigen"                                                                                                               |
+    | Standalone instruction with no other cue | **Yes** — keep it                    | `location_sharing.click_drop_pin` renders as text over an empty map; „Standort setzen" would read as a button label, so it becomes „Wähle einen Ort auf der Karte" |
+    - Where the verb must stay, use the device-neutral **wählen**, not _klicken_ or _tippen_.
+
+- **Element X is mobile-only**, so **tippen** is correct throughout it — not only in strings that instruct the user about a phone. The exception is a string describing what to do on a _desktop_, e.g. the QR sign-in steps.
+
+- **Double-tap:** **doppeltippen**
+
+## Messaging Concepts (preferred German)
+
+- **Room (Matrix) / generic conversation:** **Chat** — the catch-all term, covering DMs and groups alike („Alle Chats", „Chats erkunden").
+
+- **Group:** **Gruppe** — only where the English distinguishes a non-DM room from a DM, or where the UI creates one specifically („Neue Gruppe").
+
+- **Direct 1:1 chat:** **Direktnachricht**
+
+- **Channel (kontextspezifisch, wenn vorhanden):** **Chat**
+
+- **Chat bubbles:** **Sprechblasen**
+
+- **@-mention:** **Erwähnung** / **jemanden mit @ erwähnen**
+
+- **Group image / room avatar:** **Gruppenbild** (WhatsApp convention). A person's avatar is **Profilbild**. Do not use „Avatar".
+
+- **Join:** **beitreten** (dative), noun **Beitritt**, **Beitrittsanfrage**.
+
+    - ❌ Never _betreten_ — Element German calls rooms „Chats", so the physical-entry metaphor does not fit.
+
+    - Watch the case: _beitreten_ takes the dative, _betreten_ the accusative. Sentences like „diesen Space sehen und betreten" need restructuring: „diesen Space sehen und **ihm** beitreten".
+
+- **Ban / unban:** **sperren**, noun **Sperre**; unban is **„die Sperre aufheben"**.
+
+    - ❌ Never _bannen_, _verbannen_, _ausschließen_.
+
+    - _entsperren_ is avoided for people — it reads as unlocking a phone.
+
+## Matrix-spezifische Begriffe
+
+- **Homeserver vs account provider vs service.** Ask what the word **names**, not how technical the reader is — plenty of technical-sounding strings are read by ordinary users.
+
+    | The word names…                                                                   | Use               | Examples                                                                            |
+    | --------------------------------------------------------------------------------- | ----------------- | ----------------------------------------------------------------------------------- |
+    | A **party** — whose account it is, who to contact, who supports a feature         | **Kontoanbieter** | „Dein Kontoanbieter unterstützt das nicht", „Wende dich an deinen Kontoanbieter"    |
+    | A party, but nobody is being contacted and no relationship is implied             | **Dienst**        | „Dieser Dienst hat sein Limit erreicht"                                             |
+    | A **thing** — a URL, config key, API version, discovery response, SSL certificate | **Homeserver**    | „Homeserver-URL", „SSL-Zertifikat deines Homeservers", „Homeserver-Erkennung"       |
+    | Nothing useful to the reader                                                      | drop the noun     | „Keine Verbindung möglich" — Teams German never says _Server_ in a connection error |
+    - ❌ **Never** _Heimserver_, _Heim-Server_, _Home-Server_ under any circumstances.
+
+    - **Kontoanbieter** is a closed compound — never _Konto-Anbieter_ or _Konto-Provider_.
+
+    - **Exception — Element Admin:** the admin console is only ever seen by operators, so **Homeserver** is correct throughout, including where it names a party.
+
+- **Administrator.** Use sparingly, and only where the person is acting in an admin capacity that the account provider as an organisation would not.
+
+    - ⚠ **Ambiguity risk:** in Element, _admin_ usually means a **room admin**. A string that says „wende dich an den Administrator" can easily be read as _ask a moderator in this chat_. Where the intended party is whoever runs the account, say **Kontoanbieter** instead.
+
+    - Where it genuinely is the deployment operator and no account relationship is implied, use **Server-Administration**. Element Call is currently the only case: it has no account concept today, so there is no provider to point at. Revisit if that changes.
+
+    - ❌ Never _Admin_ (clipped), _Systemadministrator_, _Serviceadministrator_, _Serveradmin_.
+
+    - _Owner_ → **Inhaber**, or restructure.
+
+- **Room upgrade (Version):** **„Chatversion aktualisieren"** / „Zum neuen Chat wechseln".
+
+- **State events:** **State-Events** (spec term, hyphenated in compounds). Encryption of them: **State-Verschlüsselung**.
+
+- **Sticky Events, Secret Storage, Sliding Sync, MSC numbers:** untranslated spec terms.
+
+- **Grant type, redirect URI, scope, client, token, user agent (OAuth/MAS):** untranslated — „Grant-Typ", „Redirect-URI", „Scope", „Client", „Token", „User-Agent".
+
+## Verschlüsselung & Sicherheit
+
+- **Digital identity:** **digitale Identität**
+
+    - ❌ Never _kryptografische Identität_, _Cross-Signing-Identität_, or _Sicherheitsnummer_. The last is Signal's _Safety Number_, a per-conversation fingerprint — a different concept that would import a false mental model.
+
+- **Backup:** noun **Backup**, verb **sichern** / **gesichert** (Signal/WhatsApp convention).
+
+    - ❌ Never _backuppen_; never _Sicherung_ as the noun in user-facing UI.
+
+    - The noun and the verb should not collide in one sentence („Das Backup wird gesichert" is nonsense).
+
+- **Recovery key:** **Wiederherstellungsschlüssel**.
+
+    - _Recovery_ never stands alone as a feature name — it appears only as part of _Wiederherstellungsschlüssel_.
+
+- **Key storage:** **Schlüsselspeicher** — a separately labelled control, distinct from Backup. Keep the two apart.
+
+- **Device (cryptographic):** **Gerät**, not _Sitzung_.
+
+    - _Sitzung_ is reserved for a locally stored login state (e.g. session restore errors), which is a different object.
+
+- **Verify:** **verifizieren** — reserved for device/identity verification (cross-signing). For confirming a one-time code, use **bestätigen** („Bestätigungscode").
+
+- **Message keys:** **Nachrichtenschlüssel**.
+
+## UI-Struktur & Aktionen
+
+- **Section:** **Abschnitt** (Teams convention). „Neuer Abschnitt", „Verschieben nach", „Aus Abschnitt entfernen".
+
+- **Collapse / expand:** always check what the control actually collapses before choosing. The same English key can need different German in different products — in Element Web `action.collapse` folds lists, trees and code blocks, while in MAS the identical key wraps an HTML `<section>`.
+
+    - Sections: **reduzieren** / **erweitern** (Teams convention).
+
+    - Lists, trees, plural objects, content blocks: **einklappen** / **ausklappen** — „Filterliste erweitern" would read as _add more filters_.
+
+    - Enlarging or shrinking a visual element (map, video tile, text field): **vergrößern** / **verkleinern**.
+
+- **Clear** — four distinct German verbs; pick by what happens to the thing:
+
+    | Situation                            | German           | Example                           |
+    | ------------------------------------ | ---------------- | --------------------------------- |
+    | Container persists, contents removed | **leeren**       | an input field, „Chat leeren"     |
+    | Stored entries are destroyed         | **löschen**      | search history, logs              |
+    | Individual items taken out of a set  | **entfernen**    | „Alle entfernen" for URL previews |
+    | Restored to a default                | **zurücksetzen** | filters, form defaults            |
+
+- **Pin / unpin:** **fixieren** / **Fixiert** / **lösen**.
+
+    - ❌ Never _anheften_.
+
+- **View source:** **Rohdaten anzeigen** — what is shown is raw event JSON, not source code. ❌ Never _Quelltext_.
+
+- **User:** **Nutzer**, **Nutzername**.
+
+    - ❌ Never _Benutzer_, _Benutzername_ — Element X is already fully _Nutzer_, and it matches German public-sector register (OZG, BSI, ZenDiS).
+
+    - **Exception:** **benutzerdefiniert** is the fixed German for _custom_ and must not be touched.
+
+## Referencing other UI elements
+
+- When a string names a button or control, the German must match that control's **own translated label**, not the English one.
+
+    - Live example of the failure mode: copy told users to press „Weiter" while `action|continue` rendered as „Fortfahren".
+
+    - Prefer an interpolated placeholder over a hardcoded label where the developer can provide one.
+
+- When a string references a **system** UI element (iOS, Android, another Element app), match that system's German exactly.
+
+    - „Genauer Standort" (iOS Settings), „Verwaltung der Verschlüsselungs-Schlüssel" (legacy Element Android).
+
+    - Apple's alert-tone names (Tri-tone, Chime, Glass, Electronic) ship untranslated in every locale — do not translate them.
+
+## Do & Don't (with examples)
+
+- **Do (imperative, short):**
+
+    - „**Nachricht senden**"
+
+    - „**Link kopieren**"
+
+- **Don't (verbose, passive, formal):**
+
+    - „Die Nachricht kann nun gesendet werden."
+
+    - „Bitte klicken Sie, um fortzufahren."
+
+- **Do (neutral, user-first):**
+
+    - „**Du wurdest** in #projekt **erwähnt**."
+
+    - „**Upload wird vorbereitet …**"
+
+- **Don't (jargon):**
+
+    - „User wurde gepingt."
+
+    - „Pre-Processing wird ausgeführt."
+
+- **Don't (invented content):** never add claims the source does not make, and never drop a consequence it does. Several legacy strings promised things the English never said, or omitted that message history would be lost.
+
+## Glossary (living list)
+
+Please make use of the built-in glossary but sense-check before applying. Some terms have different translations in different contexts.
+
+### Standard renderings
+
+Agreed across all products. Where a term is product-specific, that is noted.
+
+| English                | German                                                         | Note                                                                                                                                |
+| ---------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Continue               | „Weiter"                                                       | not _Fortfahren_                                                                                                                    |
+| Retry                  | „Erneut versuchen"                                             | not _Wiederholen_                                                                                                                   |
+| Dismiss                | „Schließen"                                                    | not _Ausblenden_, which means hide                                                                                                  |
+| Start over             | „Neu beginnen"                                                 |                                                                                                                                     |
+| Clear                  | see the four-way rule above                                    |                                                                                                                                     |
+| Loading…               | „Wird geladen …"                                               |                                                                                                                                     |
+| Confirm password       | „Passwort bestätigen"                                          |                                                                                                                                     |
+| Preferences            | „Präferenzen"                                                  | **only** as the Element Web settings tab name, where „Einstellungen" would collide with _Settings_. „Einstellungen" everywhere else |
+| View all               | „Alle anzeigen"                                                |                                                                                                                                     |
+| View source            | „Rohdaten anzeigen"                                            | raw event JSON, not source code                                                                                                     |
+| Something went wrong   | „Etwas ist schief gelaufen"                                    | no terminal period                                                                                                                  |
+| This field is required | „Dieses Feld ist ein Pflichtfeld"                              |                                                                                                                                     |
+| Not encrypted          | „Nicht verschlüsselt"                                          | not _Unverschlüsselt_                                                                                                               |
+| Invite only            | „Nur mit Einladung"                                            |                                                                                                                                     |
+| Invite people          | „Personen einladen"                                            |                                                                                                                                     |
+| Create account         | „Konto erstellen"                                              | not _Konto anlegen_                                                                                                                 |
+| Ask to join            | „Beitritt anfragen" (action) · „Auf Anfrage" (join-rule label) |                                                                                                                                     |
+| Request to join sent   | „Beitrittsanfrage gestellt"                                    | _eine Anfrage stellen_, not _schicken_                                                                                              |
+| Get recovery key       | „Wiederherstellungsschlüssel erstellen"                        |                                                                                                                                     |
+| New room               | „Neue Gruppe"                                                  | it creates a non-DM room                                                                                                            |
+| Start chat             | „Chat starten"                                                 | the umbrella action covering both DM and group                                                                                      |
+| Message history        | „Nachrichtenverlauf"                                           |                                                                                                                                     |
+| Anyone                 | „Alle"                                                         | prefer over _Jeder_                                                                                                                 |
+| Please try again       | „Bitte versuche es erneut"                                     | not _versuch's nochmal_                                                                                                             |
+| Get started            | „Los geht's"                                                   | typographic apostrophe                                                                                                              |
+
+## Practical Tips
+
+- **Name collisions:** If a term differs between ecosystems (e.g., Slack vs. Teams), pick the variant that best matches **Element's model** and document it in the comments with cross-refs.
+
+- **Space constraints:** Prefer the shorter, widely understood term („Fertig" über „Fertigstellen").
+
+- **Empty states:** explain next step: „Noch keine Nachrichten. **Schreibe die erste Nachricht.**"
+
+- **Placeholders and markup** (`%(name)s`, `%1$@`, `<a>`, `<user/>`) are copied verbatim, including case. Never introduce a placeholder the English does not have — the German will render it literally.
+
+- **Plurals:** German has `one` and `other`. Fill both; leaving `one` empty falls back to English.
+
+- **Stale translations:** when the English changes, the German is not always re-flagged. If a German string says something the English no longer says, it is stale, not a free translation.
+
+- **Whitespace:** no leading, trailing or doubled spaces. No space before punctuation or before a closing bracket. Spaces belong **outside** markup tags, not inside them — „Standard `<2>`({{name}})`</2>`", never „Standard`<2>` ({{name}} )`</2>`".
+
+- **Never add markup the English does not have.** `<b>`, `<a>`, `<user/>` and the rest are copied verbatim from the source. Adding emphasis that isn't in the English risks rendering the raw tag on screen.
+
+- **Identical English gets identical German**, across products as well as within one file. Where two call sites genuinely need different German, record why — otherwise the divergence looks like an error to the next reviewer.
+
+- **When you change one half of a pair, check the twin.** Element has many `…_room` / `…_space` and `…_one` / `…_multiple` variants that differ by a single word. Changing one and not the other is the commonest way a file drifts out of step.
+
+## Decisions log
+
+Recorded so they are not relitigated.
+
+| Decision                                                                                                   | Rationale                                                                                                                                                                                                                                                                                                                      |
+| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| _Nutzer_, not _Benutzer_                                                                                   | Element X already 100% _Nutzer_; matches German public-sector register. Microsoft uses _Benutzer_ but is outweighed here.                                                                                                                                                                                                      |
+| _digitale Identität_, not _kryptografische Identität_ or _Sicherheitsnummer_                               | User-facing term agreed with product; _Sicherheitsnummer_ is Signal's Safety Number, a different concept.                                                                                                                                                                                                                      |
+| Noun _Backup_, verb _sichern_                                                                              | Signal and WhatsApp both do this; German has no usable verb for _Backup_.                                                                                                                                                                                                                                                      |
+| _Recovery_ only as _Wiederherstellungsschlüssel_                                                           | Removes one of several competing names for one feature.                                                                                                                                                                                                                                                                        |
+| _Schlüsselspeicher_ stays distinct from _Backup_                                                           | It is a separately labelled control in the UI.                                                                                                                                                                                                                                                                                 |
+| German quotes „…" everywhere                                                                               | German convention and Microsoft's German UI style guide; straight quotes are inch marks.                                                                                                                                                                                                                                       |
+| _beitreten_, not _betreten_                                                                                | Rooms are called _Chats_; the physical-entry metaphor does not fit. Noun family already established.                                                                                                                                                                                                                           |
+| _Abschnitt_, _reduzieren/erweitern_, _Verschieben nach_                                                    | Verbatim matches with Teams German, for users migrating from M365.                                                                                                                                                                                                                                                             |
+| _einklappen/ausklappen_ for lists                                                                          | _erweitern_ on a list reads as "add more items".                                                                                                                                                                                                                                                                               |
+| _fixieren/lösen_, not _anheften_                                                                           | Element X iOS and the majority of Element Web already use it.                                                                                                                                                                                                                                                                  |
+| _Gerät_, not _Sitzung_, for the cryptographic device                                                       | Users read "sign out" as reversible; removal destroys the device.                                                                                                                                                                                                                                                              |
+| No gendered forms (_:innen_) for now                                                                       | No Element-wide policy; avoid rather than invent.                                                                                                                                                                                                                                                                              |
+| **du** in every product, including Element Admin                                                           | An earlier version of this guideline claimed Element Admin used _Sie_. The file does not: 11 strings use du forms and only 2 used Sie, which were the outliers. Element's German voice is du throughout.                                                                                                                       |
+| Homeserver / Kontoanbieter / Dienst decided by what the word **names**, not by how technical the reader is | The audience test failed in practice: strings like „This homeserver does not support login using email address" look technical but are read by ordinary users, and _homeserver_ there just means _whoever runs your account_. Only strings naming an actual artefact — a URL, a certificate, a config key — keep _Homeserver_. |
+| Element Admin keeps _Homeserver_ throughout                                                                | Only operators ever open the admin console.                                                                                                                                                                                                                                                                                    |
+| _Administrator_ used sparingly                                                                             | In Element, _admin_ normally means a room admin, so an unqualified „Administrator" is read as _a moderator in this chat_.                                                                                                                                                                                                      |

--- a/docs/ui-copy.md
+++ b/docs/ui-copy.md
@@ -1,0 +1,193 @@
+# UI Copy and Localisation Guidelines
+
+Language-independent rules for Element's interface copy: how to write the English source, and how any translation should relate to it.
+
+Applies to Element Web, Element Desktop, shared-components, Element X, Element Call, Element Admin and MAS. Per-language conventions live in the language guides in `docs/translations/` (e.g. the [German translation guidelines](./translations/de.md)).
+
+This document covers **what to write**. For **how to wire it up** — `_t()` vs `_td()`, key naming, running `pnpm i18n`, Localazy behaviour, tag substitution — see [How to translate Element (Dev Guide)](./translating-dev.md). For how to join the translation effort, see [How to translate Element](./translating.md).
+
+---
+
+## 1. Voice
+
+- **Write for the person in front of the screen, not for the code.** If a string names an internal concept the user has never seen — an event ID, a Megolm session, a MIME type, a homeserver — ask whether the user can act on it. If not, name the effect instead.
+
+- **Plain language.** Avoid jargon unless it is a fixed product or spec term. A technical-sounding string is not automatically read by a technical person.
+
+- **Short sentences.** One idea per sentence. Two sentences beat one sentence with a subordinate clause.
+
+- **Friendly, not chatty.** No filler, no unnecessary emoji.
+
+- **Say what happens next.** An error that states only what went wrong leaves the user stuck. Where a remedy exists, name it.
+
+- **Make consequences explicit, and conditional where the app knows.** "You'll lose your message history" is wrong for a user who has recovery configured. If the code can distinguish the two cases, the copy should too.
+
+---
+
+## 2. Grammatical form follows position
+
+The form a string takes depends on where it renders, not on what it says. English hides this, because the imperative and the infinitive look identical — but most languages distinguish them, so the choice is being made whether or not the author notices.
+
+The same action, in every position it can appear:
+
+| Position            | Form                                                             | Example                                                             |
+| ------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Button, menu item   | Names the action. No article, no period                          | **Deactivate account**                                              |
+| Dialog title        | Names the action, or asks about it                               | **Deactivate account?**                                             |
+| Body text           | Addresses the user. Article, full sentence, period               | **You're about to deactivate your account. This cannot be undone.** |
+| Empty state         | Addresses the user, names the next step                          | **No messages yet. Send the first one.**                            |
+| Feature description | Third person, describes behaviour                                | **Removes messages automatically after 30 days.**                   |
+| Progress state      | Progressive                                                      | **Deactivating…**                                                   |
+| Accessible label    | Self-contained: names the control and, where relevant, its state | **Deactivate account, button**                                      |
+
+**The tells, when you can't decide which you are writing:**
+
+- **Article** — "Send **the** first message" is body text; "Send message" is a button.
+- **Period** — labels and titles never have one; body text does.
+- **Length** — labels are one to three words. If it needs a comma, it is not a label.
+- **Subject** — body text can say _you_; a label never does.
+
+**Keep a family internally consistent.** Slash-command descriptions, join-rule labels, filter chips and list items are read against each other; a single outlier looks like a bug.
+
+**Why it matters beyond style:** in German, "Send the first message" is an imperative („Sende …") and "Deactivate account" is an infinitive („Konto deaktivieren") — visibly different constructions. Choosing the wrong one is immediately wrong to a reader, and the English author has no way to feel the error.
+
+---
+
+## 3. Punctuation
+
+**The test is position, not grammatical completeness.** A string can be a full sentence and still take no period.
+
+| Takes a period                      | Takes none                     |
+| ----------------------------------- | ------------------------------ |
+| Body text and descriptions          | Titles and headings            |
+| Any string of two or more sentences | Buttons, labels, menu items    |
+|                                     | Inline form-validation errors  |
+|                                     | List and bullet items          |
+|                                     | Tooltips and short status text |
+
+- **Within a list, every item follows the same convention.** Check the siblings before deciding one item.
+
+- **A string containing a sentence break must end with one.** "This session has been terminated. Sign out to be able to log back in" without a final stop is wrong.
+
+- **Punctuation belongs in the string, not in the code.** If a label is followed by a colon on screen, the colon is part of the translatable string — punctuation, spacing and quotation conventions all vary by language.
+
+- **Other punctuation:** sentence case in buttons and labels; a single ellipsis character `…` rather than three dots; acronyms uppercase (MIME, URL, URI, SSO, PIN).
+
+---
+
+## 4. Interaction verbs
+
+- **`select` is the default.** It is device-neutral and works for pointer, touch and keyboard.
+
+- **`click` only where the interaction is genuinely pointer-specific** — a drag handle, a right-click menu, something paired with dragging.
+
+- **`tap` only where the surface is touch-only** — a mobile-only product, or a string instructing the user about their phone while they read it on a desktop. Element X is mobile-only, so _tap_ is correct throughout it; the exception is a string describing what to do on a desktop, such as the QR sign-in steps.
+
+- **Before dropping the verb entirely, check what else signals the affordance.**
+
+| Surface                                  | Verb needed?                          |
+| ---------------------------------------- | ------------------------------------- |
+| Tooltip on a hovered element             | No — hovering already implies action  |
+| Link text                                | No                                    |
+| Standalone instruction with no other cue | **Yes** — e.g. text over an empty map |
+
+---
+
+## 5. Terminology
+
+- **One name per concept, across every product.** If Element Web, Element X and MAS each call the same thing something different, users moving between them have to relearn it. Five names for one feature is a product problem that copy cannot fix.
+
+- **Ask what a word _names_, not how technical the reader is.** This is the test that decides between a user-facing term and an internal one:
+
+| The word names…                                                               | Use                                       |
+| ----------------------------------------------------------------------------- | ----------------------------------------- |
+| A **party** — whose account it is, who to contact, who supports a feature     | the user-facing term (_account provider_) |
+| A party, but nobody is being contacted                                        | a neutral word (_service_)                |
+| A **thing** — a URL, config key, API version, certificate, discovery response | the technical term (_homeserver_)         |
+| Nothing the reader can use                                                    | drop the noun entirely                    |
+
+- **Check what a word already means inside Element before you use it.** Several are already spoken for, and reusing one attaches your string to the wrong concept.
+
+    - _Admin_ means a **room** admin. "Contact your admin" reads as "ask a moderator here", whatever you intended.
+    - _Session_ means a Megolm session in crypto contexts, and locally stored login state in others.
+    - _Client_ means an OAuth client in MAS and admin surfaces.
+
+    If the word you want is taken, pick a different one rather than relying on context to disambiguate. Context does not survive translation — a translator works string by string and has none.
+
+- **Never name a control that does not exist.** A string saying `By clicking "Join call now"` when the button says _Continue_ is a defect. Prefer an interpolated placeholder over a hardcoded label so the reference cannot rot.
+
+- **When referencing another system's UI** — iOS Settings, Android, another Element app — match that system's wording exactly, in every language. Some names (Apple's alert-tone names) are untranslated in every locale.
+
+- **Name variables for the translator, not for the programmer.** `recipient` tells a translator nothing — is it a person, an email address, a user ID? `recipientEmailAddress` does. The variable name is often the only context a translator gets.
+
+- **Before adding a string, check whether it already exists** in a related project. Reusing a shared string is better than a near-duplicate — but if the existing one is _wrong_, fix it rather than working around it, or the divergence spreads.
+
+---
+
+## 6. Progress and idle states must differ
+
+If a control has an idle label and a progressive one, they must be visibly different in **every** language. A button reading the same before and during an action looks broken.
+
+This is the commonest place a translation silently collapses two English states into one word.
+
+---
+
+## 7. What a translation must and must not do
+
+- **Placeholders and markup are copied verbatim**, including case and index — `%(name)s`, `%1$@`, `{{count}}`, `<a>`, `<user/>`.
+
+    - **Never introduce a placeholder the source does not have.** It will render literally.
+    - **Never add markup the source does not have.** `<b>` invented in a translation can display as raw text.
+
+- **Fill every plural form the source declares.** An empty form falls back to the source language.
+
+- **Never add a claim the source does not make, and never drop a consequence it does.** Both have happened: translations promising an invitation that was never mentioned, and translations omitting that message history would be lost.
+
+- **Identical source text gets identical translation**, across products as well as within a file. Where two call sites genuinely need different wording, record why.
+
+- **When you change one half of a pair, check the twin.** `…_room` / `…_space` and `…_one` / `…_multiple` variants differ by a single word; changing one is the commonest way a file drifts out of step.
+
+- **A translation that says something the source no longer says is stale, not free.** When the source changes, the translation is not always re-flagged.
+
+- **Whitespace:** no leading, trailing or doubled spaces; no space before punctuation or a closing bracket; spaces belong **outside** markup tags, not inside them.
+
+---
+
+## 8. Never build a sentence out of parts
+
+The most damaging thing a source string can do to a translation is arrive incomplete.
+
+- **Do not concatenate translated strings**, and do not substitute one translated string into another. Concatenation bakes in an implicit word order — typically that the subject comes first — which is wrong for many languages. It also strips the context a translator needs.
+
+- **The fragment smell test.** If a string does not begin with a capital letter, or ends with a colon, a comma or a preposition, it is probably a fragment. Check before shipping it.
+
+- **Prefer full repeated sentences over shared fragments.** Several near-identical strings that differ by a word or two look like waste, but they translate faster and more accurately than fewer strings assembled from pieces. This is the opposite of the instinct that serves you well in code.
+
+- **Use the framework's plural mechanism, never an `if`.** Choosing between a singular and a plural string in code assumes two forms; some languages have up to six. Pass the count and let the translation declare its own forms.
+
+---
+
+## 9. Renaming keys when copy changes
+
+There are two kinds of copy change and they need opposite handling.
+
+| Change                                                                        | Rename the key?                                                                        |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| **The meaning changes** — the string now says something different             | **Yes.** Renaming forces every language to retranslate, which is what should happen    |
+| **The wording changes, same referent** — the same thing described differently | **No.** The key is still accurate; the translations need updating but not invalidating |
+
+The test: **would a translator reading only the new string produce something different from what they produced before?** If yes, rename — every language should be forced to look again. If the string describes the same thing in different words, keep the key and update the translations.
+
+**Where a rename is not worth it** — a large family where every key would change and nothing user-visible improves — accept that translations will not be re-flagged automatically, and sweep them deliberately instead.
+
+---
+
+## 10. Working practice
+
+- **Run the machine checks whenever the files change.** Key coverage, placeholder and markup parity, plural completeness, whitespace, and translation-identical-to-source are all mechanical, cost seconds, and catch regressions that reading does not.
+
+- **Prefer one visit per key.** Batch related changes so a string is not edited three times in three sweeps.
+
+- **Trace the render before deciding wording.** Whether a string is a tooltip, a title, an accessible label or an overlay changes the right answer, and the key name is often misleading.
+
+- **Record decisions with their reasoning.** Every terminology choice will be questioned again by someone who wasn't there.


### PR DESCRIPTION
Adds two new documentation guides for translations and UI copy:

- `docs/ui-copy.md` — language-independent guidelines for writing Element's interface copy and for how any translation should relate to the English source (voice, grammatical form by position, punctuation, terminology, placeholders/plurals, key renaming).
- `docs/translations/de.md` — an English → German translation style guide. The new `docs/translations/` directory is intended as the home for future per-language guides.
- Cross-references added from `README.md`, `docs/translating.md`, `docs/translating-dev.md` and the VitePress sidebar.

Also fixes a pre-existing docs-site bug surfaced while verifying this: the custom link resolver rewrote every relative in-content `.md` link to a GitHub blob URL missing the `docs/` prefix, so cross-doc links (e.g. `./jitsi.md` in `jitsi-dev.md`) rendered as 404s. Links whose target exists within `docs/` now pass through to VitePress native resolution; links to repo-root files keep the GitHub fallback. (Separate commit, happy to split it out into its own PR if preferred.)

Verified locally: `oxfmt --check` passes and `vitepress build docs` succeeds with the dead-link check enabled.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible). — N/A, documentation-only change
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation. — N/A
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)