### PR TITLE
Room list: a room opened in the spotlight should be displayed in the room list

### DIFF
--- a/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-search.spec.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-search.spec.ts
@@ -5,10 +5,11 @@
  * Please see LICENSE files in the repository root for full details.
  */
 
+import { type Page } from "@playwright/test";
 import { rejectToast } from "@element-hq/element-web-playwright-common";
 
 import { test, expect } from "../../../element-web-test";
-import { getSearchSection } from "./utils";
+import { createFillerRooms, getRoomList, getSearchSection, getSectionHeader, sortAlphabetically } from "./utils";
 
 test.describe("Search section of the room list", () => {
     test.beforeEach(async ({ page, app, user }) => {
@@ -39,5 +40,48 @@ test.describe("Search section of the room list", () => {
         await expect(dialog).toBeVisible();
         // The public room filter should be displayed
         await expect(dialog.getByText("Public rooms")).toBeVisible();
+    });
+
+    /** Open the spotlight, search for `name` and pick the first result. */
+    async function pickRoomFromSpotlight(page: Page, name: string): Promise<void> {
+        await getSearchSection(page).getByRole("button", { name: "Search", exact: false }).click();
+        const dialog = page.getByRole("dialog", { name: "Search Dialog" });
+        await dialog.getByRole("textbox", { name: "Search" }).fill(name);
+        await dialog.getByRole("option", { name }).first().click();
+        await expect(dialog).not.toBeVisible();
+    }
+
+    test("should scroll a room picked from the spotlight into view", async ({ page, app, user }) => {
+        // A room named so it sorts to the very bottom under A-Z, pushed below the fold by fillers.
+        await app.client.createRoom({ name: "zzz search target" });
+        await createFillerRooms(app, 20);
+        await sortAlphabetically(page);
+
+        const targetRow = getRoomList(page).getByRole("option", { name: "Open room zzz search target" });
+        await expect(targetRow).not.toBeInViewport();
+
+        await pickRoomFromSpotlight(page, "zzz search target");
+
+        await expect(targetRow).toBeInViewport();
+    });
+
+    test("should expand a collapsed section to show a room picked from the spotlight", async ({ page, app, user }) => {
+        const targetId = await app.client.createRoom({ name: "zzz search target" });
+        await app.client.evaluate(async (client, roomId) => {
+            await client.setRoomTag(roomId, "m.favourite");
+        }, targetId);
+        await createFillerRooms(app, 5);
+
+        const favouritesHeader = getSectionHeader(page, "Favourites");
+        await expect(favouritesHeader).toBeVisible();
+        await favouritesHeader.click();
+        await expect(favouritesHeader).toHaveAttribute("aria-expanded", "false");
+
+        await pickRoomFromSpotlight(page, "zzz search target");
+
+        await expect(favouritesHeader).toHaveAttribute("aria-expanded", "true");
+        // A sectioned list is a treegrid, so rooms are rows rather than options.
+        const targetRow = getRoomList(page).getByRole("row", { name: "Open room zzz search target" });
+        await expect(targetRow).toBeInViewport();
     });
 });

--- a/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-unread-toast.spec.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/room-list-unread-toast.spec.ts
@@ -9,8 +9,7 @@ import { type Page } from "@playwright/test";
 import { rejectToast } from "@element-hq/element-web-playwright-common";
 
 import { expect, test } from "../../../element-web-test";
-import { type ElementAppPage } from "../../../pages/ElementAppPage";
-import { getRoomList, getRoomOptionsMenu, getSectionHeader } from "./utils";
+import { createFillerRooms, getRoomList, getSectionHeader, sortAlphabetically } from "./utils";
 
 /**
  * The unread-activity toast ("Unread messages") appears at the bottom of the room list when a room with a
@@ -27,22 +26,6 @@ test.describe("Room list unread activity toast", () => {
     });
 
     const getToast = (page: Page) => page.getByRole("button", { name: "Unread messages" });
-
-    /**
-     * Create `count` filler rooms whose names sort alphabetically before any room named "zzz …",
-     * so that under A-Z sorting they fill the top of the list and push the "zzz …" room below the fold.
-     */
-    async function createFillerRooms(app: ElementAppPage, count: number): Promise<void> {
-        for (let i = 0; i < count; i++) {
-            await app.client.createRoom({ name: `room ${String(i).padStart(2, "0")}` });
-        }
-    }
-
-    /** Switch the room list to alphabetical sorting so room positions are deterministic. */
-    async function sortAlphabetically(page: Page): Promise<void> {
-        await getRoomOptionsMenu(page).click();
-        await page.getByRole("menuitemradio", { name: "A-Z" }).click();
-    }
 
     test.describe("flat list", () => {
         test.beforeEach(async ({ page, app, user }) => {

--- a/apps/web/playwright/e2e/left-panel/room-list-panel/utils.ts
+++ b/apps/web/playwright/e2e/left-panel/room-list-panel/utils.ts
@@ -7,6 +7,8 @@
 
 import { expect, type Locator, type Page } from "@playwright/test";
 
+import { type ElementAppPage } from "../../../pages/ElementAppPage";
+
 /**
  * Get the room list
  * @param page
@@ -219,4 +221,20 @@ export function getRoomListView(page: Page) {
  */
 export function getSearchSection(page: Page) {
     return page.getByRole("search");
+}
+
+/**
+ * Create `count` filler rooms whose names sort alphabetically before any room named "zzz …",
+ * so that under A-Z sorting they fill the top of the list and push the "zzz …" room below the fold.
+ */
+export async function createFillerRooms(app: ElementAppPage, count: number): Promise<void> {
+    for (let i = 0; i < count; i++) {
+        await app.client.createRoom({ name: `room ${String(i).padStart(2, "0")}` });
+    }
+}
+
+/** Switch the room list to alphabetical sorting so room positions are deterministic. */
+export async function sortAlphabetically(page: Page): Promise<void> {
+    await getRoomOptionsMenu(page).click();
+    await page.getByRole("menuitemradio", { name: "A-Z" }).click();
 }

--- a/apps/web/playwright/e2e/timeline/media-preview-settings.spec.ts
+++ b/apps/web/playwright/e2e/timeline/media-preview-settings.spec.ts
@@ -54,7 +54,6 @@ test.describe("Media preview settings", () => {
             `,
         });
 
-        await page.getByRole("button", { name: "Toggle Invites section" }).click();
         const testRoomTile = page
             .getByRole("treegrid", { name: "Room list" })
             .getByRole("button", { name: "Test room" });

--- a/apps/web/src/viewmodels/room-list/RoomListViewModel.test.ts
+++ b/apps/web/src/viewmodels/room-list/RoomListViewModel.test.ts
@@ -1831,14 +1831,20 @@ describe("RoomListViewModel", () => {
         });
     });
 
-    describe("show_room_tile scroll", () => {
+    describe("scrolling the active room into view", () => {
         beforeEach(() => {
             // Dispatching ViewRoom is also handled by the global RoomViewStore, which calls
             // MatrixClientPeg.safeGet(); stubClient sets up the peg so that doesn't throw.
             stubClient();
         });
 
-        it("should scroll a room into view in a flat list", async () => {
+        it.each([
+            [
+                "a ViewRoom dispatch asking for the tile",
+                { action: Action.ViewRoom, room_id: "!room2:server", show_room_tile: true, metricsTrigger: undefined },
+            ],
+            ["the active room changing", { action: Action.ActiveRoomChanged, newRoomId: "!room2:server" }],
+        ])("should scroll a room into view in a flat list on %s", async (_trigger, payload) => {
             viewModel = new RoomListViewModel({
                 client: matrixClient,
                 roomViewStore: sdkContext.roomViewStore,
@@ -1847,12 +1853,7 @@ describe("RoomListViewModel", () => {
             const scrollSpy = vi.fn();
             viewModel.setScrollToIndex(scrollSpy);
 
-            dispatcher.dispatch({
-                action: Action.ViewRoom,
-                room_id: "!room2:server",
-                show_room_tile: true,
-                metricsTrigger: undefined,
-            });
+            dispatcher.dispatch(payload);
 
             // Flat list: entry index == room index.
             await waitFor(() => expect(scrollSpy).toHaveBeenCalledWith(1));
@@ -1899,13 +1900,133 @@ describe("RoomListViewModel", () => {
 
             dispatcher.dispatch({
                 action: Action.ViewRoom,
-                room_id: "!room3:server",
+                room_id: "!nope:server",
                 show_room_tile: true,
                 metricsTrigger: undefined,
             });
 
+            await flushPromises();
+            expect(scrollSpy).not.toHaveBeenCalled();
+        });
+
+        it("should expand a collapsed section whose header view model does not exist yet", async () => {
+            const favRoom1 = mkStubRoom("!fav1:server", "Fav 1", matrixClient);
+            const favRoom2 = mkStubRoom("!fav2:server", "Fav 2", matrixClient);
+            const regularRoom1 = mkStubRoom("!reg1:server", "Reg 1", matrixClient);
+            vi.spyOn(RoomListStoreV3.instance, "getSortedRoomsInActiveSpace").mockReturnValue({
+                spaceId: "home",
+                sections: [
+                    { tag: DefaultTagID.Favourite, rooms: [favRoom1, favRoom2] },
+                    { tag: CHATS_TAG, rooms: [regularRoom1] },
+                ],
+            });
+            // Favourites is collapsed from a previous session, and no header view model has been
+            // created for it yet.
+            sectionExpansionState = { home: { [DefaultTagID.Favourite]: false } };
+
+            viewModel = new RoomListViewModel({
+                client: matrixClient,
+                roomViewStore: sdkContext.roomViewStore,
+                spaceStore: sdkContext.spaceStore,
+            });
+            const scrollSpy = vi.fn();
+            viewModel.setScrollToIndex(scrollSpy);
+
+            dispatcher.dispatch({
+                action: Action.ActiveRoomChanged,
+                newRoomId: "!fav2:server",
+            });
+
+            // Entry space: [Fav header(0), fav1(1), fav2(2), Chats header(3), reg1(4)]
             await waitFor(() => expect(scrollSpy).toHaveBeenCalledWith(2));
-            expect(scrollSpy).toHaveBeenCalledTimes(1);
+            expect(viewModel.getSectionHeaderViewModel(DefaultTagID.Favourite).isExpanded).toBe(true);
+        });
+
+        it("should scroll once the view registers its scroll handle", async () => {
+            viewModel = new RoomListViewModel({
+                client: matrixClient,
+                roomViewStore: sdkContext.roomViewStore,
+                spaceStore: sdkContext.spaceStore,
+            });
+
+            // The room is opened before the view has mounted, so there is nothing to scroll with.
+            vi.spyOn(sdkContext.roomViewStore, "getRoomId").mockReturnValue("!room2:server");
+            dispatcher.dispatch({
+                action: Action.ActiveRoomChanged,
+                newRoomId: "!room2:server",
+            });
+            await flushPromises();
+
+            const scrollSpy = vi.fn();
+            viewModel.setScrollToIndex(scrollSpy);
+
+            await waitFor(() => expect(scrollSpy).toHaveBeenCalledWith(1));
+        });
+
+        it("should scroll once the room shows up after a space change", async () => {
+            viewModel = new RoomListViewModel({
+                client: matrixClient,
+                roomViewStore: sdkContext.roomViewStore,
+                spaceStore: sdkContext.spaceStore,
+            });
+            const scrollSpy = vi.fn();
+            viewModel.setScrollToIndex(scrollSpy);
+
+            // The room lives in another space, so it is not in the list yet.
+            vi.spyOn(sdkContext.roomViewStore, "getRoomId").mockReturnValue("!spacereg:server");
+            dispatcher.dispatch({
+                action: Action.ActiveRoomChanged,
+                newRoomId: "!spacereg:server",
+            });
+            await flushPromises();
+            expect(scrollSpy).not.toHaveBeenCalled();
+
+            // The space switch settles and the room list is refreshed.
+            const spaceRoom = mkStubRoom("!spacereg:server", "Space Reg", matrixClient);
+            vi.spyOn(RoomListStoreV3.instance, "getSortedRoomsInActiveSpace").mockReturnValue({
+                spaceId: "!space:server",
+                sections: [{ tag: CHATS_TAG, rooms: [room1, spaceRoom] }],
+            });
+            vi.spyOn(sdkContext.spaceStore, "getLastSelectedRoomIdForSpace").mockReturnValue(null);
+            RoomListStoreV3.instance.emit(RoomListStoreV3Event.ListsUpdate);
+
+            await waitFor(() => expect(scrollSpy).toHaveBeenCalledWith(1));
+        });
+
+        it("should drop a pending request once the user leaves the room", async () => {
+            viewModel = new RoomListViewModel({
+                client: matrixClient,
+                roomViewStore: sdkContext.roomViewStore,
+                spaceStore: sdkContext.spaceStore,
+            });
+            const scrollSpy = vi.fn();
+            viewModel.setScrollToIndex(scrollSpy);
+
+            // A room that isn't in the list, so the request has to wait.
+            vi.spyOn(sdkContext.roomViewStore, "getRoomId").mockReturnValue("!spacereg:server");
+            dispatcher.dispatch({
+                action: Action.ActiveRoomChanged,
+                newRoomId: "!spacereg:server",
+            });
+            await flushPromises();
+            expect(scrollSpy).not.toHaveBeenCalled();
+
+            // The user closes the room, so nothing replaces the waiting request.
+            vi.spyOn(sdkContext.roomViewStore, "getRoomId").mockReturnValue(null);
+            dispatcher.dispatch({ action: Action.ActiveRoomChanged, newRoomId: null });
+            await flushPromises();
+            scrollSpy.mockClear();
+
+            // The room finally turns up, but the request has already been dropped.
+            const spaceRoom = mkStubRoom("!spacereg:server", "Space Reg", matrixClient);
+            vi.spyOn(RoomListStoreV3.instance, "getSortedRoomsInActiveSpace").mockReturnValue({
+                spaceId: "home",
+                sections: [{ tag: CHATS_TAG, rooms: [room1, spaceRoom] }],
+            });
+            RoomListStoreV3.instance.emit(RoomListStoreV3Event.ListsUpdate);
+            await flushPromises();
+
+            expect(scrollSpy).not.toHaveBeenCalled();
         });
     });
 });

--- a/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
+++ b/apps/web/src/viewmodels/room-list/RoomListViewModel.ts
@@ -183,6 +183,16 @@ export class RoomListViewModel
      */
     private scrollToIndex?: (index: number) => void;
 
+    /**
+     * A room waiting to be scrolled into view. Selecting a room in another space switches the
+     * active space asynchronously, so the room is not in {@link roomsResult} yet when the request
+     * arrives; it is retried each time the list settles, for as long as it stays the active room.
+     */
+    private roomIdToScroll?: string;
+
+    /** Guards {@link scrollToRequestedRoom} against the list update it can trigger itself. */
+    private isResolvingRoomIdToScroll = false;
+
     public constructor(props: RoomListViewModelProps) {
         const activeSpace = props.spaceStore.activeSpaceRoom;
 
@@ -525,6 +535,8 @@ export class RoomListViewModel
      */
     public setScrollToIndex = (scrollToIndex: ((index: number) => void) | undefined): void => {
         this.scrollToIndex = scrollToIndex;
+        // A room asked for before the view was ready could not be scrolled to at the time.
+        if (scrollToIndex) void this.retryScrollRoomIntoView();
     };
 
     /**
@@ -539,23 +551,62 @@ export class RoomListViewModel
     /**
      * Scroll a room into view, expanding its section first if it is collapsed so the tile can
      * actually be shown.
+     *
+     * @returns whether the room was found and scrolled to.
      */
-    private async scrollRoomIntoView(roomId: string): Promise<void> {
+    private async scrollRoomIntoView(roomId: string): Promise<boolean> {
         // Look in the full (pre-collapse) sections so we can find rooms hidden in collapsed sections.
         const section = this.roomsResult.sections.find((s) => s.rooms.some((room) => room.roomId === roomId));
         // Room not found
-        if (!section) return;
+        if (!section) return false;
 
-        const headerViewModel = this.roomSectionHeaderViewModels.get(section.tag);
-        // Expand and rebuild the section
-        if (headerViewModel && !headerViewModel.isExpanded) {
-            headerViewModel.isExpanded = true;
-            await this.updateRoomListData();
+        if (!this.snapshot.current.isFlatList) {
+            // Expand and rebuild the section
+            const headerViewModel = this.getSectionHeaderViewModel(section.tag);
+            if (!headerViewModel.isExpanded) {
+                headerViewModel.isExpanded = true;
+                await this.updateRoomListData();
+            }
         }
 
         // Scroll to the room
         const index = this.getRoomEntryIndex(roomId);
-        if (index !== undefined) this.scrollToIndex?.(index);
+        if (index === undefined || !this.scrollToIndex) return false;
+        this.scrollToIndex(index);
+        return true;
+    }
+
+    /** Ask for a room to be scrolled into view. A newer request replaces any earlier one. */
+    private async requestScrollRoomIntoView(roomId: string): Promise<void> {
+        this.roomIdToScroll = roomId;
+        await this.scrollToRequestedRoom();
+    }
+
+    /**
+     * Try {@link roomIdToScroll} again now that the list has settled or the view has become ready,
+     * so a room that only appears once its space has finished switching is still scrolled to.
+     */
+    private async retryScrollRoomIntoView(): Promise<void> {
+        if (this.roomIdToScroll === this.props.roomViewStore.getRoomId()) {
+            await this.scrollToRequestedRoom();
+        } else {
+            this.roomIdToScroll = undefined;
+        }
+    }
+
+    /** Carry out {@link roomIdToScroll}, clearing it once the room has been scrolled to. */
+    private async scrollToRequestedRoom(): Promise<void> {
+        const roomId = this.roomIdToScroll;
+        if (roomId === undefined || this.isResolvingRoomIdToScroll) return;
+
+        this.isResolvingRoomIdToScroll = true;
+        try {
+            const scrolled = await this.scrollRoomIntoView(roomId);
+            // A newer request may have replaced ours while we were waiting; leave that one alone.
+            if (scrolled && this.roomIdToScroll === roomId) this.roomIdToScroll = undefined;
+        } finally {
+            this.isResolvingRoomIdToScroll = false;
+        }
     }
 
     /**
@@ -581,13 +632,16 @@ export class RoomListViewModel
         if (payload.action === Action.ActiveRoomChanged) {
             // When the active room changes, update the room list data to reflect the new selected room
             // Pass isRoomChange=true so sticky logic doesn't prevent the index from updating
-            void this.updateRoomListData(true);
+            await this.updateRoomListData(true);
+            // Show the room wherever it was opened from: the global search, a permalink, a
+            // notification. A tile that is already fully visible is left alone by the list.
+            if (payload.newRoomId) await this.requestScrollRoomIntoView(payload.newRoomId);
         } else if (payload.action === Action.ViewRoomDelta) {
             // Handle keyboard navigation shortcuts (Alt+ArrowUp/Down)
             // This was previously handled by useRoomListNavigation hook
             this.handleViewRoomDelta(payload as ViewRoomDeltaPayload);
         } else if (payload.action === Action.ViewRoom && payload.show_room_tile && payload.room_id) {
-            await this.scrollRoomIntoView(payload.room_id);
+            await this.requestScrollRoomIntoView(payload.room_id);
         } else if (payload.action === Action.RoomListCollapseAllSections) {
             this.onCollapseAllSections(false);
         } else if (payload.action === Action.RoomListExpandAllSections) {
@@ -871,6 +925,9 @@ export class RoomListViewModel
 
         // Ensure the room list updates its filters based on the new rooms data
         RoomListStoreV3.instance.updateRoomSkipList();
+
+        // The list has settled, so a scroll waiting on a space switch can now happen.
+        void this.retryScrollRoomIntoView();
     }
 
     /**

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.test.tsx
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.test.tsx
@@ -13,7 +13,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import userEvent from "@testing-library/user-event";
 
 import * as stories from "./VirtualizedRoomListView.stories";
-import { KEYBOARD_DRAG_OFFSET } from "./VirtualizedRoomListView";
+import { getScrollTargetEntryIndex, KEYBOARD_DRAG_OFFSET } from "./VirtualizedRoomListView";
 
 const { Default, Sections } = composeStories(stories);
 
@@ -65,6 +65,26 @@ describe("<VirtualizedRoomListView />", () => {
     it("should call updateVisibleRooms on render", () => {
         renderWithMockContext(<Default />);
         expect(Default.args.updateVisibleRooms).toHaveBeenCalled();
+    });
+
+    describe("getScrollTargetEntryIndex", () => {
+        // Entry space: [hdr(0), a(1), b(2), c(3), hdr(4), d(5), hdr(6), e(7), f(8)]
+        const sections = [{ roomIds: ["a", "b", "c"] }, { roomIds: ["d"] }, { roomIds: ["e", "f"] }];
+
+        it.each([
+            [sections, 1, 2],
+            [sections, 2, 3],
+            [sections, 5, 8],
+            // Rooms 0, 3 and 4 come first in their section, so their header is targeted instead.
+            [sections, 0, 0],
+            [sections, 3, 4],
+            [sections, 4, 6],
+            // Past the last room, and no sections at all.
+            [sections, 99, 8],
+            [[], 0, 0],
+        ])("maps room index %#", (input, roomIndex, entryIndex) => {
+            expect(getScrollTargetEntryIndex(input, roomIndex)).toBe(entryIndex);
+        });
     });
 
     describe("updateVisibleRooms range reporting", () => {

--- a/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.tsx
+++ b/packages/shared-components/src/room-list/VirtualizedRoomListView/VirtualizedRoomListView.tsx
@@ -111,6 +111,28 @@ type Context = {
 const EXTENDED_VIEWPORT_HEIGHT = 25 * ROOM_LIST_ITEM_HEIGHT;
 
 /**
+ * Work out which entry to put at the top of a grouped list to show the room at `roomIndex`.
+ *
+ * Room indices don't count section headers, but the list is given a flat list of entries in which
+ * every section contributes a header entry before its rooms. A room that comes first in its section
+ * resolves to its header, so it is not shown detached from the section it belongs to; an index past
+ * the last room resolves to the last entry.
+ */
+export function getScrollTargetEntryIndex(sections: { roomIds: string[] }[], roomIndex: number): number {
+    let headerEntry = 0;
+    let roomsBefore = 0;
+    for (const section of sections) {
+        if (roomIndex < roomsBefore + section.roomIds.length) {
+            const indexInSection = roomIndex - roomsBefore;
+            return indexInSection === 0 ? headerEntry : headerEntry + 1 + indexInSection;
+        }
+        headerEntry += section.roomIds.length + 1;
+        roomsBefore += section.roomIds.length;
+    }
+    return Math.max(0, headerEntry - 1);
+}
+
+/**
  * A virtualized list of rooms.
  * This component provides efficient rendering of large room lists using virtualization,
  * and renders RoomListItemView components for each room.
@@ -485,6 +507,11 @@ export function VirtualizedRoomListView({ vm, renderAvatar, onKeyDown }: Virtual
         ],
     );
 
+    const activeEntryIndex = useMemo(() => {
+        if (activeRoomIndex === undefined) return undefined;
+        return isFlatList ? activeRoomIndex : getScrollTargetEntryIndex(sections, activeRoomIndex);
+    }, [activeRoomIndex, isFlatList, sections]);
+
     /**
      * Determine if we should scroll the active index into view
      * This happens when the space or filters change
@@ -505,13 +532,13 @@ export function VirtualizedRoomListView({ vm, renderAvatar, onKeyDown }: Virtual
             if (shouldScrollIndexIntoView) {
                 return {
                     align: "start",
-                    index: activeRoomIndex || 0,
+                    index: activeEntryIndex ?? 0,
                     behavior: "auto",
                 };
             }
             return false;
         },
-        [activeRoomIndex],
+        [activeEntryIndex],
     );
 
     // Imperatively scroll to a newly created section header.
@@ -554,7 +581,7 @@ export function VirtualizedRoomListView({ vm, renderAvatar, onKeyDown }: Virtual
         scrollIntoViewOnChange,
         // If fixedItemHeight is not set and initialTopMostItemIndex=undefined, virtuoso crashes
         // If we don't set it, it works
-        ...(activeRoomIndex !== undefined ? { initialTopMostItemIndex: activeRoomIndex } : {}),
+        ...(activeEntryIndex !== undefined ? { initialTopMostItemIndex: activeEntryIndex } : {}),
         ["data-testid"]: "room-list",
         ["aria-label"]: _t("room_list|list_title"),
         getItemKey,


### PR DESCRIPTION
closes https://github.com/element-hq/element-web/issues/35062
Selecting a room from the spotlight has these two issues:
- If the room is off screen, the room list doesn't scroll to the room
- If the room is in a collapsed section, the section stays closed

**Before**

https://github.com/user-attachments/assets/ec5c9b62-4673-4ed7-a997-70ff501e6922

**After**

https://github.com/user-attachments/assets/ffbedf25-aa18-4acc-83fe-b4b81382a377