### PR TITLE
Open recovery setup when the backup key is missing

### DIFF
--- a/apps/web/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.test.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.test.tsx
@@ -90,11 +90,7 @@ describe("<EncryptionUserSettingsTab />", () => {
         expect(asFragment()).toMatchSnapshot();
 
         await user.click(screen.getByRole("button", { name: "Forgot recovery key?" }));
-        expect(
-            screen.getByRole("heading", {
-                name: "Forgot your recovery key? You’ll need to reset your digital identity.",
-            }),
-        ).toBeVisible();
+        expect(await screen.findByRole("heading", { name: "Get recovery key" })).toBeVisible();
     });
 
     it("should display the change recovery key panel when the user clicks on the change recovery button", async () => {

--- a/apps/web/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/EncryptionUserSettingsTab.tsx
@@ -86,7 +86,7 @@ export function EncryptionUserSettingsTab({ initialState = "main" }: Readonly<Pr
                     content = (
                         <RecoveryPanelOutOfSync
                             onFinish={() => setState("main")}
-                            onForgotRecoveryKey={() => setState("reset_identity_forgot")}
+                            onForgotRecoveryKey={() => setState("set_recovery_key")}
                             onAccessSecretStorageFailed={async () => {
                                 const needsCrossSigningReset =
                                     await DeviceListener.sharedInstance().keyStorageOutOfSyncNeedsCrossSigningReset(


### PR DESCRIPTION
Fixes #35004

When key storage is out of sync because the backup decryption key is missing, Forgot recovery key should open recovery-key setup instead of the identity-reset flow.