### PR TITLE
Stop writing removed legacy mention rules from the Labs notification settings

### DIFF
--- a/apps/web/playwright/e2e/settings/notifications/labs-mention-rules-legacy-removed.spec.ts
+++ b/apps/web/playwright/e2e/settings/notifications/labs-mention-rules-legacy-removed.spec.ts
@@ -1,0 +1,23 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { test } from "../../../element-web-test";
+import { labsMentionNotificationSettingsTests } from "./labs-mention-rules";
+
+test.use({
+    displayName: "Alice",
+    synapseConfig: {
+        experimental_features: {
+            // Do not serve the legacy text-matching mention rules (MSC4210)
+            msc4210_enabled: true,
+        },
+    },
+});
+
+test.describe("Labs notification settings, legacy mention rules not served", () => {
+    labsMentionNotificationSettingsTests(false);
+});

--- a/apps/web/playwright/e2e/settings/notifications/labs-mention-rules-legacy-served.spec.ts
+++ b/apps/web/playwright/e2e/settings/notifications/labs-mention-rules-legacy-served.spec.ts
@@ -1,0 +1,23 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { test } from "../../../element-web-test";
+import { labsMentionNotificationSettingsTests } from "./labs-mention-rules";
+
+test.use({
+    displayName: "Alice",
+    synapseConfig: {
+        experimental_features: {
+            // Serve the legacy text-matching mention rules (MSC4210)
+            msc4210_enabled: false,
+        },
+    },
+});
+
+test.describe("Labs notification settings, legacy mention rules served", () => {
+    labsMentionNotificationSettingsTests(true);
+});

--- a/apps/web/playwright/e2e/settings/notifications/labs-mention-rules.ts
+++ b/apps/web/playwright/e2e/settings/notifications/labs-mention-rules.ts
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE files in the repository root for full details.
+*/
+
+import { type Page } from "@playwright/test";
+import { type IPushRule, type IPushRules } from "matrix-js-sdk/src/matrix";
+
+import { test, expect } from "../../../element-web-test";
+import { SettingLevel } from "../../../../src/settings/SettingLevel";
+
+const ROOM_MENTION_RULE = ".m.rule.is_room_mention";
+const LEGACY_ROOM_MENTION_RULE = ".m.rule.roomnotif";
+
+const LABS_UPDATE_ERROR = "Your notification settings could not be updated";
+
+/**
+ * Record every failed request to the push rules API, so a test can assert that
+ * the client never writes to a rule the server does not have.
+ */
+function trackPushRuleErrors(page: Page): string[] {
+    const errors: string[] = [];
+    page.on("response", (response) => {
+        if (response.url().includes("/pushrules/") && response.status() >= 400) {
+            errors.push(`${response.status()} ${response.request().method()} ${response.url()}`);
+        }
+    });
+    return errors;
+}
+
+/**
+ * Fetch the push rules straight from the homeserver, bypassing the client-side
+ * defaults matrix-js-sdk merges in, so the assertions reflect the server's state.
+ */
+function getServerPushRules(page: Page, baseUrl: string, accessToken: string): () => Promise<Map<string, IPushRule>> {
+    return async () => {
+        const response = await page.request.get(`${baseUrl}/_matrix/client/v3/pushrules/`, {
+            headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        expect(response.ok()).toBeTruthy();
+        const rules = (await response.json()) as IPushRules;
+        return new Map(Object.values(rules.global).flatMap((rules) => rules.map((rule) => [rule.rule_id, rule])));
+    };
+}
+
+/**
+ * The legacy text-matching mention rules were removed from the spec in Matrix v1.17
+ * (MSC4210). Synapse stops serving them when `msc4210_enabled` is set. The labs
+ * notification settings page must save, without writing to missing rules, whether or
+ * not the server serves them.
+ *
+ * `synapseConfig` is a worker-scoped fixture and can only be set at the top level of a
+ * spec file, so each mode lives in its own spec file and both share this test.
+ *
+ * @param legacyRulesServed - whether the homeserver under test still serves the legacy rules
+ */
+export function labsMentionNotificationSettingsTests(legacyRulesServed: boolean): void {
+    test("saves the labs notification settings page", async ({ page, app, user, homeserver, credentials }) => {
+        const fetchRules = getServerPushRules(page, homeserver.baseUrl, credentials.accessToken);
+        const errors = trackPushRuleErrors(page);
+        await app.settings.setValue("feature_notification_settings2", null, SettingLevel.DEVICE, true);
+
+        // Make sure the homeserver is in the mode this test is about
+        const initialRules = await fetchRules();
+        expect(initialRules.has(LEGACY_ROOM_MENTION_RULE)).toBe(legacyRulesServed);
+
+        const settings = await app.settings.openUserSettings("Notifications");
+        const roomMentions = settings.getByLabel("Notify when someone mentions using @room");
+        await expect(roomMentions).toBeVisible();
+
+        // A fresh account has rules the labs page wants to rewrite; the page is locked until
+        // the user lets it. Proceeding writes every rule the page manages.
+        const proceed = settings.getByRole("button", { name: "Proceed" });
+        if ((await proceed.count()) > 0) {
+            await proceed.click();
+        }
+        await expect(roomMentions).toBeEnabled();
+        await expect(roomMentions).toBeChecked();
+        await expect(settings.getByText(LABS_UPDATE_ERROR)).toHaveCount(0);
+
+        await roomMentions.uncheck();
+        await expect(roomMentions).not.toBeChecked();
+
+        await expect
+            .poll(async () => {
+                const rules = await fetchRules();
+                return rules.get(ROOM_MENTION_RULE)!.actions;
+            })
+            .toEqual(["dont_notify"]);
+        const rules = await fetchRules();
+        if (legacyRulesServed) {
+            expect(rules.get(LEGACY_ROOM_MENTION_RULE)!.actions).toEqual(["dont_notify"]);
+        } else {
+            expect(rules.has(LEGACY_ROOM_MENTION_RULE)).toBe(false);
+        }
+
+        await expect(settings.getByText(LABS_UPDATE_ERROR)).toHaveCount(0);
+        expect(errors).toEqual([]);
+    });
+}

--- a/apps/web/src/models/notificationsettings/NotificationSettings.test.ts
+++ b/apps/web/src/models/notificationsettings/NotificationSettings.test.ts
@@ -231,6 +231,81 @@ describe("NotificationSettings", () => {
         ]);
     });
 
