### PR TITLE
Fix flaky WysiwygComposer keyboard-navigation test

### DIFF
--- a/apps/web/src/components/views/rooms/wysiwyg_composer/components/WysiwygComposer.test.tsx
+++ b/apps/web/src/components/views/rooms/wysiwyg_composer/components/WysiwygComposer.test.tsx
@@ -606,6 +606,14 @@ describe("WysiwygComposer", () => {
             vi.spyOn(EventUtils, "findEditableEvent").mockReturnValue(mockEvent);
         });
 
+        function select(selection: SubSelection) {
+            return act(async () => {
+                await setSelection(selection);
+                // the event is not automatically fired by jest
+                document.dispatchEvent(new CustomEvent("selectionchange"));
+            });
+        }
+
         describe("In message creation", () => {
             it("Should not moving when the composer is filled", async () => {
                 // When
@@ -628,6 +636,20 @@ describe("WysiwygComposer", () => {
                 // When
                 const { textbox, spyDispatcher } = await setup();
 
+                // Put the caret at the start of the composer explicitly, as the editing tests
+                // below do. The composer does this itself once ready, but via an effect driven by
+                // a state update from the async wasm init that is not wrapped in act(), so waiting
+                // for contentEditable="true" does not guarantee the caret has landed. With no
+                // caret inside the editor, isCaretAtStart() is false, ArrowUp is ignored, and
+                // nothing is ever dispatched.
+                await select({
+                    anchorNode: textbox,
+                    anchorOffset: 0,
+                    focusNode: textbox,
+                    focusOffset: 0,
+                    isForward: true,
+                });
+
                 fireEvent.keyDown(textbox, {
                     key: "ArrowUp",
                 });
@@ -642,14 +664,6 @@ describe("WysiwygComposer", () => {
         });
 
         describe("In message editing", () => {
-            function select(selection: SubSelection) {
-                return act(async () => {
-                    await setSelection(selection);
-                    // the event is not automatically fired by jest
-                    document.dispatchEvent(new CustomEvent("selectionchange"));
-                });
-            }
-
             describe("Moving up", () => {
                 it("Should not moving when caret is not at beginning of the text", async () => {
                     // When


### PR DESCRIPTION
Fixes flake https://github.com/element-hq/element-web/actions/runs/32992299258/job/98252605083?pr=33637#step:10:43669

By making sure the caret is at the start of the composer explicitly.