### PR TITLE
Add more features to the settings module API

### DIFF
--- a/apps/web/playwright/sample-files/settings-module.js
+++ b/apps/web/playwright/sample-files/settings-module.js
@@ -12,6 +12,6 @@ export default class SettingsModule {
     }
     async load() {
         // oxlint-disable-next-line no-alert
-        alert(this.api.settings.getValue("language"));
+        alert(this.api.settings.getValue("language").value);
     }
 }

--- a/apps/web/src/modules/SettingsApi.test.ts
+++ b/apps/web/src/modules/SettingsApi.test.ts
@@ -5,16 +5,20 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
+// @vitest-environment happy-dom
+
 import { describe, it, expect, vi } from "vitest";
+import { Level } from "@element-hq/element-web-module-api";
 
 import SettingsStore from "../settings/SettingsStore";
 import { SettingsApi } from "./SettingsApi";
+import { SettingLevel } from "../settings/SettingLevel";
 
 describe("SettingsApi", () => {
     it("should return the value from SettingsStore.getValue", () => {
         const spy = vi.spyOn(SettingsStore, "getValue").mockReturnValue("en" as any);
         const api = new SettingsApi();
-        expect(api.getValue("language")).toBe("en");
+        expect(api.getValue("language").value).toBe("en");
         expect(spy).toHaveBeenCalledWith("language", undefined, undefined);
     });
 
@@ -23,5 +27,34 @@ describe("SettingsApi", () => {
         const api = new SettingsApi();
         api.getValue("m.setting", "!room:example.org", true);
         expect(spy).toHaveBeenCalledWith("m.setting", "!room:example.org", true);
+    });
+
+    it("should update watchable when setting value changes", () => {
+        vi.spyOn(SettingsStore, "getValue").mockReturnValue("en");
+
+        const api = new SettingsApi();
+        const watchable = api.getValue("language");
+
+        // Subscribe to the watchable
+        const fn = vi.fn();
+        watchable.watch(fn);
+
+        // Setting value is initially "en"
+        expect(watchable.value).toBe("en");
+
+        // Let's change the setting value
+        vi.spyOn(SettingsStore, "getValue").mockReturnValue("fr");
+        SettingsStore.setValue("language", null, SettingLevel.DEVICE, "fr");
+
+        // Watchable should have updated
+        expect(fn).toHaveBeenCalled();
+        expect(watchable.value).toBe("fr");
+    });
+
+    it("should set setting value by calling SettingStore.setValue", () => {
+        const spy = vi.spyOn(SettingsStore, "setValue");
+        const api = new SettingsApi();
+        api.setValue("language", null, "DEVICE" as Level, "en");
+        expect(spy).toHaveBeenCalled();
     });
 });

--- a/apps/web/src/modules/SettingsApi.ts
+++ b/apps/web/src/modules/SettingsApi.ts
@@ -5,12 +5,71 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import type { SettingsApi as ISettingsApi } from "@element-hq/element-web-module-api";
-import SettingsStore from "../settings/SettingsStore";
+import {
+    type SettingsApi as ISettingsApi,
+    type Level,
+    type Settings,
+    Watchable,
+} from "@element-hq/element-web-module-api";
 
