### PR TITLE
Avoid unhandled promise rejection from CallStore.onReady()

### DIFF
--- a/apps/web/src/stores/CallStore.ts
+++ b/apps/web/src/stores/CallStore.ts
@@ -55,7 +55,7 @@ export class CallStore extends AsyncStoreWithClient<EmptyObject> {
         // Fetch transports, but don't await the result.
         this.matrixClient.cachedRtcTransports.wait().catch(() => {
             if (SdkConfig.get("enable_client_well_known_lookups")) {
-                void this.matrixClient?.waitForClientWellKnown();
+                this.matrixClient?.waitForClientWellKnown().catch(() => {});
             }
         });
 


### PR DESCRIPTION
As well as the usual network/server errors, a call to `waitForClientWellKnown()` can throw whilst the client is starting up.

This change just drops the failure and avoids `Unhandled promise rejection` getting logged.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