+    describe("legacy mention rules", () => {
+        // Removed from the spec in Matrix v1.17 (MSC4210); servers may or may not still serve them
+        const legacyMentionRuleIds: string[] = [
+            RuleId.ContainsUserName,
+            RuleId.ContainsDisplayName,
+            RuleId.AtRoomNotification,
+        ];
+        const withoutLegacyMentionRules = (pushRules: IPushRules): IPushRules => ({
+            ...pushRules,
+            global: {
+                ...pushRules.global,
+                content: pushRules.global.content?.filter((rule) => !legacyMentionRuleIds.includes(rule.rule_id)),
+                override: pushRules.global.override?.filter((rule) => !legacyMentionRuleIds.includes(rule.rule_id)),
+            },
+        });
+
+        it("parses the mention settings from the intentional rules when the legacy rules are absent", async () => {
+            const pushRules = withoutLegacyMentionRules(
+                (await import("./__mocks__/pushrules_default_new.json")) as IPushRules,
+            );
+            const model = toNotificationSettings(pushRules, true);
+            expect(model.mentions).toEqual({ user: true, room: true, keywords: true });
+        });
+
+        it("does not write the legacy rules when the server does not serve them", async () => {
+            const pushRules = withoutLegacyMentionRules(
+                (await import("./__mocks__/pushrules_default_new.json")) as IPushRules,
+            );
+            const model = toNotificationSettings(pushRules, true);
+
+            const unchanged = reconcileNotificationSettings(pushRules, model, true);
+            expect(unchanged.updated.map((rule) => rule.rule_id)).not.toEqual(
+                expect.arrayContaining(legacyMentionRuleIds),
+            );
+
+            const changes = reconcileNotificationSettings(
+                pushRules,
+                { ...model, mentions: { ...model.mentions, user: false, room: false } },
+                true,
+            );
+            expect(changes.added).toHaveLength(0);
+            expect(changes.deleted).toHaveLength(0);
+            expect(changes.updated).toEqual([
+                expect.objectContaining({
+                    kind: PushRuleKind.Override,
+                    rule_id: RuleId.IsUserMention,
+                    actions: StandardActions.ACTION_DONT_NOTIFY,
+                }),
+                expect.objectContaining({
+                    kind: PushRuleKind.Override,
+                    rule_id: RuleId.IsRoomMention,
+                    actions: StandardActions.ACTION_DONT_NOTIFY,
+                }),
+            ]);
+        });
+
+        it("keeps writing the legacy rules while the server serves them", async () => {
+            const pushRules = (await import("./__mocks__/pushrules_default_new.json")) as IPushRules;
+            const model = toNotificationSettings(pushRules, true);
+
+            const changes = reconcileNotificationSettings(
+                pushRules,
+                { ...model, mentions: { ...model.mentions, user: false, room: false } },
+                true,
+            );
+            expect(changes.updated.map((rule) => rule.rule_id)).toEqual([
+                RuleId.IsUserMention,
+                RuleId.ContainsDisplayName,
+                RuleId.ContainsUserName,
+                RuleId.IsRoomMention,
+                RuleId.AtRoomNotification,
+            ]);
+        });
+    });
+
     it("keeps the ids of two keywords that differ only by a leading dot apart", async () => {
         const pushRules = (await import("./__mocks__/pushrules_default.json")) as IPushRules;
         const model = { ...DefaultNotificationSettings, keywords: ["banana", ".banana"] };

--- a/apps/web/src/models/notificationsettings/reconcileNotificationSettings.ts
+++ b/apps/web/src/models/notificationsettings/reconcileNotificationSettings.ts
@@ -14,12 +14,13 @@ import { StandardActions } from "../../notifications/StandardActions";
 import { RoomNotifState } from "../../RoomNotifs";
 import { type NotificationSettings } from "./NotificationSettings";
 import { type PushRuleDiff, type PushRuleUpdate } from "./PushRuleDiff";
-import { buildPushRuleMap } from "./PushRuleMap";
+import { buildPushRuleMap, type PushRuleMap } from "./PushRuleMap";
 import { keywordRuleId } from "./keywordRuleId";
 
 function toStandardRules(
     model: NotificationSettings,
     supportsIntentionalMentions: boolean,
+    existingRules: PushRuleMap,
 ): Map<RuleId | string, PushRuleUpdate> {
     const standardRules = new Map<RuleId | string, PushRuleUpdate>();
 
@@ -105,18 +106,25 @@ function toStandardRules(
             actions: userMentionActions,
         });
     }
-    standardRules.set(RuleId.ContainsDisplayName, {
-        rule_id: RuleId.ContainsDisplayName,
-        kind: PushRuleKind.Override,
-        enabled: true,
-        actions: userMentionActions,
-    });
-    standardRules.set(RuleId.ContainsUserName, {
-        rule_id: RuleId.ContainsUserName,
-        kind: PushRuleKind.ContentSpecific,
-        enabled: true,
-        actions: userMentionActions,
-    });
+    // The legacy text-matching mention rules were removed from the spec in Matrix
+    // v1.17 (MSC4210). Servers that no longer serve them answer 404 to updates, so
+    // only write them when the server returned them.
+    if (existingRules.has(RuleId.ContainsDisplayName)) {
+        standardRules.set(RuleId.ContainsDisplayName, {
+            rule_id: RuleId.ContainsDisplayName,
+            kind: PushRuleKind.Override,
+            enabled: true,
+            actions: userMentionActions,
+        });
+    }
+    if (existingRules.has(RuleId.ContainsUserName)) {
+        standardRules.set(RuleId.ContainsUserName, {
+            rule_id: RuleId.ContainsUserName,
+            kind: PushRuleKind.ContentSpecific,
+            enabled: true,
+            actions: userMentionActions,
+        });
+    }
 
     const roomMentionActions = model.mentions.room ? StandardActions.ACTION_NOTIFY : StandardActions.ACTION_DONT_NOTIFY;
     if (supportsIntentionalMentions) {
@@ -127,12 +135,14 @@ function toStandardRules(
             actions: roomMentionActions,
         });
     }
