### PR TITLE
Hide Identity Server settings when UIFeature.identityServer is disabled

### DIFF
--- a/apps/web/src/components/views/settings/discovery/DiscoverySettings.tsx
+++ b/apps/web/src/components/views/settings/discovery/DiscoverySettings.tsx
@@ -25,6 +25,8 @@ import { useDispatcher } from "../../../../hooks/useDispatcher";
 import defaultDispatcher from "../../../../dispatcher/dispatcher";
 import { type ActionPayload } from "../../../../dispatcher/payloads";
 import { AddRemoveThreepids } from "../AddRemoveThreepids";
+import SettingsStore from "../../../../settings/SettingsStore";
+import { UIFeature } from "../../../../settings/UIFeature";
 
 type RequiredPolicyInfo =
     | {
@@ -44,6 +46,7 @@ type RequiredPolicyInfo =
  */
 export const DiscoverySettings: React.FC = () => {
     const client = useMatrixClientContext();
+    const identityServerEnabled = SettingsStore.getValue(UIFeature.IdentityServer);
 
     const [isLoadingThreepids, setIsLoadingThreepids] = useState<boolean>(true);
     const [emails, setEmails] = useState<ThirdPartyIdentifier[]>([]);
@@ -134,7 +137,7 @@ export const DiscoverySettings: React.FC = () => {
                     introElement={intro}
                 />
                 {/* has its own heading as it includes the current identity server */}
-                <SetIdServer missingTerms={true} />
+                {identityServerEnabled && <SetIdServer missingTerms={true} />}
             </>
         );
     }
@@ -179,7 +182,7 @@ export const DiscoverySettings: React.FC = () => {
         <SettingsSubsection heading={_t("settings|discovery|title")} data-testid="discoverySection" stretchContent>
             {threepidSection}
             {/* has its own heading as it includes the current identity server */}
-            <SetIdServer missingTerms={false} />
+            {identityServerEnabled && <SetIdServer missingTerms={false} />}
         </SettingsSubsection>
     );
 };

--- a/apps/web/src/components/views/settings/tabs/user/SecurityUserSettingsTab.test.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/SecurityUserSettingsTab.test.tsx
@@ -102,4 +102,16 @@ describe("<SecurityUserSettingsTab />", () => {
 
         expect(screen.queryByRole("heading", { name: "Privacy" })).toBeNull();
     });
+
+    it("does not render identity server settings if the identity server feature is disabled", async () => {
+        vi.spyOn(SettingsStore, "getValue").mockImplementation((key: any): any => {
+            if (key === UIFeature.ThirdPartyID) return true;
+            if (key === UIFeature.IdentityServer) return false;
+        });
+
+        render(getComponent());
+
+        expect(screen.queryByTestId("discoverySection")).toBeInTheDocument();
+        expect(screen.queryByText("Identity server")).toBeNull();
+    });
 });


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-web/issues/34950

### What this fixes

With `setting_defaults: { "UIFeature.identityServer": false }`, the "Identity Server" fieldset under All Settings → Security & Privacy → Discovery was still shown, contrary to the documented behaviour at https://web-docs.element.dev/config.html#ui-features.

`UIFeature.thirdPartyId: false` already correctly hides the whole Discovery section (email/phone number settings *and* the Identity Server block), because `SecurityUserSettingsTab` gates it on `UIFeature.ThirdPartyID`. But within that section, `<SetIdServer />` (the "Identity Server" URL/disconnect UI) was rendered unconditionally — it was pulled out into its own component in #12670 and never re-gated on `UIFeature.IdentityServer`, even though that flag is still read elsewhere (e.g. `InviteDialog.tsx`) and `Settings.tsx` already declares a `UIFeatureController` chaining `IdentityServer` to `ThirdPartyID`.

### The change

`DiscoverySettings.tsx` now reads `SettingsStore.getValue(UIFeature.IdentityServer)` and only renders `<SetIdServer />` when it's true, at both call sites (the terms-pending branch and the normal path). Email/phone discovery settings are unaffected and continue to be controlled solely by `UIFeature.ThirdPartyID`, matching the existing separation between the two flags.

### Testing

- Added a test to `SecurityUserSettingsTab.test.tsx` that mocks `ThirdPartyID: true, IdentityServer: false` and asserts the Discovery section still renders while the "Identity server" legend does not. Verified it fails without the fix and passes with it.
- `pnpm exec nx run element-web:test:vitest -- src/components/views/settings` — 521/522 passing; the one pre-existing failure (`DeviceDetails.test.tsx`, a time-formatting snapshot) reproduces identically on unmodified `develop` and is unrelated to this change.
- `pnpm exec oxfmt --check` and `pnpm exec oxlint` on the changed files — clean.
- `pnpm exec nx run element-web:lint:types` — pre-existing errors only, all inside `matrix-js-sdk`'s own type declarations in `node_modules`, reproduced identically on unmodified `develop`.

No screenshots included since the visible change only appears under a non-default config flag (`UIFeature.identityServer: false`) rather than in the default settings UI; happy to add a before/after screenshot if useful for review.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] I have linked the PR to an issue that describes what needs changing.
- [x] I have written tests for new code (and old code if feasible).
- [x] I have ensured new or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] I have confirmed linter and other CI checks pass.
- [ ] I have have included screenshots if what the user sees will change
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
- [x] I will no longer force push to this branch