### PR TITLE
Room list: improve performance

### DIFF
--- a/apps/web/src/stores/room-list-v3/RoomListStoreV3.test.ts
+++ b/apps/web/src/stores/room-list-v3/RoomListStoreV3.test.ts
@@ -1043,6 +1043,48 @@ describe("RoomListStoreV3", () => {
                 expect(noShowboldRooms).not.toContain(rooms[75]);
                 expect(showboldRooms).toHaveLength(2);
             });
+
+            it("re-applies the filters when the current room changed", async () => {
+                // Ensure that Notifications.showbold is off
+                vi.spyOn(SettingsStore, "getValue").mockImplementation(() => false);
+
+                // Given room 27 is unread
+                const { client, rooms } = getClientAndRooms();
+                const { spaceRoom, roomIds } = createSpace(rooms, [6, 8, 13, 27, 75], client);
+
+                vi.spyOn(RoomNotificationStateStore.instance, "getRoomState").mockImplementation((room) => {
+                    const state = {
+                        // Only 27 has notifications
+                        hasUnreadCount: [rooms[27]].includes(room),
+                        on: vi.fn(),
+                        off: vi.fn(),
+                    } as unknown as RoomNotificationState;
+                    return state;
+                });
+
+                // And we are in room 13, which is read
+                vi.spyOn(SDKContextClass.instance.roomViewStore, "getRoomId").mockReturnValue(rooms[13].roomId);
+
+                setupMocks(spaceRoom, roomIds);
+                const store = new RoomListStoreV3Class(dispatcher);
+                await store.start();
+
+                const unreadRooms = (): Room[] =>
+                    store.getSortedRoomsInActiveSpace([FilterEnum.UnreadFilter]).sections.flatMap((s) => s.rooms);
+
+                // Then room 13 is kept in the list even though it is read
+                expect(unreadRooms()).toEqual(expect.arrayContaining([rooms[27], rooms[13]]));
+
+                // But when we move to room 75 and the room list refreshes
+                vi.spyOn(SDKContextClass.instance.roomViewStore, "getRoomId").mockReturnValue(rooms[75].roomId);
+                store.updateRoomSkipList();
+
+                // Then room 75 is kept instead of room 13
+                const afterRoomChange = unreadRooms();
+                expect(afterRoomChange).toContain(rooms[27]);
+                expect(afterRoomChange).toContain(rooms[75]);
+                expect(afterRoomChange).not.toContain(rooms[13]);
+            });
         });
 
         describe("getServerNoticeRooms", () => {
@@ -1190,6 +1232,29 @@ describe("RoomListStoreV3", () => {
                 CHATS_TAG,
                 DefaultTagID.LowPriority,
             ]);
+        });
+
+        it("moves a room to another section when it is tagged at runtime", async () => {
+            enableSections();
+            const { rooms } = getClientAndRooms();
+
+            const store = new RoomListStoreV3Class(dispatcher);
+            await store.start();
+
+            // Given an untagged room sits in the Chats section
+            const room = rooms[3];
+            let sections = store.getSortedRoomsInActiveSpace().sections;
+            expect(findSection(sections, CHATS_TAG)!.rooms).toContain(room);
+            expect(findSection(sections, DefaultTagID.Favourite)!.rooms).not.toContain(room);
+
+            // When the user favourites it
+            room.tags[DefaultTagID.Favourite] = {};
+            dispatcher.dispatch({ action: "MatrixActions.Room.tags", room }, true);
+
+            // Then it moves to the Favourites section
+            sections = store.getSortedRoomsInActiveSpace().sections;
+            expect(findSection(sections, DefaultTagID.Favourite)!.rooms).toContain(room);
+            expect(findSection(sections, CHATS_TAG)!.rooms).not.toContain(room);
         });
 
         it("does not load the sections before the matrix client is ready", () => {

--- a/apps/web/src/stores/room-list-v3/RoomListStoreV3.ts
+++ b/apps/web/src/stores/room-list-v3/RoomListStoreV3.ts
@@ -11,7 +11,7 @@ import { EventType } from "matrix-js-sdk/src/matrix";
 import type { EmptyObject, Room } from "matrix-js-sdk/src/matrix";
 import type { MatrixDispatcher } from "../../dispatcher/dispatcher";
 import type { ActionPayload } from "../../dispatcher/payloads";
-import type { Filter, FilterKey } from "./skip-list/filters";
+import type { AnyFilter, Filter, FilterKey } from "./skip-list/filters";
 import { AsyncStoreWithClient } from "../AsyncStoreWithClient";
 import SettingsStore from "../../settings/SettingsStore";
 import defaultDispatcher from "../../dispatcher/dispatcher";
@@ -98,6 +98,12 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
      * Defines the display order of sections.
      */
     private sortedTags: string[] = [];
+
+    /** Works out which section a room belongs to. Rebuilt when the sections change. */
+    private sectionFilter?: SectionFilter;
+
+    /** The room that was open the last time the filters were applied to every room. */
+    private lastFilteredRoomId?: string | null;
 
     private readonly msc3946ProcessDynamicPredecessor: boolean;
 
@@ -491,13 +497,11 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
     }
 
     /**
-     * Get the list of filters to be used in the skip list, including the section filters.
+     * Get the list of filters to be used in the skip list, including the section filter.
      */
-    private getSkipListFilters(): Filter[] {
-        return [
-            ...this.filterByFilterKey.values(),
-            ...this.sortedTags.map((tag) => new SectionFilter(tag, this.sortedTags)),
-        ];
+    private getSkipListFilters(): AnyFilter[] {
+        if (!this.sectionFilter) this.sectionFilter = new SectionFilter(this.sortedTags);
+        return [...this.filterByFilterKey.values(), this.sectionFilter];
     }
 
     /**
@@ -543,7 +547,13 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
      * Does not emit an event.
      */
     public updateRoomSkipList(): void {
-        this.roomSkipList?.useNewFilters(this.getSkipListFilters());
+        if (!this.roomSkipList) return;
+        // UnreadFilter is the only filter that depends on which room is open, so there is
+        // nothing to redo unless that room changed.
+        const currentRoomId = SDKContextClass.instance.roomViewStore.getRoomId();
+        if (currentRoomId === this.lastFilteredRoomId) return;
+        this.lastFilteredRoomId = currentRoomId;
+        this.roomSkipList.useNewFilters(this.getSkipListFilters());
     }
 
     /**
@@ -612,6 +622,7 @@ export class RoomListStoreV3Class extends AsyncStoreWithClient<EmptyObject> {
      */
     private loadSections(): void {
         this.sortedTags = getOrderedSectionTags();
+        this.sectionFilter = undefined;
     }
 }
 

--- a/apps/web/src/stores/room-list-v3/skip-list/RoomNode.ts
+++ b/apps/web/src/stores/room-list-v3/skip-list/RoomNode.ts
@@ -6,7 +6,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import type { Room } from "matrix-js-sdk/src/matrix";
-import type { Filter, FilterKey } from "./filters";
+import type { AnyFilter, FilterKey } from "./filters";
 import { SDKContextClass } from "../../../contexts/SDKContextClass.ts";
 
 /**
@@ -62,18 +62,27 @@ export class RoomNode {
      * @param filterKeys An array of filter keys to check against.
      */
     public doesRoomMatchFilters(filterKeys: FilterKey[]): boolean {
-        return !filterKeys.some((key) => !this.filterKeysSet.has(key));
+        for (const key of filterKeys) {
+            if (!this.filterKeysSet.has(key)) return false;
+        }
+        return true;
     }
 
     /**
      * Populates {@link RoomNode#filterKeysSet} by checking if the associated room
-     * satisfies the given filters.
+     * satisfies the given filters. A {@link MultiKeyFilter} contributes the single
+     * key it picks for this room, if any.
      * @param filters A list of filters
      */
-    public applyFilters(filters: Filter[]): void {
-        this.filterKeysSet = new Set();
+    public applyFilters(filters: AnyFilter[]): void {
+        this.filterKeysSet.clear();
         for (const filter of filters) {
-            if (filter.matches(this.room)) this.filterKeysSet.add(filter.key);
+            if ("keyFor" in filter) {
+                const key = filter.keyFor(this.room);
+                if (key !== undefined) this.filterKeysSet.add(key);
+            } else if (filter.matches(this.room)) {
+                this.filterKeysSet.add(filter.key);
+            }
         }
     }
 }

--- a/apps/web/src/stores/room-list-v3/skip-list/RoomSkipList.test.ts
+++ b/apps/web/src/stores/room-list-v3/skip-list/RoomSkipList.test.ts
@@ -103,6 +103,34 @@ describe("RoomSkipList", () => {
         }
     });
 
