### PR TITLE
Log app version on startup for all platforms

### DIFF
--- a/apps/web/src/vector/init.test.ts
+++ b/apps/web/src/vector/init.test.ts
@@ -8,14 +8,16 @@ Please see LICENSE files in the repository root for full details.
 // @vitest-environment happy-dom
 // @vitest-environment-options {"url": "https://app.element.io/?loginToken=123&no_universal_links&something_else=value#/home?state=abc&code=xyz"}
 
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { logger } from "matrix-js-sdk/src/logger";
 import fetchMock from "@fetch-mock/vitest";
 import { waitFor, screen } from "test-utils-rtl";
 
-import { loadApp, showError, showIncompatibleBrowser } from "./init.tsx";
+import { loadApp, logAppVersion, showError, showIncompatibleBrowser } from "./init.tsx";
 import SdkConfig from "../SdkConfig.ts";
 import MatrixChat from "../components/structures/MatrixChat.tsx";
 import { parseAppUrl } from "./url_utils.ts";
+import { mockPlatformPeg, unmockPlatformPeg } from "../../test/test-utils/platform.ts";
 
 function setUpMatrixChatDiv() {
     document.getElementById("matrixchat")?.remove();
@@ -86,5 +88,28 @@ describe("loadApp", () => {
         window.matrixChat!.props.onTokenLoginCompleted(parseAppUrl(window.location).params, "/home");
 
         expect(spy).toHaveBeenCalledWith(null, "", "https://app.element.io/?something_else=value#/home");
+    });
+});
+
+describe("logAppVersion", () => {
+    afterEach(unmockPlatformPeg);
+
+    it("should log the version reported by the platform", async () => {
+        const spy = vi.spyOn(logger, "info");
+        mockPlatformPeg({ getAppVersion: vi.fn().mockResolvedValue("1.12.34") });
+
+        await logAppVersion();
+
+        expect(spy).toHaveBeenCalledWith("App version: 1.12.34");
+    });
+
+    it("should warn rather than throw if the version cannot be determined", async () => {
+        const spy = vi.spyOn(logger, "warn");
+        const error = new Error("no version for you");
+        mockPlatformPeg({ getAppVersion: vi.fn().mockRejectedValue(error) });
+
+        await logAppVersion();
+
+        expect(spy).toHaveBeenCalledWith("Unable to determine app version for logging", error);
     });
 });

--- a/apps/web/src/vector/init.tsx
+++ b/apps/web/src/vector/init.tsx
@@ -62,6 +62,23 @@ export function preparePlatform(): void {
         logger.log("Using Web platform");
         PlatformPeg.set(new WebPlatform());
     }
+
+    // Deliberately not awaited: the version is only wanted for the logs, so it must not hold up startup.
+    void logAppVersion();
+}
+
+/**
+ * Log the version of the app, so that each rageshake log file starts with the version that produced it.
+ *
+ * The rageshake store keeps one log file per app instance, so logging this at startup means an upgrade or
+ * downgrade between sessions is visible when reading a report.
+ */
+export async function logAppVersion(): Promise<void> {
+    try {
+        logger.info(`App version: ${await PlatformPeg.get()!.getAppVersion()}`);
+    } catch (e) {
+        logger.warn("Unable to determine app version for logging", e);
+    }
 }
 
 export function setupLogStorage(): Promise<void> {


### PR DESCRIPTION
This is to make upgrades/downgrades visible when looking at rageshake logs. Currently we only get the version of the app that submitted the rageshake.

n.b. on Web there are log lines like `startUpdater, current version is 1.12.27` but this change makes it consistent across platforms

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- Thanks for submitting a PR! This checklist has the essential things that needs to be done so we can review your PR. Make sure each item is completed before checking its box. -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] I have linked the PR to an issue that describes what needs changing.
- [x] I have written tests for new code (and old code if feasible).
- [x] I have ensured new or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] I have confirmed linter and other CI checks pass.
- [ ] I have have included screenshots if what the user sees will change
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
- [x] I will no longer force push to this branch
