### PR TITLE
Transition to stable identifier for media preview configuration

### DIFF
--- a/apps/web/src/@types/matrix-js-sdk.d.ts
+++ b/apps/web/src/@types/matrix-js-sdk.d.ts
@@ -91,6 +91,8 @@ declare module "matrix-js-sdk/src/types" {
         // MSC4155: Invite filtering
         [INVITE_RULES_ACCOUNT_DATA_TYPE]: InviteConfigAccountData;
 
+        // Media preview configuration, stable and unstable (MSC4278) identifiers
+        "m.media_preview_config": MediaPreviewConfig;
         "io.element.msc4278.media_preview_config": MediaPreviewConfig;
 
         // Indicate whether recovery is enabled or disabled

--- a/apps/web/src/@types/media_preview.ts
+++ b/apps/web/src/@types/media_preview.ts
@@ -20,7 +20,17 @@ export enum MediaPreviewValue {
     Off = "off",
 }
 
-export const MEDIA_PREVIEW_ACCOUNT_DATA_TYPE = "io.element.msc4278.media_preview_config";
+/**
+ * The stable account data type for media preview configuration, as specified in the
+ * Client-Server API. This is preferred over the unstable type when both exist.
+ */
+export const MEDIA_PREVIEW_ACCOUNT_DATA_TYPE = "m.media_preview_config";
+/**
+ * The unstable account data type from MSC4278. Still read for backwards compatibility
+ * with older clients, but new values are always written to the stable type.
+ * Can be removed once enough clients have migrated to the stable type.
+ */
+export const MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE = "io.element.msc4278.media_preview_config";
 export interface MediaPreviewConfig extends Record<string, unknown> {
     /**
      * Media preview setting for thumbnails of media in rooms.

--- a/apps/web/src/components/views/settings/tabs/user/MediaPreviewAccountSettings.test.tsx
+++ b/apps/web/src/components/views/settings/tabs/user/MediaPreviewAccountSettings.test.tsx
@@ -19,6 +19,7 @@ import MatrixClientBackedController from "../../../../../settings/controllers/Ma
 import MatrixClientBackedSettingsHandler from "../../../../../settings/handlers/MatrixClientBackedSettingsHandler";
 import {
     MEDIA_PREVIEW_ACCOUNT_DATA_TYPE,
+    MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE,
     type MediaPreviewConfig,
     MediaPreviewValue,
 } from "../../../../../@types/media_preview";
@@ -56,12 +57,14 @@ describe("MediaPreviewAccountSettings", () => {
         // Defaults
         const element = getByLabelText("Hide avatars of room and inviter");
         await userEvent.click(element);
-        expect(client.setAccountData).toHaveBeenCalledWith(MEDIA_PREVIEW_ACCOUNT_DATA_TYPE, {
+        const expected = {
             invite_avatars: MediaPreviewValue.Off,
             media_previews: MediaPreviewValue.On,
-        });
-        // Ensure we don't double set the account data.
-        expect(client.setAccountData).toHaveBeenCalledTimes(1);
+        };
+        expect(client.setAccountData).toHaveBeenCalledWith(MEDIA_PREVIEW_ACCOUNT_DATA_TYPE, expected);
+        expect(client.setAccountData).toHaveBeenCalledWith(MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE, expected);
+        // Ensure we don't double set the account data (one call per type).
+        expect(client.setAccountData).toHaveBeenCalledTimes(2);
     });
 
     // Skip the default.
@@ -87,11 +90,13 @@ describe("MediaPreviewAccountSettings", () => {
 
         const element = getByLabelText(key);
         await userEvent.click(element);
-        expect(client.setAccountData).toHaveBeenCalledWith(MEDIA_PREVIEW_ACCOUNT_DATA_TYPE, {
+        const expected = {
             invite_avatars: MediaPreviewValue.On,
             media_previews: value,
-        });
-        // Ensure we don't double set the account data.
-        expect(client.setAccountData).toHaveBeenCalledTimes(1);
+        };
+        expect(client.setAccountData).toHaveBeenCalledWith(MEDIA_PREVIEW_ACCOUNT_DATA_TYPE, expected);
+        expect(client.setAccountData).toHaveBeenCalledWith(MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE, expected);
+        // Ensure we don't double set the account data (one call per type).
+        expect(client.setAccountData).toHaveBeenCalledTimes(2);
     });
 });

--- a/apps/web/src/settings/SettingsStore.test.ts
+++ b/apps/web/src/settings/SettingsStore.test.ts
@@ -215,7 +215,7 @@ describe("SettingsStore", () => {
             it("migrates media preview configuration immediately", async () => {
                 client.setAccountData = vi.fn();
                 SettingsStore.runMigrations(false);
-                expect(client.setAccountData).toHaveBeenCalledWith("io.element.msc4278.media_preview_config", {
+                expect(client.setAccountData).toHaveBeenCalledWith("m.media_preview_config", {
                     invite_avatars: "off",
                     media_previews: "off",
                 });
@@ -228,7 +228,7 @@ describe("SettingsStore", () => {
                 client.emit(ClientEvent.Sync, SyncState.Prepared, null);
                 // Update is asynchronous
                 await waitFor(() => {
-                    expect(client.setAccountData).toHaveBeenCalledWith("io.element.msc4278.media_preview_config", {
+                    expect(client.setAccountData).toHaveBeenCalledWith("m.media_preview_config", {
                         invite_avatars: "off",
                         media_previews: "off",
                     });
@@ -247,6 +247,92 @@ describe("SettingsStore", () => {
                 client.getAccountData = vi.fn().mockReturnValue({});
                 SettingsStore.runMigrations(false);
                 client.emit(ClientEvent.Sync, SyncState.Prepared, null);
+                expect(client.setAccountData).not.toHaveBeenCalled();
+            });
+
+            it("does not migrate media preview configuration if the unstable account data is already set", async () => {
+                client.setAccountData = vi.fn();
+                client.getAccountData = vi.fn().mockImplementation((type) => {
+                    if (type === "io.element.msc4278.media_preview_config") {
+                        return { getContent: vi.fn().mockReturnValue({ media_previews: "on" }) };
+                    }
+                    return undefined;
+                });
+                SettingsStore.runMigrations(false);
+                client.emit(ClientEvent.Sync, SyncState.Prepared, null);
+                // Only the unstable -> stable migration should run, not the legacy migration.
+                await waitFor(() => {
+                    expect(client.setAccountData).toHaveBeenCalledTimes(1);
+                });
+                expect(client.setAccountData).toHaveBeenCalledWith("m.media_preview_config", {
+                    media_previews: "on",
+                });
+            });
+        });
+
+        describe("Migrate media preview configuration to the stable type", () => {
+            const unstableContent = { invite_avatars: "off", media_previews: "private" };
+
+            function mockAccountData(data: Record<string, Record<string, unknown>>): void {
+                client.getAccountData = vi.fn().mockImplementation((type) => {
+                    if (type in data) {
+                        return { getContent: vi.fn().mockReturnValue(data[type]) };
+                    }
+                    return undefined;
+                });
+            }
+
+            beforeEach(() => {
+                MatrixClientBackedController.matrixClient = client;
+                client.setAccountData = vi.fn();
+            });
+
+            it("copies the unstable config to the stable type", async () => {
+                mockAccountData({ "io.element.msc4278.media_preview_config": unstableContent });
+                SettingsStore.runMigrations(false);
+                await waitFor(() => {
+                    expect(client.setAccountData).toHaveBeenCalledWith("m.media_preview_config", unstableContent);
+                });
+                expect(client.setAccountData).toHaveBeenCalledTimes(1);
+            });
+
+            it("migrates even on a fresh login, as the data is server-side", async () => {
+                mockAccountData({ "io.element.msc4278.media_preview_config": unstableContent });
+                SettingsStore.runMigrations(true);
+                await waitFor(() => {
+                    expect(client.setAccountData).toHaveBeenCalledWith("m.media_preview_config", unstableContent);
+                });
+            });
+
+            it("migrates once the client is ready", async () => {
+                mockAccountData({ "io.element.msc4278.media_preview_config": unstableContent });
+                const mockInitialSync = (client.isInitialSyncComplete = vi.fn().mockReturnValue(false));
+                SettingsStore.runMigrations(false);
+                await Promise.resolve();
+                expect(client.setAccountData).not.toHaveBeenCalled();
+                mockInitialSync.mockReturnValue(true);
+                client.emit(ClientEvent.Sync, SyncState.Prepared, null);
+                await waitFor(() => {
+                    expect(client.setAccountData).toHaveBeenCalledWith("m.media_preview_config", unstableContent);
+                });
+            });
+
+            it("does nothing if the stable config already exists", async () => {
+                mockAccountData({
+                    "m.media_preview_config": { media_previews: "on" },
+                    "io.element.msc4278.media_preview_config": unstableContent,
+                });
+                SettingsStore.runMigrations(false);
+                client.emit(ClientEvent.Sync, SyncState.Prepared, null);
+                await Promise.resolve();
+                expect(client.setAccountData).not.toHaveBeenCalled();
+            });
+
+            it("does nothing if there is no unstable config", async () => {
+                mockAccountData({});
+                SettingsStore.runMigrations(false);
+                client.emit(ClientEvent.Sync, SyncState.Prepared, null);
+                await Promise.resolve();
                 expect(client.setAccountData).not.toHaveBeenCalled();
             });
         });

--- a/apps/web/src/settings/SettingsStore.ts
+++ b/apps/web/src/settings/SettingsStore.ts
@@ -39,7 +39,12 @@ import { Action } from "../dispatcher/actions";
 import PlatformSettingsHandler from "./handlers/PlatformSettingsHandler";
 import ReloadOnChangeController from "./controllers/ReloadOnChangeController";
 import { MatrixClientPeg } from "../MatrixClientPeg";
-import { MediaPreviewValue } from "../@types/media_preview";
+import {
+    MEDIA_PREVIEW_ACCOUNT_DATA_TYPE,
+    MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE,
+    type MediaPreviewConfig,
+    MediaPreviewValue,
+} from "../@types/media_preview";
 import SettingController, { getSettingDisabled, toControllers } from "./controllers/SettingController.ts";
 
 // Convert the settings to easier to manage objects for the handlers
@@ -691,19 +696,30 @@ export default class SettingsStore {
     }
 
     /**
-     * Migrate the setting for visible images to a setting.
+     * Wait for the client to have completed its initial sync, so that account data is available.
+     */
+    private static async waitForInitialSync(): Promise<void> {
+        const client = MatrixClientPeg.safeGet();
+        while (!client.isInitialSyncComplete()) {
+            await new Promise((r) => client.once(ClientEvent.Sync, r));
+        }
+    }
+
+    /**
+     * Migrate the legacy showImages / showAvatarsOnInvites account settings to the media preview config.
      *
      * @param isFreshLogin True if the user has just logged in, false if a previous session is being restored.
      */
     private static async migrateMediaControlsToSetting(isFreshLogin: boolean): Promise<void> {
         if (isFreshLogin) return;
         const client = MatrixClientPeg.safeGet();
+        if (!client.isInitialSyncComplete()) await this.waitForInitialSync();
 
-        while (!client.isInitialSyncComplete()) {
-            await new Promise((r) => client.once(ClientEvent.Sync, r));
-        }
-        // Never migrate if the config already exists.
-        if (client.getAccountData("io.element.msc4278.media_preview_config")) {
+        // Never migrate if the config already exists, under either the stable or unstable type.
+        if (
+            client.getAccountData(MEDIA_PREVIEW_ACCOUNT_DATA_TYPE) ||
+            client.getAccountData(MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE)
+        ) {
             return;
         }
         logger.info("Performing one-time settings migration of show images and invite avatars to account data");
@@ -720,6 +736,32 @@ export default class SettingsStore {
     }
 
     /**
+     * Migrate the global media preview config from the unstable MSC4278 account data type
+     * to the stable `m.media_preview_config` type. This only runs once: as soon as the stable
+     * account data exists (written by this or any other client), it is never touched again.
+     *
+     * Room-level account data is not migrated here; MediaPreviewConfigController falls back to
+     * the unstable room-level event when no stable one exists.
+     */
+    private static async migrateMediaPreviewConfigToStable(): Promise<void> {
+        const client = MatrixClientPeg.safeGet();
+        if (!client.isInitialSyncComplete()) await this.waitForInitialSync();
+
+        // Never migrate if the stable config already exists.
+        if (client.getAccountData(MEDIA_PREVIEW_ACCOUNT_DATA_TYPE)) {
+            return;
+        }
+        const unstableContent = client
+            .getAccountData(MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE)
+            ?.getContent<MediaPreviewConfig>();
+        if (!unstableContent) {
+            return;
+        }
+        logger.info("Performing one-time migration of media preview config to the stable account data type");
+        await client.setAccountData(MEDIA_PREVIEW_ACCOUNT_DATA_TYPE, unstableContent);
+    }
+
+    /**
      * Runs or queues any setting migrations needed.
      */
     public static runMigrations(isFreshLogin: boolean): void {
@@ -733,9 +775,18 @@ export default class SettingsStore {
         // this migration.
         // The consequences of missing the migration are that the previously set
         // media controls for this user will be missing
-        SettingsStore.migrateMediaControlsToSetting(isFreshLogin).catch((e) => {
-            logger.error("Failed to migrate media config settings", e);
-        });
+        // The unstable -> stable migration runs afterwards so that if the legacy migration
+        // above wrote a (stable) config, this one correctly sees it and does nothing.
+        // This can be removed once enough users have run a version of Element with this
+        // migration and the unstable type is no longer read.
+        SettingsStore.migrateMediaControlsToSetting(isFreshLogin)
+            .catch((e) => {
+                logger.error("Failed to migrate media config settings", e);
+            })
+            .then(() => SettingsStore.migrateMediaPreviewConfigToStable())
+            .catch((e) => {
+                logger.error("Failed to migrate media preview config to the stable type", e);
+            });
         // Dev notes: to add your migration, just add a new `migrateMyFeature` function, call it, and
         // add a comment to note when it can be removed.
         return;

--- a/apps/web/src/settings/controllers/MediaPreviewConfigController.test.ts
+++ b/apps/web/src/settings/controllers/MediaPreviewConfigController.test.ts
@@ -14,7 +14,22 @@ import { getMockClientWithEventEmitter, mockClientMethodsServer } from "test-uti
 import MatrixClientBackedController from "./MatrixClientBackedController";
 import MediaPreviewConfigController from "./MediaPreviewConfigController";
 import { SettingLevel } from "../SettingLevel";
-import { MEDIA_PREVIEW_ACCOUNT_DATA_TYPE, MediaPreviewValue } from "../../@types/media_preview";
+import {
+    MEDIA_PREVIEW_ACCOUNT_DATA_TYPE,
+    MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE,
+    type MediaPreviewConfig,
+    MediaPreviewValue,
+} from "../../@types/media_preview";
+
+/**
+ * Builds a getAccountData mock which returns an event for each of the given types.
+ */
+function mockAccountData(data: Partial<Record<string, Partial<MediaPreviewConfig>>>) {
+    return vi.fn().mockImplementation((type: string) => {
+        const content = data[type];
+        return content ? new MatrixEvent({ type, content }) : null;
+    });
+}
 
 describe("MediaPreviewConfigController", () => {
     afterEach(() => {
@@ -164,4 +179,140 @@ describe("MediaPreviewConfigController", () => {
             expect(roomValue[key]).toEqual(MediaPreviewValue.Off);
         },
     );
+
+    describe("stable and unstable account data types", () => {
+        it("falls back to the unstable type when no stable type exists", () => {
+            const controller = new MediaPreviewConfigController();
+            MatrixClientBackedController.matrixClient = getMockClientWithEventEmitter({
+                ...mockClientMethodsServer(),
+                getAccountData: mockAccountData({
+                    [MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE]: {
+                        media_previews: MediaPreviewValue.Off,
+                        invite_avatars: MediaPreviewValue.Off,
+                    },
+                }),
+                getRoom: vi.fn().mockReturnValue({
+                    getAccountData: mockAccountData({
+                        [MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE]: { media_previews: MediaPreviewValue.Private },
+                    }),
+                }),
+            });
+
+            expect(controller.getValueOverride(SettingLevel.ACCOUNT, null)).toEqual({
+                media_previews: MediaPreviewValue.Off,
+                invite_avatars: MediaPreviewValue.Off,
+            });
+            expect(controller.getValueOverride(SettingLevel.ROOM_ACCOUNT, ROOM_ID)).toEqual({
+                media_previews: MediaPreviewValue.Private,
+                invite_avatars: MediaPreviewValue.Off,
+            });
+        });
+
+        it("prefers the stable type over the unstable type at the same level", () => {
+            const controller = new MediaPreviewConfigController();
+            MatrixClientBackedController.matrixClient = getMockClientWithEventEmitter({
+                ...mockClientMethodsServer(),
+                getAccountData: mockAccountData({
+                    [MEDIA_PREVIEW_ACCOUNT_DATA_TYPE]: {
+                        media_previews: MediaPreviewValue.Private,
+                        invite_avatars: MediaPreviewValue.On,
+                    },
+                    [MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE]: {
+                        media_previews: MediaPreviewValue.Off,
+                        invite_avatars: MediaPreviewValue.Off,
+                    },
+                }),
+            });
+
+            expect(controller.getValueOverride(SettingLevel.ACCOUNT, null)).toEqual({
+                media_previews: MediaPreviewValue.Private,
+                invite_avatars: MediaPreviewValue.On,
+            });
+        });
+
+        it("does not merge stable and unstable types at the same level", () => {
+            const controller = new MediaPreviewConfigController();
+            MatrixClientBackedController.matrixClient = getMockClientWithEventEmitter({
+                ...mockClientMethodsServer(),
+                // Stable exists but is missing invite_avatars; the unstable value must NOT fill it in.
+                getAccountData: mockAccountData({
+                    [MEDIA_PREVIEW_ACCOUNT_DATA_TYPE]: { media_previews: MediaPreviewValue.Private },
+                    [MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE]: {
+                        media_previews: MediaPreviewValue.Off,
+                        invite_avatars: MediaPreviewValue.Off,
+                    },
+                }),
+            });
+
+            expect(controller.getValueOverride(SettingLevel.ACCOUNT, null)).toEqual({
+                media_previews: MediaPreviewValue.Private,
+                invite_avatars: MediaPreviewConfigController.default.invite_avatars,
+            });
+        });
+
+        it("merges a stable room-level type with an unstable global type", () => {
+            const controller = new MediaPreviewConfigController();
+            MatrixClientBackedController.matrixClient = getMockClientWithEventEmitter({
+                ...mockClientMethodsServer(),
+                getAccountData: mockAccountData({
+                    [MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE]: { invite_avatars: MediaPreviewValue.Off },
+                }),
+                getRoom: vi.fn().mockReturnValue({
+                    getAccountData: mockAccountData({
+                        [MEDIA_PREVIEW_ACCOUNT_DATA_TYPE]: { media_previews: MediaPreviewValue.Private },
+                    }),
+                }),
+            });
+
+            expect(controller.getValueOverride(SettingLevel.ROOM_ACCOUNT, ROOM_ID)).toEqual({
+                media_previews: MediaPreviewValue.Private,
+                invite_avatars: MediaPreviewValue.Off,
+            });
+        });
+
+        it("merges an unstable room-level type with a stable global type", () => {
+            const controller = new MediaPreviewConfigController();
+            MatrixClientBackedController.matrixClient = getMockClientWithEventEmitter({
+                ...mockClientMethodsServer(),
+                getAccountData: mockAccountData({
+                    [MEDIA_PREVIEW_ACCOUNT_DATA_TYPE]: { invite_avatars: MediaPreviewValue.Off },
+                }),
+                getRoom: vi.fn().mockReturnValue({
+                    getAccountData: mockAccountData({
+                        [MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE]: { media_previews: MediaPreviewValue.Private },
+                    }),
+                }),
+            });
+
+            expect(controller.getValueOverride(SettingLevel.ROOM_ACCOUNT, ROOM_ID)).toEqual({
+                media_previews: MediaPreviewValue.Private,
+                invite_avatars: MediaPreviewValue.Off,
+            });
+        });
+
+        it("writes new values to both the stable and unstable types", async () => {
+            const controller = new MediaPreviewConfigController();
+            const setAccountData = vi.fn().mockResolvedValue({});
+            const setRoomAccountData = vi.fn().mockResolvedValue({});
+            MatrixClientBackedController.matrixClient = getMockClientWithEventEmitter({
+                ...mockClientMethodsServer(),
+                setAccountData,
+                setRoomAccountData,
+            });
+            const value: MediaPreviewConfig = {
+                media_previews: MediaPreviewValue.Off,
+                invite_avatars: MediaPreviewValue.Off,
+            };
+
+            await controller.beforeChange(SettingLevel.ACCOUNT, null, value);
+            expect(setAccountData).toHaveBeenCalledTimes(2);
+            expect(setAccountData).toHaveBeenCalledWith(MEDIA_PREVIEW_ACCOUNT_DATA_TYPE, value);
+            expect(setAccountData).toHaveBeenCalledWith(MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE, value);
+
+            await controller.beforeChange(SettingLevel.ROOM_ACCOUNT, ROOM_ID, value);
+            expect(setRoomAccountData).toHaveBeenCalledTimes(2);
+            expect(setRoomAccountData).toHaveBeenCalledWith(ROOM_ID, MEDIA_PREVIEW_ACCOUNT_DATA_TYPE, value);
+            expect(setRoomAccountData).toHaveBeenCalledWith(ROOM_ID, MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE, value);
+        });
+    });
 });

--- a/apps/web/src/settings/controllers/MediaPreviewConfigController.ts
+++ b/apps/web/src/settings/controllers/MediaPreviewConfigController.ts
@@ -5,11 +5,12 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import { type IContent } from "matrix-js-sdk/src/matrix";
+import { type IContent, type MatrixClient, type Room } from "matrix-js-sdk/src/matrix";
 import { type AccountDataEvents } from "matrix-js-sdk/src/types";
 
 import {
     MEDIA_PREVIEW_ACCOUNT_DATA_TYPE,
+    MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE,
     type MediaPreviewConfig,
     MediaPreviewValue,
 } from "../../@types/media_preview.ts";
@@ -19,12 +20,19 @@ import MatrixClientBackedController from "./MatrixClientBackedController.ts";
 declare module "matrix-js-sdk/src/types" {
     interface RoomAccountDataEvents {
         [MEDIA_PREVIEW_ACCOUNT_DATA_TYPE]: MediaPreviewConfig;
+        [MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE]: MediaPreviewConfig;
     }
 }
 
 /**
- * Handles media preview settings provided by MSC4278.
+ * Handles media preview settings provided by MSC4278 / the `m.media_preview_config` module.
  * This uses both account-level and room-level account data.
+ *
+ * Both the stable (`m.media_preview_config`) and unstable (`io.element.msc4278.media_preview_config`)
+ * account data types are read, with the stable type preferred. Within a single level (global or room)
+ * only one of the two events is consulted: the stable one if present, otherwise the unstable one.
+ * Missing properties then fall back per-property from room to global to defaults, as the spec requires.
+ * New values are written to both types during the transition period, so older clients stay in sync.
  */
 export default class MediaPreviewConfigController extends MatrixClientBackedController {
     public static readonly default: AccountDataEvents[typeof MEDIA_PREVIEW_ACCOUNT_DATA_TYPE] = {
@@ -43,14 +51,26 @@ export default class MediaPreviewConfigController extends MatrixClientBackedCont
         };
     }
 
+    /**
+     * Read the media preview config content from a single source (the client for global,
+     * or a room for room-level), preferring the stable event type over the unstable one.
+     * The two event types are never merged with each other at the same level.
+     */
+    private static getContentFromSource(source: MatrixClient | Room | null | undefined): IContent {
+        const stableContent = source?.getAccountData(MEDIA_PREVIEW_ACCOUNT_DATA_TYPE)?.getContent<MediaPreviewConfig>();
+        if (stableContent) {
+            return stableContent;
+        }
+        return source?.getAccountData(MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE)?.getContent<MediaPreviewConfig>() ?? {};
+    }
+
     public constructor() {
         super();
     }
 
     private getValue = (roomId?: string): MediaPreviewConfig => {
         const source = roomId ? this.client?.getRoom(roomId) : this.client;
-        const accountData =
-            source?.getAccountData(MEDIA_PREVIEW_ACCOUNT_DATA_TYPE)?.getContent<MediaPreviewConfig>() ?? {};
+        const accountData = MediaPreviewConfigController.getContentFromSource(source);
 
         const calculatedConfig = MediaPreviewConfigController.getValidSettingData(accountData);
 
@@ -96,11 +116,20 @@ export default class MediaPreviewConfigController extends MatrixClientBackedCont
         if (!this.client) {
             return false;
         }
+        // Write to both the stable and unstable types for now, so that older clients which only
+        // read the unstable type stay in sync. The unstable write can be dropped once enough
+        // clients read the stable type.
         if (roomId) {
-            await this.client.setRoomAccountData(roomId, MEDIA_PREVIEW_ACCOUNT_DATA_TYPE, newValue);
+            await Promise.all([
+                this.client.setRoomAccountData(roomId, MEDIA_PREVIEW_ACCOUNT_DATA_TYPE, newValue),
+                this.client.setRoomAccountData(roomId, MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE, newValue),
+            ]);
             return true;
         }
-        await this.client.setAccountData(MEDIA_PREVIEW_ACCOUNT_DATA_TYPE, newValue);
+        await Promise.all([
+            this.client.setAccountData(MEDIA_PREVIEW_ACCOUNT_DATA_TYPE, newValue),
+            this.client.setAccountData(MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE, newValue),
+        ]);
         return true;
     }
 }

--- a/apps/web/src/settings/handlers/AccountSettingsHandler.ts
+++ b/apps/web/src/settings/handlers/AccountSettingsHandler.ts
@@ -14,7 +14,7 @@ import MatrixClientBackedSettingsHandler from "./MatrixClientBackedSettingsHandl
 import { objectClone, objectKeyChanges } from "../../utils/objects";
 import { SettingLevel } from "../SettingLevel";
 import { type WatchManager } from "../WatchManager";
-import { MEDIA_PREVIEW_ACCOUNT_DATA_TYPE } from "../../@types/media_preview";
+import { MEDIA_PREVIEW_ACCOUNT_DATA_TYPE, MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE } from "../../@types/media_preview";
 import { type SettingKey, type Settings } from "../Settings.tsx";
 import { mergeEmojiData, type RecentEmojiData, translateLegacyEmojiData } from "../../emojipicker/recent.ts";
 
@@ -71,8 +71,12 @@ export default class AccountSettingsHandler extends MatrixClientBackedSettingsHa
         } else if (event.getType() === RECENT_EMOJI_EVENT_TYPE || event.getType() === LEGACY_RECENT_EMOJI_EVENT_TYPE) {
             const val = this.getRecentEmoji();
             this.watchers.notifyUpdate("recent_emoji", null, SettingLevel.ACCOUNT, val);
-        } else if (event.getType() === MEDIA_PREVIEW_ACCOUNT_DATA_TYPE) {
-            this.watchers.notifyUpdate("mediaPreviewConfig", null, SettingLevel.ROOM_ACCOUNT, event.getContent());
+        } else if (
+            event.getType() === MEDIA_PREVIEW_ACCOUNT_DATA_TYPE ||
+            event.getType() === MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE
+        ) {
+            // The resolved value is computed by MediaPreviewConfigController, so the content here is only a hint.
+            this.watchers.notifyUpdate("mediaPreviewConfig", null, SettingLevel.ACCOUNT, event.getContent());
         }
     };
 

--- a/apps/web/src/settings/handlers/RoomAccountSettingsHandler.ts
+++ b/apps/web/src/settings/handlers/RoomAccountSettingsHandler.ts
@@ -19,7 +19,7 @@ import MatrixClientBackedSettingsHandler from "./MatrixClientBackedSettingsHandl
 import { objectClone, objectKeyChanges } from "../../utils/objects";
 import { SettingLevel } from "../SettingLevel";
 import { type WatchManager } from "../WatchManager";
-import { MEDIA_PREVIEW_ACCOUNT_DATA_TYPE } from "../../@types/media_preview";
+import { MEDIA_PREVIEW_ACCOUNT_DATA_TYPE, MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE } from "../../@types/media_preview";
 
 const ALLOWED_WIDGETS_EVENT_TYPE = "im.vector.setting.allowed_widgets";
 const DEFAULT_SETTINGS_EVENT_TYPE = "im.vector.web.settings";
@@ -70,7 +70,11 @@ export default class RoomAccountSettingsHandler extends MatrixClientBackedSettin
             }
         } else if (event.getType() === ALLOWED_WIDGETS_EVENT_TYPE) {
             this.watchers.notifyUpdate("allowedWidgets", roomId, SettingLevel.ROOM_ACCOUNT, event.getContent());
-        } else if (event.getType() === MEDIA_PREVIEW_ACCOUNT_DATA_TYPE) {
+        } else if (
+            event.getType() === MEDIA_PREVIEW_ACCOUNT_DATA_TYPE ||
+            event.getType() === MEDIA_PREVIEW_UNSTABLE_ACCOUNT_DATA_TYPE
+        ) {
+            // The resolved value is computed by MediaPreviewConfigController, so the content here is only a hint.
             this.watchers.notifyUpdate("mediaPreviewConfig", roomId, SettingLevel.ROOM_ACCOUNT, event.getContent());
         }
     };


### PR DESCRIPTION
Fixes #34976 

This adds support for the stable identifier for MSC4278. Since at the moment clients may use either, this writes to both account data types and eventually will drop support for the older type.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] I have linked the PR to an issue that describes what needs changing.
- [ ] I have written tests for new code (and old code if feasible).
- [ ] I have ensured new or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] I have confirmed linter and other CI checks pass.
- [ ] I have have included screenshots if what the user sees will change
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
- [ ] I will no longer force push to this branch
