### PR TITLE
Do not force identity reset if user forgets recovery key

### DIFF
--- a/apps/web/src/DeviceListener.test.ts
+++ b/apps/web/src/DeviceListener.test.ts
@@ -1404,31 +1404,6 @@ describe("DeviceListener", () => {
         });
 
         describe("needs cross-signing reset", () => {
-            it("should not need resetting if cross-signing keys are present locally or in 4S, and user has 4S key", async () => {
-                const deviceListener = await createAndStart();
-                mockCrypto.getCrossSigningStatus.mockResolvedValue({
-                    publicKeysOnDevice: true,
-                    privateKeysInSecretStorage: false,
-                    privateKeysCachedLocally: {
-                        masterKey: true,
-                        selfSigningKey: true,
-                        userSigningKey: true,
-                    },
-                });
-                expect(await deviceListener.keyStorageOutOfSyncNeedsCrossSigningReset(false)).toBe(false);
-
-                mockCrypto.getCrossSigningStatus.mockResolvedValue({
-                    publicKeysOnDevice: true,
-                    privateKeysInSecretStorage: true,
-                    privateKeysCachedLocally: {
-                        masterKey: false,
-                        selfSigningKey: false,
-                        userSigningKey: false,
-                    },
-                });
-                expect(await deviceListener.keyStorageOutOfSyncNeedsCrossSigningReset(false)).toBe(false);
-            });
-
             it("should not need resetting if cross-signing keys are present locally and user forgot 4S key", async () => {
                 const deviceListener = await createAndStart();
                 mockCrypto.getCrossSigningStatus.mockResolvedValue({
@@ -1440,7 +1415,7 @@ describe("DeviceListener", () => {
                         userSigningKey: true,
                     },
                 });
-                expect(await deviceListener.keyStorageOutOfSyncNeedsCrossSigningReset(true)).toBe(false);
+                expect(await deviceListener.keyStorageOutOfSyncNeedsCrossSigningReset()).toBe(false);
             });
 
             it("should need resetting if cross-signing keys are missing locally and user forgot 4S key", async () => {
@@ -1454,7 +1429,7 @@ describe("DeviceListener", () => {
                         userSigningKey: false,
                     },
                 });
-                expect(await deviceListener.keyStorageOutOfSyncNeedsCrossSigningReset(true)).toBe(true);
+                expect(await deviceListener.keyStorageOutOfSyncNeedsCrossSigningReset()).toBe(true);
             });
 
             it("should need resetting if cross-signing keys are missing locally and in 4S key", async () => {
@@ -1468,7 +1443,7 @@ describe("DeviceListener", () => {
                         userSigningKey: false,
                     },
                 });
-                expect(await deviceListener.keyStorageOutOfSyncNeedsCrossSigningReset(false)).toBe(true);
+                expect(await deviceListener.keyStorageOutOfSyncNeedsCrossSigningReset()).toBe(true);
             });
         });
     });

