### PR TITLE
Add a wait for first sync before showing the Home screen

### DIFF
--- a/apps/web/playwright/e2e/login/session-restore.ts
+++ b/apps/web/playwright/e2e/login/session-restore.ts
@@ -1,0 +1,47 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { expect, test as base } from "../../element-web-test";
+
+const test = base.extend({
+    // Same as the base `user` fixture, but delays the first `/sync` response so we can inspect
+    // the app's state while the client is still waiting for it to complete.
+    user: async ({ pageWithCredentials: page, credentials }, use) => {
+        let delayedOnce = false;
+        await page.route("**/_matrix/client/*/sync*", async (route) => {
+            if (!delayedOnce) {
+                delayedOnce = true;
+                await new Promise((resolve) => setTimeout(resolve, 4000));
+            }
+            await route.continue();
+        });
+
+        await page.goto("/");
+        // Deliberately do NOT wait for `.mx_MatrixChat` here (unlike the base fixture) — this
+        // test needs to inspect state before the first sync completes.
+        await use(credentials);
+    },
+});
+
+test.describe("session restore", () => {
+    test("should not show the logged-in view until the first sync completes", async ({ page, user }) => {
+        test.slow();
+
+        // The app should still be on the pre-sync splash screen while /sync is delayed.
+        await expect(page.getByTestId("spinner")).toBeVisible();
+
+        // `not.toBeVisible()` resolves as soon as the element is absent *at that instant* — it does not
+        // wait around to see whether the element appears later. So we deliberately wait well into the
+        // artificial /sync delay (but comfortably before it elapses) before checking, to give a buggy
+        // premature transition every chance to have already happened.
+        await page.waitForTimeout(2000);
+        await expect(page.locator(".mx_MatrixChat")).not.toBeVisible();
+
+        // Once the delayed /sync resolves, the real logged-in view should appear.
+        await page.waitForSelector(".mx_MatrixChat", { timeout: 30000 });
+    });
+});

--- a/apps/web/playwright/e2e/login/session-restore.ts
+++ b/apps/web/playwright/e2e/login/session-restore.ts
@@ -34,10 +34,7 @@ test.describe("session restore", () => {
         // The app should still be on the pre-sync splash screen while /sync is delayed.
         await expect(page.getByTestId("spinner")).toBeVisible();
 
-        // `not.toBeVisible()` resolves as soon as the element is absent *at that instant* — it does not
-        // wait around to see whether the element appears later. So we deliberately wait well into the
-        // artificial /sync delay (but comfortably before it elapses) before checking, to give a buggy
-        // premature transition every chance to have already happened.
+        // Wait *some* time* to check that the spinner doesn't insta-resolve.
         await page.waitForTimeout(2000);
         await expect(page.locator(".mx_MatrixChat")).not.toBeVisible();
 

--- a/apps/web/src/components/structures/MatrixChat.tsx
+++ b/apps/web/src/components/structures/MatrixChat.tsx
@@ -1808,6 +1808,13 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
         // If the view is something else, that probably means it's a login or registration view; we handle that in
         // `postLoginSetup`.
         if (this.state.view === Views.PENDING_CLIENT_START) {
+            // Wait for the first sync to complete before showing the logged-in view: otherwise we render
+            // LoggedInView/HomePage against an empty store, with no loading indicator, while /sync is still
+            // in flight.
+            if (!this.firstSyncComplete) {
+                await this.firstSyncPromise.promise;
+            }
+
             if (shouldForceVerification) {
                 this.setStateForNewView({ view: Views.COMPLETE_SECURITY });
             } else {


### PR DESCRIPTION
Possible fix for #34872

This waits for sync to complete before showing the home screen.


https://github.com/user-attachments/assets/61e65063-e555-4867-a5e8-fb2d103776ca



## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
