### PR TITLE
Only emit warnings about camelCase config settings once per setting

### DIFF
--- a/apps/web/src/utils/SnakedObject.test.ts
+++ b/apps/web/src/utils/SnakedObject.test.ts
@@ -75,7 +75,7 @@ describe("SnakedObject", () => {
         expect(warn).toHaveBeenCalledExactlyOnceWith(
             `\
 Using deprecated camelCase config camelCase
-See https://github.com/vector-im/element-web/blob/develop/docs/config.md#-deprecation-notice`
+See https://github.com/vector-im/element-web/blob/develop/docs/config.md#-deprecation-notice`,
         );
     });
 

--- a/apps/web/src/utils/SnakedObject.test.ts
+++ b/apps/web/src/utils/SnakedObject.test.ts
@@ -57,13 +57,13 @@ describe("SnakedObject", () => {
     });
 
     it("should only log camelCase warning once per key", () => {
-        const snake = new SnakedObject(input);
-
         // Given we are collecting  all warnings
+        SnakedObject.resetFallbackWarnings();
         let warn = vi.spyOn(console, "warn");
         warn.mockClear();
 
         // When we ask for the same camelCase key twice
+        const snake = new SnakedObject(input);
 
         // @ts-ignore - intentionally different case
         expect(snake.get("camel_case")).toBe(input.camelCase);
@@ -77,5 +77,26 @@ describe("SnakedObject", () => {
 Using deprecated camelCase config camelCase
 See https://github.com/vector-im/element-web/blob/develop/docs/config.md#-deprecation-notice`
         );
+    });
+
+    it("should only log camelCase warning once per key, even with different instances", () => {
+        // Given we are collecting  all warnings
+        SnakedObject.resetFallbackWarnings();
+        let warn = vi.spyOn(console, "warn");
+        warn.mockClear();
+
+        // When we ask for the same camelCase key twice, from two different
+        // instances of SnakedObject
+
+        const snake1 = new SnakedObject(input);
+        // @ts-ignore - intentionally different case
+        expect(snake1.get("camel_case")).toBe(input.camelCase);
+
+        const snake2 = new SnakedObject(input);
+        // @ts-ignore - intentionally different case
+        expect(snake2.get("camel_case")).toBe(input.camelCase);
+
+        // Then we log the warning only once
+        expect(warn).toHaveBeenCalledOnce();
     });
 });

