### PR TITLE
Fix thread staying unread after a non-counting event follows your reply

### DIFF
--- a/apps/web/src/Unread.test.ts
+++ b/apps/web/src/Unread.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, beforeEach, beforeAll, vi } from "vitest";
 import { MatrixEvent, EventType, MsgType, Room, ReceiptType } from "matrix-js-sdk/src/matrix";
 import { logger } from "matrix-js-sdk/src/logger";
 import { makeBeaconEvent, mkEvent, stubClient } from "test-utils";
-import { makeThreadEvents, mkThread, populateThread } from "test-utils/threads";
+import { makeThreadEvent, makeThreadEvents, mkThread, populateThread } from "test-utils/threads";
 
 import { haveRendererForEvent } from "./events/EventTileFactory";
 import {
@@ -162,6 +162,30 @@ describe("Unread", () => {
                 room.addLiveEvents([event], { addToState: true });
 
                 expect(doesRoomHaveUnreadMessages(room, false)).toBe(false);
+            });
+
+            it("returns true when another user's message arrives after ours", () => {
+                room.addLiveEvents(
+                    [
+                        mkEvent({
+                            event: true,
+                            type: "m.room.message",
+                            user: myId,
+                            room: roomId,
+                            content: {},
+                        }),
+                        mkEvent({
+                            event: true,
+                            type: "m.room.message",
+                            user: aliceId,
+                            room: roomId,
+                            content: {},
+                        }),
+                    ],
+                    { addToState: true },
+                );
+
+                expect(doesRoomHaveUnreadMessages(room, false)).toBe(true);
             });
 
             it("returns false for a room when the read receipt is at the latest event", () => {
@@ -572,6 +596,56 @@ describe("Unread", () => {
             });
 
             // There is no receipt for the thread, it should be unread
+            expect(doesRoomHaveUnreadThreads(room)).toBe(true);
+        });
+
+        it("returns false when we replied and a non-counting event landed after our reply", async () => {
+            // Thread: root(alice) -> reply(me) -> redacted(alice). Our reply is newer than the
+            // only unread-triggering event, so we have clearly seen the thread, but we are no
+            // longer the sender of the literal last event.
+            const { rootEvent, events } = await populateThread({
+                room,
+                client,
+                authorId: aliceId,
+                participantUserIds: [myId],
+            });
+
+            const trailing = makeThreadEvent({
+                event: true,
+                user: aliceId,
+                room: roomId,
+                msg: "redacted",
+                rootEventId: rootEvent.getId()!,
+                replyToEventId: events.at(-1)!.getId()!,
+                ts: 100,
+            });
+            vi.spyOn(trailing, "isRedacted").mockReturnValue(true);
+            await room.addLiveEvents([trailing], { addToState: false });
+
+            expect(doesRoomHaveUnreadThreads(room)).toBe(false);
+        });
+
+        it("returns true when an incoming message landed after our reply", async () => {
+            // Thread: root(alice) -> reply(me) -> message(alice). The trailing message does
+            // trigger an unread count, so the thread is genuinely unread.
+            const { rootEvent, events } = await populateThread({
+                room,
+                client,
+                authorId: aliceId,
+                participantUserIds: [myId],
+            });
+
+            const trailing = makeThreadEvent({
+                event: true,
+                user: aliceId,
+                room: roomId,
+                msg: "a real reply",
+                rootEventId: rootEvent.getId()!,
+                replyToEventId: events.at(-1)!.getId()!,
+                ts: 100,
+            });
+            await room.addLiveEvents([trailing], { addToState: false });
+
             expect(doesRoomHaveUnreadThreads(room)).toBe(true);
         });
 

--- a/apps/web/src/Unread.ts
+++ b/apps/web/src/Unread.ts
@@ -71,6 +71,12 @@ function doesTimelineHaveUnreadMessages(room: Room, timeline: Array<MatrixEvent>
     const myUserId = room.client.getSafeUserId();
     const latestImportantEventId = findLatestImportantEvent(room.client, timeline)?.getId();
     if (latestImportantEventId) {
+        // Sending a message means we have seen everything before it. The js-sdk applies this
+        // shortcut only when our event is the *literal* last one in the timeline, so any event
+        // that doesn't trigger an unread count (a reaction, an edit, a membership change...)
+        // landing after our message would otherwise make the timeline unread again.
+        if (userSentEventAfterLatestImportantEvent(room.client, timeline)) return false;
+
         return !room.hasUserReadEvent(myUserId, latestImportantEventId);
     } else {
         // We couldn't find an important event to check - check the unimportant ones.
@@ -139,6 +145,25 @@ function findLatestImportantEvent(client: MatrixClient, timeline: Array<MatrixEv
         }
     }
     return null;
+}
+
+/**
+ * Look backwards through the timeline for whichever comes first: an event we sent, or an
+ * important event. An event we sent is never important (see {@link eventTriggersUnreadCount}),
+ * so finding ours first means it is newer than every important event in the timeline.
+ *
+ * @returns true if we sent an event after the latest important event
+ */
+function userSentEventAfterLatestImportantEvent(client: MatrixClient, timeline: Array<MatrixEvent>): boolean {
+    const myUserId = client.getSafeUserId();
+    for (let index = timeline.length - 1; index >= 0; index--) {
+        const event = timeline[index];
+        if (isImportantEvent(client, event)) return false;
+        // Ignore local echoes that haven't made it to the server yet: they carry no timeline
+        // position, and a failed send shouldn't mark anything as read.
+        if (event.getSender() === myUserId && !event.status) return true;
+    }
+    return false;
 }
 
 /**


### PR DESCRIPTION
Fixes #34904

### Problem

`doesTimelineHaveUnreadMessages` decides whether a timeline is unread by finding the latest *important* event and asking whether we have read it:

```ts
const latestImportantEventId = findLatestImportantEvent(room.client, timeline)?.getId();
if (latestImportantEventId) {
    return !room.hasUserReadEvent(myUserId, latestImportantEventId);
}
```

"Important" filters through `eventTriggersUnreadCount`, which returns `false` for our own events — so the latest important event is always the newest event **from someone else**, never our reply. Whether that event counts as read then comes down to the js-sdk shortcut in `RoomReceipts.hasUserReadEvent`, which only fires when we sent the *literal* last event in the timeline:

```ts
// TODO: what if they sent the second-last event in the thread?
if (this.userSentLatestEventInThread(threadId, userId)) { ... }
```

```ts
return !!(timeline && timeline.length > 0 && timeline[timeline.length - 1].getSender() === userId);
```

So: you reply in a thread, then *anything* that doesn't trigger an unread count arrives after your reply — a reaction, an edit, a redaction, a membership change — and the thread goes back to unread, judged against a message you had already read before replying.

The main timeline is shielded from this, because `Room.addLiveEvent` synthesizes a read receipt for every event's sender, including ours. Threads have no equivalent, which is where the bug actually surfaces (and why the new test lives in the `doesRoomHaveUnreadThreads()` block — an equivalent main-timeline test passes with or without this change).

### Change

Ask the right question — "is our latest event newer than the latest important event?" instead of "is our event the very last one?":

```ts
if (userSentEventAfterLatestImportantEvent(room.client, timeline)) return false;
```

The helper walks the timeline backwards and returns on whichever comes first, one of our events or an important event. Since our own events are never important, there's no ordering ambiguity. Pending/failed local echoes are skipped (`!event.status`), so a send that hasn't landed doesn't mark anything read.

### Tests

Two tests in `doesRoomHaveUnreadThreads()`:

- thread `root(alice) -> reply(me) -> redacted(alice)` is **read** — fails on `develop` with `expected true to be false`, passes with this change;
- thread `root(alice) -> reply(me) -> message(alice)` is still **unread**, so a genuinely newer incoming message isn't swallowed.

Plus a main-timeline test that another user's message arriving after ours still reads as unread.

```
Unread.test.ts                                    32 passed
+ RoomNotifs, utils/notifications, useRoomThreadNotifications,
  room-list-v3, notification-badge viewmodels     278 passed (13 files)
```

`oxlint`, `oxfmt --check` and `tsc --noEmit` are clean for the changed files.

### Context

Found while working on #32851 (Threads Activity Centre cross-room threads panel), which currently carries a local guard in `useUnreadThreadRooms.ts` to suppress the false positive. @florianduros asked in review that the helper be fixed rather than worked around — this is that fix; the TAC guard will be dropped once this lands.

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)

<!-- Please note that the `Preview Changelog` check needs a type label, which I cannot add: `T-Defect` would be right here. -->
