### PR TITLE
Run DeviceListener rechecks one at a time

### DIFF
--- a/apps/web/src/DeviceListener.test.ts
+++ b/apps/web/src/DeviceListener.test.ts
@@ -30,6 +30,8 @@ import { getMockClientWithEventEmitter, mockPlatformPeg } from "test-utils";
 
 import {
     DeviceListener,
+    CurrentDeviceEvents,
+    type DeviceState,
     ACCOUNT_DATA_KEY_M_KEY_BACKUP,
     ACCOUNT_DATA_KEY_M_KEY_BACKUP_DISABLED_UNSTABLE,
     RECOVERY_ACCOUNT_DATA_KEY,
@@ -373,6 +375,41 @@ describe("DeviceListener", () => {
             });
             await createAndStart();
             expect(console.error).toHaveBeenCalledTimes(1);
+        });
+
+        it("does not let an older recheck's verdict overwrite a newer one", async () => {
+            // Given the device is not verified, and the recheck that notices that is held up on its
+            // last step - waiting for our own device keys - before it writes the state, as in the app.
+            mockCrypto!.isCrossSigningReady.mockResolvedValue(true);
+            mockCrypto!.getDeviceVerificationStatus.mockResolvedValue(
+                new DeviceVerificationStatus({ trustCrossSignedDevices: true, crossSigningVerified: false }),
+            );
+            const deviceInfo = Promise.withResolvers<Map<string, Map<string, Device>>>();
+            mockCrypto!.getUserDeviceInfo.mockReturnValue(deviceInfo.promise);
+
+            const instance = await createAndStart();
+            const states: DeviceState[] = [];
+            instance.currentDeviceChangedEmitter.on(CurrentDeviceEvents.DeviceStateChanged, (state) =>
+                states.push(state),
+            );
+
+            // When the device becomes verified while that recheck is still in flight, and something
+            // asks for another recheck
+            mockCrypto!.getDeviceVerificationStatus.mockResolvedValue(
+                new DeviceVerificationStatus({ trustCrossSignedDevices: true, crossSigningVerified: true }),
+            );
+            mockCrypto!.getSecretStorageStatus.mockResolvedValue(readySecretStorageStatus);
+            mockCrypto!.getActiveSessionBackupVersion.mockResolvedValue("1");
+            instance.recheck();
+            await flushPromises();
+
+            // ... and the older recheck is finally allowed to write its now-stale verdict
+            deviceInfo.resolve(new Map());
+            await flushPromises();
+
+            // Then we end up in the state the newer recheck found, not the one the older one found
+            expect(states).toEqual(["verify_this_session", "ok"]);
+            expect(instance.getDeviceState()).toBe("ok");
         });
 
         describe("set up encryption", () => {

--- a/apps/web/src/device-listener/DeviceListener.ts
+++ b/apps/web/src/device-listener/DeviceListener.ts
@@ -67,6 +67,10 @@ export class DeviceListener {
     public currentDeviceChangedEmitter = new CurrentDeviceChangedEmitter();
 
     private running = false;
+    // Whether a recheck is in flight. Rechecks run one at a time; see `recheck`.
+    private recheckRunning = false;
+    // Whether something asked for a recheck while one was in flight, so another is owed once it ends.
+    private recheckQueued = false;
     // The client with which the instance is running. Only set if `running` is true, otherwise undefined.
     private client?: MatrixClient;
     private shouldRecordClientInformation = false;
@@ -231,13 +235,30 @@ export class DeviceListener {
     };
 
     public recheck(): void {
-        this.doRecheck().catch((e) => {
-            if (e instanceof ClientStoppedError) {
-                // the client was stopped while recheck() was running. Nothing left to do.
-            } else {
-                logger.error("Error during `DeviceListener.recheck`", e);
-            }
-        });
+        if (this.recheckRunning) {
+            // Run rechecks one at a time and coalesce any that arrive meanwhile into a single
+            // re-run. Concurrent rechecks finish in arbitrary order, so a stale verdict could
+            // overwrite a newer one with nothing left to trigger a correction.
+            this.recheckQueued = true;
+            return;
+        }
+
+        this.recheckRunning = true;
+        this.doRecheck()
+            .catch((e) => {
+                if (e instanceof ClientStoppedError) {
+                    // the client was stopped while recheck() was running. Nothing left to do.
+                } else {
+                    logger.error("Error during `DeviceListener.recheck`", e);
+                }
+            })
+            .finally(() => {
+                this.recheckRunning = false;
+                if (this.recheckQueued) {
+                    this.recheckQueued = false;
+                    this.recheck();
+                }
+            });
     }
 
     private async doRecheck(): Promise<void> {


### PR DESCRIPTION
recheck() started a new check on every crypto, sync or account-data event, so several could run at once, each writing its verdict when it finished. "Not verified" is decided after a couple of local reads; "ok" only after the full chain of checks, some hitting the server. 
So around a verification, an older "not verified" could land after a newer "ok" and stick, with no further event to correct it - leaving the app asking the user to verify a device they had just verified.

Serialise rechecks and coalesce any requested while one is running into a
single re-run, so the last verdict written is always the latest computed.

Fixes https://github.com/element-hq/element-web/issues/33784
Fixes https://github.com/element-hq/element-web/issues/33787
Fixes https://github.com/element-hq/element-web/issues/29451