### PR TITLE
Prevent close button from being hidden by long PDF title

### DIFF
--- a/apps/web/res/css/views/right_panel/_BaseCard.pcss
+++ b/apps/web/res/css/views/right_panel/_BaseCard.pcss
@@ -50,6 +50,7 @@ Please see LICENSE files in the repository root for full details.
             justify-content: space-between;
             height: 24px;
             flex: 1;
+            min-width: 0;
 
             .mx_BaseCard_header_title_heading {
                 overflow: hidden;


### PR DESCRIPTION
This no longer happens

https://github.com/user-attachments/assets/7464d75b-8ea0-401a-b8be-3f99710cacf2