--- a/apps/web/src/utils/SnakedObject.test.ts
+++ b/apps/web/src/utils/SnakedObject.test.ts
@@ -38,14 +38,17 @@ describe("SnakedObject", () => {
         snakeCase: "oh no", // ensure different value from snake_case for tests
         camelCase: "fallback",
     };
-    const snake = new SnakedObject(input);
 
     it("should prefer snake_case keys", () => {
+        const snake = new SnakedObject(input);
+
         expect(snake.get("snake_case")).toBe(input.snake_case);
         expect(snake.get("snake_case", "camelCase")).toBe(input.snake_case);
     });
 
     it("should fall back to camelCase keys when needed", () => {
+        const snake = new SnakedObject(input);
+
         // @ts-ignore - we're deliberately supplying a key that doesn't exist
         expect(snake.get("camel_case")).toBe(input.camelCase);
 

--- a/apps/web/src/utils/SnakedObject.test.ts
+++ b/apps/web/src/utils/SnakedObject.test.ts
@@ -59,7 +59,7 @@ describe("SnakedObject", () => {
     it("should only log camelCase warning once per key", () => {
         // Given we are collecting  all warnings
         SnakedObject.resetFallbackWarnings();
-        let warn = vi.spyOn(console, "warn");
+        const warn = vi.spyOn(console, "warn");
         warn.mockClear();
 
         // When we ask for the same camelCase key twice
@@ -82,7 +82,7 @@ See https://github.com/vector-im/element-web/blob/develop/docs/config.md#-deprec
     it("should only log camelCase warning once per key, even with different instances", () => {
         // Given we are collecting  all warnings
         SnakedObject.resetFallbackWarnings();
-        let warn = vi.spyOn(console, "warn");
+        const warn = vi.spyOn(console, "warn");
         warn.mockClear();
 
         // When we ask for the same camelCase key twice, from two different

--- a/apps/web/src/utils/SnakedObject.test.ts
+++ b/apps/web/src/utils/SnakedObject.test.ts
@@ -61,6 +61,7 @@ describe("SnakedObject", () => {
 
         // Given we are collecting  all warnings
         let warn = vi.spyOn(console, "warn");
+        warn.mockClear();
 
         // When we ask for the same camelCase key twice
 
@@ -70,7 +71,11 @@ describe("SnakedObject", () => {
         // @ts-ignore - intentionally different case
         expect(snake.get("camel_case")).toBe(input.camelCase);
 
-        // Then we log 2 lines of warning (which is actually just one combined message)
-        expect(warn).toHaveBeenCalledTimes(2);
+        // Then we log the warning only once
+        expect(warn).toHaveBeenCalledExactlyOnceWith(
+            `\
+Using deprecated camelCase config camelCase
+See https://github.com/vector-im/element-web/blob/develop/docs/config.md#-deprecation-notice`
+        );
     });
 });

--- a/apps/web/src/utils/SnakedObject.test.ts
+++ b/apps/web/src/utils/SnakedObject.test.ts
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { SnakedObject, snakeToCamel } from "./SnakedObject";
 
@@ -54,5 +54,23 @@ describe("SnakedObject", () => {
 
         // @ts-ignore - we're deliberately supplying a key that doesn't exist
         expect(snake.get("e_no_exist", "camelCase")).toBe(input.camelCase);
+    });
+
+    it("should only log camelCase warning once per key", () => {
+        const snake = new SnakedObject(input);
+
+        // Given we are collecting  all warnings
+        let warn = vi.spyOn(console, "warn");
+
+        // When we ask for the same camelCase key twice
+
+        // @ts-ignore - intentionally different case
+        expect(snake.get("camel_case")).toBe(input.camelCase);
+
+        // @ts-ignore - intentionally different case
+        expect(snake.get("camel_case")).toBe(input.camelCase);
+
+        // Then we log 2 lines of warning (which is actually just one combined message)
+        expect(warn).toHaveBeenCalledTimes(2);
     });
 });

--- a/apps/web/src/utils/SnakedObject.ts
+++ b/apps/web/src/utils/SnakedObject.ts
@@ -23,8 +23,8 @@ export class SnakedObject<T = Record<string, any>> {
         const fallback = this.obj[<K>fallbackKey];
         if (!!fallback && !this.fallbackWarnings.has(fallbackKey)) {
             this.fallbackWarnings.add(fallbackKey);
-            console.warn(`Using deprecated camelCase config ${fallbackKey}`);
             console.warn(
+                `Using deprecated camelCase config ${fallbackKey}\n` +
                 "See https://github.com/vector-im/element-web/blob/develop/docs/config.md#-deprecation-notice",
             );
         }

--- a/apps/web/src/utils/SnakedObject.ts
+++ b/apps/web/src/utils/SnakedObject.ts
@@ -40,7 +40,7 @@ export class SnakedObject<T = Record<string, any>> {
      * Clear our record of warnings we have emitted about using a camelCase
      * fallback. Likely only useful for tests.
      */
-    public static resetFallbackWarnings() {
+    public static resetFallbackWarnings(): void {
         SnakedObject.fallbackWarnings.clear();
     }
 }

--- a/apps/web/src/utils/SnakedObject.ts
+++ b/apps/web/src/utils/SnakedObject.ts
@@ -11,7 +11,7 @@ export function snakeToCamel(s: string): string {
 }
 
 export class SnakedObject<T = Record<string, any>> {
-    private fallbackWarnings = new Set<string>();
+    private static fallbackWarnings = new Set<string>();
 
     public constructor(private obj: T) {}
 
@@ -21,8 +21,8 @@ export class SnakedObject<T = Record<string, any>> {
 
         const fallbackKey = altCaseName ?? snakeToCamel(key);
         const fallback = this.obj[<K>fallbackKey];
-        if (!!fallback && !this.fallbackWarnings.has(fallbackKey)) {
-            this.fallbackWarnings.add(fallbackKey);
+        if (!!fallback && !SnakedObject.fallbackWarnings.has(fallbackKey)) {
+            SnakedObject.fallbackWarnings.add(fallbackKey);
             console.warn(
                 `Using deprecated camelCase config ${fallbackKey}\n` +
                 "See https://github.com/vector-im/element-web/blob/develop/docs/config.md#-deprecation-notice",
@@ -34,5 +34,13 @@ export class SnakedObject<T = Record<string, any>> {
     // Make JSON.stringify() pretend that everything is fine
     public toJSON(): T {
         return this.obj;
+    }
+
+    /**
+     * Clear our record of warnings we have emitted about using a camelCase
+     * fallback. Likely only useful for tests.
+     */
+    public static resetFallbackWarnings() {
+        SnakedObject.fallbackWarnings.clear();
     }
 }

--- a/apps/web/src/utils/SnakedObject.ts
+++ b/apps/web/src/utils/SnakedObject.ts
@@ -25,7 +25,7 @@ export class SnakedObject<T = Record<string, any>> {
             SnakedObject.fallbackWarnings.add(fallbackKey);
             console.warn(
                 `Using deprecated camelCase config ${fallbackKey}\n` +
-                "See https://github.com/vector-im/element-web/blob/develop/docs/config.md#-deprecation-notice",
+                    "See https://github.com/vector-im/element-web/blob/develop/docs/config.md#-deprecation-notice",
             );
         }
         return fallback;


### PR DESCRIPTION
Part of https://github.com/element-hq/element-web/issues/33449

I suggest reviewing commit by commit.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] I have linked the PR to an issue that describes what needs changing.
- [x] I have written tests for new code (and old code if feasible).
- [x] I have ensured new or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] I have confirmed linter and other CI checks pass.
- [x] I have have included screenshots if what the user sees will change
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
- [x] I will no longer force push to this branch