-    standardRules.set(RuleId.AtRoomNotification, {
-        rule_id: RuleId.AtRoomNotification,
-        kind: PushRuleKind.Override,
-        enabled: true,
-        actions: roomMentionActions,
-    });
+    if (existingRules.has(RuleId.AtRoomNotification)) {
+        standardRules.set(RuleId.AtRoomNotification, {
+            rule_id: RuleId.AtRoomNotification,
+            kind: PushRuleKind.Override,
+            enabled: true,
+            actions: roomMentionActions,
+        });
+    }
 
     standardRules.set(RuleId.Tombstone, {
         rule_id: RuleId.Tombstone,
@@ -166,7 +176,7 @@ export function reconcileNotificationSettings(
     };
 
     const oldRules = buildPushRuleMap(pushRules);
-    const newRules = toStandardRules(model, supportsIntentionalMentions);
+    const newRules = toStandardRules(model, supportsIntentionalMentions, oldRules);
 
     for (const rule of newRules.values()) {
         const original = oldRules.get(rule.rule_id);


### PR DESCRIPTION
Fixes #34999

## Problem

The Labs notification settings page (`feature_notification_settings2`) wrote the legacy text-matching mention rules (`.m.rule.contains_display_name`, `.m.rule.contains_user_name`, `.m.rule.roomnotif`) on every save, whether or not the server had them. It also treated a rule the server did not return as an unsaved change, so the "Update" banner never cleared and every control stayed disabled.

## When it happens

Only against a server that no longer serves those rules. They were removed from the spec in Matrix v1.17 (MSC4210), and Synapse drops them with `experimental_features.msc4210_enabled: true` (soon by default, element-hq/synapse#19415).

- Synapse today accepts the writes with `200 {}` but still does not serve the rules, so the "Update" banner never clears and the page stays locked.
- Once Synapse returns `404` for missing rules (element-hq/synapse#20202), every save fails with "Your notification settings could not be updated".

Servers that still serve the rules are unaffected.

## Solution

Only write the legacy mention rules when the server returned them. All other rules are handled as before.

## Checklist

- [x] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [x] I have linked the PR to an issue that describes what needs changing.
- [x] I have written tests for new code (and old code if feasible).
- [x] I have ensured new or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] I have confirmed linter and other CI checks pass.
- [x] I have have included screenshots if what the user sees will change
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
- [x] I will no longer force push to this branch
