### PR TITLE
Bump Shared components to 0.2.0

### DIFF
--- a/packages/shared-components/package.json
+++ b/packages/shared-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@element-hq/web-shared-components",
-    "version": "0.1.2",
+    "version": "0.2.0",
     "description": "Shared components for Element",
     "author": "New Vector Ltd.",
     "repository": {


### PR DESCRIPTION
https://github.com/element-hq/element-web/pull/34290 introduced a breaking change. The PR bumps to to 2.0.0.