+    it("Inserting a room only compares it against a few rooms per level", () => {
+        const client = stubClient();
+        const sorter = new RecencySorter(client.getSafeUserId());
+        let comparisons = 0;
+        const countingSorter: Sorter = {
+            sort: (rooms) => sorter.sort(rooms),
+            comparator: (roomA, roomB) => {
+                ++comparisons;
+                return sorter.comparator(roomA, roomB);
+            },
+            type: sorter.type,
+        };
+        const skipList = new RoomSkipList(countingSorter);
+
+        // Seed small and grow, so the list has to add levels of its own.
+        const rooms = getMockedRooms(client, 2000);
+        skipList.seed(rooms.slice(0, 20));
+        for (const room of rooms.slice(20)) {
+            skipList.addNewRoom(room);
+        }
+        expect(skipList.size).toEqual(rooms.length);
+
+        // The first room has the oldest timestamp, so it sorts last: the worst case.
+        comparisons = 0;
+        skipList.reInsertRoom(rooms[0]);
+        expect(comparisons).toBeLessThan(200);
+    });
+
     it("Room is not duplicated when same room is added via addNewRoom", () => {
         const { skipList, rooms } = generateSkipList();
         const room = rooms[5];

--- a/apps/web/src/stores/room-list-v3/skip-list/RoomSkipList.ts
+++ b/apps/web/src/stores/room-list-v3/skip-list/RoomSkipList.ts
@@ -152,7 +152,13 @@ export class RoomSkipList implements Iterable<Room> {
          * node.
          *
          * We start at the top most level and move downwards ...
+         *
+         * Every node in a level is also present in the level below it, so
+         * each level carries on from the predecessor found in the level
+         * above instead of starting again at the head.
          */
+        let predecessor: RoomNode | null = null;
+
         for (let j = this.levels.length - 1; j >= 0; --j) {
             const level = this.levels[j];
 
@@ -160,8 +166,10 @@ export class RoomSkipList implements Iterable<Room> {
              * If the head is undefined, that means this level is empty.
              * So mark it as such in insertionNodes and skip over this
              * level.
+             * predecessor is always null here, since a node in the level
+             * above would also be in this one.
              */
-            if (!level.head) {
+            if (!level?.head) {
                 insertionNodes[j] = null;
                 continue;
             }
@@ -171,8 +179,8 @@ export class RoomSkipList implements Iterable<Room> {
              * All we need to do is find the node that is smaller or
              * equal to the node that we wish to insert.
              */
-            let current = level.head;
-            let previous: RoomNode | null = null;
+            let previous: RoomNode | null = predecessor;
+            let current: RoomNode | undefined = predecessor ? predecessor.next[j] : level.head;
             while (current) {
                 if (this.sorter.comparator(current.room, room) < 0) {
                     previous = current;
@@ -187,25 +195,41 @@ export class RoomSkipList implements Iterable<Room> {
              * This is exactly what we need to track in insertionNodes!
              */
             insertionNodes[j] = previous;
+            predecessor = previous;
         }
 
         /**
          * We're done with difficult part, now we just need to do the
          * actual node insertion.
+         *
+         * Whether our new node should be present in a level
+         * is decided by coin toss.
+         * We work the height out up front so that a level can be added
+         * once the list outgrows the levels it was seeded with.
          */
-        for (const [level, node] of insertionNodes.entries()) {
+        let height = 1;
+        const maxLevels = this.maxLevels;
+        while (height < maxLevels && shouldPromote()) ++height;
+
+        for (let level = 0; level < height; ++level) {
+            if (!this.levels[level]) this.levels[level] = new Level(level);
             /**
-             * Whether our new node should be present in a level
-             * is decided by coin toss.
+             * A level that didn't exist during the search has no
+             * insertionNodes entry and is empty, so the new node becomes
+             * its head.
              */
-            if (level === 0 || shouldPromote()) {
-                const levelObj = this.levels[level];
-                if (node) levelObj.insertAfter(node, newNode);
-                else levelObj.insertAtHead(newNode);
-            } else {
-                break;
-            }
+            const node = insertionNodes[level] ?? null;
+            if (node) this.levels[level].insertAfter(node, newNode);
+            else this.levels[level].insertAtHead(newNode);
         }
+    }
+
+    /**
+     * The largest number of levels this list will use, kept in step with its size so the
+     * search doesn't look at more and more nodes as rooms are added after the seed.
+     */
+    private get maxLevels(): number {
+        return Math.max(1, Math.ceil(Math.log2(this.size + 1)));
     }
 
     public [Symbol.iterator](): SortedRoomIterator {

--- a/apps/web/src/stores/room-list-v3/skip-list/RoomSkipList.ts
+++ b/apps/web/src/stores/room-list-v3/skip-list/RoomSkipList.ts
@@ -8,7 +8,7 @@ Please see LICENSE files in the repository root for full details.
 import type { Room } from "matrix-js-sdk/src/matrix";
 import { logger } from "matrix-js-sdk/src/logger";
 import type { Sorter, SortingAlgorithm } from "./sorters";
-import type { Filter, FilterKey } from "./filters";
+import type { AnyFilter, FilterKey } from "./filters";
 import { RoomNode } from "./RoomNode";
 import { shouldPromote } from "./utils";
 import { Level } from "./Level";
@@ -25,7 +25,7 @@ export class RoomSkipList implements Iterable<Room> {
 
     public constructor(
         private sorter: Sorter,
-        private filters: Filter[] = [],
+        private filters: AnyFilter[] = [],
     ) {}
 
     private reset(): void {
@@ -81,7 +81,7 @@ export class RoomSkipList implements Iterable<Room> {
      * Change the filters used by the skip list.
      * This will apply the new filters to all existing nodes.
      */
-    public useNewFilters(filters: Filter[]): void {
+    public useNewFilters(filters: AnyFilter[]): void {
         this.filters = filters;
         for (const node of this.roomNodeMap.values()) {
             node.applyFilters(this.filters);

--- a/apps/web/src/stores/room-list-v3/skip-list/filters/SectionFilter.ts
+++ b/apps/web/src/stores/room-list-v3/skip-list/filters/SectionFilter.ts
@@ -7,52 +7,45 @@
 
 import { type Room, KnownMembership } from "matrix-js-sdk/src/matrix";
 
-import { type Filter, type FilterKey } from ".";
+import { type FilterKey, type MultiKeyFilter } from ".";
 import DMRoomMap from "../../../../utils/DMRoomMap";
 import { CHATS_TAG } from "../../section";
 import { DefaultTagID } from "../tag";
 
 /**
- * Matches the rooms of a single section. A room belongs to exactly one section: the Invites section
- * while the invitation is pending, otherwise the section of the first tag it is tagged with, or, when
- * it has none of those tags, the People section if it is a direct message and the Chats section
- * otherwise.
+ * Works out which section a room belongs to. A room belongs to exactly one section: the Invites
+ * section while the invitation is pending, otherwise the section of the first tag it is tagged
+ * with, or, when it has none of those tags, the People section if it is a direct message and the
+ * Chats section otherwise.
  *
  * The People section is optional, see the "RoomList.showPeopleSection" setting. When it is absent
  * from the section tags, direct messages go to the Chats section like any other room.
  */
-export class SectionFilter implements Filter {
+export class SectionFilter implements MultiKeyFilter {
     /**
      * Whether the People section is one of the sections being displayed.
-     * Computed once because {@link matches} runs for every room.
+     * Computed once because {@link keyFor} runs for every room.
      */
     private readonly hasPeopleSection: boolean;
 
     /**
-     * @param tag The tag of the section this filter matches.
      * @param sectionTags All the section tags, in display order.
      */
-    public constructor(
-        private readonly tag: string,
-        private readonly sectionTags: string[],
-    ) {
+    public constructor(private readonly sectionTags: string[]) {
         this.hasPeopleSection = sectionTags.includes(DefaultTagID.DM);
     }
 
-    public matches(room: Room): boolean {
+    public keyFor(room: Room): FilterKey | undefined {
         // The invite tag comes from the membership rather than from account data, so it is not in
         // room.tags. A pending invitation wins over every tag the user applied.
-        if (room.getMyMembership() === KnownMembership.Invite) return this.tag === DefaultTagID.Invite;
-        if (this.tag === DefaultTagID.Invite) return false;
+        if (room.getMyMembership() === KnownMembership.Invite) return DefaultTagID.Invite;
 
-        // A tag the user applied wins over being a direct message.
+        // A tag the user applied wins over being a direct message. A room carrying the invite tag
+        // without a pending invitation belongs to no section.
         const tag = this.sectionTags.find((sectionTag) => room.tags[sectionTag]);
-        if (tag) return tag === this.tag;
-        const isDm = this.hasPeopleSection && !!DMRoomMap.shared().getUserIdForRoomId(room.roomId);
-        return this.tag === (isDm ? DefaultTagID.DM : CHATS_TAG);
-    }
+        if (tag) return tag === DefaultTagID.Invite ? undefined : tag;
 
-    public get key(): FilterKey {
-        return this.tag;
+        const isDm = this.hasPeopleSection && !!DMRoomMap.shared().getUserIdForRoomId(room.roomId);
+        return isDm ? DefaultTagID.DM : CHATS_TAG;
     }
 }

--- a/apps/web/src/stores/room-list-v3/skip-list/filters/index.ts
+++ b/apps/web/src/stores/room-list-v3/skip-list/filters/index.ts
@@ -30,3 +30,15 @@ export interface Filter {
      */
     key: FilterKey;
 }
+
+/**
+ * A filter that picks the one key a room belongs to out of several, so the answer is
+ * worked out once per room instead of once per key.
+ */
+export interface MultiKeyFilter {
+    /** The key that applies to this room, or undefined when none does. */
+    keyFor(room: Room): FilterKey | undefined;
+}
+
+/** Anything the skip list can apply to a room to work out its filter keys. */
+export type AnyFilter = Filter | MultiKeyFilter;


### PR DESCRIPTION
This PR introduces two performances improvements in the room list skip list. I asked AI to see if measurable performance improvements on the skip list and it came with these results:

### Room insertion

When a room is inserted in `RoomSkipList.insertRoom`, the skip list restarted its scan at each level's `head` instead of carrying on from the predessour found the above level. In the result, inserting a room compared it against every room in the list instead of a subset.

The number of levels is also fixed now so a list seeded with 20 rooms that grew to 2000 stayed effectively linear.

**AI metrics:** Measured on 2000 rooms seeded at 20, re-inserting the room that sorts last: **3498 → ~18 comparisons.** 

###  Filters

`updateRoomSkipList` ran at the end of every `RoomListViewModel.updateRoomListData`
and re-ran every filter against every room.

`SectionFilter` also asked "which section is this room in?" once per section per
room. It's asking once per room via a new `MultiKeyFilter` shape.