### PR TITLE
Bypass the pnpm version check when installing the linked js-sdk

### DIFF
--- a/scripts/docker-link-repos.sh
+++ b/scripts/docker-link-repos.sh
@@ -21,6 +21,11 @@ fi
 echo "Linking js-sdk"
 git clone --depth 1 --branch $JS_SDK_BRANCH "$JS_SDK_REPO" js-sdk
 cd js-sdk
+# The cloned js-sdk may pin a different pnpm version than element-web. Corepack
+# won't switch pnpm versions mid-process, so bypass the version check instead of
+# failing. Exported (not just a CLI flag) so it also applies to the nested
+# `pnpm build` spawned by js-sdk's `prepare` lifecycle script.
+export npm_config_pm_on_fail=ignore
 pnpm install
 cd ../
 


### PR DESCRIPTION
`scripts/docker-link-repos.sh` clones matrix-js-sdk and runs `pnpm install` inside the clone. That clone pins its own pnpm version in `devEngines.packageManager`, which can differ from element-web's (currently `11.23.0`). pnpm won't switch versions mid-process, so the install fails on the version guard rather than proceeding, and `docker-bake` / the linked-SDK Docker build stops there.

Set `npm_config_pm_on_fail=ignore` for the js-sdk install so the guard is bypassed instead of fatal. It's `export`ed rather than passed as a CLI flag so it also covers the nested `pnpm build` that js-sdk's `prepare` lifecycle script spawns — that child process hits the same guard.

Scoped to the js-sdk clone only: element-web's own installs are untouched, so the pin still applies everywhere it should.

Split out of #32851 at review request — unrelated to that PR's feature work and purely devx.

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)

<!-- Shell script for the Docker linked-SDK build; not covered by the unit test suites. The `Preview Changelog` check needs a type label I can't add — `T-Task` would be right here. -->