-export class SettingsApi implements ISettingsApi {
-    public getValue<T = any>(settingName: string, roomId?: string | null, excludeDefault?: boolean): T | undefined {
-        //@ts-expect-error: SettingsStore.getValue will throw on an invalid setting name anyway.
-        return SettingsStore.getValue(settingName, roomId, excludeDefault);
+import SettingsStore from "../settings/SettingsStore";
+import type { ModuleSettings } from "../settings/Settings";
+import type { SettingLevel } from "../settings/SettingLevel";
+
+export class SettingsApi<T extends Settings = Settings> implements ISettingsApi<T> {
+    public registerSettings(settings: T): void {
+        SettingsStore.registerRuntimeSettings(settings as unknown as ModuleSettings);
+    }
+
+    public getValue<K extends keyof T | string>(
+        settingName: K,
+        roomId?: string | null,
+        excludeDefault?: boolean,
+    ): Watchable<K extends keyof T ? T[K] : unknown> {
+        //@ts-expect-error: settingsName is strictly typed but we want relaxed type here.
+        return new SettingsWatchable(settingName, roomId, excludeDefault);
+    }
+
+    public setValue<K extends keyof T | string>(
+        settingName: K,
+        roomId: string | null,
+        level: Level,
+        value: K extends keyof T ? T[K] : unknown,
+    ): Promise<void> {
+        //@ts-expect-error: settingsName is strictly typed but we want relaxed type here.
+        return SettingsStore.setValue(settingName, roomId, level, value);
+    }
+}
+
+class SettingsWatchable<T> extends Watchable<T> {
+    private watcherReference?: string;
+
+    public constructor(
+        private readonly settingName: string,
+        roomId?: string | null,
+        excludeDefault?: boolean,
+    ) {
+        //@ts-expect-error: settingsName is strictly typed but we want relaxed type here.
+        super(SettingsStore.getValue(settingName, roomId, excludeDefault));
+    }
+
+    private onSettingUpdate = (
+        settingsName: string,
+        roomId: string | null,
+        atLevel: SettingLevel,
+        newValAtLevel: T,
+        newVal: T,
+    ): void => {
+        // This only needs to checks atLevel when we add a getValueAtLevel to the API.
+        this.value = newVal;
+    };
+
+    protected onFirstWatch(): void {
+        //@ts-expect-error: settingsName is strictly typed but we want relaxed type here.
+        this.watcherReference = SettingsStore.watchSetting(this.settingName, null, this.onSettingUpdate);
+    }
+
+    protected onLastWatch(): void {
+        if (this.watcherReference) SettingsStore.unwatchSetting(this.watcherReference);
     }
 }

--- a/apps/web/src/modules/SettingsApi.ts
+++ b/apps/web/src/modules/SettingsApi.ts
@@ -21,20 +21,48 @@ export class SettingsApi<T extends Settings = Settings> implements ISettingsApi<
         SettingsStore.registerRuntimeSettings(settings as unknown as ModuleSettings);
     }
 
-    public getValue<K extends keyof T | string>(
+    // The idea with the typing here is to be strict with the settings typed in the
+    // generic parameter while being less strict with the others.
+    // For instance, if you had a type `MySettings` which mapped "module.myModule.foo"
+    // to a boolean, `SettingsApi<MySettings>.getValue("module.myModule.foo")` should return
+    // a Watchable<boolean>.
+    // But for the settings not defined, the watchable would have weaker type (eg: any).
+    // So `SettingsApi<MySettings>.getValue("bar")` would return Watchable<any> and
+    // `SettingsApi<MySettings>.getValue<string>("bar") would return Watchable<string>.
+    // This is done to provide a good balance between type safety and flexibility.
+    public getValue<K extends keyof Settings>(
         settingName: K,
         roomId?: string | null,
         excludeDefault?: boolean,
-    ): Watchable<K extends keyof T ? T[K] : unknown> {
-        //@ts-expect-error: settingsName is strictly typed but we want relaxed type here.
-        return new SettingsWatchable(settingName, roomId, excludeDefault);
+    ): Watchable<T[K]["default"]>;
+    public getValue<V = any>(settingName: string, roomId?: string | null, excludeDefault?: boolean): Watchable<V>;
+    public getValue<K extends keyof Settings, V = any>(
+        settingName: K | string,
+        roomId?: string | null,
+        excludeDefault?: boolean,
+    ): Watchable<T[K]["default"]> | Watchable<V> {
+        return new SettingsWatchable(settingName, roomId, excludeDefault) as Watchable<T[K]["default"]> | Watchable<V>;
     }
 
-    public setValue<K extends keyof T | string>(
+    // Continuing with the example above, `SettingsApi<MySettings>.setValue("module.myModule.foo", null, Level.Device, "hello")`
+    // would throw a type error because the setting value isn't a boolean.
+    // However, any value could be provided for a non typed setting like "bar", so
+    // `SettingsApi<MySettings>.setValue("bar", null, Level.Device, "hello")`
+    // `SettingsApi<MySettings>.setValue("bar", null, Level.Device, true)`
+    // `SettingsApi<MySettings>.setValue("bar", null, Level.Device, 123)`
+    // are all acceptable from a type POV.
+    public setValue<K extends keyof Settings>(
         settingName: K,
         roomId: string | null,
         level: Level,
-        value: K extends keyof T ? T[K] : unknown,
+        value: T[K]["default"],
+    ): Promise<void>;
+    public setValue<V = any>(settingName: string, roomId: string | null, level: Level, value: V): Promise<void>;
+    public setValue<K extends keyof Settings, V = any>(
+        settingName: K | string,
+        roomId: string | null,
+        level: Level,
+        value: T[K]["default"] | V,
     ): Promise<void> {
         //@ts-expect-error: settingsName is strictly typed but we want relaxed type here.
         return SettingsStore.setValue(settingName, roomId, level, value);
@@ -60,7 +88,6 @@ class SettingsWatchable<T> extends Watchable<T> {
         newValAtLevel: T,
         newVal: T,
     ): void => {
-        // This only needs to checks atLevel when we add a getValueAtLevel to the API.
         this.value = newVal;
     };
 

--- a/apps/web/src/settings/Settings.tsx
+++ b/apps/web/src/settings/Settings.tsx
@@ -205,7 +205,12 @@ export interface IFeature extends Omit<IBaseSetting<boolean>, "isFeature"> {
 // Type using I-identifier for backwards compatibility from before it became a discriminated union
 export type ISetting = IBaseSetting | IFeature;
 
-export interface Settings {
+export interface ModuleSettings {
+    // Settings added by modules
+    [settingsName: `module.${string}`]: IBaseSetting;
+}
+
+export interface Settings extends ModuleSettings {
     [settingName: `UIFeature.${string}`]: IBaseSetting<boolean>;
 
     // We can't use the following type because of `feature_sliding_sync_proxy_url` & `feature_hidebold` being in the namespace incorrectly

--- a/apps/web/src/settings/SettingsStore.ts
+++ b/apps/web/src/settings/SettingsStore.ts
@@ -29,6 +29,7 @@ import {
     defaultWatchManager,
     type SettingKey,
     type Settings,
+    type ModuleSettings,
 } from "./Settings";
 import LocalEchoWrapper from "./handlers/LocalEchoWrapper";
 import { type CallbackFn as WatchCallbackFn } from "./WatchManager";
@@ -139,6 +140,14 @@ export default class SettingsStore {
 
     // Counter used for generation of watcher IDs
     private static watcherCount = 1;
+
+    /**
+     * Register runtime settings, mostly used by the module api.
+     * @param settings Runtime settings to be registered.
+     */
+    public static registerRuntimeSettings(settings: ModuleSettings): void {
+        Object.assign(SETTINGS, settings);
+    }
 
     public static reset(): void {
         for (const handler of Object.values(LEVEL_HANDLERS)) {

--- a/packages/module-api/element-web-module-api.api.md
+++ b/packages/module-api/element-web-module-api.api.md
@@ -73,6 +73,12 @@ export interface Api extends LegacyModuleApiExtension, LegacyCustomisationsApiEx
 }
 
 // @alpha
+export interface BaseSettings<T extends SettingValueType = SettingValueType> {
+    default: T;
+    supportedLevels: Level[];
+}
+
+// @alpha
 export interface BuiltinsApi {
     renderNotificationDecoration(roomId: string): React.ReactNode;
     renderRoomAvatar(roomId: string, size?: string): React.ReactNode;
@@ -317,6 +323,12 @@ export interface LegacyModuleApiExtension {
     _registerLegacyModule(LegacyModule: RuntimeModuleConstructor): Promise<void>;
 }
 
+// @alpha
+export enum Level {
+    // (undocumented)
+    DEVICE = "device"
+}
+
 // @alpha @deprecated (undocumented)
 export interface LifecycleCustomisations {
     // (undocumented)
@@ -490,9 +502,20 @@ export interface RoomViewProps {
 export type RuntimeModuleConstructor = new (api: ModuleApi) => RuntimeModule;
 
 // @alpha
-export interface SettingsApi {
-    getValue<T = any>(settingName: string, roomId?: string | null, excludeDefault?: boolean): T | undefined;
+export interface Settings {
+    // (undocumented)
+    [settingsName: `module.${string}`]: BaseSettings;
 }
+
+// @alpha
+export interface SettingsApi<T extends Settings = Settings> {
+    getValue<K extends keyof T | string>(settingName: K, roomId?: string | null, excludeDefault?: boolean): Watchable<K extends keyof T ? T[K] : unknown>;
+    registerSettings(settings: T): void;
+    setValue<K extends keyof T | string>(settingName: K, roomId: string | null, level: Level, value: K extends keyof T ? T[K] : unknown): Promise<void>;
+}
+
+// @alpha
+export type SettingValueType = null | string | number | boolean;
 
 // @alpha
 export interface SpacePanelItemProps {

--- a/packages/module-api/element-web-module-api.api.md
+++ b/packages/module-api/element-web-module-api.api.md
@@ -509,9 +509,11 @@ export interface Settings {
 
 // @alpha
 export interface SettingsApi<T extends Settings = Settings> {
-    getValue<K extends keyof T | string>(settingName: K, roomId?: string | null, excludeDefault?: boolean): Watchable<K extends keyof T ? T[K] : unknown>;
+    getValue<K extends keyof Settings>(settingName: K, roomId?: string | null, excludeDefault?: boolean): Watchable<T[K]["default"]>;
+    getValue<T = any>(settingName: string, roomId?: string | null, excludeDefault?: boolean): Watchable<T>;
     registerSettings(settings: T): void;
-    setValue<K extends keyof T | string>(settingName: K, roomId: string | null, level: Level, value: K extends keyof T ? T[K] : unknown): Promise<void>;
+    setValue<K extends keyof Settings>(settingName: K, roomId: string | null, level: Level, value: T[K]["default"]): Promise<void>;
+    setValue<T = any>(settingName: string, roomId: string | null, level: Level, value: T): Promise<void>;
 }
 
 // @alpha

--- a/packages/module-api/src/api/settings.ts
+++ b/packages/module-api/src/api/settings.ts
@@ -63,11 +63,21 @@ export interface SettingsApi<T extends Settings = Settings> {
      * non-room-scoped value.
      * @param excludeDefault - If true, do not fall back to the setting's default value.
      */
-    getValue<K extends keyof T | string>(
+    getValue<K extends keyof Settings>(
         settingName: K,
         roomId?: string | null,
         excludeDefault?: boolean,
-    ): Watchable<K extends keyof T ? T[K] : unknown>;
+    ): Watchable<T[K]["default"]>;
+
+    /**
+     * Gets the value of a setting, computed across all applicable levels
+     * (device, room, account, config, default, etc.).
+     * @param settingName - The name of the setting to read.
+     * @param roomId - Room ID to read a room-scoped value for, or null/undefined for a
+     * non-room-scoped value.
+     * @param excludeDefault - If true, do not fall back to the setting's default value.
+     */
+    getValue<T = any>(settingName: string, roomId?: string | null, excludeDefault?: boolean): Watchable<T>;
 
     /**
      * Set the value of a setting.
@@ -76,12 +86,19 @@ export interface SettingsApi<T extends Settings = Settings> {
      * @param level - The level at which this setting is set, see {@link Level}
      * @param value - The setting value
      */
-    setValue<K extends keyof T | string>(
+    setValue<K extends keyof Settings>(
         settingName: K,
         roomId: string | null,
         level: Level,
-        // For the settings defined by the module (T), make sure the value is strictly typed.
-        // For other strings, relax the type requirement.
-        value: K extends keyof T ? T[K] : unknown,
+        value: T[K]["default"],
     ): Promise<void>;
+
+    /**
+     * Set the value of a setting.
+     * @param settingName - The setting to set
+     * @param roomId - The room in which to change the setting, may be null.
+     * @param level - The level at which this setting is set, see {@link Level}
+     * @param value - The setting value
+     */
+    setValue<T = any>(settingName: string, roomId: string | null, level: Level, value: T): Promise<void>;
 }

--- a/packages/module-api/src/api/settings.ts
+++ b/packages/module-api/src/api/settings.ts
@@ -5,11 +5,56 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE files in the repository root for full details.
 */
 
+import type { Watchable } from "./watchable";
+
+/**
+ * The different levels at which settings can be stored,
+ * @alpha Subject to change.
+ */
+export enum Level {
+    DEVICE = "device",
+}
+
+/**
+ * The possible types that a setting value could be.
+ * @alpha Subject to change.
+ */
+export type SettingValueType = null | string | number | boolean;
+
+/**
+ * Details of a given setting.
+ * @alpha Subject to change.
+ */
+export interface BaseSettings<T extends SettingValueType = SettingValueType> {
+    /**
+     * The default value of this setting.
+     */
+    default: T;
+    /**
+     * The levels at which this setting can be set.
+     */
+    supportedLevels: Level[];
+}
+
+/**
+ * This type represents custom settings used by a module.
+ * @alpha Subject to change.
+ */
+export interface Settings {
+    [settingsName: `module.${string}`]: BaseSettings;
+}
+
 /**
  * API for reading application settings.
  * @alpha Subject to change.
  */
-export interface SettingsApi {
+export interface SettingsApi<T extends Settings = Settings> {
+    /**
+     * Register new settings used by your module.
+     * @param settings - The new settings to register.
+     */
+    registerSettings(settings: T): void;
+
     /**
      * Gets the value of a setting, computed across all applicable levels
      * (device, room, account, config, default, etc.).
@@ -18,5 +63,25 @@ export interface SettingsApi {
      * non-room-scoped value.
      * @param excludeDefault - If true, do not fall back to the setting's default value.
      */
-    getValue<T = any>(settingName: string, roomId?: string | null, excludeDefault?: boolean): T | undefined;
+    getValue<K extends keyof T | string>(
+        settingName: K,
+        roomId?: string | null,
+        excludeDefault?: boolean,
+    ): Watchable<K extends keyof T ? T[K] : unknown>;
+
+    /**
+     * Set the value of a setting.
+     * @param settingName - The setting to set
+     * @param roomId - The room in which to change the setting, may be null.
+     * @param level - The level at which this setting is set, see {@link Level}
+     * @param value - The setting value
+     */
+    setValue<K extends keyof T | string>(
+        settingName: K,
+        roomId: string | null,
+        level: Level,
+        // For the settings defined by the module (T), make sure the value is strictly typed.
+        // For other strings, relax the type requirement.
+        value: K extends keyof T ? T[K] : unknown,
+    ): Promise<void>;
 }


### PR DESCRIPTION
- Modifies `getValue` to return a watchable that holds the setting value. This allows consumers to subscribe to changes in the setting value.
- Adds a `registerRuntimeSettings` method to `SettingsStore` that can be used to add custom settings. This is exposed through the settings API.
- Supports setting setting values via `setValue`.
