### PR TITLE
Fix authenticated avatar fetching for macOS Touch Bar

### DIFF
--- a/apps/desktop/src/ipc.test.ts
+++ b/apps/desktop/src/ipc.test.ts
@@ -6,7 +6,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { expect, describe, it, beforeEach, afterEach, vi } from "vitest";
-import { desktopCapturer } from "electron";
+import { desktopCapturer, nativeImage, TouchBar } from "electron";
 
 import { getConfig } from "./config.js";
 import { consumeDisplayMediaCallback } from "./displayMediaCallback.js";
@@ -42,7 +42,10 @@ vi.mock("electron", () => ({
         }),
     },
     powerSaveBlocker: { isStarted: vi.fn(), start: vi.fn(), stop: vi.fn() },
-    TouchBar: class {},
+    TouchBar: class {
+        static TouchBarPopover = class {};
+        static TouchBarButton = vi.fn(function () {});
+    },
     nativeImage: { createFromBuffer: vi.fn() },
 }));
 
@@ -175,6 +178,46 @@ describe("ipcCall: clearStorage", () => {
 
         expect(clearData).toHaveBeenCalledExactlyOnceWith(session);
         expect(send).toHaveBeenCalledWith("ipcReply", { id: 15, reply: null });
+    });
+});
+
+describe("ipcCall: breadcrumbs", () => {
+    const session = { fetch: vi.fn<typeof fetch>() };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+        vi.spyOn(global, "fetch").mockResolvedValue(new Response(null, { status: 404 }));
+        (global as unknown as { mainWindow: unknown }).mainWindow = {
+            webContents: { send, session },
+            setTouchBar: vi.fn(),
+        };
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("loads avatars through the window session so authenticated media interception applies", async () => {
+        const avatarUrl = "https://example.org/_matrix/media/v3/thumbnail/example.org/avatar";
+        const bytes = new Uint8Array([1, 2, 3]);
+        session.fetch.mockResolvedValue(new Response(bytes));
+        const icon = {} as Electron.NativeImage;
+        vi.mocked(nativeImage.createFromBuffer).mockReturnValue(icon);
+
+        await callIpc("breadcrumbs", 16, [
+            [
+                { roomId: "!room:example.org", avatarUrl, initial: "R" },
+                { roomId: "!no-avatar:example.org", avatarUrl: null, initial: "N" },
+            ],
+        ]);
+
+        expect(session.fetch).toHaveBeenCalledExactlyOnceWith(avatarUrl);
+        expect(global.fetch).not.toHaveBeenCalled();
+        await vi.waitFor(() => {
+            expect(nativeImage.createFromBuffer).toHaveBeenCalledExactlyOnceWith(Buffer.from(bytes));
+            expect(vi.mocked(TouchBar.TouchBarButton).mock.instances[0]).toMatchObject({ icon, label: "" });
+        });
     });
 });
 

--- a/apps/desktop/src/ipc.ts
+++ b/apps/desktop/src/ipc.ts
@@ -190,7 +190,6 @@ ipcMain.on("ipcCall", async function (_ev: IpcMainEvent, payload) {
                             },
                         });
                         if (r.avatarUrl) {
-                            // Use the window session so authenticated media interception applies.
                             void global.mainWindow?.webContents.session
                                 .fetch(r.avatarUrl)
                                 .then((resp) => {

--- a/apps/desktop/src/ipc.ts
+++ b/apps/desktop/src/ipc.ts
@@ -190,7 +190,9 @@ ipcMain.on("ipcCall", async function (_ev: IpcMainEvent, payload) {
                             },
                         });
                         if (r.avatarUrl) {
-                            void fetch(r.avatarUrl)
+                            // Use the window session so authenticated media interception applies.
+                            void global.mainWindow?.webContents.session
+                                .fetch(r.avatarUrl)
                                 .then((resp) => {
                                     if (!resp.ok) return;
                                     return resp.arrayBuffer();


### PR DESCRIPTION
This is the smallest fix I could think of for https://github.com/element-hq/element-web/issues/34992.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] I have linked the PR to an issue that describes what needs changing.
- [x] I have written tests for new code (and old code if feasible).
- [x] I have ensured new or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] I have confirmed linter and other CI checks pass.
- [ ] I have have included screenshots if what the user sees will change => I don't have a touchbar available
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
- [x] I will no longer force push to this branch
