### PR TITLE
Use the asynchronous safeStorage APIs

### DIFF
--- a/apps/desktop/src/store.test.ts
+++ b/apps/desktop/src/store.test.ts
@@ -6,10 +6,10 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { expect, describe, it, beforeAll, beforeEach, vi } from "vitest";
+import { expect, describe, it, afterEach, beforeAll, beforeEach, vi, type MockInstance } from "vitest";
 import { app, safeStorage } from "electron";
 
-import Store, { SafeStorageDecryptionError } from "./store.js";
+import Store, { Mode, SafeStorageDecryptionError } from "./store.js";
 
 // In-memory ElectronStore replacement so the tests don't touch the filesystem or real config.
 const backing = new Map<string, unknown>();
@@ -73,27 +73,75 @@ vi.mock("electron", () => ({
 }));
 
 const KEY = "@alice:example.org|DEVICEID";
+// The key `KEY` is stored under: dots are not legal in an electron-store path segment.
+const STORED_KEY = "safeStorage.@alice:example-org|DEVICEID";
+const SESSION = {} as unknown as Electron.Session;
+
+const encrypted = (secret: string): string => Buffer.from(PREFIX + secret, "utf8").toString("base64");
+
+/**
+ * Drop the Store singleton so a test can build one with a different mode, platform or on-disk
+ * state. Store.initialize refuses to run twice, and prepareSafeStorage is what we want to exercise.
+ */
+const freshStore = (mode?: Mode): Store => {
+    (Store as unknown as { internalInstance?: Store }).internalInstance = undefined;
+    return Store.initialize(mode);
+};
+
+let platformSpy: MockInstance<() => NodeJS.Platform> | undefined;
+
+/**
+ * Pin what process.platform reports for the rest of the test.
+ *
+ * Every test which builds a Store must do this rather than inherit the host's platform:
+ * chooseBackend takes a completely different path on Linux, so an inherited platform makes a test
+ * pass on a macOS dev machine and fail on a Linux CI runner. The ambient value is not trustworthy
+ * either - other test files in this project mock process.platform without restoring it, and vitest
+ * shares one process between the files in a worker.
+ */
+const usePlatform = (platform: NodeJS.Platform): void => {
+    restorePlatform();
+    platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue(platform);
+};
+
+const restorePlatform = (): void => {
+    platformSpy?.mockRestore();
+    platformSpy = undefined;
+};
 
 describe("Store secret encryption (safeStorage)", () => {
     let store: Store;
 
     beforeAll(async () => {
-        store = Store.initialize(undefined);
-        // getSelectedStorageBackend is mocked to "basic_text", so this walks the degraded-mode
-        // path and takes the mocked dialog's "use basic_text" answer.
-        await store.prepareSafeStorage({} as unknown as Electron.Session);
+        // On Linux with getSelectedStorageBackend mocked to "basic_text" this walks the
+        // degraded-mode path and takes the mocked dialog's "use basic_text" answer.
+        usePlatform("linux");
+        try {
+            store = Store.initialize(undefined);
+            await store.prepareSafeStorage(SESSION);
+        } finally {
+            restorePlatform();
+        }
     });
 
     beforeEach(() => {
+        // Default to a non-Linux platform; the tests which exercise the Linux paths say so.
+        usePlatform("darwin");
         backing.clear();
         vi.mocked(safeStorage.decryptStringAsync).mockClear();
         vi.mocked(safeStorage.encryptStringAsync).mockClear();
+        vi.mocked(safeStorage.isAsyncEncryptionAvailable).mockResolvedValue(true);
+        vi.mocked(safeStorage.getSelectedStorageBackend).mockReturnValue("basic_text");
         // Restore the default reversible decrypt implementation between tests.
         vi.mocked(safeStorage.decryptStringAsync).mockImplementation((buf: Buffer) => {
             const s = buf.toString("utf8");
             if (!s.startsWith(PREFIX)) return Promise.reject(new Error("Failed to decrypt"));
             return Promise.resolve({ result: s.slice(PREFIX.length), shouldReEncrypt: false });
         });
+    });
+
+    afterEach(() => {
+        restorePlatform();
     });
 
     it("round-trips a stored secret", async () => {
@@ -177,16 +225,124 @@ describe("Store secret encryption (safeStorage)", () => {
         });
     });
 
-    describe("basic_text -> plaintext migration", () => {
-        // The private migration step normally runs via prepareSafeStorage on a relaunch with
-        // safeStorageBackendMigrate set; drive it directly to keep the singleton harness simple.
-        const migrate = (): Promise<void> =>
-            (store as unknown as { migrateBasicTextToPlaintext(): Promise<void> }).migrateBasicTextToPlaintext();
+    describe("backend selection", () => {
+        it("uses the encrypted system backend when async encryption is available", async () => {
+            usePlatform("darwin");
 
-        const GOOD_CIPHERTEXT = Buffer.from(`${PREFIX}goodsecret`, "utf8").toString("base64");
+            const store = freshStore();
+            await expect(store.prepareSafeStorage(SESSION)).resolves.toBe(true);
+            expect(backing.get("safeStorageBackend")).toBe("system");
+        });
+
+        it("falls back to plaintext when async encryption is unavailable", async () => {
+            usePlatform("darwin");
+            vi.mocked(safeStorage.isAsyncEncryptionAvailable).mockResolvedValue(false);
+
+            const store = freshStore();
+            await expect(store.prepareSafeStorage(SESSION)).resolves.toBe(true);
+
+            expect(backing.get("safeStorageBackend")).toBe("plaintext");
+        });
+
+        it("uses the keyring Linux reports when it supports async encryption", async () => {
+            usePlatform("linux");
+            vi.mocked(safeStorage.getSelectedStorageBackend).mockReturnValue("gnome_libsecret");
+
+            const store = freshStore();
+            await expect(store.prepareSafeStorage(SESSION)).resolves.toBe(true);
+
+            expect(backing.get("safeStorageBackend")).toBe("gnome_libsecret");
+            // Set up front so that a fallback to basic_text is already encrypted, see chooseBackend.
+            expect(safeStorage.setUsePlainTextEncryption).toHaveBeenCalledWith(true);
+        });
+
+        it("falls back to plaintext when Linux reports an unknown keyring", async () => {
+            usePlatform("linux");
+            vi.mocked(safeStorage.getSelectedStorageBackend).mockReturnValue("unknown");
+
+            const store = freshStore();
+            await expect(store.prepareSafeStorage(SESSION)).resolves.toBe(true);
+
+            expect(backing.get("safeStorageBackend")).toBe("plaintext");
+        });
+
+        it("falls back to plaintext when the Linux keyring cannot encrypt", async () => {
+            usePlatform("linux");
+            vi.mocked(safeStorage.getSelectedStorageBackend).mockReturnValue("gnome_libsecret");
+            vi.mocked(safeStorage.isAsyncEncryptionAvailable).mockResolvedValue(false);
+
+            const store = freshStore();
+            await expect(store.prepareSafeStorage(SESSION)).resolves.toBe(true);
+
+            expect(backing.get("safeStorageBackend")).toBe("plaintext");
+        });
+    });
+
+    describe("plaintext storage", () => {
+        it("round-trips a secret without going near safeStorage", async () => {
+            const store = freshStore(Mode.ForcePlaintext);
+            await store.prepareSafeStorage(SESSION);
+
+            await store.setSecret(KEY, "s3cr3t");
+
+            expect(backing.get(STORED_KEY)).toBe("s3cr3t");
+            await expect(store.getSecret(KEY)).resolves.toBe("s3cr3t");
+            expect(safeStorage.encryptStringAsync).not.toHaveBeenCalled();
+            expect(safeStorage.decryptStringAsync).not.toHaveBeenCalled();
+        });
+
+        it("reports a missing secret as absent rather than undecryptable", async () => {
+            const store = freshStore(Mode.ForcePlaintext);
+            await store.prepareSafeStorage(SESSION);
+
+            await expect(store.getSecret(KEY)).resolves.toBeUndefined();
+            await expect(store.isSecretUndecryptable(KEY)).resolves.toBe(false);
+        });
+    });
+
+    describe("plaintext -> encrypted migration", () => {
+        beforeEach(() => {
+            usePlatform("linux");
+            vi.mocked(safeStorage.getSelectedStorageBackend).mockReturnValue("gnome_libsecret");
+            backing.set("safeStorageBackend", "plaintext");
+        });
+
+        it("encrypts existing plaintext secrets once an encrypted backend is available", async () => {
+            backing.set("safeStorage", { good: "goodsecret" });
+            backing.set("safeStorage.good", "goodsecret");
+
+            const store = freshStore();
+            // Migrating in place, so startup continues rather than relaunching.
+            await expect(store.prepareSafeStorage(SESSION)).resolves.toBe(true);
+
+            expect(backing.get("safeStorage.good")).toBe(encrypted("goodsecret"));
+            expect(backing.get("safeStorageBackend")).toBe("gnome_libsecret");
+            await expect(store.getSecret("good")).resolves.toBe("goodsecret");
+        });
+
+        it("does nothing when there are no secrets to migrate", async () => {
+            const store = freshStore();
+            await expect(store.prepareSafeStorage(SESSION)).resolves.toBe(true);
+
+            expect(backing.get("safeStorageBackend")).toBe("gnome_libsecret");
+            expect(safeStorage.encryptStringAsync).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("basic_text -> plaintext migration", () => {
+        // The migration runs on a relaunch into the basic_text backend with safeStorageBackendMigrate
+        // set, so drive it through prepareSafeStorage exactly as that relaunch does.
+        const migrate = async (): Promise<void> => {
+            const migrating = freshStore();
+            // The migration always ends in a relaunch, so startup is told to abort.
+            await expect(migrating.prepareSafeStorage(SESSION)).resolves.toBe(false);
+        };
+
+        const GOOD_CIPHERTEXT = encrypted("goodsecret");
         const BAD_CIPHERTEXT = Buffer.from("not-decryptable", "utf8").toString("base64");
 
         beforeEach(() => {
+            usePlatform("linux");
             backing.set("safeStorageBackend", "basic_text");
             backing.set("safeStorageBackendMigrate", true);
         });

--- a/apps/desktop/src/store.test.ts
+++ b/apps/desktop/src/store.test.ts
@@ -87,6 +87,7 @@ describe("Store secret encryption (safeStorage)", () => {
     beforeEach(() => {
         backing.clear();
         vi.mocked(safeStorage.decryptStringAsync).mockClear();
+        vi.mocked(safeStorage.encryptStringAsync).mockClear();
         // Restore the default reversible decrypt implementation between tests.
         vi.mocked(safeStorage.decryptStringAsync).mockImplementation((buf: Buffer) => {
             const s = buf.toString("utf8");
@@ -112,6 +113,35 @@ describe("Store secret encryption (safeStorage)", () => {
         );
 
         await expect(store.getSecret(KEY)).rejects.toBeInstanceOf(SafeStorageDecryptionError);
+    });
+
+    it("re-encrypts a secret when safeStorage reports the key has been rotated", async () => {
+        await store.setSecret(KEY, "s3cr3t");
+        const stored = backing.get("safeStorage.@alice:example-org|DEVICEID");
+
+        // safeStorage decrypted with the old key and wants the secret written back under the new one.
+        vi.mocked(safeStorage.decryptStringAsync).mockImplementationOnce(() =>
+            Promise.resolve({ result: "s3cr3t", shouldReEncrypt: true }),
+        );
+        vi.mocked(safeStorage.encryptStringAsync).mockImplementationOnce(() =>
+            Promise.resolve(Buffer.from(`${PREFIX}rotated:s3cr3t`, "utf8")),
+        );
+
+        await expect(store.getSecret(KEY)).resolves.toBe("s3cr3t");
+        expect(backing.get("safeStorage.@alice:example-org|DEVICEID")).not.toBe(stored);
+        await expect(store.getSecret(KEY)).resolves.toBe("rotated:s3cr3t");
+    });
+
+    it("still returns the secret when re-encrypting it fails", async () => {
+        await store.setSecret(KEY, "s3cr3t");
+        vi.mocked(safeStorage.decryptStringAsync).mockImplementationOnce(() =>
+            Promise.resolve({ result: "s3cr3t", shouldReEncrypt: true }),
+        );
+        vi.mocked(safeStorage.encryptStringAsync).mockImplementationOnce(() =>
+            Promise.reject(new Error("keychain unavailable")),
+        );
+
+        await expect(store.getSecret(KEY)).resolves.toBe("s3cr3t");
     });
 
     describe("isSecretUndecryptable", () => {

--- a/apps/desktop/src/store.test.ts
+++ b/apps/desktop/src/store.test.ts
@@ -60,14 +60,14 @@ vi.mock("electron", () => ({
         showMessageBox: vi.fn(() => Promise.resolve({ response: 1 })),
     },
     safeStorage: {
-        isEncryptionAvailable: vi.fn(() => true),
+        isAsyncEncryptionAvailable: vi.fn(() => Promise.resolve(true)),
         getSelectedStorageBackend: vi.fn(() => "basic_text"),
         setUsePlainTextEncryption: vi.fn(),
-        encryptString: vi.fn((plaintext: string) => Buffer.from(PREFIX + plaintext, "utf8")),
-        decryptString: vi.fn((buf: Buffer) => {
+        encryptStringAsync: vi.fn((plaintext: string) => Promise.resolve(Buffer.from(PREFIX + plaintext, "utf8"))),
+        decryptStringAsync: vi.fn((buf: Buffer) => {
             const s = buf.toString("utf8");
-            if (!s.startsWith(PREFIX)) throw new Error("Failed to decrypt");
-            return s.slice(PREFIX.length);
+            if (!s.startsWith(PREFIX)) return Promise.reject(new Error("Failed to decrypt"));
+            return Promise.resolve({ result: s.slice(PREFIX.length), shouldReEncrypt: false });
         }),
     },
 }));
@@ -86,12 +86,12 @@ describe("Store secret encryption (safeStorage)", () => {
 
     beforeEach(() => {
         backing.clear();
-        vi.mocked(safeStorage.decryptString).mockClear();
+        vi.mocked(safeStorage.decryptStringAsync).mockClear();
         // Restore the default reversible decrypt implementation between tests.
-        vi.mocked(safeStorage.decryptString).mockImplementation((buf: Buffer) => {
+        vi.mocked(safeStorage.decryptStringAsync).mockImplementation((buf: Buffer) => {
             const s = buf.toString("utf8");
-            if (!s.startsWith(PREFIX)) throw new Error("Failed to decrypt");
-            return s.slice(PREFIX.length);
+            if (!s.startsWith(PREFIX)) return Promise.reject(new Error("Failed to decrypt"));
+            return Promise.resolve({ result: s.slice(PREFIX.length), shouldReEncrypt: false });
         });
     });
 
@@ -107,9 +107,9 @@ describe("Store secret encryption (safeStorage)", () => {
     it("throws SafeStorageDecryptionError when the stored secret cannot be decrypted", async () => {
         await store.setSecret(KEY, "s3cr3t");
         // Simulate a transient keychain failure (e.g. keychain locked / ACL invalidated by re-sign).
-        vi.mocked(safeStorage.decryptString).mockImplementationOnce(() => {
-            throw new Error("keychain unavailable");
-        });
+        vi.mocked(safeStorage.decryptStringAsync).mockImplementationOnce(() =>
+            Promise.reject(new Error("keychain unavailable")),
+        );
 
         await expect(store.getSecret(KEY)).rejects.toBeInstanceOf(SafeStorageDecryptionError);
     });
@@ -126,9 +126,9 @@ describe("Store secret encryption (safeStorage)", () => {
 
         it("is true when a stored secret exists but cannot be decrypted", async () => {
             await store.setSecret(KEY, "s3cr3t");
-            vi.mocked(safeStorage.decryptString).mockImplementationOnce(() => {
-                throw new Error("keychain unavailable");
-            });
+            vi.mocked(safeStorage.decryptStringAsync).mockImplementationOnce(() =>
+                Promise.reject(new Error("keychain unavailable")),
+            );
             await expect(store.isSecretUndecryptable(KEY)).resolves.toBe(true);
         });
 
@@ -150,8 +150,8 @@ describe("Store secret encryption (safeStorage)", () => {
     describe("basic_text -> plaintext migration", () => {
         // The private migration step normally runs via prepareSafeStorage on a relaunch with
         // safeStorageBackendMigrate set; drive it directly to keep the singleton harness simple.
-        const migrate = (): void =>
-            (store as unknown as { migrateBasicTextToPlaintext(): void }).migrateBasicTextToPlaintext();
+        const migrate = (): Promise<void> =>
+            (store as unknown as { migrateBasicTextToPlaintext(): Promise<void> }).migrateBasicTextToPlaintext();
 
         const GOOD_CIPHERTEXT = Buffer.from(`${PREFIX}goodsecret`, "utf8").toString("base64");
         const BAD_CIPHERTEXT = Buffer.from("not-decryptable", "utf8").toString("base64");
@@ -161,11 +161,11 @@ describe("Store secret encryption (safeStorage)", () => {
             backing.set("safeStorageBackendMigrate", true);
         });
 
-        it("migrates all secrets to plaintext and records the plaintext backend", () => {
+        it("migrates all secrets to plaintext and records the plaintext backend", async () => {
             backing.set("safeStorage", { good: GOOD_CIPHERTEXT });
             backing.set("safeStorage.good", GOOD_CIPHERTEXT);
 
-            migrate();
+            await migrate();
 
             expect(backing.get("safeStorage.good")).toBe("goodsecret");
             expect(backing.get("safeStorageBackend")).toBe("plaintext");
@@ -174,12 +174,12 @@ describe("Store secret encryption (safeStorage)", () => {
             expect(app.relaunch).toHaveBeenCalled();
         });
 
-        it("defers the whole migration when any secret cannot be decrypted", () => {
+        it("defers the whole migration when any secret cannot be decrypted", async () => {
             backing.set("safeStorage", { good: GOOD_CIPHERTEXT, bad: BAD_CIPHERTEXT });
             backing.set("safeStorage.good", GOOD_CIPHERTEXT);
             backing.set("safeStorage.bad", BAD_CIPHERTEXT);
 
-            migrate();
+            await migrate();
 
             // Nothing may be rewritten: recording "plaintext" while `bad` is still ciphertext would
             // make the next launch re-encrypt the ciphertext as though it were the secret itself,

--- a/apps/desktop/src/store.test.ts
+++ b/apps/desktop/src/store.test.ts
@@ -60,6 +60,7 @@ vi.mock("electron", () => ({
         showMessageBox: vi.fn(() => Promise.resolve({ response: 1 })),
     },
     safeStorage: {
+        isEncryptionAvailable: vi.fn(() => true),
         isAsyncEncryptionAvailable: vi.fn(() => Promise.resolve(true)),
         getSelectedStorageBackend: vi.fn(() => "basic_text"),
         setUsePlainTextEncryption: vi.fn(),
@@ -130,6 +131,7 @@ describe("Store secret encryption (safeStorage)", () => {
         backing.clear();
         vi.mocked(safeStorage.decryptStringAsync).mockClear();
         vi.mocked(safeStorage.encryptStringAsync).mockClear();
+        vi.mocked(safeStorage.isEncryptionAvailable).mockReturnValue(true);
         vi.mocked(safeStorage.isAsyncEncryptionAvailable).mockResolvedValue(true);
         vi.mocked(safeStorage.getSelectedStorageBackend).mockReturnValue("basic_text");
         // Restore the default reversible decrypt implementation between tests.
@@ -237,6 +239,31 @@ describe("Store secret encryption (safeStorage)", () => {
         it("falls back to plaintext when async encryption is unavailable", async () => {
             usePlatform("darwin");
             vi.mocked(safeStorage.isAsyncEncryptionAvailable).mockResolvedValue(false);
+
+            const store = freshStore();
+            await expect(store.prepareSafeStorage(SESSION)).resolves.toBe(true);
+
+            expect(backing.get("safeStorageBackend")).toBe("plaintext");
+        });
+
+        // A machine with no usable keychain - a GitHub Actions macOS runner, for instance - reports
+        // false here while the async probe does not, so both have to be consulted. Picking an
+        // encrypted backend on such a machine leaves every secret unstorable.
+        it("falls back to plaintext when the OS reports no encryption at all", async () => {
+            usePlatform("darwin");
+            vi.mocked(safeStorage.isEncryptionAvailable).mockReturnValue(false);
+
+            const store = freshStore();
+            await expect(store.prepareSafeStorage(SESSION)).resolves.toBe(true);
+
+            expect(backing.get("safeStorageBackend")).toBe("plaintext");
+            await store.setSecret(KEY, "s3cr3t");
+            await expect(store.getSecret(KEY)).resolves.toBe("s3cr3t");
+        });
+
+        it("falls back to plaintext when the async encryptor fails to initialise", async () => {
+            usePlatform("darwin");
+            vi.mocked(safeStorage.isAsyncEncryptionAvailable).mockRejectedValue(new Error("no keychain"));
 
             const store = freshStore();
             await expect(store.prepareSafeStorage(SESSION)).resolves.toBe(true);

--- a/apps/desktop/src/store.ts
+++ b/apps/desktop/src/store.ts
@@ -103,11 +103,11 @@ class StorageWriter {
         return `safeStorage.${key.replaceAll(".", "-")}`;
     }
 
-    public set(key: string, secret: string): void {
+    public async set(key: string, secret: string): Promise<void> {
         this.store.set(this.getKey(key), secret);
     }
 
-    public get(key: string): string | undefined {
+    public async get(key: string): Promise<string | undefined> {
         return this.store.get(this.getKey(key));
     }
 
@@ -122,20 +122,25 @@ class StorageWriter {
 
 /**
  * Storage writer for secrets using safeStorage.
+ *
+ * Uses the asynchronous safeStorage APIs so that reads and writes of secrets do not block the
+ * main process on the OS keychain.
  */
 class SafeStorageWriter extends StorageWriter {
-    public set(key: string, secret: string): void {
-        this.store.set(this.getKey(key), safeStorage.encryptString(secret).toString("base64"));
+    public async set(key: string, secret: string): Promise<void> {
+        const ciphertext = await safeStorage.encryptStringAsync(secret);
+        this.store.set(this.getKey(key), ciphertext.toString("base64"));
     }
 
-    public get(key: string): string | undefined {
+    public async get(key: string): Promise<string | undefined> {
         const ciphertext = this.store.get<string, string | undefined>(this.getKey(key));
         if (!ciphertext) {
             // No secret stored.
             return undefined;
         }
         try {
-            return safeStorage.decryptString(Buffer.from(ciphertext, "base64"));
+            const { result } = await safeStorage.decryptStringAsync(Buffer.from(ciphertext, "base64"));
+            return result;
         } catch (e) {
             // The secret exists but cannot be decrypted in this session. Returning undefined here (as
             // we used to) is indistinguishable from "no secret stored", which makes callers create or
@@ -266,7 +271,7 @@ class Store extends ElectronStore<StoreData> {
      * @param forcePlaintext - whether to force plaintext mode
      * @private
      */
-    private chooseBackend(forcePlaintext: boolean): SaneSafeStorageBackend {
+    private async chooseBackend(forcePlaintext: boolean): Promise<SaneSafeStorageBackend> {
         if (forcePlaintext) {
             return "plaintext";
         }
@@ -282,13 +287,13 @@ class Store extends ElectronStore<StoreData> {
             // https://github.com/electron/electron/issues/39789 https://github.com/microsoft/vscode/issues/185212
             const selectedBackend = safeStorage.getSelectedStorageBackend();
 
-            if (selectedBackend === "unknown" || !safeStorage.isEncryptionAvailable()) {
+            if (selectedBackend === "unknown" || !(await safeStorage.isAsyncEncryptionAvailable())) {
                 return "plaintext";
             }
             return selectedBackend;
         }
 
-        return safeStorage.isEncryptionAvailable() ? "system" : "plaintext";
+        return (await safeStorage.isAsyncEncryptionAvailable()) ? "system" : "plaintext";
     }
 
     /**
@@ -310,7 +315,7 @@ class Store extends ElectronStore<StoreData> {
         // The backend the existing data is written with if any
         let existingSafeStorageBackend = this.get("safeStorageBackend");
         // The backend and encryption status of the currently loaded backend
-        const backend = this.chooseBackend(this.mode === Mode.ForcePlaintext);
+        const backend = await this.chooseBackend(this.mode === Mode.ForcePlaintext);
 
         // Handle migrations
         if (existingSafeStorageBackend) {
@@ -320,12 +325,12 @@ class Store extends ElectronStore<StoreData> {
             }
 
             if (this.get("safeStorageBackendMigrate") && backend === "basic_text") {
-                this.migrateBasicTextToPlaintext();
+                await this.migrateBasicTextToPlaintext();
                 return false;
             }
 
             if (existingSafeStorageBackend === "plaintext" && backend !== "plaintext") {
-                this.migratePlaintextToEncrypted();
+                await this.migratePlaintextToEncrypted();
                 // Ensure we update existingSafeStorageBackend so we don't fall into the "backend changed" clause below
                 existingSafeStorageBackend = this.get("safeStorageBackend");
             }
@@ -442,7 +447,7 @@ class Store extends ElectronStore<StoreData> {
         this.set("safeStorageBackendMigrate", true);
         relaunchApp();
     }
-    private migrateBasicTextToPlaintext(): void {
+    private async migrateBasicTextToPlaintext(): Promise<void> {
         const secrets = new SafeStorageWriter(this);
         console.info("Performing safeStorage migration");
         const data = this.get("safeStorage");
@@ -454,7 +459,7 @@ class Store extends ElectronStore<StoreData> {
             const decrypted = new Map<string, string | undefined>();
             try {
                 for (const key in data) {
-                    decrypted.set(secrets.getKey(key), secrets.get(key));
+                    decrypted.set(secrets.getKey(key), await secrets.get(key));
                 }
             } catch (e) {
                 // Abort the migration with the data untouched and stick with the basic_text backend
@@ -474,14 +479,14 @@ class Store extends ElectronStore<StoreData> {
         this.delete("safeStorageBackendMigrate");
         relaunchApp();
     }
-    private migratePlaintextToEncrypted(): void {
+    private async migratePlaintextToEncrypted(): Promise<void> {
         const secrets = new SafeStorageWriter(this);
         const selectedSafeStorageBackend = safeStorage.getSelectedStorageBackend();
         console.info(`Finishing safeStorage migration to ${selectedSafeStorageBackend}`);
         const data = this.get("safeStorage");
         if (data) {
             for (const key in data) {
-                secrets.set(key, data[key]);
+                await secrets.set(key, data[key]);
             }
         }
         this.recordSafeStorageBackend(selectedSafeStorageBackend);
@@ -496,7 +501,7 @@ class Store extends ElectronStore<StoreData> {
      */
     public async getSecret(key: string): Promise<string | undefined> {
         await this.safeStorageReady();
-        return this.secrets!.get(key);
+        return await this.secrets!.get(key);
     }
 
     /**
@@ -513,7 +518,7 @@ class Store extends ElectronStore<StoreData> {
         await this.safeStorageReady();
         if (!this.secrets!.has(key)) return false;
         try {
-            this.secrets!.get(key);
+            await this.secrets!.get(key);
             return false;
         } catch (e) {
             if (!(e instanceof SafeStorageDecryptionError)) {
@@ -533,7 +538,7 @@ class Store extends ElectronStore<StoreData> {
      */
     public async setSecret(key: string, secret: string): Promise<void> {
         await this.safeStorageReady();
-        this.secrets!.set(key, secret);
+        await this.secrets!.set(key, secret);
     }
 
     /**

--- a/apps/desktop/src/store.ts
+++ b/apps/desktop/src/store.ts
@@ -290,6 +290,21 @@ class Store extends ElectronStore<StoreData> {
     }
 
     /**
+     * Whether we can actually encrypt secrets.
+     *
+     * We need both `isEncryptionAvailable` and `isAsyncEncryptionAvailable` to be true to be able to encrypt secrets.
+     */
+    private async canEncrypt(): Promise<boolean> {
+        if (!safeStorage.isEncryptionAvailable()) return false;
+        try {
+            return await safeStorage.isAsyncEncryptionAvailable();
+        } catch (e) {
+            console.error("Failed to initialise the async safeStorage encryptor", e);
+            return false;
+        }
+    }
+
+    /**
      * Normalise the backend to a sane value (exclude `unknown`), respect forcePlaintext mode,
      * and ensure that if an encrypted backend is picked that encryption is available, falling back to plaintext if not.
      * @param forcePlaintext - whether to force plaintext mode
@@ -311,13 +326,13 @@ class Store extends ElectronStore<StoreData> {
             // https://github.com/electron/electron/issues/39789 https://github.com/microsoft/vscode/issues/185212
             const selectedBackend = safeStorage.getSelectedStorageBackend();
 
-            if (selectedBackend === "unknown" || !(await safeStorage.isAsyncEncryptionAvailable())) {
+            if (selectedBackend === "unknown" || !(await this.canEncrypt())) {
                 return "plaintext";
             }
             return selectedBackend;
         }
 
-        return (await safeStorage.isAsyncEncryptionAvailable()) ? "system" : "plaintext";
+        return (await this.canEncrypt()) ? "system" : "plaintext";
     }
 
     /**

--- a/apps/desktop/src/store.ts
+++ b/apps/desktop/src/store.ts
@@ -123,8 +123,8 @@ class StorageWriter {
 /**
  * Storage writer for secrets using safeStorage.
  *
- * Uses the asynchronous safeStorage APIs so that reads and writes of secrets do not block the
- * main process on the OS keychain.
+ * Uses the asynchronous safeStorage APIs, which do not block the main process on the OS keychain
+ * and which support key rotation via the `shouldReEncrypt` flag on decryption.
  */
 class SafeStorageWriter extends StorageWriter {
     public async set(key: string, secret: string): Promise<void> {
@@ -133,14 +133,38 @@ class SafeStorageWriter extends StorageWriter {
     }
 
     public async get(key: string): Promise<string | undefined> {
+        const decrypted = await this.decrypt(key);
+        if (!decrypted) return undefined;
+        if (decrypted.shouldReEncrypt) {
+            // safeStorage has rotated its key, or a stronger one is now available, so write the
+            // secret back under the new key. Failing to do so is not fatal - we still have the
+            // secret - so don't let it break the read.
+            try {
+                await this.set(key, decrypted.result);
+            } catch (e) {
+                console.error("Failed to re-encrypt secret after key rotation", e);
+            }
+        }
+        return decrypted.result;
+    }
+
+    /**
+     * As {@link get}, but never writes the secret back, even when safeStorage asks for it to be
+     * re-encrypted. The migration paths must be able to read every secret before deciding whether
+     * to write anything at all, so they cannot use a read which has a write as a side effect.
+     */
+    public async getWithoutReEncrypt(key: string): Promise<string | undefined> {
+        return (await this.decrypt(key))?.result;
+    }
+
+    private async decrypt(key: string): Promise<Electron.DecryptStringAsyncReturnValue | undefined> {
         const ciphertext = this.store.get<string, string | undefined>(this.getKey(key));
         if (!ciphertext) {
             // No secret stored.
             return undefined;
         }
         try {
-            const { result } = await safeStorage.decryptStringAsync(Buffer.from(ciphertext, "base64"));
-            return result;
+            return await safeStorage.decryptStringAsync(Buffer.from(ciphertext, "base64"));
         } catch (e) {
             // The secret exists but cannot be decrypted in this session. Returning undefined here (as
             // we used to) is indistinguishable from "no secret stored", which makes callers create or
@@ -459,7 +483,7 @@ class Store extends ElectronStore<StoreData> {
             const decrypted = new Map<string, string | undefined>();
             try {
                 for (const key in data) {
-                    decrypted.set(secrets.getKey(key), await secrets.get(key));
+                    decrypted.set(secrets.getKey(key), await secrets.getWithoutReEncrypt(key));
                 }
             } catch (e) {
                 // Abort the migration with the data untouched and stick with the basic_text backend


### PR DESCRIPTION
Fixes #34963

This switches the desktop secret store (used for pickle keys) over to the recommended [asynchronous safeStorage API](https://www.electronjs.org/docs/latest/api/safe-storage#asynchronous-api).

This includes implementing key rotation when the storage backend requests it in 7168840921a7a5eac5aa36670b6e9b73988466df.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Since making this PR it appears that Chromium has removed the underlying synchronous API and the position in Electron is that it will be deprecated in v45 and removed in v46: https://github.com/electron/electron/pull/53662. So, this will need to be dealt with one way or another before too long.

<!-- Thanks for submitting a PR! This checklist has the essential things that needs to be done so we can review your PR. Make sure each item is completed before checking its box. -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] I have linked the PR to an issue that describes what needs changing.
- [x] I have written tests for new code (and old code if feasible).
- [x] I have ensured new or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] I have confirmed linter and other CI checks pass.
- [ ] I have have included screenshots if what the user sees will change
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
- [x] I will no longer force push to this branch
