### PR TITLE
Store the token fallback under its own key so it can actually be read

### DIFF
--- a/apps/web/src/Lifecycle.test.ts
+++ b/apps/web/src/Lifecycle.test.ts
@@ -775,6 +775,28 @@ describe("Lifecycle", () => {
                 expect(localStorage.getItem("mx_refresh_token_fallback")).toBeNull();
             });
 
+            it("should discard an unreachable plaintext token left at the primary key by an older version", async () => {
+                // Older versions wrote their fallback to the primary key rather than the fallback
+                // key, and never cleared it on a later successful write. We cannot tell whether it
+                // is newer or older than the idb copy, so it must not be used - but it must not be
+                // left sitting in localStorage in the clear either.
+                initIdbMock(idbStorageSession);
+                for (const key in localStorageSession) {
+                    localStorage.setItem(key, localStorageSession[key]);
+                }
+                localStorage.setItem("mx_access_token", "old-plaintext-token");
+
+                expect(await restoreSessionFromStorage()).toEqual(true);
+
+                // the idb token wins...
+                expect(createMatrixClientModule.createClientWithCreds).toHaveBeenCalledWith(
+                    expect.objectContaining({ accessToken }),
+                    undefined,
+                );
+                // ...and the unreachable plaintext copy is swept up
+                expect(localStorage.getItem("mx_access_token")).toBeNull();
+            });
+
             it("should remove any access token from storage when there is none in credentials and idb save fails", async () => {
                 // dont fail for pickle key persist
                 vi.spyOn(StorageAccess, "idbSave").mockImplementation(async (table: string, key: string | string[]) => {

--- a/apps/web/src/Lifecycle.test.ts
+++ b/apps/web/src/Lifecycle.test.ts
@@ -275,9 +275,9 @@ describe("Lifecycle", () => {
                     // put accessToken in localstorage at the fallback key, which takes precedence
                     // over anything left in indexeddb
                     expect(localStorage.getItem("mx_access_token_fallback")).toEqual(accessToken);
-                    // and clear the stale indexeddb entry so a client which does not know about the
-                    // fallback key cannot read an outdated token
-                    expect(StorageAccess.idbDelete).toHaveBeenCalledWith("account", "mx_access_token");
+                    // but leave the indexeddb entry alone: the service worker can only read the
+                    // token from there, so removing it would break authenticated media
+                    await expect(StorageAccess.idbLoad("account", "mx_access_token")).resolves.toEqual(accessToken);
                 });
 
                 it("should create and start new matrix client with credentials", async () => {
@@ -661,6 +661,7 @@ describe("Lifecycle", () => {
 
                 expect(localStorage.getItem("mx_has_access_token")).toBeFalsy();
                 expect(localStorage.getItem("mx_access_token")).toBeFalsy();
+                expect(localStorage.getItem("mx_access_token_fallback")).toBeFalsy();
             });
 
             it("should clear stores", async () => {
@@ -812,6 +813,7 @@ describe("Lifecycle", () => {
 
                 expect(localStorage.getItem("mx_has_access_token")).toBeFalsy();
                 expect(localStorage.getItem("mx_access_token")).toBeFalsy();
+                expect(localStorage.getItem("mx_access_token_fallback")).toBeFalsy();
             });
 
             it("should create new matrix client with credentials", async () => {

--- a/apps/web/src/Lifecycle.test.ts
+++ b/apps/web/src/Lifecycle.test.ts
@@ -89,7 +89,11 @@ describe("Lifecycle", () => {
         vi.resetAllMocks();
     });
 
-    const initIdbMock = (mockStore: Record<string, Record<string, unknown>> = {}): void => {
+    const initIdbMock = (initialStore: Record<string, Record<string, unknown>> = {}): void => {
+        // Take a copy: the mocks below mutate the store, and several tests pass in the same
+        // shared fixture object (eg `idbStorageSession`). Without this, a write or delete in one
+        // test leaks into every test that runs after it.
+        const mockStore: Record<string, Record<string, unknown>> = structuredClone(initialStore);
         vi.spyOn(StorageAccess, "idbLoad")
             .mockClear()
             .mockImplementation(
@@ -268,8 +272,12 @@ describe("Lifecycle", () => {
                     expect(await restoreSessionFromStorage()).toEqual(true);
 
                     expect(StorageAccess.idbSave).toHaveBeenCalledWith("account", "mx_access_token", accessToken);
-                    // put accessToken in localstorage as fallback
-                    expect(localStorage.getItem("mx_access_token")).toEqual(accessToken);
+                    // put accessToken in localstorage at the fallback key, which takes precedence
+                    // over anything left in indexeddb
+                    expect(localStorage.getItem("mx_access_token_fallback")).toEqual(accessToken);
+                    // and clear the stale indexeddb entry so a client which does not know about the
+                    // fallback key cannot read an outdated token
+                    expect(StorageAccess.idbDelete).toHaveBeenCalledWith("account", "mx_access_token");
                 });
 
                 it("should create and start new matrix client with credentials", async () => {
@@ -393,8 +401,9 @@ describe("Lifecycle", () => {
                         "mx_access_token",
                         encryptedTokenShapedObject,
                     );
-                    // put accessToken in localstorage as fallback
-                    expect(localStorage.getItem("mx_access_token")).toEqual(accessToken);
+                    // put accessToken in localstorage at the fallback key. Note this is the plain
+                    // token: localStorage can only hold strings.
+                    expect(localStorage.getItem("mx_access_token_fallback")).toEqual(accessToken);
                 });
 
                 it("should create and start new matrix client with credentials", async () => {
@@ -735,8 +744,35 @@ describe("Lifecycle", () => {
                 });
                 await setLoggedIn(credentials);
 
-                // put plain accessToken in localstorage when we dont have idb
-                expect(localStorage.getItem("mx_access_token")).toEqual(accessToken);
+                // put plain accessToken in localstorage at the fallback key when we dont have idb
+                expect(localStorage.getItem("mx_access_token_fallback")).toEqual(accessToken);
+            });
+
+            it("should prefer the localStorage fallback over a stale token in idb", async () => {
+                // A previous write failed, leaving the new token in localStorage and an outdated
+                // one behind in idb. Reading must return the fallback, not the stale value:
+                // otherwise a rotated refresh token is lost and the session dies on next start.
+                initIdbMock({ account: { mx_refresh_token: "stale-refresh-token" } });
+                localStorage.setItem("mx_refresh_token_fallback", "fresh-refresh-token");
+                for (const key in localStorageSession) {
+                    localStorage.setItem(key, localStorageSession[key]);
+                }
+                localStorage.setItem("mx_has_access_token", "true");
+                await idbSave("account", "mx_access_token", accessToken);
+
+                expect(await restoreSessionFromStorage()).toEqual(true);
+
+                expect(createMatrixClientModule.createClientWithCreds).toHaveBeenCalledWith(
+                    expect.objectContaining({ refreshToken: "fresh-refresh-token" }),
+                    undefined,
+                );
+                // having recovered it, the fallback is migrated back into idb and cleared
+                expect(StorageAccess.idbSave).toHaveBeenCalledWith(
+                    "account",
+                    "mx_refresh_token",
+                    "fresh-refresh-token",
+                );
+                expect(localStorage.getItem("mx_refresh_token_fallback")).toBeNull();
             });
 
             it("should remove any access token from storage when there is none in credentials and idb save fails", async () => {

--- a/apps/web/src/Lifecycle.test.ts
+++ b/apps/web/src/Lifecycle.test.ts
@@ -555,6 +555,33 @@ describe("Lifecycle", () => {
                     "Error decrypting secret access_token: no pickle key found.",
                 );
             });
+
+            it("should keep a plaintext token in localStorage when the idb token cannot be decrypted", async () => {
+                // When the pickle key has gone missing, a plaintext copy left at the primary key by
+                // an older version is the only way back into the account, so nothing on the read
+                // path may throw it away.
+                for (const key in localStorageSession) {
+                    localStorage.setItem(key, localStorageSession[key]);
+                }
+                initIdbMock({});
+
+                // Create a pickle key, and store the token encrypted with it.
+                const pickleKey = (await PlatformPeg.get()!.createPickleKey(credentials.userId, credentials.deviceId))!;
+                localStorage.setItem("mx_has_pickle_key", "true");
+                await persistTokens(pickleKey, credentials);
+
+                // Residue at the primary key, left behind by an older version's fallback.
+                localStorage.setItem("mx_access_token", "old-plaintext-token");
+
+                // Now destroy the pickle key, making the idb token undecryptable.
+                await PlatformPeg.get()!.destroyPickleKey(credentials.userId, credentials.deviceId);
+
+                await expect(restoreSessionFromStorage()).rejects.toThrow(
+                    "Error decrypting secret access_token: no pickle key found.",
+                );
+
+                expect(localStorage.getItem("mx_access_token")).toEqual("old-plaintext-token");
+            });
         });
     });
 
@@ -794,7 +821,8 @@ describe("Lifecycle", () => {
                     expect.objectContaining({ accessToken }),
                     undefined,
                 );
-                // ...and the unreachable plaintext copy is swept up
+                // ...and the unreachable plaintext copy is swept up, once the restore has
+                // written a token of its own to idb and thereby proved the copy is spare
                 expect(localStorage.getItem("mx_access_token")).toBeNull();
             });
 

--- a/apps/web/src/Lifecycle.test.ts
+++ b/apps/web/src/Lifecycle.test.ts
@@ -89,11 +89,14 @@ describe("Lifecycle", () => {
         vi.resetAllMocks();
     });
 
-    const initIdbMock = (initialStore: Record<string, Record<string, unknown>> = {}): void => {
-        // Take a copy: the mocks below mutate the store, and several tests pass in the same
-        // shared fixture object (eg `idbStorageSession`). Without this, a write or delete in one
-        // test leaks into every test that runs after it.
-        const mockStore: Record<string, Record<string, unknown>> = structuredClone(initialStore);
+    /**
+     * Install the IndexedDB mocks, backed by `mockStore`.
+     *
+     * The mocks mutate the store, so each test must supply its own. Seed data is provided by
+     * factories (eg `idbStorageSession()`) rather than shared objects for exactly that reason:
+     * otherwise a write in one test leaks into every test that runs after it.
+     */
+    const initIdbMock = (mockStore: Record<string, Record<string, unknown>> = {}): void => {
         vi.spyOn(StorageAccess, "idbLoad")
             .mockClear()
             .mockImplementation(
@@ -129,11 +132,13 @@ describe("Lifecycle", () => {
         mx_user_id: userId,
         mx_device_id: deviceId,
     };
-    const idbStorageSession = {
+    // A factory, not a shared object: initIdbMock takes ownership of what it is given and the
+    // mocks write into it, so every test needs its own.
+    const idbStorageSession = (): Record<string, Record<string, unknown>> => ({
         account: {
             mx_access_token: accessToken,
         },
-    };
+    });
     const credentials = {
         homeserverUrl,
         identityServerUrl,
@@ -224,7 +229,7 @@ describe("Lifecycle", () => {
                     for (const key in localStorageSession) {
                         localStorage.setItem(key, localStorageSession[key]);
                     }
-                    initIdbMock(idbStorageSession);
+                    initIdbMock(idbStorageSession());
                 });
 
                 it("should ignore guest accounts when ignoreGuest is true", async () => {
@@ -251,7 +256,7 @@ describe("Lifecycle", () => {
                     for (const key in localStorageSession) {
                         localStorage.setItem(key, localStorageSession[key]);
                     }
-                    initIdbMock(idbStorageSession);
+                    initIdbMock(idbStorageSession());
                 });
 
                 it("should persist credentials", async () => {
@@ -319,7 +324,7 @@ describe("Lifecycle", () => {
                         for (const key in localStorageSession) {
                             localStorage.setItem(key, localStorageSession[key]);
                         }
-                        initIdbMock(idbStorageSession);
+                        initIdbMock(idbStorageSession());
                     });
 
                     it("should persist credentials", async () => {
@@ -531,7 +536,7 @@ describe("Lifecycle", () => {
                 for (const key in localStorageSession) {
                     localStorage.setItem(key, localStorageSession[key]);
                 }
-                initIdbMock(idbStorageSession);
+                initIdbMock(idbStorageSession());
                 mockClient.isVersionSupported.mockRejectedValue(new Error("Oh, noes, the server is down!"));
 
                 expect(await restoreSessionFromStorage()).toEqual(true);
@@ -808,7 +813,7 @@ describe("Lifecycle", () => {
                 // key, and never cleared it on a later successful write. We cannot tell whether it
                 // is newer or older than the idb copy, so it must not be used - but it must not be
                 // left sitting in localStorage in the clear either.
-                initIdbMock(idbStorageSession);
+                initIdbMock(idbStorageSession());
                 for (const key in localStorageSession) {
                     localStorage.setItem(key, localStorageSession[key]);
                 }

--- a/apps/web/src/Lifecycle.ts
+++ b/apps/web/src/Lifecycle.ts
@@ -56,6 +56,7 @@ import { getOAuthParams, getStoredOAuthClientId, persistOAuthClientId } from "./
 import {
     ACCESS_TOKEN_IV,
     ACCESS_TOKEN_STORAGE_KEY,
+    getFallbackStorageKey,
     HAS_ACCESS_TOKEN_STORAGE_KEY,
     HAS_REFRESH_TOKEN_STORAGE_KEY,
     persistTokens,
@@ -547,6 +548,24 @@ export interface IStoredSession {
  * @returns Promise that resolves to token or undefined
  */
 async function getStoredToken(storageKey: string): Promise<string | undefined> {
+    // A token at the fallback key was written because an IndexedDB write failed, and is cleared
+    // again as soon as one succeeds. It is therefore always at least as new as whatever
+    // IndexedDB holds, and must take precedence — otherwise a stale IndexedDB value shadows it
+    // forever, and a rotated refresh token is silently lost.
+    const fallbackStorageKey = getFallbackStorageKey(storageKey);
+    const fallbackToken = localStorage.getItem(fallbackStorageKey) ?? undefined;
+    if (fallbackToken) {
+        logger.warn(`Using localStorage fallback for ${storageKey}; a previous IndexedDB write failed`);
+        try {
+            // try to move the token back into IndexedDB now that it may be writable again
+            await StorageAccess.idbSave("account", storageKey, fallbackToken);
+            localStorage.removeItem(fallbackStorageKey);
+        } catch (e) {
+            logger.error(`Recovery of token ${storageKey} into IndexedDB failed`, e);
+        }
+        return fallbackToken;
+    }
+
     let token: string | undefined;
     try {
         token = await StorageAccess.idbLoad("account", storageKey);
@@ -554,6 +573,7 @@ async function getStoredToken(storageKey: string): Promise<string | undefined> {
         logger.error(`StorageManager.idbLoad failed for account:${storageKey}`, e);
     }
     if (!token) {
+        // Legacy location, from before tokens were moved into IndexedDB.
         token = localStorage.getItem(storageKey) ?? undefined;
         if (token) {
             try {

--- a/apps/web/src/Lifecycle.ts
+++ b/apps/web/src/Lifecycle.ts
@@ -584,6 +584,22 @@ async function getStoredToken(storageKey: string): Promise<string | undefined> {
                 logger.error(`migration of token ${storageKey} to IndexedDB failed`, e);
             }
         }
+    } else if (localStorage.getItem(storageKey) !== null) {
+        // We got a token from IndexedDB, but there is *also* one at the primary key in
+        // localStorage. That is residue from an older version of persistTokenInStorage, whose
+        // fallback wrote here rather than to the fallback key above.
+        //
+        // We must not start preferring it: that version did not clear it after a later
+        // successful write, so it may well be older than the IndexedDB copy, and using it could
+        // demote a working session to a dead token.
+        //
+        // But it is a token in plain text, which is what the pickle key exists to avoid, and
+        // nothing reads it any more, so don't leave it lying around either.
+        logger.warn(
+            `Discarding unreachable plaintext ${storageKey} from localStorage: ` +
+                `this session previously hit a failed IndexedDB write`,
+        );
+        localStorage.removeItem(storageKey);
     }
     return token;
 }

--- a/apps/web/src/Lifecycle.ts
+++ b/apps/web/src/Lifecycle.ts
@@ -584,23 +584,18 @@ async function getStoredToken(storageKey: string): Promise<string | undefined> {
                 logger.error(`migration of token ${storageKey} to IndexedDB failed`, e);
             }
         }
-    } else if (localStorage.getItem(storageKey) !== null) {
-        // We got a token from IndexedDB, but there is *also* one at the primary key in
-        // localStorage. That is residue from an older version of persistTokenInStorage, whose
-        // fallback wrote here rather than to the fallback key above.
-        //
-        // We must not start preferring it: that version did not clear it after a later
-        // successful write, so it may well be older than the IndexedDB copy, and using it could
-        // demote a working session to a dead token.
-        //
-        // But it is a token in plain text, which is what the pickle key exists to avoid, and
-        // nothing reads it any more, so don't leave it lying around either.
-        logger.warn(
-            `Discarding unreachable plaintext ${storageKey} from localStorage: ` +
-                `this session previously hit a failed IndexedDB write`,
-        );
-        localStorage.removeItem(storageKey);
     }
+
+    // Note that when IndexedDB has a token we ignore any token at the primary key in localStorage,
+    // rather than treating it as a fallback. It is residue from an older version of
+    // persistTokenInStorage, whose fallback wrote there rather than to the fallback key above, and
+    // which never cleared it after a later successful write — so it may well be older than the
+    // IndexedDB copy, and preferring it could demote a working session to a dead token.
+    //
+    // We do not delete it here either. This is a read path, and the token we just loaded may yet
+    // turn out to be undecryptable (see tryDecryptToken), in which case that plaintext copy is the
+    // only way back into the account. persistTokenInStorage sweeps it up once it has successfully
+    // written a token of its own, which proves the copy is spare.
     return token;
 }
 

--- a/apps/web/src/utils/tokens/tokens.ts
+++ b/apps/web/src/utils/tokens/tokens.ts
@@ -188,15 +188,15 @@ async function persistTokenInStorage(
             localStorage.removeItem(fallbackStorageKey);
         }
 
-        // Whatever is in IndexedDB is now stale. Remove it, so that a client which does not know
-        // about the fallback key (eg after a downgrade) reads "no token" rather than an outdated
-        // one. This is best-effort: getStoredToken prefers the fallback regardless, so a failure
-        // here is not fatal.
-        try {
-            await StorageAccess.idbDelete("account", storageKey);
-        } catch (e2) {
-            logger.error(`Failed to remove stale ${tokenName} from IndexedDB after a failed write`, e2);
-        }
+        // Deliberately leave whatever IndexedDB holds alone, even though it is now stale. The
+        // service worker reads the access token from IndexedDB *only* — it cannot reach
+        // localStorage, see apps/web/src/serviceworker/index.ts — so removing it would leave that
+        // reader with no token at all and send every media request out unauthenticated for the
+        // rest of the session. A stale token is no worse than none for it, and after a failure
+        // like this it is usually the very token we were trying to write.
+        //
+        // This client is unaffected either way: getStoredToken prefers the fallback key, and the
+        // next write to succeed overwrites IndexedDB and clears the fallback again.
     }
 }
 

--- a/apps/web/src/utils/tokens/tokens.ts
+++ b/apps/web/src/utils/tokens/tokens.ts
@@ -171,6 +171,18 @@ async function persistTokenInStorage(
         // write. If we left it in place, getStoredToken would keep preferring it over the value
         // we have just written.
         localStorage.removeItem(fallbackStorageKey);
+
+        // An older version of this function wrote its fallback to the primary key rather than to
+        // the fallback key. Nothing reads that any more, so it is just a plaintext token sitting
+        // in localStorage — exactly what the pickle key exists to avoid. Sweep it up.
+        //
+        // This has to happen here rather than on the read path: only a successful write proves we
+        // have a good token in IndexedDB, so only here can we be sure we are discarding a spare
+        // copy rather than the last recoverable one.
+        if (localStorage.getItem(storageKey) !== null) {
+            logger.warn(`Discarding unreachable plaintext ${tokenName} from localStorage`);
+            localStorage.removeItem(storageKey);
+        }
     } catch (e) {
         // We could not save to IndexedDB, so fall back to localStorage. We store the token
         // unencrypted since localStorage only saves strings.

--- a/apps/web/src/utils/tokens/tokens.ts
+++ b/apps/web/src/utils/tokens/tokens.ts
@@ -36,6 +36,22 @@ export const HAS_ACCESS_TOKEN_STORAGE_KEY = "mx_has_access_token";
 export const HAS_REFRESH_TOKEN_STORAGE_KEY = "mx_has_refresh_token";
 
 /**
+ * Derive the localStorage key used to hold a token when writing it to IndexedDB fails.
+ *
+ * This is deliberately distinct from `storageKey` itself. Very old sessions may still have a
+ * plain token sitting at `storageKey` in localStorage, from before tokens were moved into
+ * IndexedDB, and those are *not* authoritative — IndexedDB may well hold a newer value. A token
+ * at the fallback key, by contrast, is only ever written by {@link persistTokenInStorage} when
+ * the IndexedDB write failed, and is cleared again as soon as one succeeds, so it is always at
+ * least as new as anything in IndexedDB.
+ *
+ * @param storageKey - the primary storage key, eg {@link ACCESS_TOKEN_STORAGE_KEY}
+ */
+export function getFallbackStorageKey(storageKey: string): string {
+    return `${storageKey}_fallback`;
+}
+
+/**
  * The pickle key is a string of unspecified length and format.  For AES, we need a 256-bit Uint8Array. So we HKDF the pickle key to generate the AES key.  The AES key should be zeroed after it is used.
  * @param pickleKey
  * @returns AES key
@@ -131,44 +147,55 @@ async function persistTokenInStorage(
         localStorage.removeItem(hasTokenStorageKey);
     }
 
-    if (pickleKey) {
-        let encryptedToken: AESEncryptedSecretStoragePayload | undefined;
+    let valueToStore: AESEncryptedSecretStoragePayload | string | undefined = token;
+    if (pickleKey && token) {
+        try {
+            // try to encrypt the access token using the pickle key
+            const encrKey = await pickleKeyToAesKey(pickleKey);
+            valueToStore = await encryptAESSecretStorageItem(token, encrKey, tokenName);
+            encrKey.fill(0);
+        } catch (e) {
+            // This is likely due to the browser not having WebCrypto or somesuch.
+            // Warn about it, but fall back to storing the unencrypted token.
+            logger.warn(`Could not encrypt token for ${tokenName}`, e);
+        }
+    }
+
+    const fallbackStorageKey = getFallbackStorageKey(storageKey);
+
+    try {
+        // Save either the encrypted token, or the plain token if there is no token or we were
+        // unable to encrypt (e.g. if the browser doesn't have WebCrypto).
+        await StorageAccess.idbSave("account", storageKey, valueToStore);
+        // IndexedDB is now authoritative, so drop any fallback left behind by an earlier failed
+        // write. If we left it in place, getStoredToken would keep preferring it over the value
+        // we have just written.
+        localStorage.removeItem(fallbackStorageKey);
+    } catch (e) {
+        // We could not save to IndexedDB, so fall back to localStorage. We store the token
+        // unencrypted since localStorage only saves strings.
+        logger.error(
+            `Failed to write ${tokenName} to IndexedDB; falling back to localStorage. ` +
+                `If this token is rotated and the fallback is not read back, the session will be lost.`,
+            e,
+        );
+
+        // Write the fallback *before* touching IndexedDB below, so that there is never a moment
+        // where neither store holds a token.
         if (token) {
-            try {
-                // try to encrypt the access token using the pickle key
-                const encrKey = await pickleKeyToAesKey(pickleKey);
-                encryptedToken = await encryptAESSecretStorageItem(token, encrKey, tokenName);
-                encrKey.fill(0);
-            } catch (e) {
-                // This is likely due to the browser not having WebCrypto or somesuch.
-                // Warn about it, but fall back to storing the unencrypted token.
-                logger.warn(`Could not encrypt token for ${tokenName}`, e);
-            }
+            localStorage.setItem(fallbackStorageKey, token);
+        } else {
+            localStorage.removeItem(fallbackStorageKey);
         }
+
+        // Whatever is in IndexedDB is now stale. Remove it, so that a client which does not know
+        // about the fallback key (eg after a downgrade) reads "no token" rather than an outdated
+        // one. This is best-effort: getStoredToken prefers the fallback regardless, so a failure
+        // here is not fatal.
         try {
-            // Save either the encrypted access token, or the plain access
-            // token if there is no token or we were unable to encrypt (e.g. if the browser doesn't
-            // have WebCrypto).
-            await StorageAccess.idbSave("account", storageKey, encryptedToken || token);
-        } catch {
-            // if we couldn't save to indexedDB, fall back to localStorage.  We
-            // store the access token unencrypted since localStorage only saves
-            // strings.
-            if (!!token) {
-                localStorage.setItem(storageKey, token);
-            } else {
-                localStorage.removeItem(storageKey);
-            }
-        }
-    } else {
-        try {
-            await StorageAccess.idbSave("account", storageKey, token);
-        } catch {
-            if (!!token) {
-                localStorage.setItem(storageKey, token);
-            } else {
-                localStorage.removeItem(storageKey);
-            }
+            await StorageAccess.idbDelete("account", storageKey);
+        } catch (e2) {
+            logger.error(`Failed to remove stale ${tokenName} from IndexedDB after a failed write`, e2);
         }
     }
 }

--- a/apps/web/src/utils/tokens/tokens.ts
+++ b/apps/web/src/utils/tokens/tokens.ts
@@ -192,8 +192,8 @@ async function persistTokenInStorage(
             e,
         );
 
-        // Write the fallback *before* touching IndexedDB below, so that there is never a moment
-        // where neither store holds a token.
+        // Mirror the requested state at the fallback key: the token to fall back to, or nothing
+        // at all if the caller asked for it to be cleared.
         if (token) {
             localStorage.setItem(fallbackStorageKey, token);
         } else {


### PR DESCRIPTION
Fixes #34866

When an IndexedDB write failed, `persistTokenInStorage()` fell back to writing the token to localStorage under the primary storage key. But getStoredToken reads IndexedDB first and only consults localStorage when the IndexedDB returns no value. The fallback was therefore sometimes unreachable: the stale IndexedDB value shadowed it permanently.

This PR writes the fallback to a distinct `<key>_fallback` localStorage key instead, and prefers it on read. It is only ever written when an IndexedDB write failed, and is cleared as soon as one succeeds, so it is always at least as new as IndexedDB. The primary key in localStorage keeps its existing meaning - a pre-IndexedDB legacy token, which may well be older than IndexedDB - so the migration path is unchanged and the change is safe on upgrade.

Also:
 - logs the write failure, which was previously silent — a session becoming doomed left no trace in rageshakes.
 - leaves the stale IndexedDB entry alone after a failed write. The service worker reads the access token from IndexedDB only, so deleting it would break authenticated media for the rest of the session.
 - sweeps up plaintext tokens left at the primary key by the old fallback. Done on the write path, since only a successful write proves the copy is spare rather than the last recoverable one.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
