### PR TITLE
simplify ChangeRecoveryKey states

### DIFF
--- a/apps/web/src/components/views/settings/encryption/ChangeRecoveryKey.test.tsx
+++ b/apps/web/src/components/views/settings/encryption/ChangeRecoveryKey.test.tsx
@@ -252,5 +252,46 @@ describe("<ChangeRecoveryKey />", () => {
             expect(screen.getByText("encoded private key")).toBeInTheDocument();
             expect(asFragment()).toMatchSnapshot();
         });
+
+        it("should ask the user to enter the recovery key", async () => {
+            vi.spyOn(DeviceListener.sharedInstance(), "keyStorageOutOfSyncNeedsBackupReset").mockResolvedValue(false);
+
+            const user = userEvent.setup();
+
+            const onFinish = vi.fn();
+            const { asFragment } = renderComponent(true, onFinish);
+
+            // Display the form to confirm the recovery key
+            await waitFor(() => user.click(screen.getByRole("button", { name: "Continue" })));
+
+            await waitFor(() =>
+                expect(
+                    screen.getByText("Enter your new recovery key below to finish. Your old one will no longer work."),
+                ).toBeInTheDocument(),
+            );
+            expect(asFragment()).toMatchSnapshot();
+
+            // The finish button should be disabled by default
+            const finishButton = screen.getByRole("button", { name: "Confirm new recovery key" });
+            expect(finishButton).toHaveAttribute("aria-disabled", "true");
+
+            const input = screen.getByTitle("Enter recovery key");
+            // If the user enters an incorrect recovery key, the finish button should be disabled
+            // and we display an error message
+            await userEvent.type(input, "wrong recovery key");
+            expect(finishButton).toHaveAttribute("aria-disabled", "true");
+            expect(screen.getByText("The recovery key you entered is not correct.")).toBeInTheDocument();
+            expect(asFragment()).toMatchSnapshot();
+
+            const setAccountDataSpy = vi.spyOn(matrixClient, "setAccountData");
+            await userEvent.clear(input);
+            // If the user enters the correct recovery key, the finish button should be enabled
+            await userEvent.type(input, "encoded private key");
+            await waitFor(() => expect(finishButton).not.toHaveAttribute("aria-disabled", "true"));
+
+            await user.click(finishButton);
+            expect(setAccountDataSpy).toHaveBeenCalledWith("io.element.recovery", { enabled: true });
+            expect(onFinish).toHaveBeenCalledWith();
+        });
     });
 });

--- a/apps/web/src/components/views/settings/encryption/ChangeRecoveryKey.tsx
+++ b/apps/web/src/components/views/settings/encryption/ChangeRecoveryKey.tsx
@@ -37,22 +37,16 @@ import { resetKeyBackupAndWait } from "../../../../utils/crypto/resetKeyBackup";
 /**
  * The possible states of the component.
  * - `inform_user`: The user is informed about the recovery key.
- * - `save_key_setup_flow`: The user is asked to save the new recovery key during the setup flow.
- * - `save_key_change_flow`: The user is asked to save the new recovery key during the change key flow.
- * - `confirm_key_setup_flow`: The user is asked to confirm the new recovery key during the set up flow.
- * - `confirm_key_change_flow`: The user is asked to confirm the new recovery key during the change key flow.
+ * - `save_key_flow`: A new generated recovery key is displayed to the user and they are asked to save it.
+ * - `confirm_key_flow`: The user is asked to confirm the new recovery key.
  */
