### PR TITLE
Deflake editing test for events edited without the edit event

### DIFF
--- a/apps/web/playwright/e2e/editing/editing.spec.ts
+++ b/apps/web/playwright/e2e/editing/editing.spec.ts
@@ -358,11 +358,17 @@ test.describe("Editing", () => {
 
         // now have the cypress user join the room, jump to the original event, and wait for the event to be visible
         await app.client.joinRoom(testRoomId);
-        await app.viewRoomByName("TestRoom");
+        // joinRoom is a bare API call, so wait for the join to arrive over sync before the client can
+        // know the room (getRoom() below is null until then). Do not open the room in the UI to achieve
+        // this: that starts a scroll-to-bottom which races the permalink's scroll-to-event and can
+        // unmount the target tile from the virtualised timeline. See element-hq/element-web#30579.
+        await app.client.awaitRoomMembership(testRoomId);
         await page.goto(`#/room/${testRoomId}/${originalEventId}`);
 
         const messageTile = page.locator(`[data-event-id="${originalEventId}"]`);
-        // at this point, the edit event should still be unknown
+        // At this point the edit event should still be unknown to the client: it sits ten padding
+        // events before the end of the timeline, outside the window this permalink loaded. That is the
+        // premise of the test - the edited text below has to come from the server's bundled aggregation.
         const timeline = await app.client.evaluate(
             (cli, { testRoomId, editEventId }) => cli.getRoom(testRoomId)!.getTimelineForEvent(editEventId),
             { testRoomId, editEventId },


### PR DESCRIPTION
app.client.joinRoom is a bare API call and does not wait for the join to arrive over sync, unlike createRoom. The test worked around that without saying so by opening the room in the UI first, which only succeeds once the room has synced
- but opening it that way starts a scroll-to-bottom, and the permalink jump that follows starts a scroll-to-event. The timeline virtualises off-screen tiles, so when the two raced the target event could be unmounted before the assertions ran, failing with "element(s) not found".

Wait for the membership explicitly instead and open the room exactly once, by permalink. There is then only one scroll, so nothing to race, and the check that the edit event is still unknown keeps its place straight after that single open.

Fixes #30579