--- a/apps/web/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.test.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.test.tsx
@@ -83,18 +83,38 @@ describe("<EncryptionUserSettingsTab />", () => {
     it("should display the recovery out of sync panel when secrets are not cached", async () => {
         vi.mocked(DeviceListener.sharedInstance().getDeviceState).mockReturnValue("key_storage_out_of_sync");
 
-        const user = userEvent.setup();
         const { asFragment } = renderComponent();
 
         await waitFor(() => screen.getByRole("button", { name: "Enter recovery key" }));
         expect(asFragment()).toMatchSnapshot();
+    });
 
+    it("should enter the 'reset identity' flow if user clicks 'forgot password' and we are missing identity keys", async () => {
+        vi.mocked(DeviceListener.sharedInstance().getDeviceState).mockReturnValue("key_storage_out_of_sync");
+        vi.spyOn(DeviceListener.sharedInstance(), "keyStorageOutOfSyncNeedsCrossSigningReset").mockResolvedValue(true);
+        renderComponent();
+        await waitFor(() => screen.getByRole("button", { name: "Enter recovery key" }));
+
+        const user = userEvent.setup();
         await user.click(screen.getByRole("button", { name: "Forgot recovery key?" }));
-        expect(
-            screen.getByRole("heading", {
-                name: "Forgot your recovery key? You’ll need to reset your digital identity.",
-            }),
-        ).toBeVisible();
+        await waitFor(() =>
+            expect(
+                screen.getByRole("heading", {
+                    name: "Forgot your recovery key? You’ll need to reset your digital identity.",
+                }),
+            ).toBeVisible(),
+        );
+    });
+
+    it("should enter the 'change recovery key' flow if user clicks 'forgot password' and we have identity keys", async () => {
+        vi.mocked(DeviceListener.sharedInstance().getDeviceState).mockReturnValue("key_storage_out_of_sync");
+        vi.spyOn(DeviceListener.sharedInstance(), "keyStorageOutOfSyncNeedsCrossSigningReset").mockResolvedValue(false);
+        renderComponent();
+        await waitFor(() => screen.getByRole("button", { name: "Enter recovery key" }));
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole("button", { name: "Forgot recovery key?" }));
+        await waitFor(() => expect(screen.getByText("Change recovery key")).toBeVisible());
     });
 
     it("should display the change recovery key panel when the user clicks on the change recovery button", async () => {

--- a/apps/web/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.tsx
@@ -5,6 +5,7 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
+import { logger } from "matrix-js-sdk/src/logger";
 import React, { type JSX, useState } from "react";
 import { Button, Separator } from "@vector-im/compound-web";
 import ComputerIcon from "@vector-im/compound-design-tokens/assets/web/icons/computer";
@@ -86,7 +87,9 @@ export function EncryptionUserSettingsTab({ initialState = "main" }: Readonly<Pr
                     content = (
                         <RecoveryPanelOutOfSync
                             onFinish={() => setState("main")}
-                            onForgotRecoveryKey={() => setState("reset_identity_forgot")}
+                            onForgotRecoveryKey={async () => {
+                                setState(await encryptionSettingsStateForKeyStorageOutOfSyncForgotRecovery());
+                            }}
                             onAccessSecretStorageFailed={async () => {
                                 const needsCrossSigningReset =
                                     await DeviceListener.sharedInstance().keyStorageOutOfSyncNeedsCrossSigningReset();
@@ -241,4 +244,24 @@ function IdentityNeedsResetNoticePanel({ onContinue }: Readonly<IdentityNeedsRes
             </div>
         </SettingsSection>
     );
+}
+
+/**
+ * Calculate the correct state for the Encryption Settings after the user clicks "Forgot recovery key" on a
+ * "key storage out of sync" toast or panel.
+ */
+export async function encryptionSettingsStateForKeyStorageOutOfSyncForgotRecovery(): Promise<State> {
+    const deviceListener = DeviceListener.sharedInstance();
+    const needsCrossSigningReset = await deviceListener.keyStorageOutOfSyncNeedsCrossSigningReset();
+    if (needsCrossSigningReset) {
+        logger.info(
+            "Key storage is out of sync, user forgot recovery key, and we are missing some identity keys. Entering reset identity flow.",
+        );
+        return "reset_identity_forgot";
+    } else {
+        logger.info(
+            "Key storage is out of sync, user forgot recovery key, but we have identity keys. Entering change recovery flow.",
+        );
+        return "change_recovery_key";
+    }
 }

--- a/apps/web/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.tsx
@@ -89,9 +89,7 @@ export function EncryptionUserSettingsTab({ initialState = "main" }: Readonly<Pr
                             onForgotRecoveryKey={() => setState("reset_identity_forgot")}
                             onAccessSecretStorageFailed={async () => {
                                 const needsCrossSigningReset =
-                                    await DeviceListener.sharedInstance().keyStorageOutOfSyncNeedsCrossSigningReset(
-                                        true,
-                                    );
+                                    await DeviceListener.sharedInstance().keyStorageOutOfSyncNeedsCrossSigningReset();
                                 setState(needsCrossSigningReset ? "reset_identity_sync_failed" : "change_recovery_key");
                             }}
                         />

--- a/apps/web/src/device-listener/DeviceListener.ts
+++ b/apps/web/src/device-listener/DeviceListener.ts
@@ -174,7 +174,7 @@ export class DeviceListener {
      * we have a complete set between the two, we could be OK, but that
      * should be exceptionally rare, and is more complicated to detect.
      */
-    public async keyStorageOutOfSyncNeedsCrossSigningReset(forgotRecovery: boolean): Promise<boolean> {
+    public async keyStorageOutOfSyncNeedsCrossSigningReset(): Promise<boolean> {
         const crypto = this.client?.getCrypto();
         if (!crypto) {
             return false;
@@ -185,11 +185,7 @@ export class DeviceListener {
             crossSigningStatus.privateKeysCachedLocally.selfSigningKey &&
             crossSigningStatus.privateKeysCachedLocally.userSigningKey;
 
-        if (forgotRecovery) {
-            return !allCrossSigningSecretsCached;
-        } else {
-            return !allCrossSigningSecretsCached && !crossSigningStatus.privateKeysInSecretStorage;
-        }
+        return !allCrossSigningSecretsCached;
     }
 
     /**

--- a/apps/web/src/toasts/SetupEncryptionToast.tsx
+++ b/apps/web/src/toasts/SetupEncryptionToast.tsx
@@ -32,6 +32,7 @@ import ConfirmKeyStorageOffDialog from "../components/views/dialogs/ConfirmKeySt
 import { MatrixClientPeg } from "../MatrixClientPeg";
 import { resetKeyBackupAndWait } from "../utils/crypto/resetKeyBackup";
 import { PosthogAnalytics } from "../PosthogAnalytics";
+import { encryptionSettingsStateForKeyStorageOutOfSyncForgotRecovery } from "../components/views/settings/tabs/user/EncryptionUserSettingsTab.tsx";
 
 const TOAST_KEY = "setupencryption";
 
@@ -273,11 +274,8 @@ export const showToast = (state: DeviceStateForToast): void => {
             }
             case "key_storage_out_of_sync": {
                 // Open the user settings dialog to the encryption tab and start the flow to reset encryption or change the recovery key
-                const deviceListener = DeviceListener.sharedInstance();
-                const needsCrossSigningReset = await deviceListener.keyStorageOutOfSyncNeedsCrossSigningReset();
-                const props = {
-                    initialEncryptionState: needsCrossSigningReset ? "reset_identity_forgot" : "change_recovery_key",
-                };
+                const initialEncryptionState = await encryptionSettingsStateForKeyStorageOutOfSyncForgotRecovery();
+                const props = { initialEncryptionState };
                 myLogger.debug(`Secondary button clicked: opening encryption settings dialog with props`, props);
                 const payload: OpenToTabPayload = {
                     action: Action.ViewUserSettings,

--- a/apps/web/src/toasts/SetupEncryptionToast.tsx
+++ b/apps/web/src/toasts/SetupEncryptionToast.tsx
@@ -274,7 +274,7 @@ export const showToast = (state: DeviceStateForToast): void => {
             case "key_storage_out_of_sync": {
                 // Open the user settings dialog to the encryption tab and start the flow to reset encryption or change the recovery key
                 const deviceListener = DeviceListener.sharedInstance();
-                const needsCrossSigningReset = await deviceListener.keyStorageOutOfSyncNeedsCrossSigningReset(true);
+                const needsCrossSigningReset = await deviceListener.keyStorageOutOfSyncNeedsCrossSigningReset();
                 const props = {
                     initialEncryptionState: needsCrossSigningReset ? "reset_identity_forgot" : "change_recovery_key",
                 };
@@ -329,7 +329,7 @@ export const showToast = (state: DeviceStateForToast): void => {
             // A real error happened - jump to the reset identity or change
             // recovery tab
             const needsCrossSigningReset =
-                await DeviceListener.sharedInstance().keyStorageOutOfSyncNeedsCrossSigningReset(true);
+                await DeviceListener.sharedInstance().keyStorageOutOfSyncNeedsCrossSigningReset();
             const props = {
                 initialEncryptionState: needsCrossSigningReset ? "reset_identity_sync_failed" : "change_recovery_key",
             };


### PR DESCRIPTION
If we are missing the backup decryption key, and the user has forgotten the recovery key, we do not need to reset the user's identity: it is adequate to change the recovery key and create a new key backup.

We already support this for the "key storage out of sync" toast, but if the user opens the encryption settings and clicks "forgot recovery key" on the "storage out of sync" panel there, we currently force them to do an identity reset.

Fixes: #35004

Includes a preparatory refactoring commit: review commit-by-commit.