### PR TITLE
Test that disabled client well-known lookups make no network request

### DIFF
--- a/apps/web/src/MatrixClientPeg.test.ts
+++ b/apps/web/src/MatrixClientPeg.test.ts
@@ -16,6 +16,7 @@ import { advanceDateAndTime, stubClient, createTestClient } from "test-utils";
 
 import { type IMatrixClientPeg, MatrixClientPeg as peg } from "./MatrixClientPeg";
 import SdkConfig from "./SdkConfig";
+import { createClientWithCreds } from "./utils/createMatrixClient";
 
 vi.useFakeTimers();
 
@@ -141,6 +142,55 @@ describe("MatrixClientPeg", () => {
 
             const opts = startClient.mock.calls[0][0];
             expect(opts?.clientWellKnownPollPeriod).toBeUndefined();
+        });
+
+        describe("client well-known lookups", () => {
+            const WELL_KNOWN_URL = "https://example.com/.well-known/matrix/client";
+
+            beforeEach(() => {
+                // Use a real MatrixClient and really start it: these tests exist to observe what the SDK
+                // requests over the network, which mocking `startClient` (as above) cannot see. This is
+                // what caught matrix-js-sdk fetching the well-known despite `clientWellKnownPollPeriod`
+                // being unset.
+                testPeg = new PegClass();
+                testPeg.set(
+                    createClientWithCreds({
+                        homeserverUrl: "http://example.com",
+                        userId: "@user:example.com",
+                        deviceId: "DEVICE",
+                        accessToken: "token",
+                    }),
+                );
+                vi.spyOn(testPeg.safeGet(), "initRustCrypto").mockResolvedValue(undefined);
+            });
+
+            afterEach(() => {
+                testPeg.get()?.stopClient();
+                testPeg.unset();
+            });
+
+            async function requestedUrls(): Promise<string[]> {
+                await fetchMock.callHistory.flush();
+                return fetchMock.callHistory.calls().map((call) => call.url);
+            }
+
+            it("requests the client well-known on startup by default", async () => {
+                await testPeg.start();
+
+                expect(await requestedUrls()).toContain(WELL_KNOWN_URL);
+            });
+
+            it("never requests the client well-known when enable_client_well_known_lookups is false", async () => {
+                const sdkConfigGet = SdkConfig.get;
+                vi.spyOn(SdkConfig, "get").mockImplementation((key?: any, altCaseName?: string): any => {
+                    if (key === "enable_client_well_known_lookups") return false;
+                    return sdkConfigGet(key, altCaseName);
+                });
+
+                await testPeg.start();
+
+                expect(await requestedUrls()).not.toContainEqual(expect.stringContaining("/.well-known/matrix/"));
+            });
         });
     });
 });


### PR DESCRIPTION
Resolves https://github.com/element-hq/element-web/issues/34921
Depends on https://github.com/matrix-org/matrix-js-sdk/pull/5521
The existing MatrixClientPeg tests only check the option handed to the SDK (`clientWellKnownPollPeriod` unset when
`enable_client_well_known_lookups` is false), so they stayed green when matrix-js-sdk stopped honouring that option (matrix-org/matrix-js-sdk#5470, shipped in js-sdk 42.2.0 / Element Web 1.12.26).

Now it starts a real MatrixClient against the fetch mock instead and assert on the requests actually made: the well-known is requested by default and never requested when the config disables the lookups. 

The second case fails against matrix-js-sdk develop until https://github.com/matrix-org/matrix-js-sdk/pull/5521 lands.