-type State =
-    | "inform_user"
-    | "save_key_setup_flow"
-    | "save_key_change_flow"
-    | "confirm_key_setup_flow"
-    | "confirm_key_change_flow";
+type State = "inform_user" | "save_key_flow" | "confirm_key_flow";
 
 interface ChangeRecoveryKeyProps {
     /**
-     * If true, the component will display the flow to change the recovery key.
-     * If false,the component will display the flow to set up a new recovery key.
+     * Whether the user already has a recovery key.
+     * This affects some labels (referring to changing the recovery key, versus setting up recovery), and the starting
+     * state of component (whether the introductory text is shown or not).
      */
     userHasRecoveryKey: boolean;
     /**
@@ -77,7 +71,7 @@ export function ChangeRecoveryKey({
 
     // If the user is setting up recovery for the first time, we first show them a panel explaining what
     // "recovery" is about. Otherwise, we jump straight to showing the user the new key.
-    const [state, setState] = useState<State>(userHasRecoveryKey ? "save_key_change_flow" : "inform_user");
+    const [state, setState] = useState<State>(userHasRecoveryKey ? "save_key_flow" : "inform_user");
 
     const onCancelClickWrapper = useCallback(() => {
         logger.debug("ChangeRecoveryKey: user cancelled");
@@ -95,31 +89,23 @@ export function ChangeRecoveryKey({
             // Show a panel explaining what "recovery" is for, and what a recovery key does.
             content = (
                 <InformationPanel
-                    onContinueClick={() => setState("save_key_setup_flow")}
+                    onContinueClick={() => setState("save_key_flow")}
                     onCancelClick={onCancelClickWrapper}
                 />
             );
             break;
-        case "save_key_setup_flow":
-        case "save_key_change_flow":
+        case "save_key_flow":
             // Show a generated recovery key and ask the user to save it.
             content = (
                 <KeyPanel
                     // encodedPrivateKey is always defined, the optional typing is incorrect
                     recoveryKey={recoveryKey.encodedPrivateKey!}
-                    onConfirmClick={() =>
-                        setState((currentState) =>
-                            currentState === "save_key_change_flow"
-                                ? "confirm_key_change_flow"
-                                : "confirm_key_setup_flow",
-                        )
-                    }
+                    onConfirmClick={() => setState("confirm_key_flow")}
                     onCancelClick={onCancelClickWrapper}
                 />
             );
             break;
-        case "confirm_key_setup_flow":
-        case "confirm_key_change_flow":
+        case "confirm_key_flow":
             // Ask the user to enter the recovery key they just saved to confirm it.
             content = (
                 <KeyForm
@@ -166,9 +152,9 @@ export function ChangeRecoveryKey({
                         }
                     }}
                     submitButtonLabel={
-                        state === "confirm_key_setup_flow"
-                            ? _t("settings|encryption|recovery|set_up_recovery_confirm_button")
-                            : _t("settings|encryption|recovery|change_recovery_confirm_button")
+                        userHasRecoveryKey
+                            ? _t("settings|encryption|recovery|change_recovery_confirm_button")
+                            : _t("settings|encryption|recovery|set_up_recovery_confirm_button")
                     }
                 />
             );
@@ -180,7 +166,7 @@ export function ChangeRecoveryKey({
             ? _t("settings|encryption|recovery|change_recovery_key")
             : _t("settings|encryption|recovery|set_up_recovery"),
     ];
-    const labels = getLabels(state);
+    const labels = getLabels(state, userHasRecoveryKey);
 
     return (
         <>
@@ -217,7 +203,7 @@ type Labels = {
  * Get the header title and description for the given state.
  * @param state
  */
-function getLabels(state: State): Labels {
+function getLabels(state: State, userHasRecoveryKey: boolean): Labels {
     switch (state) {
         case "inform_user":
             return {
@@ -226,26 +212,26 @@ function getLabels(state: State): Labels {
                     changeRecoveryKeyButton: _t("settings|encryption|recovery|change_recovery_key"),
                 }),
             };
-        case "save_key_setup_flow":
-            return {
-                title: _t("settings|encryption|recovery|set_up_recovery_save_key_title"),
-                description: _t("settings|encryption|recovery|set_up_recovery_save_key_description"),
-            };
-        case "save_key_change_flow":
-            return {
-                title: _t("settings|encryption|recovery|change_recovery_key_title"),
-                description: _t("settings|encryption|recovery|change_recovery_key_description"),
-            };
-        case "confirm_key_setup_flow":
-            return {
-                title: _t("settings|encryption|recovery|set_up_recovery_confirm_title"),
-                description: _t("settings|encryption|recovery|set_up_recovery_confirm_description"),
-            };
-        case "confirm_key_change_flow":
-            return {
-                title: _t("settings|encryption|recovery|change_recovery_confirm_title"),
-                description: _t("settings|encryption|recovery|change_recovery_confirm_description"),
-            };
+        case "save_key_flow":
+            return userHasRecoveryKey
+                ? {
+                      title: _t("settings|encryption|recovery|change_recovery_key_title"),
+                      description: _t("settings|encryption|recovery|change_recovery_key_description"),
+                  }
+                : {
+                      title: _t("settings|encryption|recovery|set_up_recovery_save_key_title"),
+                      description: _t("settings|encryption|recovery|set_up_recovery_save_key_description"),
+                  };
+        case "confirm_key_flow":
+            return userHasRecoveryKey
+                ? {
+                      title: _t("settings|encryption|recovery|change_recovery_confirm_title"),
+                      description: _t("settings|encryption|recovery|change_recovery_confirm_description"),
+                  }
+                : {
+                      title: _t("settings|encryption|recovery|set_up_recovery_confirm_title"),
+                      description: _t("settings|encryption|recovery|set_up_recovery_confirm_description"),
+                  };
     }
 }
 

--- a/apps/web/src/components/views/settings/encryption/__snapshots__/ChangeRecoveryKey.test.tsx.snap
+++ b/apps/web/src/components/views/settings/encryption/__snapshots__/ChangeRecoveryKey.test.tsx.snap
@@ -1,5 +1,349 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`<ChangeRecoveryKey /> > flow to change the recovery key > should ask the user to enter the recovery key 1`] = `
+<DocumentFragment>
+  <nav
+    class="_breadcrumb_t96w3_8"
+  >
+    <button
+      aria-disabled="false"
+      aria-label="Back"
+      class="_icon-button_1215g_8"
+      data-kind="secondary"
+      role="button"
+      style="--cpd-icon-button-size: 28px;"
+      tabindex="0"
+    >
+      <div
+        class="_indicator-icon_147l5_17"
+        style="--cpd-icon-button-size: 100%;"
+      >
+        <svg
+          fill="currentColor"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m13.3 17.3-4.6-4.6a.9.9 0 0 1-.213-.325A1.1 1.1 0 0 1 8.425 12q0-.2.062-.375A.9.9 0 0 1 8.7 11.3l4.6-4.6a.95.95 0 0 1 .7-.275q.425 0 .7.275a.95.95 0 0 1 .275.7.95.95 0 0 1-.275.7L10.8 12l3.9 3.9a.95.95 0 0 1 .275.7.95.95 0 0 1-.275.7.95.95 0 0 1-.7.275.95.95 0 0 1-.7-.275"
+          />
+        </svg>
+      </div>
+    </button>
+    <ol
+      class="_pages_t96w3_17"
+    >
+      <li>
+        <a
+          class="_link_13esb_8"
+          data-kind="primary"
+          data-size="sm"
+          rel="noreferrer noopener"
+          role="button"
+          tabindex="0"
+        >
+          Encryption
+        </a>
+      </li>
+      <li>
+        <span
+          aria-current="page"
+          class="_last-page_t96w3_30"
+        >
+          Change recovery key
+        </span>
+      </li>
+    </ol>
+  </nav>
+  <div
+    class="mx_EncryptionCard mx_ChangeRecoveryKey"
+  >
+    <div
+      class="mx_EncryptionCard_header"
+    >
+      <div
+        class="_big-icon_1ssbv_8"
+        data-kind="primary"
+        data-size="lg"
+      >
+        <svg
+          fill="currentColor"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10.475 16.9A5.86 5.86 0 0 1 7 18q-2.5 0-4.25-1.75T1 12t1.75-4.25T7 6q2.026 0 3.537 1.15Q12.05 8.3 12.65 10h7.95q.2 0 .387.075.189.075.338.225l1.025 1.025a1 1 0 0 1 .2.288q.075.162.075.362t-.062.375a1.1 1.1 0 0 1-.188.325l-2.25 2.575a.97.97 0 0 1-1.038.313 1 1 0 0 1-.337-.188L17 14l-1.3 1.3q-.15.15-.325.212a1.1 1.1 0 0 1-.375.063q-.2 0-.375-.062a.9.9 0 0 1-.325-.213L13 14h-.35a5.8 5.8 0 0 1-2.175 2.9m-4.887-3.487Q6.175 14 7 14q.824 0 1.412-.588Q9 12.826 9 12t-.588-1.412A1.93 1.93 0 0 0 7 10q-.824 0-1.412.588A1.93 1.93 0 0 0 5 12q0 .825.588 1.412"
+          />
+        </svg>
+      </div>
+      <h2
+        class="_typography_6v6n8_153 _font-heading-sm-semibold_6v6n8_93"
+      >
+        Enter your new recovery key
+      </h2>
+      <span>
+        Enter your new recovery key below to finish. Your old one will no longer work.
+      </span>
+    </div>
+    <form
+      class="_root_1o4d9_17 mx_KeyForm"
+    >
+      <div
+        class="_field_1o4d9_27"
+      >
+        <label
+          class="_label_1o4d9_60"
+          for="radix-react-use-id-1"
+        >
+          Enter recovery key
+        </label>
+        <div
+          class="_container_1s836_8 mx_KeyForm_password mx_no_textinput"
+          id="react-use-id-2"
+        >
+          <input
+            class="_control_d83jn_10 _control_1s836_13"
+            id="radix-react-use-id-1"
+            name="recoveryKey"
+            required=""
+            title="Enter recovery key"
+            type="password"
+          />
+          <button
+            aria-controls="react-use-id-2"
+            aria-labelledby="react-use-id-3"
+            class="_action_1s836_24"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m16.1 13.3-1.45-1.45q.225-1.175-.675-2.2t-2.325-.8L10.2 7.4q.424-.2.863-.3A4.2 4.2 0 0 1 12 7q1.875 0 3.188 1.312Q16.5 9.625 16.5 11.5q0 .5-.1.938t-.3.862m3.2 3.15-1.45-1.4a11 11 0 0 0 1.688-1.588A9 9 0 0 0 20.8 11.5q-1.25-2.524-3.588-4.013Q14.875 6 12 6q-.724 0-1.425.1a10 10 0 0 0-1.375.3L7.65 4.85A11.1 11.1 0 0 1 12 4q3.575 0 6.425 1.887T22.7 10.8a.8.8 0 0 1 .1.313q.025.188.025.387a2 2 0 0 1-.125.7 10.9 10.9 0 0 1-3.4 4.25m-.2 5.45-3.5-3.45q-.874.274-1.762.413Q12.95 19 12 19q-3.575 0-6.425-1.887T1.3 12.2a.8.8 0 0 1-.1-.312 3 3 0 0 1 0-.763.8.8 0 0 1 .1-.3Q1.825 9.7 2.55 8.75A13.3 13.3 0 0 1 4.15 7L2.075 4.9a.93.93 0 0 1-.275-.688q0-.412.3-.712a.95.95 0 0 1 .7-.275q.425 0 .7.275l17 17q.275.275.288.688a.93.93 0 0 1-.288.712.95.95 0 0 1-.7.275.95.95 0 0 1-.7-.275M5.55 8.4q-.725.65-1.325 1.425A9 9 0 0 0 3.2 11.5q1.25 2.524 3.588 4.012T12 17q.5 0 .975-.062.475-.063.975-.138l-.9-.95q-.274.075-.525.113A3.5 3.5 0 0 1 12 16q-1.875 0-3.187-1.312Q7.5 13.375 7.5 11.5q0-.274.038-.525.037-.25.112-.525z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div
+        class="mx_EncryptionCard_buttons"
+      >
+        <button
+          aria-disabled="true"
+          class="_button_1nw83_8"
+          data-kind="primary"
+          data-size="lg"
+          role="button"
+          tabindex="0"
+        >
+          Confirm new recovery key
+        </button>
+        <button
+          class="_button_1nw83_8"
+          data-kind="tertiary"
+          data-size="lg"
+          role="button"
+          tabindex="0"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<ChangeRecoveryKey /> > flow to change the recovery key > should ask the user to enter the recovery key 2`] = `
+<DocumentFragment>
+  <nav
+    class="_breadcrumb_t96w3_8"
+  >
+    <button
+      aria-disabled="false"
+      aria-label="Back"
+      class="_icon-button_1215g_8"
+      data-kind="secondary"
+      role="button"
+      style="--cpd-icon-button-size: 28px;"
+      tabindex="0"
+    >
+      <div
+        class="_indicator-icon_147l5_17"
+        style="--cpd-icon-button-size: 100%;"
+      >
+        <svg
+          fill="currentColor"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m13.3 17.3-4.6-4.6a.9.9 0 0 1-.213-.325A1.1 1.1 0 0 1 8.425 12q0-.2.062-.375A.9.9 0 0 1 8.7 11.3l4.6-4.6a.95.95 0 0 1 .7-.275q.425 0 .7.275a.95.95 0 0 1 .275.7.95.95 0 0 1-.275.7L10.8 12l3.9 3.9a.95.95 0 0 1 .275.7.95.95 0 0 1-.275.7.95.95 0 0 1-.7.275.95.95 0 0 1-.7-.275"
+          />
+        </svg>
+      </div>
+    </button>
+    <ol
+      class="_pages_t96w3_17"
+    >
+      <li>
+        <a
+          class="_link_13esb_8"
+          data-kind="primary"
+          data-size="sm"
+          rel="noreferrer noopener"
+          role="button"
+          tabindex="0"
+        >
+          Encryption
+        </a>
+      </li>
+      <li>
+        <span
+          aria-current="page"
+          class="_last-page_t96w3_30"
+        >
+          Change recovery key
+        </span>
+      </li>
+    </ol>
+  </nav>
+  <div
+    class="mx_EncryptionCard mx_ChangeRecoveryKey"
+  >
+    <div
+      class="mx_EncryptionCard_header"
+    >
+      <div
+        class="_big-icon_1ssbv_8"
+        data-kind="primary"
+        data-size="lg"
+      >
+        <svg
+          fill="currentColor"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10.475 16.9A5.86 5.86 0 0 1 7 18q-2.5 0-4.25-1.75T1 12t1.75-4.25T7 6q2.026 0 3.537 1.15Q12.05 8.3 12.65 10h7.95q.2 0 .387.075.189.075.338.225l1.025 1.025a1 1 0 0 1 .2.288q.075.162.075.362t-.062.375a1.1 1.1 0 0 1-.188.325l-2.25 2.575a.97.97 0 0 1-1.038.313 1 1 0 0 1-.337-.188L17 14l-1.3 1.3q-.15.15-.325.212a1.1 1.1 0 0 1-.375.063q-.2 0-.375-.062a.9.9 0 0 1-.325-.213L13 14h-.35a5.8 5.8 0 0 1-2.175 2.9m-4.887-3.487Q6.175 14 7 14q.824 0 1.412-.588Q9 12.826 9 12t-.588-1.412A1.93 1.93 0 0 0 7 10q-.824 0-1.412.588A1.93 1.93 0 0 0 5 12q0 .825.588 1.412"
+          />
+        </svg>
+      </div>
+      <h2
+        class="_typography_6v6n8_153 _font-heading-sm-semibold_6v6n8_93"
+      >
+        Enter your new recovery key
+      </h2>
+      <span>
+        Enter your new recovery key below to finish. Your old one will no longer work.
+      </span>
+    </div>
+    <form
+      class="_root_1o4d9_17 mx_KeyForm"
+    >
+      <div
+        class="_field_1o4d9_27"
+        data-invalid="true"
+      >
+        <label
+          class="_label_1o4d9_60"
+          data-invalid="true"
+          for="radix-react-use-id-1"
+        >
+          Enter recovery key
+        </label>
+        <div
+          class="_container_1s836_8 mx_KeyForm_password mx_no_textinput"
+          id="react-use-id-2"
+        >
+          <input
+            aria-describedby="radix-react-use-id-3"
+            aria-invalid="true"
+            class="_control_d83jn_10 _control_1s836_13"
+            data-invalid="true"
+            id="radix-react-use-id-1"
+            name="recoveryKey"
+            required=""
+            title="Enter recovery key"
+            type="password"
+          />
+          <button
+            aria-controls="react-use-id-2"
+            aria-labelledby="react-use-id-4"
+            class="_action_1s836_24"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m16.1 13.3-1.45-1.45q.225-1.175-.675-2.2t-2.325-.8L10.2 7.4q.424-.2.863-.3A4.2 4.2 0 0 1 12 7q1.875 0 3.188 1.312Q16.5 9.625 16.5 11.5q0 .5-.1.938t-.3.862m3.2 3.15-1.45-1.4a11 11 0 0 0 1.688-1.588A9 9 0 0 0 20.8 11.5q-1.25-2.524-3.588-4.013Q14.875 6 12 6q-.724 0-1.425.1a10 10 0 0 0-1.375.3L7.65 4.85A11.1 11.1 0 0 1 12 4q3.575 0 6.425 1.887T22.7 10.8a.8.8 0 0 1 .1.313q.025.188.025.387a2 2 0 0 1-.125.7 10.9 10.9 0 0 1-3.4 4.25m-.2 5.45-3.5-3.45q-.874.274-1.762.413Q12.95 19 12 19q-3.575 0-6.425-1.887T1.3 12.2a.8.8 0 0 1-.1-.312 3 3 0 0 1 0-.763.8.8 0 0 1 .1-.3Q1.825 9.7 2.55 8.75A13.3 13.3 0 0 1 4.15 7L2.075 4.9a.93.93 0 0 1-.275-.688q0-.412.3-.712a.95.95 0 0 1 .7-.275q.425 0 .7.275l17 17q.275.275.288.688a.93.93 0 0 1-.288.712.95.95 0 0 1-.7.275.95.95 0 0 1-.7-.275M5.55 8.4q-.725.65-1.325 1.425A9 9 0 0 0 3.2 11.5q1.25 2.524 3.588 4.012T12 17q.5 0 .975-.062.475-.063.975-.138l-.9-.95q-.274.075-.525.113A3.5 3.5 0 0 1 12 16q-1.875 0-3.187-1.312Q7.5 13.375 7.5 11.5q0-.274.038-.525.037-.25.112-.525z"
+              />
+            </svg>
+          </button>
+        </div>
+        <span
+          class="_message_1o4d9_86 _error-message_1o4d9_96"
+          id="radix-react-use-id-3"
+        >
+          <svg
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 17q.424 0 .713-.288A.97.97 0 0 0 13 16a.97.97 0 0 0-.287-.713A.97.97 0 0 0 12 15a.97.97 0 0 0-.713.287A.97.97 0 0 0 11 16q0 .424.287.712.288.288.713.288m0-4q.424 0 .713-.287A.97.97 0 0 0 13 12V8a.97.97 0 0 0-.287-.713A.97.97 0 0 0 12 7a.97.97 0 0 0-.713.287A.97.97 0 0 0 11 8v4q0 .424.287.713.288.287.713.287m0 9a9.7 9.7 0 0 1-3.9-.788 10.1 10.1 0 0 1-3.175-2.137q-1.35-1.35-2.137-3.175A9.7 9.7 0 0 1 2 12q0-2.075.788-3.9a10.1 10.1 0 0 1 2.137-3.175q1.35-1.35 3.175-2.137A9.7 9.7 0 0 1 12 2q2.075 0 3.9.788a10.1 10.1 0 0 1 3.175 2.137q1.35 1.35 2.137 3.175A9.7 9.7 0 0 1 22 12a9.7 9.7 0 0 1-.788 3.9 10.1 10.1 0 0 1-2.137 3.175q-1.35 1.35-3.175 2.137A9.7 9.7 0 0 1 12 22"
+            />
+          </svg>
+          The recovery key you entered is not correct.
+        </span>
+      </div>
+      <div
+        class="mx_EncryptionCard_buttons"
+      >
+        <button
+          aria-disabled="true"
+          class="_button_1nw83_8"
+          data-kind="primary"
+          data-size="lg"
+          role="button"
+          tabindex="0"
+        >
+          Confirm new recovery key
+        </button>
+        <button
+          class="_button_1nw83_8"
+          data-kind="tertiary"
+          data-size="lg"
+          role="button"
+          tabindex="0"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`<ChangeRecoveryKey /> > flow to change the recovery key > should display the recovery key 1`] = `
 <DocumentFragment>
   <nav


### PR DESCRIPTION
This component had separate sets of states for setting up a new recovery key, or changing a recovery key.  The states are almost identical, and can also be distinguished by the value `userHasRecoveryKey` property (if `userHasRecoveryKey` is `true` then it will always use the `change` states, and if `false` will use the `setup` states).  So this PR collapses the states and uses `userHasRecoveryKey` instead.

Also some improvements to the comments.

<!-- Thanks for submitting a PR! This checklist has the essential things that needs to be done so we can review your PR. Make sure each item is completed before checking its box. -->

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] I have linked the PR to an issue that describes what needs changing.
- [x] I have written tests for new code (and old code if feasible).
- [ ] ~I have ensured new or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.~
- [x] I have confirmed linter and other CI checks pass.
- [ ] ~I have have included screenshots if what the user sees will change~
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
- [x] I will no longer force push to this branch
